### PR TITLE
Fluent locks

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/MultilevelSplitQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/MultilevelSplitQueue.java
@@ -128,7 +128,7 @@ public class MultilevelSplitQueue
     /**
      * Presto attempts to give each level a target amount of scheduled time, which is configurable
      * using levelTimeMultiplier.
-     *
+     * <p>
      * This function selects the level that has the the lowest ratio of actual to the target time
      * with the objective of minimizing deviation from the target scheduled time. From this level,
      * we pick the split with the lowest priority.
@@ -168,10 +168,10 @@ public class MultilevelSplitQueue
     /**
      * During periods of time when a level has no waiting splits, it will not accumulate
      * accumulate scheduled time and will fall behind relative to other levels.
-     *
+     * <p>
      * This can cause temporary starvation for other levels when splits do reach the
      * previously-empty level.
-     *
+     * <p>
      * To prevent this we set the scheduled time for levels which are empty to the expected
      * scheduled time.
      *
@@ -200,7 +200,8 @@ public class MultilevelSplitQueue
                     break;
                 }
             }
-        } while (updated && level0ExpectedTime != 0);
+        }
+        while (updated && level0ExpectedTime != 0);
 
         return level0ExpectedTime;
     }
@@ -222,7 +223,7 @@ public class MultilevelSplitQueue
      * Presto 'charges' the quanta run time to the task <i>and</i> the level it belongs to in
      * an effort to maintain the target thread utilization ratios between levels and to
      * maintain fairness within a level.
-     *
+     * <p>
      * Consider an example split where a read hung for several minutes. This is either a bug
      * or a failing dependency. In either case we do not want to charge the task too much,
      * and we especially do not want to charge the level too much - i.e. cause other queries

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -186,6 +186,7 @@ import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
+import static com.facebook.presto.util.concurrent.Locks.locking;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -459,33 +460,25 @@ public class LocalQueryRunner
     @Override
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return transaction(transactionManager, accessControl)
                     .readOnly()
                     .execute(session, transactionSession -> {
                         return getMetadata().listTables(transactionSession, new QualifiedTablePrefix(catalog, schema));
                     });
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     @Override
     public boolean tableExists(Session session, String table)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return transaction(transactionManager, accessControl)
                     .readOnly()
                     .execute(session, transactionSession -> {
                         return MetadataUtil.tableExists(getMetadata(), transactionSession, table);
                     });
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/util/CheckedCallable.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/CheckedCallable.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+/**
+ * Interface designed to capture lambda producing a value and throwing a checked exception.
+ *
+ * @param <E> type of exception thrown by the captured lambda
+ */
+public interface CheckedCallable<T, E extends Throwable>
+{
+    T call()
+            throws E;
+}

--- a/presto-main/src/main/java/com/facebook/presto/util/CheckedRunnable.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/CheckedRunnable.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+/**
+ * Interface designed to capture lambda throwing a checked exception.
+ *
+ * @param <E> type of exception thrown by the captured lambda
+ */
+public interface CheckedRunnable<E extends Throwable>
+{
+    void run()
+            throws E;
+}

