### PR TITLE
Use throwIfInstanceOf instead of the deprecated propagateIfInstanceOf

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java
@@ -93,6 +93,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.Iterables.toArray;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.Math.max;
@@ -579,7 +580,7 @@ public class PrestoS3FileSystem
             throw Throwables.propagate(e);
         }
         catch (Exception e) {
-            Throwables.propagateIfInstanceOf(e, IOException.class);
+            throwIfInstanceOf(e, IOException.class);
             throw Throwables.propagate(e);
         }
     }
@@ -830,7 +831,7 @@ public class PrestoS3FileSystem
                 throw Throwables.propagate(e);
             }
             catch (Exception e) {
-                Throwables.propagateIfInstanceOf(e, IOException.class);
+                throwIfInstanceOf(e, IOException.class);
                 throw Throwables.propagate(e);
             }
         }
@@ -918,7 +919,7 @@ public class PrestoS3FileSystem
                 throw Throwables.propagate(e);
             }
             catch (Exception e) {
-                Throwables.propagateIfInstanceOf(e, IOException.class);
+                throwIfInstanceOf(e, IOException.class);
                 throw Throwables.propagate(e);
             }
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -87,6 +87,7 @@ import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.spi.type.Varchars.truncateToLength;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.max;
@@ -371,7 +372,7 @@ public class ParquetHiveRecordCursor
             });
         }
         catch (Exception e) {
-            Throwables.propagateIfInstanceOf(e, PrestoException.class);
+            throwIfInstanceOf(e, PrestoException.class);
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
                 throw Throwables.propagate(e);

--- a/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
@@ -54,7 +54,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_PROCEDU
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
 import static com.facebook.presto.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static com.facebook.presto.util.Failures.checkCondition;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Arrays.asList;
 
@@ -164,7 +164,7 @@ public class CallTask
             if (t instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            propagateIfInstanceOf(t, PrestoException.class);
+            throwIfInstanceOf(t, PrestoException.class);
             throw new PrestoException(PROCEDURE_CALL_FAILED, t);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -56,7 +56,6 @@ import com.facebook.presto.sql.tree.Explain;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.concurrent.SetThreadName;
 import io.airlift.log.Logger;
@@ -77,6 +76,7 @@ import static com.facebook.presto.OutputBuffers.BROADCAST_PARTITION_ID;
 import static com.facebook.presto.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -266,7 +266,7 @@ public final class SqlQueryExecution
             }
             catch (Throwable e) {
                 fail(e);
-                Throwables.propagateIfInstanceOf(e, Error.class);
+                throwIfInstanceOf(e, Error.class);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/AbstractTypedJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/AbstractTypedJacksonModule.java
@@ -34,7 +34,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.databind.type.SimpleType;
-import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
@@ -43,7 +42,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractTypedJacksonModule<T>
@@ -111,8 +110,11 @@ public abstract class AbstractTypedJacksonModule<T>
                 serializer.serializeWithType(value, generator, provider, typeSerializer);
             }
             catch (ExecutionException e) {
-                propagateIfInstanceOf(e.getCause(), IOException.class);
-                throw Throwables.propagate(e.getCause());
+                Throwable cause = e.getCause();
+                if (cause != null) {
+                    throwIfInstanceOf(cause, IOException.class);
+                }
+                throw new RuntimeException(e);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
@@ -24,7 +24,6 @@ import com.facebook.presto.operator.aggregation.state.NullableDoubleState;
 import com.facebook.presto.operator.aggregation.state.NullableLongState;
 import com.facebook.presto.operator.aggregation.state.SliceState;
 import com.facebook.presto.operator.aggregation.state.StateCompiler;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.AccumulatorState;
@@ -33,7 +32,6 @@ import com.facebook.presto.spi.function.AccumulatorStateSerializer;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
@@ -46,9 +44,9 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Failures.internalError;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -185,9 +183,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -204,9 +200,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -222,9 +216,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -241,9 +233,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -259,9 +249,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -278,9 +266,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -297,9 +283,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -316,9 +300,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -334,9 +316,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -352,9 +332,7 @@ public abstract class AbstractMinMaxAggregationFunction
             }
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayContains.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayContains.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.OperatorDependency;
@@ -23,13 +22,12 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.util.Failures.internalError;
 
 @Description("Determines whether given value exists in the array")
 @ScalarFunction("contains")
@@ -64,10 +62,7 @@ public final class ArrayContains
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (foundNull) {
@@ -96,10 +91,7 @@ public final class ArrayContains
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (foundNull) {
@@ -128,10 +120,7 @@ public final class ArrayContains
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (foundNull) {
@@ -160,10 +149,7 @@ public final class ArrayContains
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (foundNull) {
@@ -192,10 +178,7 @@ public final class ArrayContains
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (foundNull) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayDistinctFromOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayDistinctFromOperator.java
@@ -13,7 +13,6 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.IsNull;
 import com.facebook.presto.spi.function.OperatorDependency;
@@ -22,13 +21,12 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
+import static com.facebook.presto.util.Failures.internalError;
 import static com.google.common.base.Defaults.defaultValue;
 
 @ScalarOperator(IS_DISTINCT_FROM)
@@ -76,10 +74,7 @@ public final class ArrayDistinctFromOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return false;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayEqualOperator.java
@@ -13,7 +13,6 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarOperator;
@@ -21,15 +20,14 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.type.ArrayType.ARRAY_NULL_ELEMENT_MSG;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarOperator(EQUAL)
 public final class ArrayEqualOperator
@@ -58,10 +56,7 @@ public final class ArrayEqualOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return true;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOperator.java
@@ -13,7 +13,6 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarOperator;
@@ -22,15 +21,14 @@ import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.function.TypeParameterSpecialization;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
 import static com.facebook.presto.spi.type.ArrayType.ARRAY_NULL_ELEMENT_MSG;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarOperator(GREATER_THAN)
 public final class ArrayGreaterThanOperator
@@ -61,10 +59,7 @@ public final class ArrayGreaterThanOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
             index++;
         }
@@ -97,10 +92,7 @@ public final class ArrayGreaterThanOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
             index++;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayGreaterThanOrEqualOperator.java
@@ -13,7 +13,6 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarOperator;
@@ -21,16 +20,15 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.type.ArrayType.ARRAY_NULL_ELEMENT_MSG;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarOperator(GREATER_THAN_OR_EQUAL)
 public final class ArrayGreaterThanOrEqualOperator
@@ -61,10 +59,7 @@ public final class ArrayGreaterThanOrEqualOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
             index++;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
@@ -13,8 +13,6 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 
-import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarOperator;
@@ -23,7 +21,6 @@ import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.function.TypeParameterSpecialization;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
@@ -31,6 +28,7 @@ import java.lang.invoke.MethodHandle;
 import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.type.TypeUtils.NULL_HASH_CODE;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarOperator(HASH_CODE)
 public final class ArrayHashCodeOperator
@@ -134,13 +132,5 @@ public final class ArrayHashCodeOperator
         catch (Throwable t) {
             throw internalError(t);
         }
-    }
-
-    private static PrestoException internalError(Throwable t)
-    {
-        Throwables.propagateIfInstanceOf(t, Error.class);
-        Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-        return new PrestoException(StandardErrorCode.GENERIC_INTERNAL_ERROR, t);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOperator.java
@@ -13,7 +13,6 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarOperator;
@@ -22,15 +21,14 @@ import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.function.TypeParameterSpecialization;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.type.ArrayType.ARRAY_NULL_ELEMENT_MSG;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarOperator(LESS_THAN)
 public final class ArrayLessThanOperator
@@ -61,10 +59,7 @@ public final class ArrayLessThanOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
             index++;
         }
@@ -97,10 +92,7 @@ public final class ArrayLessThanOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
             index++;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayLessThanOrEqualOperator.java
@@ -13,7 +13,6 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarOperator;
@@ -22,16 +21,15 @@ import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.function.TypeParameterSpecialization;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.type.ArrayType.ARRAY_NULL_ELEMENT_MSG;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarOperator(LESS_THAN_OR_EQUAL)
 public final class ArrayLessThanOrEqualOperator
@@ -62,10 +60,7 @@ public final class ArrayLessThanOrEqualOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
             index++;
         }
@@ -98,10 +93,7 @@ public final class ArrayLessThanOrEqualOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
             index++;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMaxFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMaxFunction.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.OperatorDependency;
@@ -31,9 +30,8 @@ import static com.facebook.presto.operator.scalar.ArrayMinMaxUtils.booleanArrayM
 import static com.facebook.presto.operator.scalar.ArrayMinMaxUtils.doubleArrayMinMax;
 import static com.facebook.presto.operator.scalar.ArrayMinMaxUtils.longArrayMinMax;
 import static com.facebook.presto.operator.scalar.ArrayMinMaxUtils.sliceArrayMinMax;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarFunction("array_max")
 @Description("Get maximum value of array")
@@ -122,9 +120,7 @@ public final class ArrayMaxFunction
             return selectedValue;
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMinFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMinFunction.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.OperatorDependency;
@@ -31,9 +30,8 @@ import static com.facebook.presto.operator.scalar.ArrayMinMaxUtils.booleanArrayM
 import static com.facebook.presto.operator.scalar.ArrayMinMaxUtils.doubleArrayMinMax;
 import static com.facebook.presto.operator.scalar.ArrayMinMaxUtils.longArrayMinMax;
 import static com.facebook.presto.operator.scalar.ArrayMinMaxUtils.sliceArrayMinMax;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarFunction("array_min")
 @Description("Get minimum value of array")
@@ -122,9 +120,7 @@ public final class ArrayMinFunction
             return selectedValue;
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMinMaxUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMinMaxUtils.java
@@ -14,15 +14,13 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.annotation.UsedByGeneratedCode;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.facebook.presto.util.Failures.internalError;
 
 public final class ArrayMinMaxUtils
 {
@@ -50,9 +48,7 @@ public final class ArrayMinMaxUtils
             return selectedValue;
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -78,9 +74,7 @@ public final class ArrayMinMaxUtils
             return selectedValue;
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -106,9 +100,7 @@ public final class ArrayMinMaxUtils
             return selectedValue;
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 
@@ -134,9 +126,7 @@ public final class ArrayMinMaxUtils
             return selectedValue;
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+            throw internalError(t);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayPositionFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayPositionFunction.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.OperatorDependency;
@@ -23,13 +22,12 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.util.Failures.internalError;
 
 @Description("Returns the position of the first occurrence of the given value in array (or 0 if not found)")
 @ScalarFunction("array_position")
@@ -54,9 +52,7 @@ public final class ArrayPositionFunction
                     }
                 }
                 catch (Throwable t) {
-                    Throwables.propagateIfInstanceOf(t, Error.class);
-                    Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                    throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                    throw internalError(t);
                 }
             }
         }
