### PR TITLE
Add more flexible and complete WindowNode matching

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -56,6 +56,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
@@ -193,26 +194,11 @@ public final class PlanMatchPattern
                 Optional.of(new SymbolAlias(hashSymbol))));
     }
 
-    public static PlanMatchPattern window(
-            ExpectedValueProvider<WindowNode.Specification> specification,
-            List<ExpectedValueProvider<FunctionCall>> windowFunctions,
-            PlanMatchPattern source)
+    public static PlanMatchPattern window(Consumer<WindowMatcher.Builder> windowMatcherBuilderConsumer, PlanMatchPattern source)
     {
-        PlanMatchPattern result = node(WindowNode.class, source).with(new WindowMatcher(specification));
-        windowFunctions.forEach(
-                function -> result.withAlias(Optional.empty(), new WindowFunctionMatcher(function)));
-        return result;
-    }
-
-    public static PlanMatchPattern window(
-            ExpectedValueProvider<WindowNode.Specification> specification,
-            Map<String, ExpectedValueProvider<FunctionCall>> assignments,
-            PlanMatchPattern source)
-    {
-        PlanMatchPattern result = node(WindowNode.class, source).with(new WindowMatcher(specification));
-        assignments.entrySet().forEach(
-                assignment -> result.withAlias(assignment.getKey(), new WindowFunctionMatcher(assignment.getValue())));
-        return result;
+        WindowMatcher.Builder windowMatcherBuilder = new WindowMatcher.Builder(source);
+        windowMatcherBuilderConsumer.accept(windowMatcherBuilder);
+        return windowMatcherBuilder.build();
     }
 
     public static PlanMatchPattern sort(PlanMatchPattern source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -43,6 +43,7 @@ import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.WindowFrame;
@@ -192,6 +193,21 @@ public final class PlanMatchPattern
                 new SymbolAlias(markerSymbol),
                 toSymbolAliases(distinctSymbols),
                 Optional.of(new SymbolAlias(hashSymbol))));
