### PR TITLE
Fix InlineProjections on subqueries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/InlineProjections.java
@@ -29,6 +29,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Literal;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.util.AstUtils;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import java.util.Map;
@@ -134,10 +135,14 @@ public class InlineProjections
         //      a. are not inputs to try() expressions
         //      b. appear only once across all expressions
         //      c. are not identity projections
+        // which come from the child, as opposed to an enclosing scope.
+
+        Set<Symbol> childOutputSet = ImmutableSet.copyOf(child.getOutputSymbols());
 
         Map<Symbol, Long> dependencies = parent.getAssignments()
                 .getExpressions().stream()
                 .flatMap(expression -> SymbolsExtractor.extractAll(expression).stream())
+                .filter(childOutputSet::contains)
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
         // find references to simple constants

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineProjections.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineProjections.java
@@ -80,4 +80,18 @@ public class TestInlineProjections
                                         p.values(p.symbol("value")))))
                 .doesNotFire();
     }
+
+    @Test
+    public void testSubqueryProjections()
+            throws Exception
+    {
+        tester().assertThat(new InlineProjections())
+                .on(p ->
+                        p.project(
+                                Assignments.identity(p.symbol("fromOuterScope"), p.symbol("value")),
+                                p.project(
+                                        Assignments.identity(p.symbol("value")),
+                                        p.values(p.symbol("value")))))
+                .doesNotFire();
+    }
 }


### PR DESCRIPTION
InlineProjections assumed that all input symbols to the parent
ProjectNode came from the child, but that's not always the case in
subqueries, where symbols are available even when not defined by the
child.  This resulted in a loop where the rule fired, but emitted an
unchanged plan fragment.

This patch simply corrects the logic for identifying inline-able
definitions to ignore symbols that don't come from the child..

https://github.com/prestodb/presto/issues/8451