@@ -80,9 +76,7 @@ public final class ArrayPositionFunction
                     }
                 }
                 catch (Throwable t) {
-                    Throwables.propagateIfInstanceOf(t, Error.class);
-                    Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                    throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                    throw internalError(t);
                 }
             }
         }
@@ -106,9 +100,7 @@ public final class ArrayPositionFunction
                     }
                 }
                 catch (Throwable t) {
-                    Throwables.propagateIfInstanceOf(t, Error.class);
-                    Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                    throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                    throw internalError(t);
                 }
             }
         }
@@ -132,9 +124,7 @@ public final class ArrayPositionFunction
                     }
                 }
                 catch (Throwable t) {
-                    Throwables.propagateIfInstanceOf(t, Error.class);
-                    Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                    throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                    throw internalError(t);
                 }
             }
         }
@@ -158,9 +148,7 @@ public final class ArrayPositionFunction
                     }
                 }
                 catch (Throwable t) {
-                    Throwables.propagateIfInstanceOf(t, Error.class);
-                    Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                    throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                    throw internalError(t);
                 }
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayRemoveFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayRemoveFunction.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -24,15 +23,14 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarFunction("array_remove")
 @Description("Remove specified values from the given array")
@@ -94,10 +92,7 @@ public final class ArrayRemoveFunction
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapElementAtFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapElementAtFunction.java
@@ -19,13 +19,11 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 import io.airlift.slice.Slice;
@@ -34,9 +32,9 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
+import static com.facebook.presto.util.Failures.internalError;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class MapElementAtFunction
@@ -127,9 +125,7 @@ public class MapElementAtFunction
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return null;
@@ -145,9 +141,7 @@ public class MapElementAtFunction
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return null;
@@ -163,9 +157,7 @@ public class MapElementAtFunction
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return null;
@@ -181,9 +173,7 @@ public class MapElementAtFunction
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return null;
@@ -199,9 +189,7 @@ public class MapElementAtFunction
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return null;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapGenericEquality.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapGenericEquality.java
@@ -13,17 +13,15 @@ package com.facebook.presto.operator.scalar;
  * limitations under the License.
  */
 
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 
 import java.lang.invoke.MethodHandle;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
