### PR TITLE
Fix native memory leak in RCFile writer

### DIFF
--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileWriter.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileWriter.java
@@ -188,11 +188,15 @@ public class RcFileWriter
     public void close()
             throws IOException
     {
-        writeRowGroup();
-        output.close();
-        keySectionOutput.destroy();
-        for (ColumnEncoder columnEncoder : columnEncoders) {
-            columnEncoder.destroy();
+        try {
+            writeRowGroup();
+            output.close();
+        }
+        finally {
+            keySectionOutput.destroy();
+            for (ColumnEncoder columnEncoder : columnEncoders) {
+                columnEncoder.destroy();
+            }
         }
     }
 


### PR DESCRIPTION
When closing RcFileWriters, exception may appear. We need to make sure
all compressors are returned even exception occurs.