### PR TITLE
Bound block sizes read from ORC files with metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
             <dependency>
                 <groupId>com.facebook.presto.orc</groupId>
                 <artifactId>orc-protobuf</artifactId>
-                <version>4</version>
+                <version>5</version>
             </dependency>
 
             <dependency>

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
@@ -406,6 +406,9 @@ public class OrcRecordReader
 
         RowGroup currentRowGroup = rowGroups.next();
         currentGroupRowCount = currentRowGroup.getRowCount();
+        if (currentRowGroup.getMinAverageRowBytes() > 0) {
+            maxBatchSize = toIntExact(min(maxBatchSize, max(1, maxBlockBytes / currentRowGroup.getMinAverageRowBytes())));
+        }
 
         currentPosition = currentStripePosition + currentRowGroup.getRowOffset();
         filePosition = stripeFilePositions.get(currentStripe) + currentRowGroup.getRowOffset();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -387,7 +387,7 @@ public class OrcWriter
 
         // the 0th column is a struct column for the whole row
         columnEncodings.put(0, new ColumnEncoding(DIRECT, 0));
-        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, null, null, null, null, null, null, null));
+        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, null, null, null, null, null, null, null, null));
 
         StripeFooter stripeFooter = new StripeFooter(allStreams, toDenseList(columnEncodings, orcTypes.size()));
         int footerLength = metadataWriter.writeStripeFooter(output, stripeFooter);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -387,7 +387,7 @@ public class OrcWriter
 
         // the 0th column is a struct column for the whole row
         columnEncodings.put(0, new ColumnEncoding(DIRECT, 0));
-        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, null, null, null, null, null, null, null, null));
+        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, 0, null, null, null, null, null, null, null, null));
 
         StripeFooter stripeFooter = new StripeFooter(allStreams, toDenseList(columnEncodings, orcTypes.size()));
         int footerLength = metadataWriter.writeStripeFooter(output, stripeFooter);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/RowGroup.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/RowGroup.java
@@ -23,13 +23,15 @@ public class RowGroup
     private final int groupId;
     private final long rowOffset;
     private final long rowCount;
+    private final long minAverageRowBytes;
     private final InputStreamSources streamSources;
 
-    public RowGroup(int groupId, long rowOffset, long rowCount, InputStreamSources streamSources)
+    public RowGroup(int groupId, long rowOffset, long rowCount, long minAverageRowBytes, InputStreamSources streamSources)
     {
         this.groupId = groupId;
         this.rowOffset = rowOffset;
         this.rowCount = rowCount;
+        this.minAverageRowBytes = minAverageRowBytes;
         this.streamSources = requireNonNull(streamSources, "streamSources is null");
     }
 
@@ -48,6 +50,11 @@ public class RowGroup
         return rowCount;
     }
 
+    public long getMinAverageRowBytes()
+    {
+        return minAverageRowBytes;
+    }
+
     public InputStreamSources getStreamSources()
     {
         return streamSources;
@@ -60,6 +67,7 @@ public class RowGroup
                 .add("groupId", groupId)
                 .add("rowOffset", rowOffset)
                 .add("rowCount", rowCount)
+                .add("minAverageRowBytes", minAverageRowBytes)
                 .add("streamSources", streamSources)
                 .toString();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
+import com.facebook.presto.orc.metadata.statistics.BinaryStatistics;
 import com.facebook.presto.orc.metadata.statistics.BooleanStatistics;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.DoubleStatistics;
@@ -207,6 +208,7 @@ public class DwrfMetadataReader
                 toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup),
                 null,
                 null,
+                toBinaryStatistics(statistics.getBinaryStatistics()),
                 null);
     }
 
@@ -271,6 +273,15 @@ public class DwrfMetadataReader
         }
 
         return new StringStatistics(minimum, maximum);
+    }
+
+    private static BinaryStatistics toBinaryStatistics(DwrfProto.BinaryStatistics binaryStatistics)
+    {
+        if (!binaryStatistics.hasSum()) {
+            return null;
+        }
+
+        return new BinaryStatistics(binaryStatistics.getSum());
     }
 
     private static OrcType toType(DwrfProto.Type type)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -271,8 +271,9 @@ public class DwrfMetadataReader
             minimum = stringStatistics.hasMinimum() ? getMinSlice(stringStatistics.getMinimum()) : null;
             maximum = stringStatistics.hasMaximum() ? getMaxSlice(stringStatistics.getMaximum()) : null;
         }
+        long sum = stringStatistics.hasSum() ? stringStatistics.getSum() : 0;
 
-        return new StringStatistics(minimum, maximum);
+        return new StringStatistics(minimum, maximum, sum);
     }
 
     private static BinaryStatistics toBinaryStatistics(DwrfProto.BinaryStatistics binaryStatistics)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -318,8 +318,9 @@ public class OrcMetadataReader
             minimum = stringStatistics.hasMinimum() ? getMinSlice(stringStatistics.getMinimum()) : null;
             maximum = stringStatistics.hasMaximum() ? getMaxSlice(stringStatistics.getMaximum()) : null;
         }
+        long sum = stringStatistics.hasSum() ? stringStatistics.getSum() : 0;
 
-        return new StringStatistics(minimum, maximum);
+        return new StringStatistics(minimum, maximum, sum);
     }
 
     private static DecimalStatistics toDecimalStatistics(OrcProto.DecimalStatistics decimalStatistics)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
+import com.facebook.presto.orc.metadata.statistics.BinaryStatistics;
 import com.facebook.presto.orc.metadata.statistics.BooleanStatistics;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.DateStatistics;
@@ -215,6 +216,7 @@ public class OrcMetadataReader
                 toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup),
                 toDateStatistics(hiveWriterVersion, statistics.getDateStatistics(), isRowGroup),
                 toDecimalStatistics(statistics.getDecimalStatistics()),
+                toBinaryStatistics(statistics.getBinaryStatistics()),
                 null);
     }
 
