### PR TITLE
Add async retry to RetryDriver

### DIFF
--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorConfig.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorConfig.java
@@ -27,6 +27,7 @@ public class ThriftConnectorConfig
 {
     private DataSize maxResponseSize = new DataSize(16, MEGABYTE);
     private int metadataRefreshThreads = 1;
+    private int retryDriverThreads = 8;
 
     @NotNull
     @MinDataSize("1MB")
@@ -53,6 +54,19 @@ public class ThriftConnectorConfig
     public ThriftConnectorConfig setMetadataRefreshThreads(int metadataRefreshThreads)
     {
         this.metadataRefreshThreads = metadataRefreshThreads;
+        return this;
+    }
+
+    @Min(1)
+    public int getRetryDriverThreads()
+    {
+        return retryDriverThreads;
+    }
+
+    @Config("presto-thrift.retry-driver-threads")
+    public ThriftConnectorConfig setRetryDriverThreads(int retryDriverThreads)
+    {
+        this.retryDriverThreads = retryDriverThreads;
         return this;
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/annotations/ForRetryDriver.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/annotations/ForRetryDriver.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.annotations;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({PARAMETER, METHOD, FIELD})
+@Qualifier
+public @interface ForRetryDriver
+{
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/util/RetryDriver.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/util/RetryDriver.java
@@ -13,18 +13,23 @@
  */
 package com.facebook.presto.connector.thrift.util;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class RetryDriver
 {
@@ -42,6 +47,7 @@ public class RetryDriver
     private final Optional<Runnable> retryRunnable;
     private final Predicate<Exception> stopRetrying;
     private final Function<Exception, Exception> classifier;
+    private final ListeningScheduledExecutorService retryExecutorService;
 
     private RetryDriver(
             int maxAttempts,
@@ -51,7 +57,8 @@ public class RetryDriver
             Duration maxRetryTime,
             Optional<Runnable> retryRunnable,
             Predicate<Exception> stopRetrying,
-            Function<Exception, Exception> classifier)
+            Function<Exception, Exception> classifier,
+            ListeningScheduledExecutorService retryExecutorService)
     {
         this.maxAttempts = maxAttempts;
         this.minSleepTime = minSleepTime;
@@ -61,9 +68,10 @@ public class RetryDriver
         this.retryRunnable = retryRunnable;
         this.stopRetrying = stopRetrying;
         this.classifier = classifier;
+        this.retryExecutorService = retryExecutorService;
     }
 
-    private RetryDriver()
+    private RetryDriver(ListeningScheduledExecutorService executor)
     {
         this(DEFAULT_RETRY_ATTEMPTS,
                 DEFAULT_SLEEP_TIME,
@@ -72,53 +80,51 @@ public class RetryDriver
                 DEFAULT_MAX_RETRY_TIME,
                 Optional.empty(),
                 e -> false,
-                Function.identity());
+                Function.identity(),
+                executor);
     }
 
-    public static RetryDriver retry()
+    public static RetryDriver retry(ListeningScheduledExecutorService executor)
     {
-        return new RetryDriver();
+        return new RetryDriver(executor);
     }
 
     public final RetryDriver maxAttempts(int maxAttempts)
     {
-        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, retryRunnable, stopRetrying, classifier);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, retryRunnable, stopRetrying, classifier, retryExecutorService);
     }
 
     public final RetryDriver exponentialBackoff(Duration minSleepTime, Duration maxSleepTime, Duration maxRetryTime, double scaleFactor)
     {
-        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, retryRunnable, stopRetrying, classifier);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, retryRunnable, stopRetrying, classifier, retryExecutorService);
     }
 
     public final RetryDriver onRetry(Runnable retryRunnable)
     {
-        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, Optional.ofNullable(retryRunnable), stopRetrying, classifier);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, Optional.ofNullable(retryRunnable), stopRetrying, classifier, retryExecutorService);
     }
 
     public RetryDriver stopRetryingWhen(Predicate<Exception> stopRetrying)
     {
-        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, retryRunnable, stopRetrying, classifier);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, retryRunnable, stopRetrying, classifier, retryExecutorService);
     }
 
     public RetryDriver withClassifier(Function<Exception, Exception> classifier)
     {
-        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, retryRunnable, stopRetrying, classifier);
+        return new RetryDriver(maxAttempts, minSleepTime, maxSleepTime, scaleFactor, maxRetryTime, retryRunnable, stopRetrying, classifier, retryExecutorService);
     }
 
