### PR TITLE
Access control checks for SHOW TABLES in Hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
@@ -148,7 +148,7 @@ public class SqlStandardAccessControl
     @Override
     public Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
     {
-        return tableNames;
+        return tableNames.stream().filter(tableName -> checkTablePermission(transactionHandle, identity, tableName, SELECT)).collect(Collectors.toSet());
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
@@ -57,7 +57,6 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denySelectV
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("SimplifiableIfStatement")
 public class SqlStandardAccessControl
         implements ConnectorAccessControl
 {


### PR DESCRIPTION
Access control checks for SHOW TABLES to return only those tables for which user has SELECT privilege.

Fixes: #8368