### PR TITLE
Factor out ProjectOffPushDownRule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ProjectOffPushDownRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ProjectOffPushDownRule.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
+
+/**
+ * @param <N> The node type to look for under the ProjectNode
+ * Looks for a Project parent over a N child, such that the parent doesn't use all the output columns of the child.
+ * Given that situation, invokes the pushDownProjectOff helper to possibly rewrite the child to produce fewer outputs.
+ */
+public abstract class ProjectOffPushDownRule<N extends PlanNode>
+    implements Rule
+{
+    private static final Pattern PATTERN = Pattern.typeOf(ProjectNode.class);
+    private final Class<N> targetNodeClass;
+
+    protected ProjectOffPushDownRule(Class<N> targetNodeClass)
+    {
+        this.targetNodeClass = targetNodeClass;
+    }
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Context context)
+    {
+        ProjectNode parent = (ProjectNode) node;
+
+        PlanNode child = context.getLookup().resolve(parent.getSource());
+        if (!targetNodeClass.isInstance(child)) {
+            return Optional.empty();
+        }
+
+        N targetNode = targetNodeClass.cast(child);
+
+        return pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions())
+                .flatMap(prunedOutputs -> this.pushDownProjectOff(context.getIdAllocator(), targetNode, prunedOutputs))
+                .map(newChild -> parent.replaceChildren(ImmutableList.of(newChild)));
+    }
+
+    protected abstract Optional<PlanNode> pushDownProjectOff(PlanNodeIdAllocator idAllocator, N targetNode, Set<Symbol> referencedOutputs);
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCrossJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCrossJoinColumns.java
@@ -13,50 +13,34 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
-import com.facebook.presto.matching.Pattern;
-import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.ProjectNode;
-import com.google.common.collect.ImmutableList;
 
 import java.util.Optional;
+import java.util.Set;
 
-import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
 import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictChildOutputs;
 
 /**
  * Cross joins don't support output symbol selection, so push the project-off through the node.
  */
 public class PruneCrossJoinColumns