+    /**
+     * This is only for sync calls. For Callable that returns Future object, use runAsync instead.
+     */
     public <V> V run(String callableName, Callable<V> callable)
     {
         requireNonNull(callableName, "callableName is null");
         requireNonNull(callable, "callable is null");
+        RetryStatus retryStatus = new RetryStatus();
 
-        long startTime = System.nanoTime();
-        int attempt = 0;
         while (true) {
-            attempt++;
-
-            if (attempt > 1) {
-                retryRunnable.ifPresent(Runnable::run);
-            }
-
+            retryStatus.nextAttempt();
             try {
                 return callable.call();
             }
@@ -127,18 +133,13 @@ public class RetryDriver
                 throw propagate(ie);
             }
             catch (Exception e) {
-                if (stopRetrying.test(e)) {
+                if (retryStatus.shouldStopRetry(e)) {
                     throw propagate(e);
                 }
-                if (attempt >= maxAttempts || Duration.nanosSince(startTime).compareTo(maxRetryTime) >= 0) {
-                    throw propagate(e);
-                }
-                log.warn("Failed on executing %s with attempt %d, will retry. Exception: %s", callableName, attempt, e.getMessage());
 
-                int delayInMs = (int) Math.min(minSleepTime.toMillis() * Math.pow(scaleFactor, attempt - 1), maxSleepTime.toMillis());
-                int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayInMs * 0.1)));
+                log.warn(e, "Failed on executing %s with attempt %d, will retry.", callableName, retryStatus.getAttempts());
                 try {
-                    TimeUnit.MILLISECONDS.sleep(delayInMs + jitter);
+                    MILLISECONDS.sleep(retryStatus.getRetryDelayInMs());
                 }
                 catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
@@ -148,10 +149,81 @@ public class RetryDriver
         }
     }
 
+    public <V> ListenableFuture<V> runAsync(String callableName, Callable<ListenableFuture<V>> callable)
+    {
+        requireNonNull(callableName, "callableName is null");
+        requireNonNull(callable, "callable is null");
+        return runAsyncInternal(callableName, callable, new RetryStatus());
+    }
+
+    private <V> ListenableFuture<V> runAsyncInternal(String callableName, Callable<ListenableFuture<V>> callable, RetryStatus retryStatus)
+    {
+        retryStatus.nextAttempt();
+        ListenableFuture<V> resultFuture;
+        try {
+            resultFuture = callable.call();
+        }
+        catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw propagate(ie);
+        }
+        catch (Exception e) {
+            resultFuture = immediateFailedFuture(e);
+        }
+
+        return Futures.catchingAsync(resultFuture, Exception.class, e -> {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw propagate(e);
+            }
+            else if (retryStatus.shouldStopRetry(e)) {
+                throw propagate(e);
+            }
+            log.warn(e, "Failed on executing %s with attempt %d, will perform async retry.", callableName, retryStatus.getAttempts());
+            return Futures.dereference(retryExecutorService.schedule(() -> runAsyncInternal(callableName, callable, retryStatus), retryStatus.getRetryDelayInMs(), MILLISECONDS));
+        });
+    }
+
     private RuntimeException propagate(Exception e)
     {
         Exception classified = classifier.apply(e);
         throwIfUnchecked(classified);
         throw new RuntimeException(classified);
+    }
+
+    private final class RetryStatus
+    {
+        private final long startTime;
+        private final AtomicInteger attempts;
+
+        RetryStatus()
+        {
+            this.startTime = System.nanoTime();
+            this.attempts = new AtomicInteger(0);
+        }
+
+        long getRetryDelayInMs()
+        {
+            int delayInMs = (int) Math.min(minSleepTime.toMillis() * Math.pow(scaleFactor, attempts.get() - 1), maxSleepTime.toMillis());
+            int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayInMs * 0.1)));
+            return delayInMs + jitter;
+        }
+
+        boolean shouldStopRetry(Exception e)
+        {
+            return stopRetrying.test(e) || attempts.get() >= maxAttempts || Duration.nanosSince(startTime).compareTo(maxRetryTime) >= 0;
+        }
+
+        int getAttempts()
+        {
+            return attempts.get();
+        }
+
+        void nextAttempt()
+        {
+            if (attempts.incrementAndGet() > 1) {
+                retryRunnable.ifPresent(Runnable::run);
+            }
+        }
     }
 }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftConnectorConfig.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftConnectorConfig.java
@@ -29,7 +29,8 @@ public class TestThriftConnectorConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(ThriftConnectorConfig.class)
                 .setMaxResponseSize(new DataSize(16, MEGABYTE))