@@ -330,6 +332,15 @@ public class OrcMetadataReader
         BigDecimal maximum = decimalStatistics.hasMaximum() ? new BigDecimal(decimalStatistics.getMaximum()) : null;
 
         return new DecimalStatistics(minimum, maximum);
+    }
+
+    private static BinaryStatistics toBinaryStatistics(OrcProto.BinaryStatistics binaryStatistics)
+    {
+        if (!binaryStatistics.hasSum()) {
+            return null;
+        }
+
+        return new BinaryStatistics(binaryStatistics.getSum());
     }
 
     @VisibleForTesting

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatistics.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class BinaryStatistics
+{
+    private final long sum;
+
+    public BinaryStatistics(long sum)
+    {
+        this.sum = sum;
+    }
+
+    public long getSum()
+    {
+        return sum;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("sum", sum)
+                .toString();
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatistics.java
@@ -17,6 +17,9 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class BinaryStatistics
 {
+    // 1 byte to denote if null + 4 bytes to denote offset
+    public static final long BINARY_VALUE_BYTES_OVERHEAD = Byte.BYTES + Integer.BYTES;
+
     private final long sum;
 
     public BinaryStatistics(long sum)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
@@ -18,6 +18,8 @@ import io.airlift.slice.Slice;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.statistics.BinaryStatistics.BINARY_VALUE_BYTES_OVERHEAD;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class BinaryStatisticsBuilder
@@ -54,15 +56,18 @@ public class BinaryStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
+        Optional<BinaryStatistics> binaryStatistics = buildBinaryStatistics();
+        binaryStatistics.ifPresent(s -> verify(nonNullValueCount > 0));
         return new ColumnStatistics(
                 nonNullValueCount,
+                binaryStatistics.map(s -> BINARY_VALUE_BYTES_OVERHEAD + sum / nonNullValueCount).orElse(0L),
                 null,
                 null,
                 null,
                 null,
                 null,
                 null,
-                buildBinaryStatistics().orElse(null),
+                binaryStatistics.orElse(null),
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatistics.java
@@ -19,6 +19,9 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class BooleanStatistics
 {
+    // 1 byte to denote if null + 1 byte for the value
+    public static final long BOOLEAN_VALUE_BYTES = Byte.BYTES + Byte.BYTES;
+
     private final long trueValueCount;
 
     public BooleanStatistics(long trueValueCount)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.metadata.statistics;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.statistics.BooleanStatistics.BOOLEAN_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
 public class BooleanStatisticsBuilder
@@ -51,9 +52,11 @@ public class BooleanStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
+        Optional<BooleanStatistics> booleanStatistics = buildBooleanStatistics();
         return new ColumnStatistics(
                 nonNullValueCount,
-                buildBooleanStatistics().orElse(null),
+                booleanStatistics.map(s -> BOOLEAN_VALUE_BYTES).orElse(0L),
+                booleanStatistics.orElse(null),
                 null,
                 null,
                 null,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -59,6 +59,7 @@ public class BooleanStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.metadata.statistics;
 import java.util.List;
 import java.util.Objects;
 
+import static com.facebook.presto.orc.metadata.statistics.BinaryStatisticsBuilder.mergeBinaryStatistics;
 import static com.facebook.presto.orc.metadata.statistics.BooleanStatisticsBuilder.mergeBooleanStatistics;
 import static com.facebook.presto.orc.metadata.statistics.DateStatisticsBuilder.mergeDateStatistics;
 import static com.facebook.presto.orc.metadata.statistics.DoubleStatisticsBuilder.mergeDoubleStatistics;
@@ -33,6 +34,7 @@ public class ColumnStatistics
     private final StringStatistics stringStatistics;
     private final DateStatistics dateStatistics;
     private final DecimalStatistics decimalStatistics;
+    private final BinaryStatistics binaryStatistics;
     private final HiveBloomFilter bloomFilter;
 
     public ColumnStatistics(
@@ -43,6 +45,7 @@ public class ColumnStatistics
             StringStatistics stringStatistics,
             DateStatistics dateStatistics,
             DecimalStatistics decimalStatistics,
+            BinaryStatistics binaryStatistics,
             HiveBloomFilter bloomFilter)
     {
         this.numberOfValues = numberOfValues;
@@ -52,6 +55,7 @@ public class ColumnStatistics
         this.stringStatistics = stringStatistics;
         this.dateStatistics = dateStatistics;
         this.decimalStatistics = decimalStatistics;
+        this.binaryStatistics = binaryStatistics;
         this.bloomFilter = bloomFilter;
     }
 
@@ -95,6 +99,11 @@ public class ColumnStatistics
         return decimalStatistics;
     }
 
+    public BinaryStatistics getBinaryStatistics()
+    {
+        return binaryStatistics;
+    }
+
     public HiveBloomFilter getBloomFilter()
     {
         return bloomFilter;
@@ -110,6 +119,7 @@ public class ColumnStatistics
                 stringStatistics,
                 dateStatistics,
                 decimalStatistics,
+                binaryStatistics,
                 bloomFilter);
     }
 
@@ -169,6 +179,7 @@ public class ColumnStatistics
                 mergeStringStatistics(stats).orElse(null),
                 mergeDateStatistics(stats).orElse(null),
                 mergeDecimalStatistics(stats).orElse(null),
+                mergeBinaryStatistics(stats).orElse(null),
                 null);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatistics.java
@@ -21,6 +21,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class DateStatistics
         implements RangeStatistics<Integer>
 {
+    // 1 byte to denote if null + 4 bytes for the value (date is of integer type)
+    public static final long DATE_VALUE_BYTES = Byte.BYTES + Integer.BYTES;
+
     private final Integer minimum;
     private final Integer maximum;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
@@ -66,6 +66,7 @@ public class DateStatisticsBuilder
                 null,
                 buildDateStatistics().orElse(null),
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.metadata.statistics;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.statistics.DateStatistics.DATE_VALUE_BYTES;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -58,13 +59,15 @@ public class DateStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
+        Optional<DateStatistics> dateStatistics = buildDateStatistics();
         return new ColumnStatistics(
                 nonNullValueCount,
+                dateStatistics.map(s -> DATE_VALUE_BYTES).orElse(0L),
                 null,
                 null,
                 null,
                 null,
-                buildDateStatistics().orElse(null),
+                dateStatistics.orElse(null),
                 null,
                 null,
                 null);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalStatistics.java
@@ -22,6 +22,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class DecimalStatistics
         implements RangeStatistics<BigDecimal>
 {
+    // 1 byte to denote if null
+    public static final long DECIMAL_VALUE_BYTES_OVERHEAD = Byte.BYTES;
+
     private final BigDecimal minimum;
     private final BigDecimal maximum;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatistics.java
@@ -21,6 +21,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class DoubleStatistics
         implements RangeStatistics<Double>
 {
+    // 1 byte to denote if null + 8 bytes for the value
+    public static final long DOUBLE_VALUE_BYTES = Byte.BYTES + Double.BYTES;
+
     private final Double minimum;
     private final Double maximum;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.metadata.statistics;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.statistics.DoubleStatistics.DOUBLE_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
 public class DoubleStatisticsBuilder
@@ -61,11 +62,13 @@ public class DoubleStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
+        Optional<DoubleStatistics> doubleStatistics = buildDoubleStatistics();
         return new ColumnStatistics(
                 nonNullValueCount,
+                doubleStatistics.map(s -> DOUBLE_VALUE_BYTES).orElse(0L),
                 null,
                 null,
-                buildDoubleStatistics().orElse(null),
+                doubleStatistics.orElse(null),
                 null,
                 null,
                 null,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -69,6 +69,7 @@ public class DoubleStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatistics.java
@@ -21,6 +21,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class IntegerStatistics
         implements RangeStatistics<Long>
 {
+    // 1 byte to denote if null + 8 bytes for the value (integer is of long type)
+    public static final long INTEGER_VALUE_BYTES = Byte.BYTES + Long.BYTES;
+
     private final Long minimum;
     private final Long maximum;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
@@ -64,6 +64,7 @@ public class IntegerStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.metadata.statistics;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.statistics.IntegerStatistics.INTEGER_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
 public class IntegerStatisticsBuilder
@@ -56,10 +57,12 @@ public class IntegerStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
+        Optional<IntegerStatistics> integerStatistics = buildIntegerStatistics();
         return new ColumnStatistics(
                 nonNullValueCount,
+                integerStatistics.map(s -> INTEGER_VALUE_BYTES).orElse(0L),
                 null,
-                buildIntegerStatistics().orElse(null),
+                integerStatistics.orElse(null),
                 null,
                 null,
                 null,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -17,11 +17,14 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.statistics.DecimalStatistics.DECIMAL_VALUE_BYTES_OVERHEAD;
 import static java.util.Objects.requireNonNull;
 
 public class LongDecimalStatisticsBuilder
         implements StatisticsBuilder
 {
+    public static final long LONG_DECIMAL_VALUE_BYTES = 16L;
+
     private long nonNullValueCount;
     private BigDecimal minimum;
     private BigDecimal maximum;
@@ -70,14 +73,16 @@ public class LongDecimalStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
+        Optional<DecimalStatistics> decimalStatistics = buildDecimalStatistics();
         return new ColumnStatistics(
                 nonNullValueCount,
+                decimalStatistics.map(s -> DECIMAL_VALUE_BYTES_OVERHEAD + LONG_DECIMAL_VALUE_BYTES).orElse(0L),
                 null,
                 null,
                 null,
                 null,
                 null,
-                buildDecimalStatistics().orElse(null),
+                decimalStatistics.orElse(null),
                 null,
                 null);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -78,6 +78,7 @@ public class LongDecimalStatisticsBuilder
                 null,
                 null,
                 buildDecimalStatistics().orElse(null),
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -61,6 +61,7 @@ public class ShortDecimalStatisticsBuilder
                 null,
                 null,
                 buildDecimalStatistics().orElse(null),
+                null,
                 null);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -17,9 +17,13 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.statistics.DecimalStatistics.DECIMAL_VALUE_BYTES_OVERHEAD;
+
 public class ShortDecimalStatisticsBuilder
         implements LongValueStatisticsBuilder
 {
+    public static final long SHORT_DECIMAL_VALUE_BYTES = 8L;
+
     private final int scale;
 
     private long nonNullValueCount;
@@ -53,14 +57,16 @@ public class ShortDecimalStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
+        Optional<DecimalStatistics> decimalStatistics = buildDecimalStatistics();
         return new ColumnStatistics(
                 nonNullValueCount,
+                decimalStatistics.map(s -> DECIMAL_VALUE_BYTES_OVERHEAD + SHORT_DECIMAL_VALUE_BYTES).orElse(0L),
                 null,
                 null,
                 null,
                 null,
                 null,
-                buildDecimalStatistics().orElse(null),
+                decimalStatistics.orElse(null),
                 null,
                 null);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatistics.java
@@ -23,6 +23,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class StringStatistics
         implements RangeStatistics<Slice>
 {
+    // 1 byte to denote if null + 4 bytes to denote offset
+    public static final long STRING_VALUE_BYTES_OVERHEAD = Byte.BYTES + Integer.BYTES;
+
     private final Slice minimum;
     private final Slice maximum;
     private final long sum;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatistics.java
@@ -25,12 +25,14 @@ public class StringStatistics
 {
     private final Slice minimum;
     private final Slice maximum;
+    private final long sum;
 
-    public StringStatistics(Slice minimum, Slice maximum)
+    public StringStatistics(Slice minimum, Slice maximum, long sum)
     {
         checkArgument(minimum == null || maximum == null || minimum.compareTo(maximum) <= 0, "minimum is not less than maximum");
         this.minimum = minimum;
         this.maximum = maximum;
+        this.sum = sum;
     }
 
     @Override
@@ -43,6 +45,11 @@ public class StringStatistics
     public Slice getMax()
     {
         return maximum;
+    }
+
+    public long getSum()
+    {
+        return sum;
     }
 
     @Override
@@ -71,6 +78,7 @@ public class StringStatistics
         return toStringHelper(this)
                 .add("min", minimum.toStringUtf8())
                 .add("max", maximum.toStringUtf8())
+                .add("sum", sum)
                 .toString();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -81,6 +81,7 @@ public class StringStatisticsBuilder
                 buildStringStatistics().orElse(null),
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -18,6 +18,8 @@ import io.airlift.slice.Slice;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class StringStatisticsBuilder
@@ -80,12 +82,15 @@ public class StringStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
+        Optional<StringStatistics> stringStatistics = buildStringStatistics();
+        stringStatistics.ifPresent(s -> verify(nonNullValueCount > 0));
         return new ColumnStatistics(
                 nonNullValueCount,
+                stringStatistics.map(s -> STRING_VALUE_BYTES_OVERHEAD + sum / nonNullValueCount).orElse(0L),
                 null,
                 null,
                 null,
-                buildStringStatistics().orElse(null),
+                stringStatistics.orElse(null),
                 null,
                 null,
                 null,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -26,6 +26,7 @@ public class StringStatisticsBuilder
     private long nonNullValueCount;
     private Slice minimum;
     private Slice maximum;
+    private long sum;
 
     public long getNonNullValueCount()
     {
@@ -38,7 +39,12 @@ public class StringStatisticsBuilder
         requireNonNull(value, "value is null");
 
         nonNullValueCount++;
+        sum += value.length();
+        updateMinMax(value);
+    }
 
+    private void updateMinMax(Slice value)
+    {
         if (minimum == null) {
             minimum = value;
             maximum = value;
@@ -58,8 +64,9 @@ public class StringStatisticsBuilder
         requireNonNull(value.getMax(), "value.getMax() is null");
 
         nonNullValueCount += valueCount;
-        addValue(value.getMin());
-        addValue(value.getMax());
+        sum += value.getSum();
+        updateMinMax(value.getMin());
+        updateMinMax(value.getMax());
     }
 
     private Optional<StringStatistics> buildStringStatistics()
@@ -67,7 +74,7 @@ public class StringStatisticsBuilder
         if (nonNullValueCount == 0) {
             return Optional.empty();
         }
-        return Optional.of(new StringStatistics(minimum, maximum));
+        return Optional.of(new StringStatistics(minimum, maximum, sum));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -108,7 +108,7 @@ public class ByteColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(column, statistics);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -108,7 +108,7 @@ public class ByteColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(column, statistics);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -135,7 +135,7 @@ public class ListColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -135,7 +135,7 @@ public class ListColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -142,7 +142,7 @@ public class MapColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -142,7 +142,7 @@ public class MapColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -134,7 +134,7 @@ public class StructColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -134,7 +134,7 @@ public class StructColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -144,7 +144,7 @@ public class TimestampColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(column, statistics);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -144,7 +144,7 @@ public class TimestampColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(column, statistics);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -171,6 +171,7 @@ import static org.testng.Assert.assertTrue;
 
 public class OrcTester
 {
+    public static final DataSize MAX_BLOCK_SIZE = new DataSize(1, Unit.MEGABYTE);
     public static final DateTimeZone HIVE_STORAGE_TIME_ZONE = DateTimeZone.forID("Asia/Katmandu");
 
     private static final TypeManager TYPE_MANAGER = new TypeRegistry();
@@ -615,7 +616,7 @@ public class OrcTester
             throws IOException
     {
         OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
-        OrcReader orcReader = new OrcReader(orcDataSource, metadataReader, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+        OrcReader orcReader = new OrcReader(orcDataSource, metadataReader, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), MAX_BLOCK_SIZE);
 
         assertEquals(orcReader.getColumnNames(), ImmutableList.of("test"));
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
@@ -295,6 +295,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 toHiveBloomFilter(orcBloomFilter)));
 
         Map<Integer, ColumnStatistics> nonMatchingStatisticsByColumnIndex = ImmutableMap.of(0, new ColumnStatistics(
@@ -305,12 +306,14 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 toHiveBloomFilter(emptyOrcBloomFilter)));
 
         Map<Integer, ColumnStatistics> withoutBloomFilterStatisticsByColumnIndex = ImmutableMap.of(0, new ColumnStatistics(
                 null,
                 null,
                 new IntegerStatistics(10L, 2000L),
+                null,
                 null,
                 null,
                 null,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
@@ -289,6 +289,7 @@ public class TestOrcBloomFilters
 
         Map<Integer, ColumnStatistics> matchingStatisticsByColumnIndex = ImmutableMap.of(0, new ColumnStatistics(
                 null,
+                0,
                 null,
                 new IntegerStatistics(10L, 2000L),
                 null,
@@ -300,6 +301,7 @@ public class TestOrcBloomFilters
 
         Map<Integer, ColumnStatistics> nonMatchingStatisticsByColumnIndex = ImmutableMap.of(0, new ColumnStatistics(
                 null,
+                0,
                 null,
                 new IntegerStatistics(10L, 2000L),
                 null,
@@ -311,6 +313,7 @@ public class TestOrcBloomFilters
 
         Map<Integer, ColumnStatistics> withoutBloomFilterStatisticsByColumnIndex = ImmutableMap.of(0, new ColumnStatistics(
                 null,
+                0,
                 null,
                 new IntegerStatistics(10L, 2000L),
                 null,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
@@ -44,14 +44,18 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
+import static com.facebook.presto.orc.OrcTester.MAX_BLOCK_SIZE;
 import static com.facebook.presto.orc.OrcTester.createCustomOrcRecordReader;
 import static com.facebook.presto.orc.OrcTester.createOrcRecordWriter;
 import static com.facebook.presto.orc.OrcTester.createSettableStructObjectInspector;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hive.ql.io.orc.CompressionKind.SNAPPY;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestOrcReaderPositions
 {
@@ -173,6 +177,110 @@ public class TestOrcReaderPositions
     }
 
     @Test
+    public void testBatchSizesForVariableWidth()
+            throws Exception
+    {
+        // the test creates a table with one column and 10 row groups (i.e., 100K rows)
+        // the 1st row group has strings with each of length 300,
+        // the 2nd row group has strings with each of length 600,
+        // the 3rd row group has strings with each of length 900, and so on
+        // the test is to show when loading those strings,
+        // we are first bounded by MAX_BATCH_SIZE = 1024 rows because 1024 X 900B < 1MB
+        // then bounded by MAX_BLOCK_SIZE = 1MB because 1024 X 1200B > 1MB
+        try (TempFile tempFile = new TempFile()) {
+            // create single strip file with multiple row groups
+            int rowsInRowGroup = 10_000;
+            int rowGroupCounts = 10;
+            int baseStringBytes = 300;
+            int rowCount = rowsInRowGroup * rowGroupCounts;
+            createGrowingSequentialFile(tempFile.getFile(), rowCount, rowsInRowGroup, baseStringBytes);
+
+            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, new OrcMetadataReader(), OrcPredicate.TRUE, VARCHAR)) {
+                assertEquals(reader.getFileRowCount(), rowCount);
+                assertEquals(reader.getReaderRowCount(), rowCount);
+                assertEquals(reader.getFilePosition(), 0);
+                assertEquals(reader.getReaderPosition(), 0);
+
+                // each value's length = original value length + 4 bytes to denote offset + 1 byte to denote if null
+                int currentStringBytes = baseStringBytes + Integer.BYTES + Byte.BYTES;
+                int rowCountsInCurrentRowGroup = 0;
+                while (true) {
+                    int batchSize = reader.nextBatch();
+                    if (batchSize == -1) {
+                        break;
+                    }
+                    rowCountsInCurrentRowGroup += batchSize;
+
+                    Block block = reader.readBlock(VARCHAR, 0);
+                    if (MAX_BATCH_SIZE * currentStringBytes <= MAX_BLOCK_SIZE.toBytes()) {
+                        // Either we are bounded by 1024 rows per batch, or it is the last batch in the row group
+                        // For the first 3 row groups, the strings are of length 300, 600, and 900 respectively
+                        // So the loaded data is bounded by MAX_BATCH_SIZE
+                        assertTrue(block.getPositionCount() == MAX_BATCH_SIZE || rowCountsInCurrentRowGroup == rowsInRowGroup);
+                    }
+                    else {
+                        // Either we are bounded by 1MB per batch, or it is the last batch in the row group
+                        // From the 4th row group, the strings are have length > 1200
+                        // So the loaded data is bounded by MAX_BLOCK_SIZE
+                        assertTrue(block.getPositionCount() == MAX_BLOCK_SIZE.toBytes() / currentStringBytes || rowCountsInCurrentRowGroup == rowsInRowGroup);
+                    }
+
+                    if (rowCountsInCurrentRowGroup == rowsInRowGroup) {
+                        rowCountsInCurrentRowGroup = 0;
+                        currentStringBytes += baseStringBytes;
+                    }
+                    else if (rowCountsInCurrentRowGroup > rowsInRowGroup) {
+                        assertTrue(false, "read more rows in the current row group");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testBatchSizesForFixedWidth()
+            throws Exception
+    {
+        // the test creates a table with one column and 10 row groups
+        // the each row group has bigints of length 8 in bytes,
+        // the test is to show that the loaded data is always bounded by MAX_BATCH_SIZE because 1024 X 8B < 1MB
+        try (TempFile tempFile = new TempFile()) {
+            // create single strip file with multiple row groups
+            int rowsInRowGroup = 10_000;
+            int rowGroupCounts = 10;
+            int rowCount = rowsInRowGroup * rowGroupCounts;
+            createSequentialFile(tempFile.getFile(), rowCount);
+
+            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, new OrcMetadataReader(), OrcPredicate.TRUE, BIGINT)) {
+                assertEquals(reader.getFileRowCount(), rowCount);
+                assertEquals(reader.getReaderRowCount(), rowCount);
+                assertEquals(reader.getFilePosition(), 0);
+                assertEquals(reader.getReaderPosition(), 0);
+
+                int rowCountsInCurrentRowGroup = 0;
+                while (true) {
+                    int batchSize = reader.nextBatch();
+                    if (batchSize == -1) {
+                        break;
+                    }
+                    rowCountsInCurrentRowGroup += batchSize;
+
+                    Block block = reader.readBlock(BIGINT, 0);
+                    // 8 bytes per row; 1024 row at most given 1024 X 8B < 1MB
+                    assertTrue(block.getPositionCount() == MAX_BATCH_SIZE || rowCountsInCurrentRowGroup == rowsInRowGroup);
+
+                    if (rowCountsInCurrentRowGroup == rowsInRowGroup) {
+                        rowCountsInCurrentRowGroup = 0;
+                    }
+                    else if (rowCountsInCurrentRowGroup > rowsInRowGroup) {
+                        assertTrue(false, "read more rows in the current row group");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     public void testReadUserMetadata()
             throws Exception
     {
@@ -261,6 +369,37 @@ public class TestOrcReaderPositions
 
         for (int i = 0; i < count; i++) {
             objectInspector.setStructFieldData(row, field, (long) i);
+            Writable record = serde.serialize(row, objectInspector);
+            writer.write(record);
+        }
+
+        writer.close(false);
+    }
+
+    private static void createGrowingSequentialFile(File file, int count, int step, int initialLength)
+            throws IOException, ReflectiveOperationException, SerDeException
+    {
+        FileSinkOperator.RecordWriter writer = createOrcRecordWriter(file, ORC_12, CompressionKind.NONE, VARCHAR);
+
+        @SuppressWarnings("deprecation") Serializer serde = new OrcSerde();
+        SettableStructObjectInspector objectInspector = createSettableStructObjectInspector("test", VARCHAR);
+        Object row = objectInspector.create();
+        StructField field = objectInspector.getAllStructFieldRefs().get(0);
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < initialLength; i++) {
+            builder.append("0");
+        }
+        String seedString = builder.toString();
+
+        // gradually grow the length of a cell
+        int previousLength = initialLength;
+        for (int i = 0; i < count; i++) {
+            if ((i / step + 1) * initialLength > previousLength) {
+                previousLength = (i / step + 1) * initialLength;
+                builder.append(seedString);
+            }
+            objectInspector.setStructFieldData(row, field, builder.toString());
             Writable record = serde.serialize(row, objectInspector);
             writer.write(record);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -88,7 +88,7 @@ public class TestTupleDomainOrcPredicate
         if (trueValueCount != null) {
             booleanStatistics = new BooleanStatistics(trueValueCount);
         }
-        return new ColumnStatistics(numberOfValues, booleanStatistics, null, null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 2L, booleanStatistics, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics integerColumnStats(Long numberOfValues, Long minimum, Long maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, new IntegerStatistics(minimum, maximum), null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, new IntegerStatistics(minimum, maximum), null, null, null, null, null, null);
     }
 
     @Test
@@ -148,7 +148,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics doubleColumnStats(Long numberOfValues, Double minimum, Double maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null);
     }
 
     @Test
@@ -240,7 +240,8 @@ public class TestTupleDomainOrcPredicate
     {
         Slice minimumSlice = minimum == null ? null : utf8Slice(minimum);
         Slice maximumSlice = maximum == null ? null : utf8Slice(maximum);
-        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L), null, null, null, null);
+        // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
+        return new ColumnStatistics(numberOfValues, 10L, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L), null, null, null, null);
     }
 
     @Test
@@ -270,7 +271,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics dateColumnStats(Long numberOfValues, Integer minimum, Integer maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null);
+        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null);
     }
 
     @Test
@@ -327,7 +328,7 @@ public class TestTupleDomainOrcPredicate
     {
         BigDecimal minimumDecimal = minimum == null ? null : new BigDecimal(minimum);
         BigDecimal maximumDecimal = maximum == null ? null : new BigDecimal(maximum);
-        return new ColumnStatistics(numberOfValues, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal), null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal), null, null);
     }
 
     @Test
@@ -349,7 +350,8 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics binaryColumnStats(Long numberOfValues)
     {
-        return new ColumnStatistics(numberOfValues, null, null, null, null, null, null, new BinaryStatistics(100L), null);
+        // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
+        return new ColumnStatistics(numberOfValues, 10L, null, null, null, null, null, null, new BinaryStatistics(100L), null);
     }
 
     private static Long shortDecimal(String value)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -240,7 +240,7 @@ public class TestTupleDomainOrcPredicate
     {
         Slice minimumSlice = minimum == null ? null : utf8Slice(minimum);
         Slice maximumSlice = maximum == null ? null : utf8Slice(maximum);
-        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minimumSlice, maximumSlice), null, null, null, null);
+        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L), null, null, null, null);
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.orc.metadata.statistics.BinaryStatistics;
 import com.facebook.presto.orc.metadata.statistics.BooleanStatistics;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.DateStatistics;
@@ -46,6 +47,7 @@ import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.floatToRawIntBits;
@@ -86,7 +88,7 @@ public class TestTupleDomainOrcPredicate
         if (trueValueCount != null) {
             booleanStatistics = new BooleanStatistics(trueValueCount);
         }
-        return new ColumnStatistics(numberOfValues, booleanStatistics, null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, booleanStatistics, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -116,7 +118,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics integerColumnStats(Long numberOfValues, Long minimum, Long maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, new IntegerStatistics(minimum, maximum), null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, null, new IntegerStatistics(minimum, maximum), null, null, null, null, null, null);
     }
 
     @Test
@@ -146,7 +148,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics doubleColumnStats(Long numberOfValues, Double minimum, Double maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null);
+        return new ColumnStatistics(numberOfValues, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null);
     }
 
     @Test
@@ -238,7 +240,7 @@ public class TestTupleDomainOrcPredicate
     {
         Slice minimumSlice = minimum == null ? null : utf8Slice(minimum);
         Slice maximumSlice = maximum == null ? null : utf8Slice(maximum);
-        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minimumSlice, maximumSlice), null, null, null);
+        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minimumSlice, maximumSlice), null, null, null, null);
     }
 
     @Test
@@ -268,7 +270,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics dateColumnStats(Long numberOfValues, Integer minimum, Integer maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, null, null, null, new DateStatistics(minimum, maximum), null, null);
+        return new ColumnStatistics(numberOfValues, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null);
     }
 
     @Test
@@ -325,7 +327,29 @@ public class TestTupleDomainOrcPredicate
     {
         BigDecimal minimumDecimal = minimum == null ? null : new BigDecimal(minimum);
         BigDecimal maximumDecimal = maximum == null ? null : new BigDecimal(maximum);
-        return new ColumnStatistics(numberOfValues, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal), null);
+        return new ColumnStatistics(numberOfValues, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal), null, null);
+    }
+
+    @Test
+    public void testBinary()
+            throws Exception
+    {
+        assertEquals(getDomain(VARBINARY, 0, null), none(VARBINARY));
+        assertEquals(getDomain(VARBINARY, 10, null), all(VARBINARY));
+
+        assertEquals(getDomain(VARBINARY, 0, binaryColumnStats(null)), none(VARBINARY));
+        assertEquals(getDomain(VARBINARY, 0, binaryColumnStats(0L)), none(VARBINARY));
+        assertEquals(getDomain(VARBINARY, 0, binaryColumnStats(0L)), none(VARBINARY));
+
+        assertEquals(getDomain(VARBINARY, 10, binaryColumnStats(0L)), onlyNull(VARBINARY));
+        assertEquals(getDomain(VARBINARY, 10, binaryColumnStats(10L)), notNull(VARBINARY));
+
+        assertEquals(getDomain(VARBINARY, 20, binaryColumnStats(10L)), all(VARBINARY));
+    }
+
+    private static ColumnStatistics binaryColumnStats(Long numberOfValues)
+    {
+        return new ColumnStatistics(numberOfValues, null, null, null, null, null, null, new BinaryStatistics(100L), null);
     }
 
     private static Long shortDecimal(String value)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
@@ -147,7 +147,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
     static List<ColumnStatistics> insertEmptyColumnStatisticsAt(List<ColumnStatistics> statisticsList, int index, long numberOfValues)
     {
         List<ColumnStatistics> newStatisticsList = new ArrayList<>(statisticsList);
-        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, null, null, null, null, null, null, null));
+        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, null, null, null, null, null, null, null, null));
         return newStatisticsList;
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBinaryStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBinaryStatisticsBuilder.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.NONE;
+import static com.facebook.presto.orc.metadata.statistics.BinaryStatistics.BINARY_VALUE_BYTES_OVERHEAD;
 import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -77,6 +78,15 @@ public class TestBinaryStatisticsBuilder
         statisticsBuilder.addValue(SECOND_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedBinaryStatistics(statisticsList, 6, FIRST_VALUE.length() * 2 + SECOND_VALUE.length());
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(BINARY_VALUE_BYTES_OVERHEAD, ImmutableList.of(EMPTY_SLICE));
+        assertMinAverageValueBytes(FIRST_VALUE.length() + BINARY_VALUE_BYTES_OVERHEAD, ImmutableList.of(FIRST_VALUE));
+        assertMinAverageValueBytes((FIRST_VALUE.length() + SECOND_VALUE.length()) / 2 + BINARY_VALUE_BYTES_OVERHEAD, ImmutableList.of(FIRST_VALUE, SECOND_VALUE));
     }
 
     private void assertMergedBinaryStatistics(List<ColumnStatistics> statisticsList, int expectedNumberOfValues, long expectedSum)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBooleanStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBooleanStatisticsBuilder.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.BOOLEAN;
+import static com.facebook.presto.orc.metadata.statistics.BooleanStatistics.BOOLEAN_VALUE_BYTES;
 import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
 import static org.testng.Assert.assertEquals;
 
@@ -90,6 +92,15 @@ public class TestBooleanStatisticsBuilder
         statisticsBuilder.addValue(true);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedBooleanStatistics(statisticsList, 10, 3);
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(BOOLEAN_VALUE_BYTES, ImmutableList.of(true));
+        assertMinAverageValueBytes(BOOLEAN_VALUE_BYTES, ImmutableList.of(false));
+        assertMinAverageValueBytes(BOOLEAN_VALUE_BYTES, ImmutableList.of(true, true, false, true));
     }
 
     private void assertMergedBooleanStatistics(List<ColumnStatistics> statisticsList, int expectedNumberOfValues, int trueValueCount)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDateStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDateStatisticsBuilder.java
@@ -15,10 +15,12 @@ package com.facebook.presto.orc.metadata.statistics;
 
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.DATE;
+import static com.facebook.presto.orc.metadata.statistics.DateStatistics.DATE_VALUE_BYTES;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.MIN_VALUE;
 import static org.testng.Assert.fail;
@@ -68,5 +70,14 @@ public class TestDateStatisticsBuilder
         }
         catch (ArithmeticException expected) {
         }
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(DATE_VALUE_BYTES, ImmutableList.of(42));
+        assertMinAverageValueBytes(DATE_VALUE_BYTES, ImmutableList.of(0));
+        assertMinAverageValueBytes(DATE_VALUE_BYTES, ImmutableList.of(0, 42, 42, 43));
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDoubleStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDoubleStatisticsBuilder.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.DOUBLE;
+import static com.facebook.presto.orc.metadata.statistics.DoubleStatistics.DOUBLE_VALUE_BYTES;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
@@ -79,5 +81,14 @@ public class TestDoubleStatisticsBuilder
         assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 2);
         statisticsBuilder.addValue(42.42);
         assertNoColumnStatistics(statisticsBuilder.buildColumnStatistics(), 3);
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(DOUBLE_VALUE_BYTES, ImmutableList.of(42D));
+        assertMinAverageValueBytes(DOUBLE_VALUE_BYTES, ImmutableList.of(0D));
+        assertMinAverageValueBytes(DOUBLE_VALUE_BYTES, ImmutableList.of(0D, 42D, 42D, 43D));
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestIntegerStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestIntegerStatisticsBuilder.java
@@ -15,10 +15,12 @@ package com.facebook.presto.orc.metadata.statistics;
 
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.INTEGER;
+import static com.facebook.presto.orc.metadata.statistics.IntegerStatistics.INTEGER_VALUE_BYTES;
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Long.MIN_VALUE;
 
@@ -49,5 +51,14 @@ public class TestIntegerStatisticsBuilder
         assertValues(0L, 42L, ContiguousSet.create(Range.closed(0L, 42L), DiscreteDomain.longs()).asList());
         assertValues(MIN_VALUE, MIN_VALUE + 42, ContiguousSet.create(Range.closed(MIN_VALUE, MIN_VALUE + 42), DiscreteDomain.longs()).asList());
         assertValues(MAX_VALUE - 42L, MAX_VALUE, ContiguousSet.create(Range.closed(MAX_VALUE - 42L, MAX_VALUE), DiscreteDomain.longs()).asList());
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(INTEGER_VALUE_BYTES, ImmutableList.of(42L));
+        assertMinAverageValueBytes(INTEGER_VALUE_BYTES, ImmutableList.of(0L));
+        assertMinAverageValueBytes(INTEGER_VALUE_BYTES, ImmutableList.of(0L, 42L, 42L, 43L));
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestLongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestLongDecimalStatisticsBuilder.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc.metadata.statistics;
 
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import org.testng.annotations.Test;
 
@@ -23,6 +24,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.DECIMAL;
+import static com.facebook.presto.orc.metadata.statistics.DecimalStatistics.DECIMAL_VALUE_BYTES_OVERHEAD;
+import static com.facebook.presto.orc.metadata.statistics.LongDecimalStatisticsBuilder.LONG_DECIMAL_VALUE_BYTES;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.math.BigDecimal.ZERO;
 
@@ -57,6 +60,16 @@ public class TestLongDecimalStatisticsBuilder
         assertValues(LARGE_NEGATIVE_VALUE, MEDIUM_VALUE, toBigDecimalList(LARGE_NEGATIVE_VALUE, MEDIUM_VALUE, ZERO_TO_42));
         assertValues(MEDIUM_VALUE, LARGE_POSITIVE_VALUE, toBigDecimalList(MEDIUM_VALUE, LARGE_POSITIVE_VALUE, ZERO_TO_42));
         assertValues(LARGE_NEGATIVE_VALUE, LARGE_POSITIVE_VALUE, toBigDecimalList(LARGE_NEGATIVE_VALUE, LARGE_POSITIVE_VALUE, ZERO_TO_42));
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        long longDecimalBytes = DECIMAL_VALUE_BYTES_OVERHEAD + LONG_DECIMAL_VALUE_BYTES;
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(longDecimalBytes, ImmutableList.of(LARGE_POSITIVE_VALUE));
+        assertMinAverageValueBytes(longDecimalBytes, ImmutableList.of(LARGE_NEGATIVE_VALUE));
+        assertMinAverageValueBytes(longDecimalBytes, ImmutableList.of(LARGE_POSITIVE_VALUE, LARGE_POSITIVE_VALUE, LARGE_POSITIVE_VALUE, LARGE_NEGATIVE_VALUE));
     }
 
     private static List<BigDecimal> toBigDecimalList(BigDecimal minValue, BigDecimal maxValue, List<Long> values)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestShortDecimalStatisticsBuilder.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc.metadata.statistics;
 
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import org.testng.annotations.Test;
 
@@ -22,6 +23,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.DECIMAL;
+import static com.facebook.presto.orc.metadata.statistics.DecimalStatistics.DECIMAL_VALUE_BYTES_OVERHEAD;
+import static com.facebook.presto.orc.metadata.statistics.ShortDecimalStatisticsBuilder.SHORT_DECIMAL_VALUE_BYTES;
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Long.MIN_VALUE;
 import static org.testng.Assert.assertEquals;
@@ -56,6 +59,16 @@ public class TestShortDecimalStatisticsBuilder
         assertValues(0L, 42L, ContiguousSet.create(Range.closed(0L, 42L), DiscreteDomain.longs()).asList());
         assertValues(MIN_VALUE, MIN_VALUE + 42, ContiguousSet.create(Range.closed(MIN_VALUE, MIN_VALUE + 42), DiscreteDomain.longs()).asList());
         assertValues(MAX_VALUE - 42L, MAX_VALUE, ContiguousSet.create(Range.closed(MAX_VALUE - 42L, MAX_VALUE), DiscreteDomain.longs()).asList());
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        long shortDecimalBytes = DECIMAL_VALUE_BYTES_OVERHEAD + SHORT_DECIMAL_VALUE_BYTES;
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(shortDecimalBytes, ImmutableList.of(0L));
+        assertMinAverageValueBytes(shortDecimalBytes, ImmutableList.of(42L));
+        assertMinAverageValueBytes(shortDecimalBytes, ImmutableList.of(0L, 1L, 42L, 44L, 52L));
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatistics.java
@@ -35,7 +35,8 @@ public class TestStringStatistics
     @Override
     protected StringStatistics getCreateStatistics(Slice min, Slice max)
     {
-        return new StringStatistics(min, max);
+        // a fake sum is ok
+        return new StringStatistics(min, max, 100L);
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.STRING;
 import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
+import static com.facebook.presto.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.utf8Slice;
 import static org.testng.Assert.assertEquals;
@@ -114,6 +115,15 @@ public class TestStringStatisticsBuilder
         statisticsBuilder.addValue(LOW_TOP_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 6, LOW_BOTTOM_VALUE.length() * 2 + LOW_TOP_VALUE.length());
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(STRING_VALUE_BYTES_OVERHEAD, ImmutableList.of(EMPTY_SLICE));
+        assertMinAverageValueBytes(LOW_BOTTOM_VALUE.length() + STRING_VALUE_BYTES_OVERHEAD, ImmutableList.of(LOW_BOTTOM_VALUE));
+        assertMinAverageValueBytes((LOW_BOTTOM_VALUE.length() + LOW_TOP_VALUE.length()) / 2 + STRING_VALUE_BYTES_OVERHEAD, ImmutableList.of(LOW_BOTTOM_VALUE, LOW_TOP_VALUE));
     }
 
     private void assertMergedStringStatistics(List<ColumnStatistics> statisticsList, int expectedNumberOfValues, long expectedSum)


### PR DESCRIPTION
Previously a block size is bounded by historical data collected when
loading a block. This approach can effectively bound 95% block sizes
according to the exported stats; however, It misses the first load that
could be as large as hundreds of MBs. This patch collects data in stripe
reader to estimiate the average row size in the next row group to read
and bound the block size with the estimation.