-        implements Rule
+        extends ProjectOffPushDownRule<JoinNode>
 {
-    private static final Pattern PATTERN = Pattern.typeOf(ProjectNode.class);
-
-    @Override
-    public Pattern getPattern()
+    public PruneCrossJoinColumns()
     {
-        return PATTERN;
+        super(JoinNode.class);
     }
 
     @Override
-    public Optional<PlanNode> apply(PlanNode node, Context context)
+    protected Optional<PlanNode> pushDownProjectOff(PlanNodeIdAllocator idAllocator, JoinNode joinNode, Set<Symbol> referencedOutputs)
     {
-        ProjectNode parent = (ProjectNode) node;
-
-        PlanNode child = context.getLookup().resolve(parent.getSource());
-        if (!(child instanceof JoinNode)) {
-            return Optional.empty();
-        }
-
-        JoinNode joinNode = (JoinNode) child;
         if (!joinNode.isCrossJoin()) {
             return Optional.empty();
         }
 
-        return pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions())
-                .map(dependencies ->
-                        parent.replaceChildren(ImmutableList.of(
-                                restrictChildOutputs(context.getIdAllocator(), joinNode, dependencies, dependencies).get())));
+        return restrictChildOutputs(idAllocator, joinNode, referencedOutputs, referencedOutputs);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinColumns.java
@@ -13,66 +13,45 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
-import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.ProjectNode;
-import com.google.common.collect.ImmutableList;
 
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
 import static com.facebook.presto.util.MoreLists.filteredCopy;
 
 /**
  * Non-cross joins support output symbol selection, so absorb any project-off into the node.
  */
 public class PruneJoinColumns
-        implements Rule
+        extends ProjectOffPushDownRule<JoinNode>
 {
-    private static final Pattern PATTERN = Pattern.typeOf(ProjectNode.class);
-
-    @Override
-    public Pattern getPattern()
+    public PruneJoinColumns()
     {
-        return PATTERN;
+        super(JoinNode.class);
     }
 
     @Override
-    public Optional<PlanNode> apply(PlanNode node, Context context)
+    protected Optional<PlanNode> pushDownProjectOff(PlanNodeIdAllocator idAllocator, JoinNode joinNode, Set<Symbol> referencedOutputs)
     {
-        ProjectNode parent = (ProjectNode) node;
-
-        PlanNode child = context.getLookup().resolve(parent.getSource());
-        if (!(child instanceof JoinNode)) {
-            return Optional.empty();
-        }
-
-        JoinNode joinNode = (JoinNode) child;
         if (joinNode.isCrossJoin()) {
             return Optional.empty();
         }
 
-        Optional<Set<Symbol>> dependencies = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
-        if (!dependencies.isPresent()) {
-            return Optional.empty();
-        }
-
         return Optional.of(
-                parent.replaceChildren(ImmutableList.of(
-                        new JoinNode(
-                                joinNode.getId(),
-                                joinNode.getType(),
-                                joinNode.getLeft(),
-                                joinNode.getRight(),
-                                joinNode.getCriteria(),
-                                filteredCopy(joinNode.getOutputSymbols(), dependencies.get()::contains),
-                                joinNode.getFilter(),
-                                joinNode.getLeftHashSymbol(),
-                                joinNode.getRightHashSymbol(),
-                                joinNode.getDistributionType()))));
+                new JoinNode(
+                        joinNode.getId(),
+                        joinNode.getType(),
+                        joinNode.getLeft(),
+                        joinNode.getRight(),
+                        joinNode.getCriteria(),
+                        filteredCopy(joinNode.getOutputSymbols(), referencedOutputs::contains),
+                        joinNode.getFilter(),
+                        joinNode.getLeftHashSymbol(),
+                        joinNode.getRightHashSymbol(),
+                        joinNode.getDistributionType()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneSemiJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneSemiJoinColumns.java
@@ -13,11 +13,9 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
-import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
@@ -26,54 +24,34 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
 import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 public class PruneSemiJoinColumns
-        implements Rule
+        extends ProjectOffPushDownRule<SemiJoinNode>
 {
-    private static final Pattern PATTERN = Pattern.typeOf(ProjectNode.class);
-
-    @Override
-    public Pattern getPattern()
+    public PruneSemiJoinColumns()
     {
-        return PATTERN;
+        super(SemiJoinNode.class);
     }
 
     @Override
-    public Optional<PlanNode> apply(PlanNode node, Context context)
+    protected Optional<PlanNode> pushDownProjectOff(PlanNodeIdAllocator idAllocator, SemiJoinNode semiJoinNode, Set<Symbol> referencedOutputs)
     {
-        ProjectNode parent = (ProjectNode) node;
-
-        PlanNode child = context.getLookup().resolve(parent.getSource());
-        if (!(child instanceof SemiJoinNode)) {
-            return Optional.empty();
-        }
-
-        SemiJoinNode semiJoinNode = (SemiJoinNode) child;
-
-        Optional<Set<Symbol>> prunedOutputs = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
-        if (!prunedOutputs.isPresent()) {
-            return Optional.empty();
-        }
-
-        if (!prunedOutputs.get().contains(semiJoinNode.getSemiJoinOutput())) {
-            return Optional.of(
-                    parent.replaceChildren(ImmutableList.of(semiJoinNode.getSource())));
+        if (!referencedOutputs.contains(semiJoinNode.getSemiJoinOutput())) {
+            return Optional.of(semiJoinNode.getSource());
         }
 
         Set<Symbol> requiredSourceInputs = Streams.concat(
-                prunedOutputs.get().stream()
+                referencedOutputs.stream()
                         .filter(symbol -> !symbol.equals(semiJoinNode.getSemiJoinOutput())),
                 Stream.of(semiJoinNode.getSourceJoinSymbol()),
                 semiJoinNode.getSourceHashSymbol().map(Stream::of).orElse(Stream.empty()))
                 .collect(toImmutableSet());
 
-        return restrictOutputs(context.getIdAllocator(), semiJoinNode.getSource(), requiredSourceInputs)
+        return restrictOutputs(idAllocator, semiJoinNode.getSource(), requiredSourceInputs)
                 .map(newSource ->
-                        parent.replaceChildren(ImmutableList.of(
-                                semiJoinNode.replaceChildren(ImmutableList.of(
-                                        newSource, semiJoinNode.getFilteringSource())))));
+                        semiJoinNode.replaceChildren(ImmutableList.of(
+                                newSource, semiJoinNode.getFilteringSource())));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
@@ -13,59 +13,36 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
-import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
 import static com.facebook.presto.util.MoreLists.filteredCopy;
 import static com.google.common.collect.Maps.filterKeys;
 
 public class PruneTableScanColumns
-        implements Rule
+        extends ProjectOffPushDownRule<TableScanNode>
 {
-    private static final Pattern PATTERN = Pattern.typeOf(ProjectNode.class);
-
-    @Override
-    public Pattern getPattern()
+    public PruneTableScanColumns()
     {
-        return PATTERN;
+        super(TableScanNode.class);
     }
 
     @Override
-    public Optional<PlanNode> apply(PlanNode node, Context context)
+    protected Optional<PlanNode> pushDownProjectOff(PlanNodeIdAllocator idAllocator, TableScanNode tableScanNode, Set<Symbol> referencedOutputs)
     {
-        ProjectNode parent = (ProjectNode) node;
-
-        PlanNode source = context.getLookup().resolve(parent.getSource());
-        if (!(source instanceof TableScanNode)) {
-            return Optional.empty();
-        }
-
-        TableScanNode child = (TableScanNode) source;
-
-        Optional<Set<Symbol>> dependencies = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
-        if (!dependencies.isPresent()) {
-            return Optional.empty();
-        }
-
         return Optional.of(
-                new ProjectNode(
-                        parent.getId(),
-                        new TableScanNode(
-                                child.getId(),
-                                child.getTable(),
-                                filteredCopy(child.getOutputSymbols(), dependencies.get()::contains),
-                                filterKeys(child.getAssignments(), dependencies.get()::contains),
-                                child.getLayout(),
-                                child.getCurrentConstraint(),
-                                child.getOriginalConstraint()),
-                        parent.getAssignments()));
+                new TableScanNode(
+                        tableScanNode.getId(),
+                        tableScanNode.getTable(),
+                        filteredCopy(tableScanNode.getOutputSymbols(), referencedOutputs::contains),
+                        filterKeys(tableScanNode.getAssignments(), referencedOutputs::contains),
+                        tableScanNode.getLayout(),
+                        tableScanNode.getCurrentConstraint(),
+                        tableScanNode.getOriginalConstraint()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneValuesColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneValuesColumns.java
@@ -13,11 +13,9 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
-import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
@@ -28,56 +26,34 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.facebook.presto.sql.planner.iterative.rule.Util.pruneInputs;
 import static com.facebook.presto.util.MoreLists.filteredCopy;
 
 public class PruneValuesColumns
-        implements Rule
+        extends ProjectOffPushDownRule<ValuesNode>
 {
-    private static final Pattern PATTERN = Pattern.typeOf(ProjectNode.class);
-
-    @Override
-    public Pattern getPattern()
+    public PruneValuesColumns()
     {
-        return PATTERN;
+        super(ValuesNode.class);
     }
 
     @Override
-    public Optional<PlanNode> apply(PlanNode node, Context context)
+    protected Optional<PlanNode> pushDownProjectOff(PlanNodeIdAllocator idAllocator, ValuesNode valuesNode, Set<Symbol> referencedOutputs)
     {
-        ProjectNode parent = (ProjectNode) node;
-
-        PlanNode child = context.getLookup().resolve(parent.getSource());
-        if (!(child instanceof ValuesNode)) {
-            return Optional.empty();
-        }
-
-        ValuesNode values = (ValuesNode) child;
-
-        Optional<Set<Symbol>> dependencies = pruneInputs(child.getOutputSymbols(), parent.getAssignments().getExpressions());
-        if (!dependencies.isPresent()) {
-            return Optional.empty();
-        }
-
-        List<Symbol> newOutputs = filteredCopy(child.getOutputSymbols(), dependencies.get()::contains);
+        List<Symbol> newOutputs = filteredCopy(valuesNode.getOutputSymbols(), referencedOutputs::contains);
 
         // for each output of project, the corresponding column in the values node
         int[] mapping = new int[newOutputs.size()];
         for (int i = 0; i < mapping.length; i++) {
-            mapping[i] = values.getOutputSymbols().indexOf(newOutputs.get(i));
+            mapping[i] = valuesNode.getOutputSymbols().indexOf(newOutputs.get(i));
         }
 
         ImmutableList.Builder<List<Expression>> rowsBuilder = ImmutableList.builder();
-        for (List<Expression> row : values.getRows()) {
+        for (List<Expression> row : valuesNode.getRows()) {
             rowsBuilder.add(Arrays.stream(mapping)
                     .mapToObj(row::get)
                     .collect(Collectors.toList()));
         }
 
-        return Optional.of(
-                new ProjectNode(
-                        parent.getId(),
-                        new ValuesNode(values.getId(), newOutputs, rowsBuilder.build()),
-                        parent.getAssignments()));
+        return Optional.of(new ValuesNode(valuesNode.getId(), newOutputs, rowsBuilder.build()));
     }
 }


### PR DESCRIPTION
This PR is the first of two alternatives that I have submitted to factor out this boilerplate.  As there will be roughly one such rule per node type, I'd like to do one of these to reduce copy/pasting.  The second PR (https://github.com/prestodb/presto/pull/8346) does not use a base class, and instead retains the Pattern boilerplate and delegates to a util function in apply().

Add a generic ProjectOffPushDownRule to factor out the boilerplate of
rules migrated from PruneUnreferencedOutputs.

ProjectOffPushDownRule looks for a Project parent over a child of some
type N, such that the parent doesn't use all the output columns of the
child.  Given that situation, it invokes the abstract protected
pushDownProjectOff to possibly rewrite the child to produce fewer
outputs.