### PR TITLE
Add support Postgres FOREIGN TABLE

### DIFF
--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -76,6 +76,6 @@ public class PostgreSqlClient
                 connection.getCatalog(),
                 escapeNamePattern(schemaName, escape),
                 escapeNamePattern(tableName, escape),
-                new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW"});
+                new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE"});
     }
 }


### PR DESCRIPTION
Through the Postgresql Plugin, we could also access any FOREIGN TABLE.

I tried to add a test case for it, but it's not easy to create a testing foreign table on the TestingPostgreSqlServer
```
    @Test
    public void testForeignTable()
            throws Exception
    {
        execute("CREATE EXTENSION file_fdw");
        execute("CREATE SERVER foreign_server FOREIGN DATA WRAPPER file_fdw");
        execute("CREATE FOREIGN TABLE tpch.test_ft (x bigint, y varchar(100)) SERVER foreign_server OPTIONS(filename '...', format 'csv')");
        assertTrue(getQueryRunner().tableExists(getSession(), "test_ft"));
        execute("DROP FOREIGN TABLE tpch.test_ft");
    }
```