### PR TITLE
Add 2 date columns to shards system table

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/systemtables/ShardMetadataRecordCursor.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/systemtables/ShardMetadataRecordCursor.java
@@ -16,6 +16,7 @@ package com.facebook.presto.raptor.systemtables;
 import com.facebook.presto.raptor.metadata.MetadataDao;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.predicate.Domain;
@@ -40,12 +41,14 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.raptor.RaptorColumnHandle.SHARD_UUID_COLUMN_TYPE;
+import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_CORRUPT_METADATA;
 import static com.facebook.presto.raptor.metadata.DatabaseShardManager.maxColumn;
 import static com.facebook.presto.raptor.metadata.DatabaseShardManager.minColumn;
 import static com.facebook.presto.raptor.metadata.DatabaseShardManager.shardIndexTable;
 import static com.facebook.presto.raptor.util.DatabaseUtil.metadataError;
 import static com.facebook.presto.raptor.util.DatabaseUtil.onDemandDao;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
@@ -65,6 +68,8 @@ public class ShardMetadataRecordCursor
     private static final String TABLE_NAME = "table_name";
     private static final String MIN_TIMESTAMP = "min_timestamp";
     private static final String MAX_TIMESTAMP = "max_timestamp";
+    private static final String MIN_DATE = "min_date";
+    private static final String MAX_DATE = "max_date";
 
     public static final SchemaTableName SHARD_METADATA_TABLE_NAME = new SchemaTableName("system", "shards");
     public static final ConnectorTableMetadata SHARD_METADATA = new ConnectorTableMetadata(
@@ -79,7 +84,9 @@ public class ShardMetadataRecordCursor
                     new ColumnMetadata("row_count", BIGINT),
                     new ColumnMetadata(XXHASH64, createVarcharType(16)),
                     new ColumnMetadata(MIN_TIMESTAMP, TIMESTAMP),
-                    new ColumnMetadata(MAX_TIMESTAMP, TIMESTAMP)));
+                    new ColumnMetadata(MAX_TIMESTAMP, TIMESTAMP),
+                    new ColumnMetadata(MIN_DATE, DATE),
+                    new ColumnMetadata(MAX_DATE, DATE)));
 
     private static final List<ColumnMetadata> COLUMNS = SHARD_METADATA.getColumns();
     private static final List<Type> TYPES = COLUMNS.stream().map(ColumnMetadata::getType).collect(toList());
@@ -132,8 +139,10 @@ public class ShardMetadataRecordCursor
                 .add("shards" + "." + COLUMNS.get(5).getName())
                 .add("shards" + "." + COLUMNS.get(6).getName())
                 .add("shards" + "." + COLUMNS.get(7).getName())
-                .add("min_timestamp")
-                .add("max_timestamp")
+                .add(MIN_TIMESTAMP)
+                .add(MAX_TIMESTAMP)
+                .add(MIN_DATE)
+                .add(MAX_DATE)
                 .build();
     }
 
@@ -265,11 +274,24 @@ public class ShardMetadataRecordCursor
 
         Long tableId = tableIds.next();
         Long columnId = metadataDao.getTemporalColumnId(tableId);
+        List<String> columnNames;
 
-        String minColumn = (columnId == null) ? "null" : minColumn(columnId);
-        String maxColumn = (columnId == null) ? "null" : maxColumn(columnId);
+        if (columnId == null) {
+            columnNames = getMappedColumnNames("null", "null", "null", "null");
+        }
+        else {
+            Type temporalType = metadataDao.getTableColumn(tableId, columnId).getDataType();
+            if (temporalType.equals(DATE)) {
+                columnNames = getMappedColumnNames("null", "null", minColumn(columnId), maxColumn(columnId));
+            }
+            else if (temporalType.equals(TIMESTAMP)) {
+                columnNames = getMappedColumnNames(minColumn(columnId), maxColumn(columnId), "null", "null");
+            }
+            else {
+                throw new PrestoException(RAPTOR_CORRUPT_METADATA, "Temporal column should be of type date or timestamp, not " + temporalType.getDisplayName());
+            }
+        }
 
