### PR TITLE
Fix bug where PageBuilder is not reset when full in functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
@@ -274,6 +274,7 @@ public final class MapTransformKeyFunction
         body.append(mapBlockBuilder
                 .invoke("closeEntry", BlockBuilder.class)
                 .pop());
+        body.append(pageBuilder.invoke("declarePosition", void.class));
         body.append(constantType(binder, resultMapType)
                 .invoke(
                         "getObject",

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
@@ -237,6 +237,7 @@ public final class MapTransformValueFunction
         body.append(mapBlockBuilder
                 .invoke("closeEntry", BlockBuilder.class)
                 .pop());
+        body.append(pageBuilder.invoke("declarePosition", void.class));
         body.append(constantType(binder, resultMapType)
                 .invoke(
                         "getObject",

--- a/presto-ml/src/main/java/com/facebook/presto/ml/MLFeaturesFunctions.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/MLFeaturesFunctions.java
@@ -112,6 +112,10 @@ public final class MLFeaturesFunctions
 
     private Block featuresHelper(double... features)
     {
+        if (pageBuilder.isFull()) {
+            pageBuilder.reset();
+        }
+
         BlockBuilder mapBlockBuilder = pageBuilder.getBlockBuilder(0);
         BlockBuilder blockBuilder = mapBlockBuilder.beginBlockEntry();
 
@@ -121,6 +125,7 @@ public final class MLFeaturesFunctions
         }
 
         mapBlockBuilder.closeEntry();
+        pageBuilder.declarePosition();
         return mapBlockBuilder.getObject(mapBlockBuilder.getPositionCount() - 1, Block.class);
     }
 }


### PR DESCRIPTION
A few functions cache a PageBuilder internally to avoid allocation
and size estimation on every invocation. However, it need to be
periodically cleared to make sure PageBuilder doesn't grow too
big, which would cause query failures (array exceeding 2G positions)
and GC pressure (unaccounted memory of huge arrays per function
callsite in the SQL query).

I filed #8428 to add test coverage.

@highker  is working on fixing the benchmarks, which could be used to expose this issue. The benchmarks have been broken after @dain's columnar change.