### PR TITLE
Fix NoClassDefFound for annotation based non-static scalar functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/ScalarImplementation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/ScalarImplementation.java
@@ -554,7 +554,9 @@ public class ScalarImplementation
                 }
                 constructorDependencies.add(parseDependency(annotation));
             }
-            return Optional.of(constructorMethodHandle(FUNCTION_IMPLEMENTATION_ERROR, constructor));
+            MethodHandle result = constructorMethodHandle(FUNCTION_IMPLEMENTATION_ERROR, constructor);
+            // Change type of return value to Object to make sure callers won't have classloader issues
+            return Optional.of(result.asType(result.type().changeReturnType(Object.class)));
         }
 
         private Map<String, Class<?>> getDeclaredSpecializedTypeParameters(Method method)
@@ -578,6 +580,8 @@ public class ScalarImplementation
         {
             MethodHandle methodHandle = methodHandle(FUNCTION_IMPLEMENTATION_ERROR, method);
             if (!isStatic(method.getModifiers())) {
+                // Change type of "this" argument to Object to make sure callers won't have classloader issues
+                methodHandle = methodHandle.asType(methodHandle.type().changeParameterType(0, Object.class));
                 // Re-arrange the parameters, so that the "this" parameter is after the meta parameters
                 int[] permutedIndices = new int[methodHandle.type().parameterCount()];
                 permutedIndices[0] = dependencies.size();

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/ml_functions/prediction.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/ml_functions/prediction.sql
@@ -1,9 +1,9 @@
--- database: presto; groups: ml_connector
+-- database: presto; groups: ml_functions
 --!
 SELECT classify(features(1, 2), model)
 FROM (
   SELECT learn_classifier(labels, features) AS model
-  FROM (VALUES ('cat', features(1, 2))) t (labels, features)
+  FROM (VALUES (1, features(1, 2))) t (labels, features)
 ) t2
 --!
-cat|
+1|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/ml_functions/prediction.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/ml_functions/prediction.sql
@@ -1,6 +1,6 @@
 -- database: presto; groups: ml_functions
 --!
-SELECT classify(features(1, 2), model)
+SELECT classify(features(1, 2 + random(1)), model)
 FROM (
   SELECT learn_classifier(labels, features) AS model
   FROM (VALUES (1, features(1, 2))) t (labels, features)

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/ml_functions/varcharPrediction.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/ml_functions/varcharPrediction.sql
@@ -1,6 +1,6 @@
 -- database: presto; groups: ml_functions
 --!
-SELECT classify(features(1, 2), model)
+SELECT classify(features(1, 2 + random(1)), model)
 FROM (
   SELECT learn_classifier(labels, features) AS model
   FROM (VALUES ('cat', features(1, 2))) t (labels, features)

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/ml_functions/varcharPrediction.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/ml_functions/varcharPrediction.sql
@@ -1,9 +1,9 @@
--- database: presto; groups: ml_connector
+-- database: presto; groups: ml_functions
 --!
 SELECT classify(features(1, 2), model)
 FROM (
   SELECT learn_classifier(labels, features) AS model
-  FROM (VALUES (1, features(1, 2))) t (labels, features)
+  FROM (VALUES ('cat', features(1, 2))) t (labels, features)
 ) t2
 --!
-1|
+cat|


### PR DESCRIPTION
During query execution, projection/filter do not have access to classes
defined in plugins. As a result, Object type (instead of the actual
classes) must be used.