+import static com.facebook.presto.util.Failures.internalError;
 
 public final class MapGenericEquality
 {
@@ -73,10 +71,7 @@ public final class MapGenericEquality
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return true;
@@ -102,10 +97,7 @@ public final class MapGenericEquality
                 return Long.hashCode((long) hashCode.invoke(key));
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
 
@@ -120,10 +112,7 @@ public final class MapGenericEquality
                 return (boolean) equals.invoke(key, other.key);
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
@@ -27,7 +27,6 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.FunctionInvoker;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 import io.airlift.slice.Slice;
@@ -37,12 +36,12 @@ import java.lang.invoke.MethodHandles;
 
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.sql.relational.Signatures.castSignature;
+import static com.facebook.presto.util.Failures.internalError;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.lang.String.format;
 
@@ -130,9 +129,7 @@ public class MapSubscriptOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (legacyMissingKey) {
@@ -163,9 +160,7 @@ public class MapSubscriptOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (legacyMissingKey) {
@@ -196,9 +191,7 @@ public class MapSubscriptOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (legacyMissingKey) {
@@ -229,9 +222,7 @@ public class MapSubscriptOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (legacyMissingKey) {
@@ -262,9 +253,7 @@ public class MapSubscriptOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         if (legacyMissingKey) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToMapCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToMapCast.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -35,6 +34,7 @@ import static com.facebook.presto.spi.function.OperatorType.CAST;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
+import static com.facebook.presto.util.Failures.internalError;
 
 @ScalarOperator(CAST)
 public final class MapToMapCast
@@ -87,9 +87,7 @@ public final class MapToMapCast
                 writeNativeValue(toKeyType, keyBlockBuilder, toKey);
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                throw new PrestoException(StandardErrorCode.GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         Block keyBlock = keyBlockBuilder.build();
@@ -111,9 +109,7 @@ public final class MapToMapCast
                     writeNativeValue(toValueType, blockBuilder, toValue);
                 }
                 catch (Throwable t) {
-                    Throwables.propagateIfInstanceOf(t, Error.class);
-                    Throwables.propagateIfInstanceOf(t, PrestoException.class);
-                    throw new PrestoException(StandardErrorCode.GENERIC_INTERNAL_ERROR, t);
+                    throw internalError(t);
                 }
             }
             else {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowComparisonOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowComparisonOperator.java
@@ -16,23 +16,21 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlOperator;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.orderableWithVariadicBound;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.type.TypeUtils.checkElementNotNull;
+import static com.facebook.presto.util.Failures.internalError;
 
 public abstract class RowComparisonOperator
         extends SqlOperator
@@ -77,10 +75,7 @@ public abstract class RowComparisonOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return 0;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowDistinctFromOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowDistinctFromOperator.java
@@ -17,22 +17,20 @@ import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlOperator;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
+import static com.facebook.presto.util.Failures.internalError;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Defaults.defaultValue;
 
@@ -100,10 +98,7 @@ public class RowDistinctFromOperator
                 }
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
-
-                throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                throw internalError(t);
             }
         }
         return false;

--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapFilter.java
@@ -55,7 +55,7 @@ import static com.facebook.presto.server.security.util.jndi.JndiUtils.getInitial
 import static com.google.common.base.CharMatcher.JAVA_ISO_CONTROL;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.io.ByteStreams.copy;
 import static com.google.common.io.ByteStreams.nullOutputStream;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
@@ -186,7 +186,9 @@ public class LdapFilter
         }
         catch (ExecutionException e) {
             Throwable cause = e.getCause();
-            propagateIfInstanceOf(cause, AuthenticationException.class);
+            if (cause != null) {
+                throwIfInstanceOf(cause, AuthenticationException.class);
+            }
             throw Throwables.propagate(cause);
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -128,6 +128,7 @@ import static com.facebook.presto.type.LikeFunctions.unescapeLiteralLikePattern;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.instanceOf;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.any;
@@ -760,8 +761,8 @@ public class ExpressionInterpreter
                         return handle.invokeWithArguments(value);
                     }
                     catch (Throwable throwable) {
-                        Throwables.propagateIfInstanceOf(throwable, RuntimeException.class);
-                        Throwables.propagateIfInstanceOf(throwable, Error.class);
+                        throwIfInstanceOf(throwable, RuntimeException.class);
+                        throwIfInstanceOf(throwable, Error.class);
                         throw new RuntimeException(throwable.getMessage(), throwable);
                     }
             }

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
@@ -20,7 +20,6 @@ import com.facebook.presto.metadata.SqlScalarFunctionBuilder;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.TypeSignature;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 
@@ -41,6 +40,7 @@ import static com.facebook.presto.spi.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.compare;
 import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 
 public class DecimalInequalityOperators
 {
@@ -175,8 +175,8 @@ public class DecimalInequalityOperators
             return (boolean) getResultMethodHandle.invokeExact(comparisonResult);
         }
         catch (Throwable t) {
-            Throwables.propagateIfInstanceOf(t, Error.class);
-            Throwables.propagateIfInstanceOf(t, PrestoException.class);
+            throwIfInstanceOf(t, Error.class);
+            throwIfInstanceOf(t, PrestoException.class);
             throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/util/Failures.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/Failures.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.PrestoTransportException;
+import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.tree.NodeLocation;
@@ -35,6 +36,7 @@ import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.SYNTAX_ERROR;
 import static com.google.common.base.Functions.toStringFunction;
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -131,5 +133,12 @@ public final class Failures
             return toErrorCode(throwable.getCause());
         }
         return GENERIC_INTERNAL_ERROR.toErrorCode();
