### PR TITLE
Optimize json_parse with cast

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/CastJsonParseBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/CastJsonParseBenchmark.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class CastJsonParseBenchmark
+        extends AbstractSqlBenchmark
+{
+    public CastJsonParseBenchmark(LocalQueryRunner localQueryRunner)
+    {
+        super(
+                localQueryRunner,
+                "sql_cast_json_parse",
+                10,
+                100,
+                "select cast(json_parse('[' || array_join(repeat(totalprice, 100), ',') || ']') as array(real)) from orders");
+    }
+
+    public static void main(String[] args)
+    {
+        new CastJsonParseBenchmark(createLocalQueryRunner()).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -227,6 +227,8 @@ import static com.facebook.presto.operator.scalar.ConcatFunction.VARCHAR_CONCAT;
 import static com.facebook.presto.operator.scalar.ElementToArrayConcatFunction.ELEMENT_TO_ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.Greatest.GREATEST;
 import static com.facebook.presto.operator.scalar.IdentityCast.IDENTITY_CAST;
+import static com.facebook.presto.operator.scalar.JsonStringToArrayCast.JSON_STRING_TO_ARRAY;
+import static com.facebook.presto.operator.scalar.JsonStringToMapCast.JSON_STRING_TO_MAP;
 import static com.facebook.presto.operator.scalar.JsonToArrayCast.JSON_TO_ARRAY;
 import static com.facebook.presto.operator.scalar.JsonToMapCast.JSON_TO_MAP;
 import static com.facebook.presto.operator.scalar.Least.LEAST;
@@ -543,9 +545,9 @@ public class FunctionRegistry
                 .function(MAP_CONCAT_FUNCTION)
                 .function(ARRAY_FLATTEN_FUNCTION)
                 .function(ARRAY_CONCAT_FUNCTION)
-                .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_TO_JSON, JSON_TO_ARRAY)
+                .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_TO_JSON, JSON_TO_ARRAY, JSON_STRING_TO_ARRAY)
                 .functions(new MapSubscriptOperator(featuresConfig.isLegacyMapSubscript(), featuresConfig.isNewMapBlock()))
-                .functions(MAP_CONSTRUCTOR, MAP_TO_JSON, JSON_TO_MAP)
+                .functions(MAP_CONSTRUCTOR, MAP_TO_JSON, JSON_TO_MAP, JSON_STRING_TO_MAP)
                 .functions(MAP_AGG, MULTIMAP_AGG, MAP_UNION)
                 .functions(DECIMAL_TO_VARCHAR_CAST, DECIMAL_TO_INTEGER_CAST, DECIMAL_TO_BIGINT_CAST, DECIMAL_TO_DOUBLE_CAST, DECIMAL_TO_REAL_CAST, DECIMAL_TO_BOOLEAN_CAST, DECIMAL_TO_TINYINT_CAST, DECIMAL_TO_SMALLINT_CAST)
                 .functions(VARCHAR_TO_DECIMAL_CAST, INTEGER_TO_DECIMAL_CAST, BIGINT_TO_DECIMAL_CAST, DOUBLE_TO_DECIMAL_CAST, REAL_TO_DECIMAL_CAST, BOOLEAN_TO_DECIMAL_CAST, TINYINT_TO_DECIMAL_CAST, SMALLINT_TO_DECIMAL_CAST)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
