### PR TITLE
Avoid memory allocation when copy a compact block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dep.antlr.version>4.6</dep.antlr.version>
         <dep.airlift.version>0.155</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.slice.version>0.31</dep.slice.version>
+        <dep.slice.version>0.32</dep.slice.version>
         <dep.aws-sdk.version>1.11.165</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.tempto.version>1.36</dep.tempto.version>

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -225,13 +225,12 @@ public class PagesIndex
             ObjectArrayList<Block> blocks = channels[channel];
             for (int i = nextBlockToCompact; i < blocks.size(); i++) {
                 Block block = blocks.get(i);
-                if (block.getSizeInBytes() < block.getRetainedSizeInBytes()) {
-                    // Copy the block to compact its size
-                    Block compactedBlock = block.copyRegion(0, block.getPositionCount());
-                    blocks.set(i, compactedBlock);
-                    pagesMemorySize -= block.getRetainedSizeInBytes();
-                    pagesMemorySize += compactedBlock.getRetainedSizeInBytes();
-                }
+
+                // Copy the block to compact its size
+                Block compactedBlock = block.copyRegion(0, block.getPositionCount());
+                blocks.set(i, compactedBlock);
+                pagesMemorySize -= block.getRetainedSizeInBytes();
+                pagesMemorySize += compactedBlock.getRetainedSizeInBytes();
             }
         }
         nextBlockToCompact = channels[0].size();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
@@ -118,11 +118,8 @@ public class Page
             if (block instanceof DictionaryBlock) {
                 continue;
             }
-            if (block.getSizeInBytes() < block.getRetainedSizeInBytes()) {
-                // Copy the block to compact its size
-                Block compactedBlock = block.copyRegion(0, block.getPositionCount());
-                blocks[i] = compactedBlock;
-            }
+            // Compact the block
+            blocks[i] = block.copyRegion(0, block.getPositionCount());
         }
 
         Map<DictionaryId, DictionaryBlockIndexes> dictionaryBlocks = getRelatedDictionaryBlocks();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.spi.block;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+
+import static com.facebook.presto.spi.block.BlockUtil.compactArray;
+import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
 
 public abstract class AbstractArrayBlock
         implements Block
@@ -115,13 +117,12 @@ public abstract class AbstractArrayBlock
         int endValueOffset = getOffset(position + length);
         Block newValues = getValues().copyRegion(startValueOffset, endValueOffset - startValueOffset);
 
-        int[] newOffsets = new int[length + 1];
-        for (int i = 1; i < newOffsets.length; i++) {
-            newOffsets[i] = getOffset(position + i) - startValueOffset;
+        int[] newOffsets = compactOffsets(getOffsets(), position + getOffsetBase(), length);
+        boolean[] newValueIsNull = compactArray(getValueIsNull(), position + getOffsetBase(), length);
+
+        if (newValues == getValues() && newOffsets == getOffsets() && newValueIsNull == getValueIsNull()) {
+            return this;
         }
-
-        boolean[] newValueIsNull = Arrays.copyOfRange(getValueIsNull(), position + getOffsetBase(), position + getOffsetBase() + length);
-
         return new ArrayBlock(length, newValueIsNull, newOffsets, newValues);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -176,19 +176,20 @@ public abstract class AbstractMapBlock
         for (int i = 1; i < newOffsets.length; i++) {
             newOffsets[i] = getOffset(position + i) - startValueOffset;
         }
-        boolean[] newValueIsNull = Arrays.copyOfRange(getMapIsNull(), position + getOffsetBase(), position + getOffsetBase() + length);
+        boolean[] newMapIsNull = Arrays.copyOfRange(getMapIsNull(), position + getOffsetBase(), position + getOffsetBase() + length);
         int[] newHashTable = Arrays.copyOfRange(getHashTables(), startValueOffset * HASH_MULTIPLIER, endValueOffset * HASH_MULTIPLIER);
 
         return new MapBlock(
                 0,
                 length,
-                newValueIsNull,
+                newMapIsNull,
                 newOffsets,
                 newKeys,
                 newValues,
                 newHashTable,
                 keyType,
-                keyBlockNativeEquals, keyNativeHashCode);
+                keyBlockNativeEquals,
+                keyNativeHashCode);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.spi.block;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -85,5 +89,100 @@ final class BlockUtil
             return MAX_ARRAY_SIZE;
         }
         return (int) newBytes;
