### PR TITLE
Minor improvements for Thrift connector

### DIFF
--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorSplit.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorSplit.java
@@ -57,7 +57,7 @@ public class ThriftConnectorSplit
     @Override
     public Object getInfo()
     {
-        return this;
+        return "";
     }
 
     @Override

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSource.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSource.java
@@ -181,7 +181,7 @@ public class ThriftPageSource
     @Override
     public CompletableFuture<?> isBlocked()
     {
-        return future == null || future.isDone() ? NOT_BLOCKED : future;
+        return future == null ? NOT_BLOCKED : future;
     }
 
     @Override


### PR DESCRIPTION
1. Don't return the whole split information in "getSplitInfo()". The info
contains split id which is an arbitrary byte sequence and can be
relatively large. As a result, this can potentially slow down split
stats collection mechanism.

2. Don't check if a future is done in "ThriftPageSource.isBlocked()"
this check is unnecessary, because all current callers of this method
are doing it.