### PR TITLE
Reset block builder before throwing in various map functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
@@ -195,7 +195,10 @@ public final class MapTransformValueFunction
         else {
             // make sure invokeExact will not take uninitialized keys during compile time
             // but if we reach this point during runtime, it is an exception
+            // also close the block builder before throwing as we may be in a TRY() call
+            // so that subsequent calls do not find it in an inconsistent state
             loadKeyElement = new BytecodeBlock()
+                    .append(mapBlockBuilder.invoke("closeEntry", BlockBuilder.class).pop())
                     .append(keyElement.set(constantNull(keyJavaType)))
                     .append(throwNullKeyException);
         }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -632,6 +632,9 @@ public abstract class AbstractTestQueries
     public void testMaps()
     {
         assertQuery("SELECT m[max_key] FROM (SELECT map_agg(orderkey, orderkey) m, max(orderkey) max_key FROM orders)", "SELECT max(orderkey) FROM orders");
+        // Make sure that even if the map constructor throws with the NULL key the block builders are left in a consistent state
+        // and the TRY() call eventually succeeds and return NULL values.
+        assertQuery("SELECT JSON_FORMAT(CAST(TRY(MAP(ARRAY[NULL], ARRAY[x])) AS JSON)) FROM (VALUES 1, 2) t(x)", "SELECT * FROM (VALUES NULL, NULL)");
     }
 
     @Test


### PR DESCRIPTION
Otherwise, when these functions are used within TRY() the BlockBuilders
used for intermediate state in these functions may be left in an incorrect
state causing failures on subsequent calls.

This is a temporary fix for #8323, the ultimate fix is more complicated as described in that issue.