### PR TITLE
Throw PrestoException for large columns in SliceDirectStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
@@ -21,6 +21,7 @@ import com.facebook.presto.orc.stream.ByteArrayInputStream;
 import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.SliceArrayBlock;
 import com.facebook.presto.spi.type.Type;
@@ -39,6 +40,7 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
@@ -46,6 +48,7 @@ import static com.facebook.presto.spi.type.Varchars.truncateToLength;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class SliceDirectStreamReader
@@ -148,7 +151,8 @@ public class SliceDirectStreamReader
             }
         }
         if (totalLength > ONE_GIGABYTE) {
-            throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Column values too large to process in Presto. %s column values larger than 1GB", nextBatchSize);
+            throw new PrestoException(GENERIC_INTERNAL_ERROR,
+                    format("Values in column \"%s\" are too large to process for Presto. %s column values are larger than 1GB [%s]", streamDescriptor.getFieldName(), nextBatchSize, streamDescriptor.getOrcDataSourceId()));
         }
 
         byte[] data = EMPTY_BYTE_ARRAY;


### PR DESCRIPTION
Previously OrcCorruptionException was thrown and it is confusing for the users. I also added the field name to make the exception message more informative.

Let me know if we want to use some other type of exception/error code for this.