--- a/presto-main/src/main/java/com/facebook/presto/util/concurrent/Locks.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/concurrent/Locks.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util.concurrent;
+
+import com.facebook.presto.util.CheckedCallable;
+import com.facebook.presto.util.CheckedRunnable;
+
+import java.util.concurrent.locks.Lock;
+
+import static java.util.Objects.requireNonNull;
+
+public class Locks
+{
+    public static <E extends Throwable> void locking(Lock lock, CheckedRunnable<E> callback)
+            throws E
+    {
+        locking(lock, asCallable(callback));
+    }
+
+    public static <T, E extends Throwable> T locking(Lock lock, CheckedCallable<T, E> callback)
+            throws E
+    {
+        return locking(lock, UninterruptibleLocker.INSTANCE, callback);
+    }
+
+    public static <E extends Throwable> void lockingInterruptibly(Lock lock, CheckedRunnable<E> callback)
+            throws E, InterruptedException
+    {
+        lockingInterruptibly(lock, asCallable(callback));
+    }
+
+    public static <T, E extends Throwable> T lockingInterruptibly(Lock lock, CheckedCallable<T, E> callback)
+            throws E, InterruptedException
+    {
+        return locking(lock, InterruptibleLocker.INSTANCE, callback);
+    }
+
+    private static <T, E extends Throwable, L extends Exception> T locking(
+            Lock lock,
+            Locker<L> locker,
+            CheckedCallable<T, E> callback)
+            throws L, E
+    {
+        requireNonNull(lock, "lock is null");
+        requireNonNull(locker, "locker is null");
+        requireNonNull(callback, "callback is null");
+
+        locker.lock(lock);
+        try {
+            return callback.call();
+        }
+        finally {
+            locker.unlock(lock);
+        }
+    }
+
+    private enum UninterruptibleLocker
+            implements Locker<RuntimeException>
+    {
+        INSTANCE;
+
+        @Override
+        public void lock(Lock lock)
+        {
+            lock.lock();
+        }
+
+        @Override
+        public void unlock(Lock lock)
+        {
+            lock.unlock();
+        }
+    }
+
+    private enum InterruptibleLocker
+            implements Locker<InterruptedException>
+    {
+        INSTANCE;
+
+        @Override
+        public void lock(Lock lock)
+                throws InterruptedException
+        {
+            lock.lockInterruptibly();
+        }
+
+        @Override
+        public void unlock(Lock lock)
+        {
+            lock.unlock();
+        }
+    }
+
+    private static <E extends Throwable> CheckedCallable<Void, E> asCallable(CheckedRunnable<E> callback)
+    {
+        requireNonNull(callback, "callback is null");
+        return () -> {
+            callback.run();
+            return null;
+        };
+    }
+
+    private interface Locker<LockException extends Exception>
+    {
+        void lock(Lock lock)
+                throws LockException;
+
+        void unlock(Lock lock);
+    }
+
+    private Locks() {}
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -44,6 +44,7 @@ import java.util.OptionalLong;
 
 import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
+import static com.facebook.presto.util.concurrent.Locks.locking;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -261,13 +262,7 @@ public abstract class AbstractTestQueryFramework
 
     protected void executeExclusively(Runnable executionBlock)
     {
-        queryRunner.getExclusiveLock().lock();
-        try {
-            executionBlock.run();
-        }
-        finally {
-            queryRunner.getExclusiveLock().unlock();
-        }
+        locking(queryRunner.getExclusiveLock(), executionBlock::run);
     }
 
     protected String formatSqlText(String sql)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -57,6 +57,7 @@ import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.tests.AbstractTestQueries.TEST_CATALOG_PROPERTIES;
 import static com.facebook.presto.tests.AbstractTestQueries.TEST_SYSTEM_PROPERTIES;
+import static com.facebook.presto.util.concurrent.Locks.locking;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.units.Duration.nanosSince;
 import static java.util.Objects.requireNonNull;
@@ -306,60 +307,40 @@ public class DistributedQueryRunner
     @Override
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return prestoClient.listTables(session, catalog, schema);
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     @Override
     public boolean tableExists(Session session, String table)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return prestoClient.tableExists(session, table);
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     @Override
     public MaterializedResult execute(@Language("SQL") String sql)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return prestoClient.execute(sql).getResult();
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     @Override
     public MaterializedResult execute(Session session, @Language("SQL") String sql)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return prestoClient.execute(session, sql).getResult();
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     public ResultWithQueryId<MaterializedResult> executeWithQueryId(Session session, @Language("SQL") String sql)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return prestoClient.execute(session, sql);
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     public QueryInfo getQueryInfo(QueryId queryId)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -42,6 +42,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.facebook.presto.tests.AbstractTestQueries.TEST_CATALOG_PROPERTIES;
 import static com.facebook.presto.tests.AbstractTestQueries.TEST_SYSTEM_PROPERTIES;
+import static com.facebook.presto.util.concurrent.Locks.locking;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -81,25 +82,17 @@ public final class StandaloneQueryRunner
     @Override
     public MaterializedResult execute(@Language("SQL") String sql)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return prestoClient.execute(sql).getResult();
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     @Override
     public MaterializedResult execute(Session session, @Language("SQL") String sql)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return prestoClient.execute(session, sql).getResult();
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     @Override
@@ -204,25 +197,17 @@ public final class StandaloneQueryRunner
     @Override
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return prestoClient.listTables(session, catalog, schema);
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     @Override
     public boolean tableExists(Session session, String table)
     {
-        lock.readLock().lock();
-        try {
+        return locking(lock.readLock(), () -> {
             return prestoClient.tableExists(session, table);
-        }
-        finally {
-            lock.readLock().unlock();
-        }
+        });
     }
 
     @Override


### PR DESCRIPTION
This provide helper methods to lock `Lock` objects with a syntax closer to what java offers for intrinsic locks, and removing the (un)likelihood of unlocking a wrong lock.