+    }
+
+    /**
+     * Recalculate the <code>offsets</code> array for the specified range.
+     * The returned <code>offsets</code> array contains <code>length + 1</code> integers
+     * with the first value set to 0.
+     * If the range matches the entire <code>offsets</code> array,  the input array will be returned.
+     */
+    static int[] compactOffsets(int[] offsets, int index, int length)
+    {
+        if (index == 0 && offsets.length == length + 1) {
+            return offsets;
+        }
+
+        int[] newOffsets = new int[length + 1];
+        for (int i = 1; i <= length; i++) {
+            newOffsets[i] = offsets[index + i] - offsets[index];
+        }
+        return newOffsets;
+    }
+
+    /**
+     * Returns a slice containing values in the specified range of the specified slice.
+     * If the range matches the entire slice, the input slice will be returned.
+     * Otherwise, a copy will be returned.
+     */
+    static Slice compactSlice(Slice slice, int index, int length)
+    {
+        if (slice.isCompact() && index == 0 && length == slice.length()) {
+            return slice;
+        }
+        return Slices.copyOf(slice, index, length);
+    }
+
+    /**
+     * Returns an array containing elements in the specified range of the specified array.
+     * If the range matches the entire array, the input array will be returned.
+     * Otherwise, a copy will be returned.
+     */
+    static boolean[] compactArray(boolean[] array, int index, int length)
+    {
+        if (index == 0 && length == array.length) {
+            return array;
+        }
+        return Arrays.copyOfRange(array, index, index + length);
+    }
+
+    static byte[] compactArray(byte[] array, int index, int length)
+    {
+        if (index == 0 && length == array.length) {
+            return array;
+        }
+        return Arrays.copyOfRange(array, index, index + length);
+    }
+
+    static short[] compactArray(short[] array, int index, int length)
+    {
+        if (index == 0 && length == array.length) {
+            return array;
+        }
+        return Arrays.copyOfRange(array, index, index + length);
+    }
+
+    static int[] compactArray(int[] array, int index, int length)
+    {
+        if (index == 0 && length == array.length) {
+            return array;
+        }
+        return Arrays.copyOfRange(array, index, index + length);
+    }
+
+    static long[] compactArray(long[] array, int index, int length)
+    {
+        if (index == 0 && length == array.length) {
+            return array;
+        }
+        return Arrays.copyOfRange(array, index, index + length);
+    }
+
+    /**
+     * Returns <tt>true</tt> if the two specified arrays contain the same object in every position.
+     * Unlike the {@link Arrays#equals(Object[],Object[])} method, this method compares using reference equals.
+     */
+    static boolean arraySame(Object[] array1, Object[] array2)
+    {
+        if (array1 == null || array2 == null || array1.length != array2.length) {
+            throw new IllegalArgumentException("array1 and array2 cannot be null and should have same length");
+        }
+
+        for (int i = 0; i < array1.length; i++) {
+            if (array1[i] != array2[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -15,11 +15,11 @@ package com.facebook.presto.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ByteArrayBlock
@@ -159,8 +159,12 @@ public class ByteArrayBlock
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         positionOffset += arrayOffset;
-        boolean[] newValueIsNull = Arrays.copyOfRange(valueIsNull, positionOffset, positionOffset + length);
-        byte[] newValues = Arrays.copyOfRange(values, positionOffset, positionOffset + length);
+        boolean[] newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        byte[] newValues = compactArray(values, positionOffset, length);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
         return new ByteArrayBlock(length, newValueIsNull, newValues);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
+import static com.facebook.presto.spi.block.BlockUtil.compactSlice;
 import static java.util.Objects.requireNonNull;
 
 public class FixedWidthBlock
@@ -125,8 +126,12 @@ public class FixedWidthBlock
             throw new IndexOutOfBoundsException("Invalid position " + positionOffset + " in block with " + positionCount + " positions");
         }
 
-        Slice newSlice = Slices.copyOf(slice, positionOffset * fixedSize, length * fixedSize);
-        Slice newValueIsNull = Slices.copyOf(valueIsNull, positionOffset, length);
+        Slice newSlice = compactSlice(slice, positionOffset * fixedSize, length * fixedSize);
+        Slice newValueIsNull = compactSlice(valueIsNull, positionOffset, length);
+
+        if (newSlice == slice && newValueIsNull == valueIsNull) {
+            return this;
+        }
         return new FixedWidthBlock(fixedSize, length, newSlice, newValueIsNull);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -15,11 +15,11 @@ package com.facebook.presto.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class IntArrayBlock
@@ -159,8 +159,12 @@ public class IntArrayBlock
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         positionOffset += arrayOffset;
-        boolean[] newValueIsNull = Arrays.copyOfRange(valueIsNull, positionOffset, positionOffset + length);
-        int[] newValues = Arrays.copyOfRange(values, positionOffset, positionOffset + length);
+        boolean[] newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        int[] newValues = compactArray(values, positionOffset, length);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
         return new IntArrayBlock(length, newValueIsNull, newValues);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -15,11 +15,11 @@ package com.facebook.presto.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.toIntExact;
 
@@ -206,8 +206,12 @@ public class LongArrayBlock
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         positionOffset += arrayOffset;
-        boolean[] newValueIsNull = Arrays.copyOfRange(valueIsNull, positionOffset, positionOffset + length);
-        long[] newValues = Arrays.copyOfRange(values, positionOffset, positionOffset + length);
+        boolean[] newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        long[] newValues = compactArray(values, positionOffset, length);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
         return new LongArrayBlock(length, newValueIsNull, newValues);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -15,11 +15,11 @@ package com.facebook.presto.spi.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ShortArrayBlock
@@ -159,8 +159,12 @@ public class ShortArrayBlock
         checkValidRegion(getPositionCount(), positionOffset, length);
 
         positionOffset += arrayOffset;
-        boolean[] newValueIsNull = Arrays.copyOfRange(valueIsNull, positionOffset, positionOffset + length);
-        short[] newValues = Arrays.copyOfRange(values, positionOffset, positionOffset + length);
+        boolean[] newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        short[] newValues = compactArray(values, positionOffset, length);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
         return new ShortArrayBlock(length, newValueIsNull, newValues);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
@@ -165,7 +165,7 @@ public class SliceArrayBlock
         Map<Slice, Slice> distinctValues = new IdentityHashMap<>();
         for (int i = 0; i < newValues.length; i++) {
             Slice slice = newValues[i];
-            if (slice == null) {
+            if (slice == null || slice.isCompact()) {
                 continue;
             }
             Slice distinct = distinctValues.get(slice);


### PR DESCRIPTION
When building the hash table for join or aggregation and it cannot reserve more memory (either because the local host is running out of memory, or the query is running out of global/local memory), it will tries to compact the index: https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java#L235

However, compacting the blocks requires to copy the block: https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java#L201. This will put a pressure on heap memory, especially when the old block data is already in OldGen. It sometimes causes full GC .

When the block is already in compact representation, it's unnecessary to copy into a new block. Previously, the following code tries to avoid such unnecessary compact:


    if (block.getSizeInBytes() < block.getRetainedSizeInBytes()) {
        ......
    }

However, retained size is always larger than the logical size, as retained size includes the block instance size. This heuristics don't work as expected.


In this Pull Request, we avoid memory allocation in `Block.copyRegion` if it is copying a whole compact block.

This pull request depends on slice 0.30 with this pull request patched: https://github.com/airlift/slice/pull/85


