### PR TITLE
Loosen option constraint for Java version

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/JavaVersion.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/JavaVersion.java
@@ -35,7 +35,7 @@ public class JavaVersion
     private static final Pattern PATTERN = Pattern.compile(VERSION_NUMBER + PRE + BUILD + OPT);
 
     // For Java 8 and below
-    private static final Pattern LEGACY_PATTERN = Pattern.compile("1\\.(?<MAJOR>[0-9]+)(\\.(?<MINOR>(0|[1-9][0-9]*)))?(_(?<UPDATE>[1-9][0-9]*))?(?:-ea)?");
+    private static final Pattern LEGACY_PATTERN = Pattern.compile("1\\.(?<MAJOR>[0-9]+)(\\.(?<MINOR>(0|[1-9][0-9]*)))?(_(?<UPDATE>[1-9][0-9]*))?" + OPT);
 
     private final int major;
     private final int minor;

--- a/presto-main/src/test/java/com/facebook/presto/server/TestJavaVersion.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestJavaVersion.java
@@ -31,6 +31,7 @@ public class TestJavaVersion
         assertEquals(JavaVersion.parse("1.8.0_20"), new JavaVersion(8, 0, OptionalInt.of(20)));
         assertEquals(JavaVersion.parse("1.8.1_25"), new JavaVersion(8, 1, OptionalInt.of(25)));
         assertEquals(JavaVersion.parse("1.8.0_60-ea"), new JavaVersion(8, 0, OptionalInt.of(60)));
+        assertEquals(JavaVersion.parse("1.8.0_111-internal"), new JavaVersion(8, 0, OptionalInt.of(111)));
     }
 
     @Test


### PR DESCRIPTION
Later versions of 1.8.0 include options beyond 'ea'. Example:

```
⫸  docker run -t java:8-jdk-alpine java -version
openjdk version "1.8.0_111-internal"
OpenJDK Runtime Environment (build 1.8.0_111-internal-alpine-r0-b14)
OpenJDK 64-Bit Server VM (build 25.111-b14, mixed mode)
```