+    }
+
+    public static ExpectedValueProvider<WindowNode.Frame> windowFrame(
+            WindowFrame.Type type,
+            FrameBound.Type startType,
+            Optional<String> startValue,
+            FrameBound.Type endType,
+            Optional<String> endValue)
+    {
+        return new WindowFrameProvider(
+                type,
+                startType,
+                startValue.map(SymbolAlias::new),
+                endType,
+                endValue.map(SymbolAlias::new));
     }
 
     public static PlanMatchPattern window(Consumer<WindowMatcher.Builder> windowMatcherBuilderConsumer, PlanMatchPattern source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowFrameProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowFrameProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.FrameBound;
+import com.facebook.presto.sql.tree.WindowFrame;
+
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class WindowFrameProvider
+        implements ExpectedValueProvider<WindowNode.Frame>
+{
+    private final WindowFrame.Type type;
+    private final FrameBound.Type startType;
+    private final Optional<SymbolAlias> startValue;
+    private final FrameBound.Type endType;
+    private final Optional<SymbolAlias> endValue;
+
+    WindowFrameProvider(
+            WindowFrame.Type type,
+            FrameBound.Type startType,
+            Optional<SymbolAlias> startValue,
+            FrameBound.Type endType,
+            Optional<SymbolAlias> endValue)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.startType = requireNonNull(startType, "startType is null");
+        this.startValue = requireNonNull(startValue, "startValue is null");
+        this.endType = requireNonNull(endType, "endType is null");
+        this.endValue = requireNonNull(endValue, "endValue is null");
+    }
+
+    @Override
+    public WindowNode.Frame getExpectedValue(SymbolAliases aliases)
+    {
+        return new WindowNode.Frame(
+                type,
+                startType,
+                startValue.map(alias -> alias.toSymbol(aliases)),
+                endType,
+                endValue.map(alias -> alias.toSymbol(aliases)));
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("type", this.type)
+                .add("startType", this.startType)
+                .add("startValue", this.startValue)
+                .add("endType", this.endType)
+                .add("endValue", this.endValue)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowFunctionMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowFunctionMatcher.java
@@ -15,25 +15,41 @@ package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.FunctionCall;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class WindowFunctionMatcher
         implements RvalueMatcher
 {
     private final ExpectedValueProvider<FunctionCall> callMaker;
+    private final Optional<Signature> signature;
+    private final Optional<ExpectedValueProvider<WindowNode.Frame>> frameMaker;
 
-    public WindowFunctionMatcher(ExpectedValueProvider<FunctionCall> callMaker)
+    /**
+     * @param callMaker Always validates the function call
+     * @param signature Optionally validates the signature
+     * @param frameMaker Optionally validates the frame
+     */
+    public WindowFunctionMatcher(
+            ExpectedValueProvider<FunctionCall> callMaker,
+            Optional<Signature> signature,
+            Optional<ExpectedValueProvider<WindowNode.Frame>> frameMaker)
     {
         this.callMaker = requireNonNull(callMaker, "functionCall is null");
+        this.signature = requireNonNull(signature, "signature is null");
+        this.frameMaker = requireNonNull(frameMaker, "frameMaker is null");
     }
 
     @Override
@@ -47,19 +63,33 @@ public class WindowFunctionMatcher
         WindowNode windowNode = (WindowNode) node;
 
         FunctionCall expectedCall = callMaker.getExpectedValue(symbolAliases);
-        for (Map.Entry<Symbol, WindowNode.Function> assignment : windowNode.getWindowFunctions().entrySet()) {
-            if (expectedCall.equals(assignment.getValue().getFunctionCall())) {
-                checkState(!result.isPresent(), "Ambiguous function calls in %s", windowNode);
-                result = Optional.of(assignment.getKey());
-            }
-        }
+        Optional<WindowNode.Frame> expectedFrame = frameMaker.map(maker -> maker.getExpectedValue(symbolAliases));
 
-        return result;
+        List<Symbol> matchedOutputs = windowNode.getWindowFunctions().entrySet().stream()
+                .filter(assignment ->
+                    expectedCall.equals(assignment.getValue().getFunctionCall())
+                            && signature.map(assignment.getValue().getSignature()::equals).orElse(true)
+                            && expectedFrame.map(assignment.getValue().getFrame()::equals).orElse(true))
+                .map(Map.Entry::getKey)
+                .collect(toImmutableList());
+
+        checkState(matchedOutputs.size() <= 1, "Ambiguous function calls in %s", windowNode);
+
+        if (matchedOutputs.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(matchedOutputs.get(0));
     }
 
     @Override
     public String toString()
     {
-        return callMaker.toString();
+        // Only include fields in the description if they are actual constraints.
+        return toStringHelper(this)
+                .omitNullValues()
+                .add("callMaker", callMaker)
+                .add("signature", signature.orElse(null))
+                .add("frameMaker", frameMaker.orElse(null))
+                .toString();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -16,21 +16,34 @@ package com.facebook.presto.sql.planner.assertions;
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.PlanNodeCost;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.FunctionCall;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
-final class WindowMatcher
+/**
+ * Optionally validates each of the non-function fields of the node.
+ */
+public final class WindowMatcher
         implements Matcher
 {
-    private final ExpectedValueProvider<WindowNode.Specification> specification;
+    private final Optional<ExpectedValueProvider<WindowNode.Specification>> specification;
 
-    WindowMatcher(
-            ExpectedValueProvider<WindowNode.Specification> specification)
+    private WindowMatcher(Optional<ExpectedValueProvider<WindowNode.Specification>> specification)
     {
-        this.specification = specification;
+        this.specification = requireNonNull(specification, "specification is null");
     }
 
     @Override
@@ -46,19 +59,79 @@ final class WindowMatcher
 
         WindowNode windowNode = (WindowNode) node;
 
+        if (!specification
+                .map(expectedSpecification ->
+                        expectedSpecification.getExpectedValue(symbolAliases)
+                        .equals(windowNode.getSpecification()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
         /*
          * Window functions produce a symbol (the result of the function call) that we might
          * want to bind to an alias so we can reference it further up the tree. As such,
          * they need to be matched with an Alias matcher so we can bind the symbol if desired.
          */
-        return new MatchResult(windowNode.getSpecification().equals(specification.getExpectedValue(symbolAliases)));
+        return match();
     }
 
     @Override
     public String toString()
     {
+        // Only include fields in the description if they are actual constraints.
         return toStringHelper(this)
-                .add("specification", specification)
+                .omitNullValues()
+                .add("specification", specification.orElse(null))
                 .toString();
+    }
+
+    public static class Builder
+    {
+        private final PlanMatchPattern source;
+        private Optional<ExpectedValueProvider<WindowNode.Specification>> specification = Optional.empty();
+        private List<AliasMatcher> windowFunctionMatchers = new LinkedList<>();
+
+        Builder(PlanMatchPattern source)
+        {
+            this.source = requireNonNull(source, "source is null");
+        }
+
+        public Builder specification(
+                List<String> partitionBy,
+                List<String> orderBy,
+                Map<String, SortOrder> orderings)
+        {
+            return specification(PlanMatchPattern.specification(partitionBy, orderBy, orderings));
+        }
+
+        public Builder specification(ExpectedValueProvider<WindowNode.Specification> specification)
+        {
+            this.specification = Optional.of(specification);
+            return this;
+        }
+
+        public Builder addFunction(String output, ExpectedValueProvider<FunctionCall> functionCall)
+        {
+            return addFunction(Optional.of(output), functionCall);
+        }
+
+        public Builder addFunction(ExpectedValueProvider<FunctionCall> functionCall)
+        {
+            return addFunction(Optional.empty(), functionCall);
+        }
+
+        private Builder addFunction(Optional<String> output, ExpectedValueProvider<FunctionCall> functionCall)
+        {
+            windowFunctionMatchers.add(new AliasMatcher(output, new WindowFunctionMatcher(functionCall, Optional.empty(), Optional.empty())));
+            return this;
+        }
+
+        PlanMatchPattern build()
+        {
+            PlanMatchPattern result = node(WindowNode.class, source).with(
+                    new WindowMatcher(specification));
+            windowFunctionMatchers.forEach(result::with);
+            return result;
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
@@ -43,7 +43,7 @@ import static com.facebook.presto.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
 
 public class TestMergeAdjacentWindows
-            extends BaseRuleTest
+        extends BaseRuleTest
 {
     private static final WindowNode.Frame frame = new WindowNode.Frame(WindowFrame.Type.RANGE, UNBOUNDED_PRECEDING,
             Optional.empty(), CURRENT_ROW, Optional.empty());
@@ -176,12 +176,12 @@ public class TestMergeAdjacentWindows
                                         p.values(p.symbol("a"))
                                 )
                         ))
-                .matches(window(
-                        specificationA,
-                        ImmutableList.of(
-                                functionCall("avg", Optional.empty(), ImmutableList.of(columnAAlias)),
-                                functionCall("sum", Optional.empty(), ImmutableList.of(columnAAlias))),
-                        values(ImmutableMap.of(columnAAlias, 0))));
+                .matches(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationA)
+                                        .addFunction(functionCall("avg", Optional.empty(), ImmutableList.of(columnAAlias)))
+                                        .addFunction(functionCall("sum", Optional.empty(), ImmutableList.of(columnAAlias))),
+                                values(ImmutableMap.of(columnAAlias, 0))));
     }
 
     private static WindowNode.Specification newWindowNodeSpecification(PlanBuilder planBuilder, String symbolName)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
@@ -39,7 +39,7 @@ import static com.facebook.presto.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
 
 public class TestSwapAdjacentWindowsBySpecifications
-            extends BaseRuleTest
+        extends BaseRuleTest
 {
     private WindowNode.Frame frame;
     private Signature signature;
@@ -110,11 +110,14 @@ public class TestSwapAdjacentWindowsBySpecifications
                                         ImmutableMap.of(p.symbol("avg_2", DOUBLE),
                                                 new WindowNode.Function(new FunctionCall(QualifiedName.of("avg"), windowAB, false, ImmutableList.of(new SymbolReference("b"))), signature, frame)),
                                         p.values(p.symbol("a"), p.symbol("b")))))
-                .matches(window(specificationAB,
-                        ImmutableList.of(functionCall("avg", Optional.empty(), ImmutableList.of(columnBAlias))),
-                        window(specificationA,
-                                ImmutableList.of(functionCall("avg", Optional.empty(), ImmutableList.of(columnAAlias))),
-                                values(ImmutableMap.of(columnAAlias, 0, columnBAlias, 1)))));
+                .matches(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationAB)
+                                        .addFunction(functionCall("avg", Optional.empty(), ImmutableList.of(columnBAlias))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(specificationA)
+                                                .addFunction(functionCall("avg", Optional.empty(), ImmutableList.of(columnAAlias))),
+                                        values(ImmutableMap.of(columnAAlias, 0, columnBAlias, 1)))));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -63,8 +63,9 @@ public class TestEliminateSorts
 
         PlanMatchPattern pattern =
                 output(
-                        window(windowSpec,
-                                ImmutableList.of(functionCall("row_number", Optional.empty(), ImmutableList.of())),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(windowSpec)
+                                        .addFunction(functionCall("row_number", Optional.empty(), ImmutableList.of())),
                                 anyTree(LINEITEM_TABLESCAN_Q)));
 
         assertUnitPlan(sql, pattern);