-        List<String> columnNames = getMappedColumnNames(minColumn, maxColumn);
         try {
             connection = dbi.open().getConnection();
             statement = PreparedStatementBuilder.create(
@@ -287,16 +309,22 @@ public class ShardMetadataRecordCursor
         }
     }
 
-    private List<String> getMappedColumnNames(String minColumn, String maxColumn)
+    private List<String> getMappedColumnNames(String minTimestampColumn, String maxTimestampColumn, String minDateColumn, String maxDateColumn)
     {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         for (String column : columnNames) {
             switch (column) {
                 case MIN_TIMESTAMP:
-                    builder.add(minColumn);
+                    builder.add(minTimestampColumn);
                     break;
                 case MAX_TIMESTAMP:
-                    builder.add(maxColumn);
+                    builder.add(maxTimestampColumn);
+                    break;
+                case MIN_DATE:
+                    builder.add(minDateColumn);
+                    break;
+                case MAX_DATE:
+                    builder.add(maxDateColumn);
                     break;
                 default:
                     builder.add(column);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
@@ -327,6 +327,79 @@ public class TestRaptorIntegrationSmokeTest
     }
 
     @Test
+    public void testShardsSystemTableWithTemporalColumn()
+            throws Exception
+    {
+        // Make sure we have rows in the selected range
+        assertEquals(computeActual("SELECT count(*) >= 1 FROM orders WHERE orderdate BETWEEN date '1992-01-01' AND date '1992-02-08'").getOnlyValue(), true);
+
+        // Create a table that has DATE type temporal column
+        assertUpdate("CREATE TABLE test_shards_system_table_date_temporal\n" +
+                        "WITH (temporal_column = 'orderdate') AS\n" +
+                        "SELECT orderdate, orderkey\n" +
+                        "FROM orders\n" +
+                        "WHERE orderdate BETWEEN date '1992-01-01' AND date '1992-02-08'",
+                "SELECT count(*)\n" +
+                        "FROM orders\n" +
+                        "WHERE orderdate BETWEEN date '1992-01-01' AND date '1992-02-08'");
+
+        // Create a table that has TIMESTAMP type temporal column
+        assertUpdate("CREATE TABLE test_shards_system_table_timestamp_temporal\n" +
+                        "WITH (temporal_column = 'ordertimestamp') AS\n" +
+                        "SELECT CAST (orderdate AS TIMESTAMP) AS ordertimestamp, orderkey\n" +
+                        "FROM test_shards_system_table_date_temporal",
+                "SELECT count(*)\n" +
+                        "FROM orders\n" +
+                        "WHERE orderdate BETWEEN date '1992-01-01' AND date '1992-02-08'");
+
+        // For table with DATE type temporal column, min/max_timestamp columns must be null while min/max_date columns must not be null
+        assertEquals(computeActual("" +
+                "SELECT count(*)\n" +
+                "FROM system.shards\n" +
+                "WHERE table_schema = 'tpch'\n" +
+                "AND table_name = 'test_shards_system_table_date_temporal'\n" +
+                "AND NOT \n" +
+                "(min_timestamp IS NULL AND max_timestamp IS NULL\n" +
+                "AND min_date IS NOT NULL AND max_date IS NOT NULL)").getOnlyValue(), 0L);
+
+        // For table with TIMESTAMP type temporal column, min/max_date columns must be null while min/max_timestamp columns must not be null
+        assertEquals(computeActual("" +
+                "SELECT count(*)\n" +
+                "FROM system.shards\n" +
+                "WHERE table_schema = 'tpch'\n" +
+                "AND table_name = 'test_shards_system_table_timestamp_temporal'\n" +
+                "AND NOT\n" +
+                "(min_date IS NULL AND max_date IS NULL\n" +
+                "AND min_timestamp IS NOT NULL AND max_timestamp IS NOT NULL)").getOnlyValue(), 0L);
+
+        // Test date predicates in table with DATE temporal column
+        assertQuery("" +
+                        "SELECT table_schema, table_name, sum(row_count)\n" +
+                        "FROM system.shards \n" +
+                        "WHERE table_schema = 'tpch'\n" +
+                        "AND table_name = 'test_shards_system_table_date_temporal'\n" +
+                        "AND min_date >= date '1992-01-01'\n" +
+                        "AND max_date <= date '1992-02-08'\n" +
+                        "GROUP BY 1, 2",
+                "" +
+                        "SELECT 'tpch', 'test_shards_system_table_date_temporal',\n" +
+                        "(SELECT count(*) FROM orders WHERE orderdate BETWEEN date '1992-01-01' AND date '1992-02-08')");
+
+        // Test timestamp predicates in table with TIMESTAMP temporal column
+        assertQuery("" +
+                        "SELECT table_schema, table_name, sum(row_count)\n" +
+                        "FROM system.shards \n" +
+                        "WHERE table_schema = 'tpch'\n" +
+                        "AND table_name = 'test_shards_system_table_timestamp_temporal'\n" +
+                        "AND min_timestamp >= timestamp '1992-01-01'\n" +
+                        "AND max_timestamp <= timestamp '1992-02-08'\n" +
+                        "GROUP BY 1, 2",
+                "" +
+                        "SELECT 'tpch', 'test_shards_system_table_timestamp_temporal',\n" +
+                        "(SELECT count(*) FROM orders WHERE orderdate BETWEEN date '1992-01-01' AND date '1992-02-08')");
+    }
+
+    @Test
     public void testCreateBucketedTable()
             throws Exception
     {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/systemtables/TestShardMetadataRecordCursor.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/systemtables/TestShardMetadataRecordCursor.java
@@ -18,6 +18,7 @@ import com.facebook.presto.raptor.metadata.ColumnInfo;
 import com.facebook.presto.raptor.metadata.MetadataDao;
 import com.facebook.presto.raptor.metadata.ShardInfo;
 import com.facebook.presto.raptor.metadata.ShardManager;
+import com.facebook.presto.raptor.metadata.TableColumn;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.SchemaTableName;
@@ -27,6 +28,7 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -34,7 +36,6 @@ import io.airlift.slice.Slice;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.IDBI;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -68,12 +69,13 @@ public class TestShardMetadataRecordCursor
 
     private Handle dummyHandle;
     private ConnectorMetadata metadata;
-    private IDBI dbi;
+    private DBI dbi;
 
     @BeforeMethod
     public void setup()
     {
         this.dbi = new DBI("jdbc:h2:mem:test" + System.nanoTime());
+        this.dbi.registerMapper(new TableColumn.Mapper(new TypeRegistry()));
         this.dummyHandle = dbi.open();
         createTablesWithRetry(dbi);
         this.metadata = new RaptorMetadata("raptor", dbi, createShardManager(dbi));
@@ -141,9 +143,9 @@ public class TestShardMetadataRecordCursor
         assertEquals(actual.size(), 3);
 
         List<MaterializedRow> expected = ImmutableList.of(
-                new MaterializedRow(DEFAULT_PRECISION, schema, table, utf8Slice(uuid1.toString()), null, 100L, 10L, 1L, utf8Slice("0000000000001234"), null, null),
-                new MaterializedRow(DEFAULT_PRECISION, schema, table, utf8Slice(uuid2.toString()), null, 200L, 20L, 2L, utf8Slice("cafebabedeadbeef"), null, null),
-                new MaterializedRow(DEFAULT_PRECISION, schema, table, utf8Slice(uuid3.toString()), null, 300L, 30L, 3L, utf8Slice("fedcba0987654321"), null, null));
+                new MaterializedRow(DEFAULT_PRECISION, schema, table, utf8Slice(uuid1.toString()), null, 100L, 10L, 1L, utf8Slice("0000000000001234"), null, null, null, null),
+                new MaterializedRow(DEFAULT_PRECISION, schema, table, utf8Slice(uuid2.toString()), null, 200L, 20L, 2L, utf8Slice("cafebabedeadbeef"), null, null, null, null),
+                new MaterializedRow(DEFAULT_PRECISION, schema, table, utf8Slice(uuid3.toString()), null, 300L, 30L, 3L, utf8Slice("fedcba0987654321"), null, null, null, null));
 
         assertEquals(actual, expected);
     }


### PR DESCRIPTION
Add 2 DATE columns to 'shards' system table to display the shard ranges for tables with DATE type temporal columns.

#7884