### PR TITLE
Use zlib from JDK instead of Hadoop for RCFile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>0.7</version>
+                <version>0.8</version>
             </dependency>
 
             <dependency>

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/AircompressorCodecFactory.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/AircompressorCodecFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.rcfile;
 
+import io.airlift.compress.gzip.JdkGzipCodec;
 import io.airlift.compress.lz4.Lz4Codec;
 import io.airlift.compress.lzo.LzoCodec;
 import io.airlift.compress.snappy.SnappyCodec;
@@ -27,6 +28,7 @@ public class AircompressorCodecFactory
     private static final String LZO_CODEC_NAME_DEPRECATED = "org.apache.hadoop.io.compress.LzoCodec";
     private static final String LZ4_CODEC_NAME = "org.apache.hadoop.io.compress.Lz4Codec";
     private static final String LZ4_HC_CODEC_NAME = "org.apache.hadoop.io.compress.Lz4Codec";
+    private static final String GZIP_CODEC_NAME = "org.apache.hadoop.io.compress.GzipCodec";
 
     private final RcFileCodecFactory delegate;
 
@@ -47,6 +49,9 @@ public class AircompressorCodecFactory
         if (LZ4_CODEC_NAME.equals(codecName)) {
             return new AircompressorCompressor(new Lz4Codec());
         }
+        if (GZIP_CODEC_NAME.equals(codecName)) {
+            return new AircompressorCompressor(new JdkGzipCodec());
+        }
         return delegate.createCompressor(codecName);
     }
 
@@ -61,6 +66,9 @@ public class AircompressorCodecFactory
         }
         if (LZ4_CODEC_NAME.equals(codecName) || LZ4_HC_CODEC_NAME.equals(codecName)) {
             return new AircompressorDecompressor(new Lz4Codec());
+        }
+        if (GZIP_CODEC_NAME.equals(codecName)) {
+            return new AircompressorDecompressor(new JdkGzipCodec());
         }
         return delegate.createDecompressor(codecName);
     }

--- a/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
@@ -87,6 +87,7 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.compress.BZip2Codec;
 import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.io.compress.Lz4Codec;
 import org.apache.hadoop.io.compress.SnappyCodec;
@@ -123,6 +124,7 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.rcfile.RcFileDecoderUtils.findFirstSyncPosition;
+import static com.facebook.presto.rcfile.RcFileTester.Compression.BZIP2;
 import static com.facebook.presto.rcfile.RcFileTester.Compression.LZ4;
 import static com.facebook.presto.rcfile.RcFileTester.Compression.NONE;
 import static com.facebook.presto.rcfile.RcFileTester.Compression.SNAPPY;
@@ -246,6 +248,13 @@ public class RcFileTester
 
     public enum Compression
     {
+        BZIP2 {
+            @Override
+            Optional<String> getCodecName()
+            {
+                return Optional.of(BZip2Codec.class.getName());
+            }
+        },
         ZLIB {
             @Override
             Optional<String> getCodecName()
@@ -318,7 +327,7 @@ public class RcFileTester
         // These compression algorithms were chosen to cover the three different
         // cases: uncompressed, aircompressor, and hadoop compression
         // We assume that the compression algorithms generally work
-        rcFileTester.compressions = ImmutableSet.of(NONE, LZ4, ZLIB);
+        rcFileTester.compressions = ImmutableSet.of(NONE, LZ4, ZLIB, BZIP2);
         return rcFileTester;
     }
 


### PR DESCRIPTION
Gzip compressors created by apache hadoop use system native memory and
hold them forever in a codec pool. This can easily lead to memory leak
and make memory tracking hard. Replace the compression library with the
java one.