@@ -78,8 +79,9 @@ public class TestEliminateSorts
         PlanMatchPattern pattern =
                 anyTree(
                         sort(
-                                window(windowSpec,
-                                        ImmutableList.of(functionCall("row_number", Optional.empty(), ImmutableList.of())),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(windowSpec)
+                                                .addFunction(functionCall("row_number", Optional.empty(), ImmutableList.of())),
                                         anyTree(LINEITEM_TABLESCAN_Q))));
 
         assertUnitPlan(sql, pattern);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
@@ -85,9 +85,9 @@ public class TestMergeWindows
                     EXTENDEDPRICE_ALIAS, "extendedprice"));
 
     private static final Optional<WindowFrame> COMMON_FRAME = Optional.of(new WindowFrame(
-        WindowFrame.Type.ROWS,
-                new FrameBound(FrameBound.Type.UNBOUNDED_PRECEDING),
-                Optional.of(new FrameBound(FrameBound.Type.CURRENT_ROW))));
+            WindowFrame.Type.ROWS,
+            new FrameBound(FrameBound.Type.UNBOUNDED_PRECEDING),
+            Optional.of(new FrameBound(FrameBound.Type.CURRENT_ROW))));
 
     private static final Optional<WindowFrame> UNSPECIFIED_FRAME = Optional.empty();
 