-                .setMetadataRefreshThreads(1));
+                .setMetadataRefreshThreads(1)
+                .setRetryDriverThreads(8));
     }
 
     @Test
@@ -38,11 +39,13 @@ public class TestThriftConnectorConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("presto-thrift.max-response-size", "2MB")
                 .put("presto-thrift.metadata-refresh-threads", "10")
+                .put("presto-thrift.retry-driver-threads", "16")
                 .build();
 
         ThriftConnectorConfig expected = new ThriftConnectorConfig()
                 .setMaxResponseSize(new DataSize(2, MEGABYTE))
-                .setMetadataRefreshThreads(10);
+                .setMetadataRefreshThreads(10)
+                .setRetryDriverThreads(16);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/util/TestRetryDriver.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/util/TestRetryDriver.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.airlift.units.Duration;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.facebook.presto.connector.thrift.util.TestRetryDriver.AttemptStatus.ASYNC_FAILURE;
+import static com.facebook.presto.connector.thrift.util.TestRetryDriver.AttemptStatus.SUCCESS;
+import static com.facebook.presto.connector.thrift.util.TestRetryDriver.AttemptStatus.SYNC_FAILURE;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static io.airlift.concurrent.Threads.threadsNamed;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestRetryDriver
+{
+    private static final Duration MIN_DURATION = new Duration(10, MILLISECONDS);
+    private static final Duration MAX_DURATION = new Duration(20, MILLISECONDS);
+    private static final Duration MAX_RETRY_TIME = new Duration(60, SECONDS);
+    private static final double BACK_OFF_SCALE_FACTOR = 1.5;
+    private static final int MAX_RETRY_ATTEMPTS = 10;
+    private static final Integer RESULT = 123;
+
+    private final ListeningScheduledExecutorService retryExecutor;
+    private final RetryDriver retry;
+
+    public TestRetryDriver()
+    {
+        retryExecutor = MoreExecutors.listeningDecorator(newScheduledThreadPool(4, threadsNamed("test-retry-retry-%s")));
+        this.retry = RetryDriver.retry(retryExecutor)
+                .exponentialBackoff(MIN_DURATION, MAX_DURATION, MAX_RETRY_TIME, BACK_OFF_SCALE_FACTOR)
+                .maxAttempts(MAX_RETRY_ATTEMPTS);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void close()
+    {
+        retryExecutor.shutdownNow();
+    }
+
+    enum AttemptStatus
+    {
+        SUCCESS,
+        ASYNC_FAILURE,
+        SYNC_FAILURE,
+    }
+
+    @Test
+    void testNoRetry()
+            throws Exception
+    {
+        SyncTaskImpl task = new SyncTaskImpl(SUCCESS);
+        Integer result = retry.run("test", task);
+
+        assertSyncSuccess(result, task, 1);
+    }
+
+    @Test
+    void testRetrySuccess()
+            throws Exception
+    {
+        SyncTaskImpl task = new SyncTaskImpl(SYNC_FAILURE, SYNC_FAILURE, SYNC_FAILURE, SYNC_FAILURE, SUCCESS);
+        Integer result = retry.run("test", task);
+
+        assertSyncSuccess(result, task, 5);
+    }
+
+    @Test
+    void testOutOfRetries()
+    {
+        SyncTaskImpl task = new SyncTaskImpl(SYNC_FAILURE, SYNC_FAILURE, SYNC_FAILURE);
+
+        try {
+            retry.maxAttempts(3).run("test", task);
+            fail("Call didn't fail as expected");
+        }
+        catch (Exception e) {
+            if (!(e instanceof SyncException)) {
+                fail("Expected " + SyncException.class + ", but got " + e.getClass());
+            }
+        }
+        assertEquals(task.totalAttemptsMade(), 3);
+    }
+
+    @Test
+    void testAsyncNoRetry()
+            throws Exception
+    {
+        AsyncTaskImpl task = new AsyncTaskImpl(SUCCESS);
+        ListenableFuture<Integer> result = retry.runAsync("test", task);
+
+        assertAsyncSuccess(result, task, 1);
+    }
+
+    @Test
+    void testAsyncMixedRetries()
+            throws Exception
+    {
+        AsyncTaskImpl task = new AsyncTaskImpl(SYNC_FAILURE, ASYNC_FAILURE, SYNC_FAILURE, ASYNC_FAILURE, SUCCESS);
+        ListenableFuture<Integer> result = retry.runAsync("test", task);
+
+        assertAsyncSuccess(result, task, 5);
+    }
+
+    @Test
+    void testAsyncMultipleAsyncFailures()
+            throws Exception
+    {
+        AsyncTaskImpl task = new AsyncTaskImpl(ASYNC_FAILURE, ASYNC_FAILURE, ASYNC_FAILURE, ASYNC_FAILURE, SUCCESS);
+        ListenableFuture<Integer> result = retry.runAsync("test", task);
+
+        assertAsyncSuccess(result, task, 5);
+    }
+
+    @Test
+    void testAsyncOutOfRetries()
+            throws Exception
+    {
+        AsyncTaskImpl task = new AsyncTaskImpl(ASYNC_FAILURE, ASYNC_FAILURE, ASYNC_FAILURE, ASYNC_FAILURE);
+        ListenableFuture<Integer> result = retry.maxAttempts(4).runAsync("test", task);
+
+        try {
+            result.get();
+            fail("Future didn't fail as expected");
+        }
+        catch (Exception e) {
+            if (!AsyncException.class.equals(e.getCause().getClass())) {
+                fail("Expected " + AsyncException.class + ", but got " + e.getClass());
+            }
+        }
+        assertEquals(task.totalAttemptsMade(), 4);
+    }
+
+    private static void assertSyncSuccess(Integer result, SyncTaskImpl task, int expectedAttempts)
+            throws Exception
+    {
+        assertEquals(result, RESULT);
+        assertEquals(task.totalAttemptsMade(), expectedAttempts);
+    }
+
+    private static void assertAsyncSuccess(ListenableFuture<Integer> result, AsyncTaskImpl task, int expectedAttempts)
+            throws Exception
+    {
+        assertEquals(result.get(), RESULT);
+        assertEquals(task.totalAttemptsMade(), expectedAttempts);
+    }
+
+    private static class TaskTracker
+    {
+        private final List<AttemptStatus> attempts;
+        private final AtomicInteger nextAttempt;
+
+        public TaskTracker(AttemptStatus... attempts)
+        {
+            this.attempts = ImmutableList.copyOf(attempts);
+            this.nextAttempt = new AtomicInteger(0);
+        }
+
+        public int totalAttemptsMade()
+        {
+            return nextAttempt.get();
+        }
+
+        public AttemptStatus getNextAttemptStatus()
+        {
+            return attempts.get(nextAttempt.getAndIncrement());
+        }
+    }
+
+    private static class SyncTaskImpl
+            implements Callable<Integer>
+    {
+        private final TaskTracker taskTracker;
+
+        public SyncTaskImpl(AttemptStatus... attempts)
+        {
+            taskTracker = new TaskTracker(attempts);
+        }
+
+        public int totalAttemptsMade()
+        {
+            return taskTracker.totalAttemptsMade();
+        }
+
+        @Override
+        public Integer call()
+        {
+            switch (taskTracker.getNextAttemptStatus()) {
+                case SUCCESS:
+                    return RESULT;
+                case SYNC_FAILURE:
+                    throw new SyncException("Failed on call " + taskTracker.totalAttemptsMade());
+                default:
+                    throw new RuntimeException("Unexpected exception type");
+            }
+        }
+    }
+
+    private static class AsyncTaskImpl
+            implements Callable<ListenableFuture<Integer>>
+    {
+        private final TaskTracker taskTracker;
+
+        public AsyncTaskImpl(AttemptStatus... attempts)
+        {
+            taskTracker = new TaskTracker(attempts);
+        }
+
+        public int totalAttemptsMade()
+        {
+            return taskTracker.totalAttemptsMade();
+        }
+
+        @Override
+        public ListenableFuture<Integer> call()
+                throws Exception
+        {
+            switch (taskTracker.getNextAttemptStatus()) {
+                case SUCCESS:
+                    return immediateFuture(RESULT);
+                case SYNC_FAILURE:
+                    throw new SyncException("Failed on call " + taskTracker.totalAttemptsMade());
+                case ASYNC_FAILURE:
+                    return immediateFailedFuture(new AsyncException("Failed on call " + taskTracker.totalAttemptsMade()));
+                default:
+                    throw new RuntimeException("Unexpected exception type");
+            }
+        }
+    }
+
+    private static final class AsyncException
+            extends RuntimeException
+    {
+        public AsyncException()
+        {
+        }
+
+        public AsyncException(String message)
+        {
+            super(message);
+        }
+    }
+
+    private static final class SyncException
+            extends RuntimeException
+    {
+        public SyncException()
+        {
+        }
+
+        public SyncException(String message)
+        {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
Wrap a returned future with a fallback that will retry upon async failure. The retry will be scheduled in a separate thread pool and will not block either the IO thread or the engine thread.

#8463 