+    }
+
+    public static PrestoException internalError(Throwable t)
+    {
+        throwIfInstanceOf(t, Error.class);
+        throwIfInstanceOf(t, PrestoException.class);
+        return new PrestoException(StandardErrorCode.GENERIC_INTERNAL_ERROR, t);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
@@ -16,7 +16,6 @@ package com.facebook.presto.util;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.booleans.BooleanOpenHashSet;
@@ -34,6 +33,7 @@ import java.util.Set;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static java.lang.Math.toIntExact;
 
 public final class FastutilSetHelper
@@ -103,8 +103,8 @@ public final class FastutilSetHelper
                 return Long.hashCode((long) hashCodeHandle.invokeExact(value));
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+                throwIfInstanceOf(t, Error.class);
+                throwIfInstanceOf(t, PrestoException.class);
                 throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
             }
         }
@@ -116,8 +116,8 @@ public final class FastutilSetHelper
                 return (boolean) equalsHandle.invokeExact(a, b);
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+                throwIfInstanceOf(t, Error.class);
+                throwIfInstanceOf(t, PrestoException.class);
                 throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
             }
         }
@@ -142,8 +142,8 @@ public final class FastutilSetHelper
                 return Long.hashCode((long) hashCodeHandle.invokeExact(value));
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+                throwIfInstanceOf(t, Error.class);
+                throwIfInstanceOf(t, PrestoException.class);
                 throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
             }
         }