@@ -96,7 +96,7 @@ public class TestMergeWindows
 
     public TestMergeWindows()
     {
-      this(ImmutableMap.of());
+        this(ImmutableMap.of());
     }
 
     public TestMergeWindows(Map<String, String> sessionProperties)
@@ -151,14 +151,14 @@ public class TestMergeWindows
 
         PlanMatchPattern pattern =
                 anyTree(
-                        window(specificationA,
-                                ImmutableList.of(
-                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS)),
-                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationA)
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS)))
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
                                 anyTree(
-                                        window(specificationB,
-                                                ImmutableList.of(
-                                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                        .specification(specificationB)
+                                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
                                                 anyNot(WindowNode.class,
                                                         LINEITEM_TABLESCAN_DOQSS)))));  // should be anyTree(LINEITEM_TABLESCAN_DOQSS) but anyTree does not handle zero nodes case correctly
 
@@ -176,13 +176,13 @@ public class TestMergeWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationA,
-                                ImmutableList.of(
-                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS)),
-                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
-                                window(specificationB,
-                                        ImmutableList.of(
-                                                functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationA)
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS)))
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(specificationB)
+                                                .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
                                         LINEITEM_TABLESCAN_DOQSS))));
     }
 
@@ -197,14 +197,16 @@ public class TestMergeWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationA,
-                                ImmutableList.of(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
-                                window(specificationB,
-                                        ImmutableList.of(functionCall("lag", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS, "ONE", "ZERO"))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationA)
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(specificationB)
+                                                .addFunction(functionCall("lag", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS, "ONE", "ZERO"))),
                                         project(ImmutableMap.of("ONE", expression("CAST(1 AS bigint)"), "ZERO", expression("0.0")),
-                                                window(specificationA,
-                                                        ImmutableList.of(
-                                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                                .specification(specificationA)
+                                                                .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
                                                         LINEITEM_TABLESCAN_DOQSS))))));
     }
 
@@ -219,14 +221,14 @@ public class TestMergeWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationA,
-                                ImmutableList.of(
-                                functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS)),
-                                functionCall("lag", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS, "ONE", "ZERO"))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationA)
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS)))
+                                        .addFunction(functionCall("lag", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS, "ONE", "ZERO"))),
                                 project(ImmutableMap.of("ONE", expression("CAST(1 AS bigint)"), "ZERO", expression("0.0")),
-                                        window(specificationA,
-                                                ImmutableList.of(
-                                                functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                        .specification(specificationA)
+                                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
                                                 LINEITEM_TABLESCAN_DOQS)))));
     }
 
@@ -251,12 +253,13 @@ public class TestMergeWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationC,
-                                ImmutableList.of(
-                                        functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(QUANTITY_ALIAS)),
-                                        functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
-                                window(specificationD,
-                                        ImmutableList.of(functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationC)
+                                        .addFunction(functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(QUANTITY_ALIAS)))
+                                        .addFunction(functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(specificationD)
+                                                .addFunction(functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
                                         LINEITEM_TABLESCAN_DOQSS))));
     }
 
@@ -286,11 +289,11 @@ public class TestMergeWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationC,
-                                ImmutableList.of(
-                                functionCall("avg", frameD, ImmutableList.of(QUANTITY_ALIAS)),
-                                functionCall("sum", frameC, ImmutableList.of(DISCOUNT_ALIAS)),
-                                functionCall("sum", frameC, ImmutableList.of(QUANTITY_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationC)
+                                        .addFunction(functionCall("avg", frameD, ImmutableList.of(QUANTITY_ALIAS)))
+                                        .addFunction(functionCall("sum", frameC, ImmutableList.of(DISCOUNT_ALIAS)))
+                                        .addFunction(functionCall("sum", frameC, ImmutableList.of(QUANTITY_ALIAS))),
                                 LINEITEM_TABLESCAN_DOQS)));
     }
 
@@ -315,11 +318,11 @@ public class TestMergeWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationD,
-                                ImmutableList.of(
-                                functionCall("avg", frameD, ImmutableList.of(QUANTITY_ALIAS)),
-                                functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(DISCOUNT_ALIAS)),
-                                functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationD)
+                                        .addFunction(functionCall("avg", frameD, ImmutableList.of(QUANTITY_ALIAS)))
+                                        .addFunction(functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(DISCOUNT_ALIAS)))
+                                        .addFunction(functionCall("sum", UNSPECIFIED_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
                                 LINEITEM_TABLESCAN_DOQS)));
     }
 
@@ -379,11 +382,15 @@ public class TestMergeWindows
                         filter("SUM = AVG",
                                 join(JoinNode.Type.INNER, ImmutableList.of(),
                                         any(
-                                                window(leftSpecification, ImmutableMap.of("SUM", functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                                .specification(leftSpecification)
+                                                                .addFunction("SUM", functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
                                                         any(
                                                                 leftTableScan))),
                                         any(
-                                                window(rightSpecification, ImmutableMap.of("AVG", functionCall("avg", COMMON_FRAME, ImmutableList.of(rQuantityAlias))),
+                                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                                .specification(rightSpecification)
+                                                                .addFunction("AVG", functionCall("avg", COMMON_FRAME, ImmutableList.of(rQuantityAlias))),
                                                         any(
                                                                 rightTableScan)))))));
     }
@@ -403,10 +410,12 @@ public class TestMergeWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationA, ImmutableList.of(
-                                functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
-                                window(specificationC, ImmutableList.of(
-                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationA)
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(specificationC)
+                                                .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
                                         LINEITEM_TABLESCAN_DOQS))));
     }
 
@@ -418,17 +427,19 @@ public class TestMergeWindows
                 "SUM(quantity) OVER (PARTITION BY suppkey ORDER BY quantity ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_quantity_C " +
                 "FROM lineitem";
 
-       ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(QUANTITY_ALIAS),
                 ImmutableMap.of(QUANTITY_ALIAS, SortOrder.ASC_NULLS_LAST));
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationC, ImmutableList.of(
-                                functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
-                                window(specificationA, ImmutableList.of(
-                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationC)
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(specificationA)
+                                                .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
                                         LINEITEM_TABLESCAN_DOQS))));
     }
 
@@ -441,18 +452,20 @@ public class TestMergeWindows
                 "SUM(discount) over (PARTITION BY suppkey ORDER BY orderkey ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_discount_A " +
                 "FROM lineitem";
 
