### PR TITLE
Quarantine TestHiveTableStatistics.testStatisticsForPartitionedTable

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -24,6 +24,7 @@ import com.teradata.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
+import static com.facebook.presto.tests.TestGroups.QUARANTINE;
 import static com.facebook.presto.tests.TestGroups.SKIP_ON_CDH;
 import static com.facebook.presto.tests.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_TEXTFILE;
 import static com.facebook.presto.tests.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_REGIONKEY;
@@ -114,7 +115,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 25.0));
     }
 
-    @Test(groups = {HIVE_CONNECTOR})
+    @Test(groups = {HIVE_CONNECTOR, QUARANTINE})
     @Requires(PartitionedNationTable.class)
     public void testStatisticsForPartitionedTable()
     {


### PR DESCRIPTION
as it hangs the build.

A fix will be provided in a separate PR.