### PR TITLE
Fix reading INT32/INT64 encoded Parquet decimals

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
@@ -14,10 +14,7 @@
 package com.facebook.presto.hive.parquet.reader;
 
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
-import org.apache.hadoop.hive.common.type.HiveDecimal;
-import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import parquet.column.ColumnDescriptor;
 
 import static com.facebook.presto.hive.util.DecimalUtils.getShortDecimalValue;
@@ -37,13 +34,12 @@ public class ParquetShortDecimalColumnReader
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             long decimalValue;
+            // When decimals are encoded with primitive types Parquet stores unscaled values
             if (columnDescriptor.getType().equals(INT32)) {
-                HiveDecimalWritable hiveDecimalWritable = new HiveDecimalWritable(HiveDecimal.create(valuesReader.readInteger()));
-                decimalValue = getShortDecimalValue(hiveDecimalWritable, ((DecimalType) type).getScale());
+                decimalValue = valuesReader.readInteger();
             }
             else if (columnDescriptor.getType().equals(INT64)) {
-                HiveDecimalWritable hiveDecimalWritable = new HiveDecimalWritable(HiveDecimal.create(valuesReader.readLong()));
-                decimalValue = getShortDecimalValue(hiveDecimalWritable, ((DecimalType) type).getScale());
+                decimalValue = valuesReader.readLong();
             }
             else {
                 decimalValue = getShortDecimalValue(valuesReader.readBytes().getBytes());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestMapredParquetOutputFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestMapredParquetOutputFormat.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.util.Progressable;
+import parquet.schema.MessageType;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Properties;
+
+import static java.util.Objects.requireNonNull;
+
+/*
+  MapredParquetOutputFormat creates the Parquet schema from the column types,
+  which is not always what we want. Because, in that case for decimal type
+  the schema always specifies FIXED_LEN_BYTE_ARRAY as the backing type. But,
+  we also want to test the cases were the backing type is INT32/INT64, which requires
+  a custom Parquet schema.
+*/
+public class TestMapredParquetOutputFormat extends MapredParquetOutputFormat
+{
+    private final Optional<MessageType> schema;
+
+    public TestMapredParquetOutputFormat(Optional<MessageType> schema)
+    {
+        this.schema = requireNonNull(schema, "schema is null");
+    }
+
+    @Override
+    public FileSinkOperator.RecordWriter getHiveRecordWriter(JobConf jobConf,
+            Path finalOutPath,
+            Class<? extends Writable> valueClass,
+            boolean isCompressed,
+            Properties tableProperties,
+            Progressable progress)
+            throws IOException
+    {
+        if (schema.isPresent()) {
+            DataWritableWriteSupport.setSchema(schema.get(), jobConf);
+            return getParquerRecordWriterWrapper(realOutputFormat, jobConf, finalOutPath.toString(), progress, tableProperties);
+        }
+        return super.getHiveRecordWriter(jobConf, finalOutPath, valueClass, isCompressed, tableProperties, progress);
+    }
+}


### PR DESCRIPTION
According to the Parquet [spec](https://github.com/Parquet/parquet-format/blob/master/LogicalTypes.md) when decimals are encoded with int32/int64 Parquet stores the unscaled values.

> The primitive type stores an unscaled integer value. For byte arrays, binary and fixed, the unscaled number must be encoded as two's complement using big-endian byte order (the most significant byte is the zeroth element). The scale stores the number of digits of that value that are to the right of the decimal point, and the precision stores the maximum number of digits supported in the unscaled value.