@@ -100,6 +100,8 @@ public final class JsonFunctions
     @SqlType(StandardTypes.JSON)
     public static Slice jsonParse(@SqlType("varchar(x)") Slice slice)
     {
+        // cast(json_parse(x) AS t)` will be optimized into `$internal$json_string_to_array/map_cast` in ExpressionOptimizer
+        // If you make any changes to this function, make sure the same changes are made in `$internal$json_string_to_array/map_cast`.
         try {
             byte[] in = slice.getBytes();
             SliceOutput dynamicSliceOutput = new DynamicSliceOutput(in.length);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonStringToArrayCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonStringToArrayCast.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.metadata.FunctionKind.SCALAR;
+import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.JsonToArrayCast.JSON_TO_ARRAY;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+
+public final class JsonStringToArrayCast
+        extends SqlScalarFunction
+{
+    public static final JsonStringToArrayCast JSON_STRING_TO_ARRAY = new JsonStringToArrayCast();
+    public static final String JSON_STRING_TO_ARRAY_NAME = "$internal$json_string_to_array_cast";
+
+    private JsonStringToArrayCast()
+    {
+        super(new Signature(
+                JSON_STRING_TO_ARRAY_NAME,
+                SCALAR,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature("array(T)"),
+                ImmutableList.of(parseTypeSignature(StandardTypes.VARCHAR)),
+                false));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        // Internal function, doesn't need a description
+        return null;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public final boolean isHidden()
+    {
+        return true;
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        return JSON_TO_ARRAY.specialize(boundVariables, arity, typeManager, functionRegistry);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonStringToMapCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonStringToMapCast.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.metadata.FunctionKind.SCALAR;
+import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
+import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.JsonToMapCast.JSON_TO_MAP;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+
+public final class JsonStringToMapCast
+        extends SqlScalarFunction
+{
+    public static final JsonStringToMapCast JSON_STRING_TO_MAP = new JsonStringToMapCast();
+    public static final String JSON_STRING_TO_MAP_NAME = "$internal$json_string_to_map_cast";
+
+    private JsonStringToMapCast()
+    {
+        super(new Signature(
+                JSON_STRING_TO_MAP_NAME,
+                SCALAR,
+                ImmutableList.of(comparableTypeParameter("K"), typeVariable("V")),
+                ImmutableList.of(),
+                parseTypeSignature("map(K,V)"),
+                ImmutableList.of(parseTypeSignature(StandardTypes.VARCHAR)),
+                false));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        // Internal function, doesn't need a description
+        return null;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public final boolean isHidden()
+    {
+        return true;
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        return JSON_TO_MAP.specialize(boundVariables, arity, typeManager, functionRegistry);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.sql.relational.CallExpression;
 import com.facebook.presto.sql.relational.ConstantExpression;
 import com.facebook.presto.sql.relational.InputReferenceExpression;
@@ -33,7 +34,14 @@ import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.facebook.presto.metadata.Signature.internalScalarFunction;
+import static com.facebook.presto.operator.scalar.JsonStringToArrayCast.JSON_STRING_TO_ARRAY_NAME;
+import static com.facebook.presto.operator.scalar.JsonStringToMapCast.JSON_STRING_TO_MAP_NAME;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
+import static com.facebook.presto.spi.type.StandardTypes.MAP;
+import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.constantNull;
@@ -49,6 +57,8 @@ import static com.facebook.presto.sql.relational.Signatures.ROW_CONSTRUCTOR;
 import static com.facebook.presto.sql.relational.Signatures.SWITCH;
 import static com.facebook.presto.sql.relational.Signatures.TRY;
 import static com.facebook.presto.sql.relational.Signatures.TRY_CAST;
+import static com.facebook.presto.type.JsonType.JSON;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -89,85 +99,80 @@ public class ExpressionOptimizer
         @Override
         public RowExpression visitCall(CallExpression call, Void context)
         {
-            ScalarFunctionImplementation function;
+            if (call.getSignature().getName().equals(CAST)) {
+                call = rewriteCast(call);
+            }
             Signature signature = call.getSignature();
 
-            if (signature.getName().equals(CAST)) {
-                Signature functionSignature = registry.getCoercion(call.getArguments().get(0).getType(), call.getType());
-                function = registry.getScalarFunctionImplementation(functionSignature);
-            }
-            else {
-                switch (signature.getName()) {
-                    // TODO: optimize these special forms
-                    case IF: {
-                        checkState(call.getArguments().size() == 3, "IF function should have 3 arguments. Get " + call.getArguments().size());
-                        RowExpression optimizedOperand = call.getArguments().get(0).accept(this, context);
-                        if (optimizedOperand instanceof ConstantExpression) {
-                            ConstantExpression constantOperand = (ConstantExpression) optimizedOperand;
-                            checkState(constantOperand.getType().equals(BOOLEAN), "Operand of IF function should be BOOLEAN type. Get type " + constantOperand.getType().getDisplayName());
-                            if (Boolean.TRUE.equals(constantOperand.getValue())) {
-                                return call.getArguments().get(1).accept(this, context);
-                            }
-                            // FALSE and NULL
-                            else {
-                                return call.getArguments().get(2).accept(this, context);
-                            }
+            switch (signature.getName()) {
+                // TODO: optimize these special forms
+                case IF: {
+                    checkState(call.getArguments().size() == 3, "IF function should have 3 arguments. Get " + call.getArguments().size());
+                    RowExpression optimizedOperand = call.getArguments().get(0).accept(this, context);
+                    if (optimizedOperand instanceof ConstantExpression) {
+                        ConstantExpression constantOperand = (ConstantExpression) optimizedOperand;
+                        checkState(constantOperand.getType().equals(BOOLEAN), "Operand of IF function should be BOOLEAN type. Get type " + constantOperand.getType().getDisplayName());
+                        if (Boolean.TRUE.equals(constantOperand.getValue())) {
+                            return call.getArguments().get(1).accept(this, context);
                         }
-                        List<RowExpression> arguments = call.getArguments().stream()
-                                .map(argument -> argument.accept(this, null))
-                                .collect(toImmutableList());
-                        return call(signature, call.getType(), arguments);
-                    }
-                    case TRY: {
-                        checkState(call.getArguments().size() == 1, "try call expressions must have a single argument");
-                        if (!(Iterables.getOnlyElement(call.getArguments()) instanceof CallExpression)) {
-                            return Iterables.getOnlyElement(call.getArguments()).accept(this, null);
+                        // FALSE and NULL
+                        else {
+                            return call.getArguments().get(2).accept(this, context);
                         }
-                        List<RowExpression> arguments = call.getArguments().stream()
-                                .map(argument -> argument.accept(this, null))
-                                .collect(toImmutableList());
-                        return call(signature, call.getType(), arguments);
                     }
-                    case BIND: {
-                        checkState(call.getArguments().size() >= 1, BIND + " function should have at least 1 argument. Got " + call.getArguments().size());
+                    List<RowExpression> arguments = call.getArguments().stream()
+                            .map(argument -> argument.accept(this, null))
+                            .collect(toImmutableList());
+                    return call(signature, call.getType(), arguments);
+                }
+                case TRY: {
+                    checkState(call.getArguments().size() == 1, "try call expressions must have a single argument");
+                    if (!(Iterables.getOnlyElement(call.getArguments()) instanceof CallExpression)) {
+                        return Iterables.getOnlyElement(call.getArguments()).accept(this, null);
+                    }
+                    List<RowExpression> arguments = call.getArguments().stream()
+                            .map(argument -> argument.accept(this, null))
+                            .collect(toImmutableList());
+                    return call(signature, call.getType(), arguments);
+                }
+                case BIND: {
+                    checkState(call.getArguments().size() >= 1, BIND + " function should have at least 1 argument. Got " + call.getArguments().size());
 
-                        boolean allConstantExpression = true;
-                        ImmutableList.Builder<RowExpression> optimizedArgumentsBuilder = ImmutableList.builder();
-                        for (RowExpression argument : call.getArguments()) {
-                            RowExpression optimizedArgument = argument.accept(this, context);
-                            if (!(optimizedArgument instanceof ConstantExpression)) {
-                                allConstantExpression = false;
-                            }
-                            optimizedArgumentsBuilder.add(optimizedArgument);
+                    boolean allConstantExpression = true;
+                    ImmutableList.Builder<RowExpression> optimizedArgumentsBuilder = ImmutableList.builder();
+                    for (RowExpression argument : call.getArguments()) {
+                        RowExpression optimizedArgument = argument.accept(this, context);
+                        if (!(optimizedArgument instanceof ConstantExpression)) {
+                            allConstantExpression = false;
                         }
-                        if (allConstantExpression) {
-                            // Here, optimizedArguments should be merged together into a new ConstantExpression.
-                            // It's not implemented because it would be dead code anyways because visitLambda does not produce ConstantExpression.
-                            throw new UnsupportedOperationException();
-                        }
-                        return call(signature, call.getType(), optimizedArgumentsBuilder.build());
+                        optimizedArgumentsBuilder.add(optimizedArgument);
                     }
-                    case NULL_IF:
-                    case SWITCH:
-                    case "WHEN":
-                    case TRY_CAST:
-                    case IS_NULL:
-                    case COALESCE:
-                    case "AND":
-                    case "OR":
-                    case IN:
-                    case DEREFERENCE:
-                    case ROW_CONSTRUCTOR: {
-                        List<RowExpression> arguments = call.getArguments().stream()
-                                .map(argument -> argument.accept(this, null))
-                                .collect(toImmutableList());
-                        return call(signature, call.getType(), arguments);
+                    if (allConstantExpression) {
+                        // Here, optimizedArguments should be merged together into a new ConstantExpression.
+                        // It's not implemented because it would be dead code anyways because visitLambda does not produce ConstantExpression.
+                        throw new UnsupportedOperationException();
                     }
-                    default:
-                        function = registry.getScalarFunctionImplementation(signature);
+                    return call(signature, call.getType(), optimizedArgumentsBuilder.build());
+                }
+                case NULL_IF:
+                case SWITCH:
+                case "WHEN":
+                case TRY_CAST:
+                case IS_NULL:
+                case COALESCE:
+                case "AND":
+                case "OR":
+                case IN:
+                case DEREFERENCE:
+                case ROW_CONSTRUCTOR: {
+                    List<RowExpression> arguments = call.getArguments().stream()
+                            .map(argument -> argument.accept(this, null))
+                            .collect(toImmutableList());
+                    return call(signature, call.getType(), arguments);
                 }
             }
 
+            ScalarFunctionImplementation function = registry.getScalarFunctionImplementation(signature);
             List<RowExpression> arguments = call.getArguments().stream()
                     .map(argument -> argument.accept(this, context))
                     .collect(toImmutableList());
@@ -216,6 +221,42 @@ public class ExpressionOptimizer
         public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
         {
             return reference;
+        }
+
+        private CallExpression rewriteCast(CallExpression call)
+        {
+            if (call.getArguments().get(0) instanceof CallExpression) {
+                // Optimization for CAST(JSON_PARSE(...) AS ARRAY/MAP)
+                CallExpression innerCall = (CallExpression) call.getArguments().get(0);
+                if (innerCall.getSignature().getName().equals("json_parse")) {
+                    checkArgument(innerCall.getType().equals(JSON));
+                    checkArgument(innerCall.getArguments().size() == 1);
+                    TypeSignature returnType = call.getSignature().getReturnType();
+                    if (returnType.getBase().equals(ARRAY)) {
+                        return call(
+                                internalScalarFunction(
+                                        JSON_STRING_TO_ARRAY_NAME,
+                                        returnType,
+                                        ImmutableList.of(parseTypeSignature(VARCHAR))),
+                                call.getType(),
+                                innerCall.getArguments());
+                    }
+                    else if (returnType.getBase().equals(MAP)) {
+                        return call(
+                                internalScalarFunction(
+                                        JSON_STRING_TO_MAP_NAME,
+                                        returnType,
+                                        ImmutableList.of(parseTypeSignature(VARCHAR))),
+                                call.getType(),
+                                innerCall.getArguments());
+                    }
+                }
+            }
+
+            return call(
+                    registry.getCoercion(call.getArguments().get(0).getType(), call.getType()),
+                    call.getType(),
+                    call.getArguments());
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionOptimizer.java
@@ -16,10 +16,13 @@ package com.facebook.presto.sql;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.block.IntArrayBlock;
 import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.relational.CallExpression;
+import com.facebook.presto.sql.relational.ConstantExpression;
 import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.sql.relational.optimizer.ExpressionOptimizer;
 import com.facebook.presto.type.TypeRegistry;
@@ -27,13 +30,25 @@ import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.block.BlockAssertions.toValues;
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.metadata.Signature.internalOperator;
+import static com.facebook.presto.metadata.Signature.internalScalarFunction;
+import static com.facebook.presto.operator.scalar.JsonStringToArrayCast.JSON_STRING_TO_ARRAY_NAME;
+import static com.facebook.presto.operator.scalar.JsonStringToMapCast.JSON_STRING_TO_MAP_NAME;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.field;
+import static com.facebook.presto.sql.relational.Signatures.CAST;
+import static com.facebook.presto.type.JsonType.JSON;
+import static com.facebook.presto.util.StructuralTestUtil.mapType;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.testing.Assertions.assertInstanceOf;
 import static org.testng.Assert.assertEquals;
 
 public class TestExpressionOptimizer
@@ -78,6 +93,39 @@ public class TestExpressionOptimizer
         Signature bigintEquals = internalOperator(OperatorType.EQUAL.name(), BOOLEAN.getTypeSignature(), BIGINT.getTypeSignature(), BIGINT.getTypeSignature());
         RowExpression condition = new CallExpression(bigintEquals, BOOLEAN, ImmutableList.of(constant(3L, BIGINT), constant(3L, BIGINT)));
         assertEquals(optimizer.optimize(ifExpression(condition, 1L, 2L)), constant(1L, BIGINT));
+    }
+
+    @Test
+    public void testCastWithJsonParseOptimization()
+    {
+        TypeRegistry typeManager = new TypeRegistry();
+        ExpressionOptimizer optimizer = new ExpressionOptimizer(new FunctionRegistry(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig()), typeManager, TEST_SESSION);
+        Signature jsonParseSignature = new Signature("json_parse", SCALAR, JSON.getTypeSignature(), ImmutableList.of(VARCHAR.getTypeSignature()));
+
+        // constant
+        Signature jsonCastSignature = new Signature(CAST, SCALAR, parseTypeSignature("array(integer)"), ImmutableList.of(JSON.getTypeSignature()));
+        RowExpression jsonCastExpression = new CallExpression(jsonCastSignature, new ArrayType(INTEGER), ImmutableList.of(call(jsonParseSignature, JSON, constant(utf8Slice("[1, 2]"), VARCHAR))));
+        RowExpression resultExpression = optimizer.optimize(jsonCastExpression);
+        assertInstanceOf(resultExpression, ConstantExpression.class);
+        Object resultValue = ((ConstantExpression) resultExpression).getValue();
+        assertInstanceOf(resultValue, IntArrayBlock.class);
+        assertEquals(toValues(INTEGER, (IntArrayBlock) resultValue), ImmutableList.of(1, 2));
+
+        // varchar to array
+        jsonCastSignature = new Signature(CAST, SCALAR, parseTypeSignature("array(varchar)"), ImmutableList.of(JSON.getTypeSignature()));
+        jsonCastExpression = new CallExpression(jsonCastSignature, new ArrayType(VARCHAR), ImmutableList.of(call(jsonParseSignature, JSON, field(1, VARCHAR))));
+        resultExpression = optimizer.optimize(jsonCastExpression);
+        assertEquals(
+                resultExpression,
+                call(internalScalarFunction(JSON_STRING_TO_ARRAY_NAME, parseTypeSignature("array(varchar)"), parseTypeSignature(StandardTypes.VARCHAR)), new ArrayType(VARCHAR), field(1, VARCHAR)));
+
+        // varchar to map
+        jsonCastSignature = new Signature(CAST, SCALAR, parseTypeSignature("map(integer,varchar)"), ImmutableList.of(JSON.getTypeSignature()));
+        jsonCastExpression = new CallExpression(jsonCastSignature, mapType(INTEGER, VARCHAR), ImmutableList.of(call(jsonParseSignature, JSON, field(1, VARCHAR))));
+        resultExpression = optimizer.optimize(jsonCastExpression);
+        assertEquals(
+                resultExpression,
+                call(internalScalarFunction(JSON_STRING_TO_MAP_NAME, parseTypeSignature("map(integer,varchar)"), parseTypeSignature(StandardTypes.VARCHAR)), mapType(INTEGER, VARCHAR), field(1, VARCHAR)));
     }
 
     private static RowExpression ifExpression(RowExpression condition, long trueValue, long falseValue)


### PR DESCRIPTION
Json objects are stored as strings in database in many use cases. It is inefficient to convert a string into json and then convert the json into an array or map. The patch optimize the two steps into way.

TPCH benchmark shows a CPU save around **30% - 40%**

100 entries in an array
```
before sql_cast_json_parse :: 1012.584 cpu ms ::    0B peak memory :: in   15K,      0B,   14.8K/s,      0B/s :: out   15K,  7.22MB,   14.8K/s,  7.13MB/s
after  sql_cast_json_parse ::  593.713 cpu ms ::    0B peak memory :: in   15K,      0B,   25.3K/s,      0B/s :: out   15K,  7.22MB,   25.3K/s,  12.2MB/s
```


10 enties in an array
```
before sql_cast_json_parse ::  162.843 cpu ms ::    0B peak memory :: in   15K,      0B,   92.1K/s,      0B/s :: out   15K,   806KB,   92.1K/s,  4.83MB/s
after  sql_cast_json_parse ::  113.290 cpu ms ::    0B peak memory :: in   15K,      0B,    132K/s,      0B/s :: out   15K,   806KB,    132K/s,  6.94MB/s
```

The PR resolves https://github.com/prestodb/presto/issues/8286
