### PR TITLE
Fix intermittent failures in Cassandra tests

### DIFF
--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/EmbeddedCassandra.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/EmbeddedCassandra.java
@@ -81,6 +81,7 @@ public final class EmbeddedCassandra
                 .withClusterName("TestCluster")
                 .addContactPointsWithPorts(ImmutableList.of(
                         new InetSocketAddress(HOST, PORT)))
+                .withMaxSchemaAgreementWaitSeconds(30)
                 .build();
 
         CassandraSession session = new NativeCassandraSession(

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -331,8 +331,10 @@ public class TestCassandraIntegrationSmokeTest
                 .build(), new Duration(1, MINUTES));
 
         // There is no way to figure out what the exactly keyspace we want to retrieve tables from
-        assertQueryFails("SHOW TABLES FROM cassandra.keyspace_3",
-                "More than one keyspace has been found for the case insensitive schema name: keyspace_3 -> \\(KeYsPaCe_3, kEySpAcE_3\\)");
+        assertQueryFailsEventually(
+                "SHOW TABLES FROM cassandra.keyspace_3",
+                "More than one keyspace has been found for the case insensitive schema name: keyspace_3 -> \\(KeYsPaCe_3, kEySpAcE_3\\)",
+                new Duration(1, MINUTES));
 
         session.execute("DROP KEYSPACE \"KeYsPaCe_3\"");
         session.execute("DROP KEYSPACE \"kEySpAcE_3\"");
@@ -359,11 +361,14 @@ public class TestCassandraIntegrationSmokeTest
                 .build(), new Duration(1, MINUTES));
 
         // There is no way to figure out what the exactly table is being queried
-        assertQueryFails("SHOW COLUMNS FROM cassandra.keyspace_4.table_4",
-                "More than one table has been found for the case insensitive table name: table_4 -> \\(TaBlE_4, tAbLe_4\\)");
-        assertQueryFails("SELECT * FROM cassandra.keyspace_4.table_4",
-                "More than one table has been found for the case insensitive table name: table_4 -> \\(TaBlE_4, tAbLe_4\\)");
-
+        assertQueryFailsEventually(
+                "SHOW COLUMNS FROM cassandra.keyspace_4.table_4",
+                "More than one table has been found for the case insensitive table name: table_4 -> \\(TaBlE_4, tAbLe_4\\)",
+                new Duration(1, MINUTES));
+        assertQueryFailsEventually(
+                "SELECT * FROM cassandra.keyspace_4.table_4",
+                "More than one table has been found for the case insensitive table name: table_4 -> \\(TaBlE_4, tAbLe_4\\)",
+                new Duration(1, MINUTES));
         session.execute("DROP KEYSPACE keyspace_4");
     }
 
@@ -381,10 +386,14 @@ public class TestCassandraIntegrationSmokeTest
                 .row("table_5")
                 .build(), new Duration(1, MINUTES));
 
-        assertQueryFails("SHOW COLUMNS FROM cassandra.keyspace_5.table_5",
-                "More than one column has been found for the case insensitive column name: column_5 -> \\(CoLuMn_5, cOlUmN_5\\)");
-        assertQueryFails("SELECT * FROM cassandra.keyspace_5.table_5",
-                "More than one column has been found for the case insensitive column name: column_5 -> \\(CoLuMn_5, cOlUmN_5\\)");
+        assertQueryFailsEventually(
+                "SHOW COLUMNS FROM cassandra.keyspace_5.table_5",
+                "More than one column has been found for the case insensitive column name: column_5 -> \\(CoLuMn_5, cOlUmN_5\\)",
+                new Duration(1, MINUTES));
+        assertQueryFailsEventually(
+                "SELECT * FROM cassandra.keyspace_5.table_5",
+                "More than one column has been found for the case insensitive column name: column_5 -> \\(CoLuMn_5, cOlUmN_5\\)",
+                new Duration(1, MINUTES));
 
         session.execute("DROP KEYSPACE keyspace_5");
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -30,6 +30,7 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilege;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.intellij.lang.annotations.Language;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -172,20 +173,19 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertUpdate(queryRunner, session, sql, OptionalLong.of(count));
     }
 
+    protected void assertQueryFailsEventually(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp, Duration timeout)
+    {
+        QueryAssertions.assertQueryFailsEventually(queryRunner, getSession(), sql, expectedMessageRegExp, timeout);
+    }
+
     protected void assertQueryFails(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
     {
-        assertQueryFails(getSession(), sql, expectedMessageRegExp);
+        QueryAssertions.assertQueryFails(queryRunner, getSession(), sql, expectedMessageRegExp);
     }
 
     protected void assertQueryFails(Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
     {
-        try {
-            queryRunner.execute(session, sql);
-            fail(format("Expected query to fail: %s", sql));
-        }
-        catch (RuntimeException ex) {
-            assertExceptionMessage(sql, ex, expectedMessageRegExp);
-        }
+        QueryAssertions.assertQueryFails(queryRunner, session, sql, expectedMessageRegExp);
     }
 
     protected void assertAccessAllowed(@Language("SQL") String sql, TestingPrivilege... deniedPrivileges)


### PR DESCRIPTION
The failing tests execute `CREATE TABLE` or `CREATE KEYSPACE` statements consecutively, followed by sql statements that retrieve the metadata. I suspect that the metadata doesn't get updated on some of the nodes after the executing of DDL statements, hence the tests fail.

Background: After executing a schema-altering query such as `CREATE TABLE`, datastax driver waits for a certain time period for "schema agreement", before refreshing the schema. If the schema agreement doesn't happen within the given time period, the driver will give up waiting, which will lead to stale metadata being seen on some of the nodes. To prevent this from happening, we can do a number of things such as:
1) Increase the default timeout to a larger value
2) Add a retry mechanism to queries that retrieve schema metadata
3) Execute the queries that retrieve metadata only if there is a schema agreement between the nodes. 

I have added code to do 1) and 2) above, but not 3). Those first two things should allow sufficient time for schema refreshment across all the nodes. Not sure if strictly executing the tests under the check is necessary. (We may need to incorporate that if this doesn't fix it).

Ran the failing tests locally 1000 times, and didn't see failures. Should fix failures such as those reported in https://github.com/prestodb/presto/issues/8180.