### PR TITLE
Use older Travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 
 sudo: required
 dist: trusty
+group: deprecated-2017Q2
 addons:
   apt:
     packages:


### PR DESCRIPTION
The Travis builds hang on TestHiveTableStatistics with the new images.

https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch