### PR TITLE
Fix statement resource handling of zero size pages

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResource.java
@@ -534,11 +534,12 @@ public class StatementResource
                 maxWait = new Duration(0, MILLISECONDS);
             }
 
-            if (bytes == 0) {
+            List<RowIterable> rowIterables = pages.build();
+            if (rowIterables.isEmpty()) {
                 return null;
             }
 
-            return Iterables.concat(pages.build());
+            return Iterables.concat(rowIterables);
         }
 
         private static boolean isQueryStarted(QueryInfo queryInfo)


### PR DESCRIPTION
If page.getSizeInBytes() is zero, the page may not be returned to the client.
The only known case when this happens is if the page contains only SliceArrayBlocks
and all values are null.