-       ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.DESC_NULLS_LAST));
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationC, ImmutableList.of(
-                                functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
-                                window(specificationA, ImmutableList.of(
-                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(EXTENDEDPRICE_ALIAS)),
-                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationC)
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(specificationA)
+                                                .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(EXTENDEDPRICE_ALIAS)))
+                                                .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
                                         LINEITEM_TABLESCAN_DEOQS))));
     }
 
@@ -465,18 +478,20 @@ public class TestMergeWindows
                 "SUM(discount) OVER (PARTITION BY suppkey ORDER BY orderkey ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_discount_A " +
                 "FROM lineitem";
 
-       ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_FIRST));
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(specificationA, ImmutableList.of(
-                                functionCall("sum", COMMON_FRAME, ImmutableList.of(EXTENDEDPRICE_ALIAS)),
-                                functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
-                                window(specificationC, ImmutableList.of(
-                                        functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specificationA)
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(EXTENDEDPRICE_ALIAS)))
+                                        .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(DISCOUNT_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(specificationC)
+                                                .addFunction(functionCall("sum", COMMON_FRAME, ImmutableList.of(QUANTITY_ALIAS))),
                                         LINEITEM_TABLESCAN_DEOQS))));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
@@ -138,17 +138,17 @@ public class TestReorderWindows
 
         PlanMatchPattern pattern =
                 anyTree(
-                        window(windowAp,
-                                ImmutableList.of(
-                                        functionCall("min", commonFrame, ImmutableList.of(TAX_ALIAS))),
-                                window(windowA,
-                                        ImmutableList.of(
-                                                functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(windowAp)
+                                        .addFunction(functionCall("min", commonFrame, ImmutableList.of(TAX_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(windowA)
+                                                .addFunction(functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
                                         anyTree(
-                                        window(windowB,
-                                                ImmutableList.of(
-                                                        functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
-                                                anyTree(LINEITEM_TABLESCAN_DOQPRSST))))));
+                                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                                .specification(windowB)
+                                                                .addFunction(functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
+                                                        anyTree(LINEITEM_TABLESCAN_DOQPRSST))))));
 
         assertPlan(sql, pattern);
     }
@@ -164,15 +164,15 @@ public class TestReorderWindows
 
         assertUnitPlan(sql,
                 anyTree(
-                        window(windowAp,
-                                ImmutableList.of(
-                                        functionCall("min", commonFrame, ImmutableList.of(TAX_ALIAS))),
-                                window(windowA,
-                                        ImmutableList.of(
-                                                functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
-                                        window(windowB,
-                                                ImmutableList.of(
-                                                        functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(windowAp)
+                                        .addFunction(functionCall("min", commonFrame, ImmutableList.of(TAX_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(windowA)
+                                                .addFunction(functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
+                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                        .specification(windowB)
+                                                        .addFunction(functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
                                                 LINEITEM_TABLESCAN_DOQPRSST))))); // should be anyTree(LINEITEM_TABLESCANE_DOQPRSST) but anyTree does not handle zero nodes case correctly
     }
 
@@ -186,13 +186,14 @@ public class TestReorderWindows
                     "from lineitem";
 
             assertUnitPlan(sql,
-                    anyTree(window(windowApp,
-                            ImmutableList.of(
-                                    functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
-                            window(windowA,
-                                    ImmutableList.of(
-                                            functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
-                                    LINEITEM_TABLESCAN_DOQRST)))); // should be anyTree(LINEITEM_TABLESCAN_DOQRST) but anyTree does not handle zero nodes case correctly
+                    anyTree(
+                            window(windowMatcherBuilder -> windowMatcherBuilder
+                                            .specification(windowApp)
+                                            .addFunction(functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
+                                    window(windowMatcherBuilder -> windowMatcherBuilder
+                                                    .specification(windowA)
+                                                    .addFunction(functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
+                                            LINEITEM_TABLESCAN_DOQRST)))); // should be anyTree(LINEITEM_TABLESCAN_DOQRST) but anyTree does not handle zero nodes case correctly
         }
 
         {
@@ -202,13 +203,14 @@ public class TestReorderWindows
                     "from lineitem";
 
             assertUnitPlan(sql,
-                    anyTree(window(windowApp,
-                            ImmutableList.of(
-                                    functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
-                            window(windowA,
-                                    ImmutableList.of(
-                                            functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
-                                    LINEITEM_TABLESCAN_DOQRST)))); // should be anyTree(LINEITEM_TABLESCAN_DOQRST) but anyTree does not handle zero nodes case correctly
+                    anyTree(
+                            window(windowMatcherBuilder -> windowMatcherBuilder
+                                            .specification(windowApp)
+                                            .addFunction(functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
+                                    window(windowMatcherBuilder -> windowMatcherBuilder
+                                                    .specification(windowA)
+                                                    .addFunction(functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
+                                            LINEITEM_TABLESCAN_DOQRST)))); // should be anyTree(LINEITEM_TABLESCAN_DOQRST) but anyTree does not handle zero nodes case correctly
         }
     }
 
@@ -221,14 +223,15 @@ public class TestReorderWindows
                 "from lineitem";
 
         assertUnitPlan(sql,
-                anyTree(window(windowA,
-                        ImmutableList.of(
-                                functionCall("lag", commonFrame, ImmutableList.of(QUANTITY_ALIAS, "ONE"))),
-                        project(ImmutableMap.of("ONE", expression("CAST(1 AS bigint)")),
-                        window(windowApp,
-                                ImmutableList.of(
-                                        functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
-                                LINEITEM_TABLESCAN_DOQRST))))); // should be anyTree(LINEITEM_TABLESCAN_DOQRST) but anyTree does not handle zero nodes case correctly
+                anyTree(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(windowA)
+                                        .addFunction(functionCall("lag", commonFrame, ImmutableList.of(QUANTITY_ALIAS, "ONE"))),
+                                project(ImmutableMap.of("ONE", expression("CAST(1 AS bigint)")),
+                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                        .specification(windowApp)
+                                                        .addFunction(functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
+                                                LINEITEM_TABLESCAN_DOQRST))))); // should be anyTree(LINEITEM_TABLESCAN_DOQRST) but anyTree does not handle zero nodes case correctly
     }
 
     @Test
@@ -253,19 +256,20 @@ public class TestReorderWindows
                 "from lineitem";
 
         assertUnitPlan(sql,
-                anyTree(window(windowD,
-                        ImmutableList.of(
-                                functionCall("avg", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
-                                window(windowA,
-                                ImmutableList.of(
-                                        functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
-                                        window(windowC,
-                                        ImmutableList.of(
-                                                functionCall("sum", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
-                                                window(windowE,
-                                                ImmutableList.of(
-                                                        functionCall("sum", commonFrame, ImmutableList.of(TAX_ALIAS))),
-                                        LINEITEM_TABLESCAN_DOQRST)))))); // should be anyTree(LINEITEM_TABLESCAN_DOQRST) but anyTree does not handle zero nodes case correctly
+                anyTree(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(windowD)
+                                        .addFunction(functionCall("avg", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
+                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                .specification(windowA)
+                                                .addFunction(functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
+                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                        .specification(windowC)
+                                                        .addFunction(functionCall("sum", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
+                                                window(windowMatcherBuilder -> windowMatcherBuilder
+                                                                .specification(windowE)
+                                                                .addFunction(functionCall("sum", commonFrame, ImmutableList.of(TAX_ALIAS))),
+                                                        LINEITEM_TABLESCAN_DOQRST)))))); // should be anyTree(LINEITEM_TABLESCAN_DOQRST) but anyTree does not handle zero nodes case correctly
     }
 
     private void assertUnitPlan(@Language("SQL") String sql, PlanMatchPattern pattern)


### PR DESCRIPTION
The previous window matching pattern didn't validate all fields, and
didn't support a WindowFrame which contained Symbols (non-empty start or
end).  This commit borrows the builder idiom from PlanBuilder to create
flexible matching for WindowNode -- fields not mentioned to the builder
will not be validated.  Test code can simply supply the constraints they
wish to check.

I was motivated to extend WindowNode matching because output pruning
needs to look at the WindowFrame symbols, and rather than extending it
in an incomplete way, I thought I'd try and do it thoroughly.  If people
like this approach, we can do it for other node types as well.