@@ -155,8 +155,8 @@ public final class FastutilSetHelper
                 return (boolean) equalsHandle.invokeExact(a, b);
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+                throwIfInstanceOf(t, Error.class);
+                throwIfInstanceOf(t, PrestoException.class);
                 throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
             }
         }
@@ -185,8 +185,8 @@ public final class FastutilSetHelper
                 return toIntExact(Long.hashCode((long) hashCodeHandle.invokeExact(value)));
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+                throwIfInstanceOf(t, Error.class);
+                throwIfInstanceOf(t, PrestoException.class);
                 throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
             }
         }
@@ -198,8 +198,8 @@ public final class FastutilSetHelper
                 return (boolean) equalsHandle.invokeExact(a, b);
             }
             catch (Throwable t) {
-                Throwables.propagateIfInstanceOf(t, Error.class);
-                Throwables.propagateIfInstanceOf(t, PrestoException.class);
+                throwIfInstanceOf(t, Error.class);
+                throwIfInstanceOf(t, PrestoException.class);
                 throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
             }
         }

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.HOURS;
@@ -232,7 +233,9 @@ public class MongoSession
         }
         catch (ExecutionException | UncheckedExecutionException e) {
             Throwable t = e.getCause();
-            Throwables.propagateIfInstanceOf(t, exceptionClass);
+            if (t != null) {
+                throwIfInstanceOf(t, exceptionClass);
+            }
             throw Throwables.propagate(t);
         }
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -83,7 +83,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.StandardErrorCode.SERVER_STARTING_UP;
 import static com.facebook.presto.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.Iterables.partition;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Math.multiplyExact;
