### PR TITLE
Build instruction with maven wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ See the [User Manual](https://prestodb.io/docs/current/) for deployment instruct
 
 Presto is a standard Maven project. Simply run the following command from the project root directory:
 
-    mvn clean install
+    ./mvnw clean install
 
 On the first build, Maven will download all the dependencies from the internet and cache them in the local repository (`~/.m2/repository`), which can take a considerable amount of time. Subsequent builds will be faster.
 
 Presto has a comprehensive set of unit tests that can take several minutes to run. You can disable the tests when building:
 
-    mvn clean install -DskipTests
+    ./mvnw clean install -DskipTests
 
 ## Running Presto in your IDE
 


### PR DESCRIPTION
Build with maven wrapper is recommended because it transparently allows users to take advantage of new maven features without any burden on their part. So maven wrapper should be used in build instruction too.