@@ -370,7 +370,10 @@ public class DatabaseShardManager
                     throw metadataError(e, "Transaction too large");
                 }
 
-                propagateIfInstanceOf(e.getCause(), PrestoException.class);
+                if (e.getCause() != null) {
+                    throwIfInstanceOf(e.getCause(), PrestoException.class);
+                }
+
                 if (attempt == maxAttempts) {
                     throw metadataError(e);
                 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -104,7 +104,7 @@ import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static io.airlift.concurrent.MoreFutures.allAsList;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -341,7 +341,9 @@ public class OrcStorageManager
                 throw Throwables.propagate(e);
             }
             catch (ExecutionException e) {
-                propagateIfInstanceOf(e.getCause(), PrestoException.class);
+                if (e.getCause() != null) {
+                    throwIfInstanceOf(e.getCause(), PrestoException.class);
+                }
                 throw new PrestoException(RAPTOR_RECOVERY_ERROR, "Error recovering shard " + shardUuid, e.getCause());
             }
             catch (TimeoutException e) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/util/DatabaseUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/util/DatabaseUtil.java
@@ -32,7 +32,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_METADATA_ERROR;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.reflect.Reflection.newProxy;
 import static com.mysql.jdbc.MysqlErrorNumbers.ER_TRANS_CACHE_FULL;
 import static java.sql.Types.INTEGER;
@@ -65,7 +65,9 @@ public final class DatabaseUtil
             return dbi.inTransaction(callback);
         }
         catch (DBIException e) {
-            propagateIfInstanceOf(e.getCause(), PrestoException.class);
+            if (e.getCause() != null) {
+                throwIfInstanceOf(e.getCause(), PrestoException.class);
+            }
             throw metadataError(e);
         }
     }

--- a/presto-teradata-functions/src/main/java/com/facebook/presto/teradata/functions/TeradataDateFunctions.java
+++ b/presto-teradata-functions/src/main/java/com/facebook/presto/teradata/functions/TeradataDateFunctions.java
@@ -37,7 +37,7 @@ import static com.facebook.presto.spi.type.DateTimeEncoding.unpackZoneKey;
 import static com.facebook.presto.spi.type.TimeZoneKey.MAX_TIME_ZONE_KEY;
 import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKeys;
 import static com.facebook.presto.teradata.functions.dateformat.DateFormatParser.createDateTimeFormatter;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -92,8 +92,8 @@ public final class TeradataDateFunctions
             return (long) castToDate.invokeExact(session, millis);
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
+            throwIfInstanceOf(t, Error.class);
+            throwIfInstanceOf(t, PrestoException.class);
             throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
         }
     }

--- a/presto-teradata-functions/src/main/java/com/facebook/presto/teradata/functions/TeradataStringFunctions.java
+++ b/presto-teradata-functions/src/main/java/com/facebook/presto/teradata/functions/TeradataStringFunctions.java
@@ -27,7 +27,7 @@ import io.airlift.slice.Slices;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static java.nio.charset.StandardCharsets.UTF_16BE;
 
 public final class TeradataStringFunctions
@@ -52,8 +52,8 @@ public final class TeradataStringFunctions
             return (long) method.invokeExact(string, substring);
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
+            throwIfInstanceOf(t, Error.class);
+            throwIfInstanceOf(t, PrestoException.class);
             throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
         }
     }
@@ -75,8 +75,8 @@ public final class TeradataStringFunctions
             return (Slice) method.invokeExact(utf8, start);
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
+            throwIfInstanceOf(t, Error.class);
+            throwIfInstanceOf(t, PrestoException.class);
             throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
         }
     }
@@ -99,8 +99,8 @@ public final class TeradataStringFunctions
             return (Slice) method.invokeExact(utf8, start, length);
         }
         catch (Throwable t) {
-            propagateIfInstanceOf(t, Error.class);
-            propagateIfInstanceOf(t, PrestoException.class);
+            throwIfInstanceOf(t, Error.class);
+            throwIfInstanceOf(t, PrestoException.class);
             throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
         }
     }


### PR DESCRIPTION
`Throwables::propagateIfInstanceOf()` is deprecated. The only gotcha is we shouldn't be passing a `null` to `throwIfInstanceOf()`.