### PR TITLE
Add function to get last day of month #8477

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -966,7 +966,7 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.DATE)
     public static long lastDayOfMonthFromDate(@SqlType(StandardTypes.DATE) long date)
     {
-        DateTime dateTime2 = new DateTime( DAYS.toMillis(date));
+        DateTime dateTime2 = new DateTime(DAYS.toMillis(date));
         return MILLISECONDS.toDays(dateTime2.dayOfMonth().withMaximumValue().getMillis());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -952,6 +952,24 @@ public final class DateTimeFunctions
         return extractZoneOffsetMinutes(timestampWithTimeZone) / 60;
     }
 
+    @Description("time zone hour of the given timestamp")
+    @ScalarFunction("last_day")
+    @SqlType(StandardTypes.DATE)
+    public static long lastDayOfMonthFromTimestamp(ConnectorSession session, @SqlType(StandardTypes.TIMESTAMP) long timestamp)
+    {
+        DateTime dateTime = new DateTime(getChronology(session.getTimeZoneKey()).millis().getMillis(timestamp));
+        return MILLISECONDS.toDays(dateTime.dayOfMonth().withMaximumValue().getMillis());
+    }
+
+    @Description("time zone hour of the given date")
+    @ScalarFunction("last_day")
+    @SqlType(StandardTypes.DATE)
+    public static long lastDayOfMonthFromDate(@SqlType(StandardTypes.DATE) long date)
+    {
+        DateTime dateTime2 = new DateTime( DAYS.toMillis(date));
+        return MILLISECONDS.toDays(dateTime2.dayOfMonth().withMaximumValue().getMillis());
+    }
+
     @SuppressWarnings("fallthrough")
     public static DateTimeFormatter createDateTimeFormatter(Slice format)
     {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -951,6 +951,16 @@ public class TestDateTimeFunctions
         assertInvalidFunction("parse_duration('abc')", "duration is not a valid data duration string: abc");
     }
 
+    @Test
+    public void testLastDayOfMonth()
+    {
+        DateTime result = DATE.withDayOfMonth(31);
+        assertFunction("last_day( " + DATE_LITERAL + ")", DateType.DATE, toDate(result));
+
+        DateTime result2 = DATE.withDayOfMonth(30);
+        assertFunction("last_day( " + TIMESTAMP_LITERAL + ")", DateType.DATE, toDate(result2));
+    }
+
     private void assertFunctionString(String projection, Type expectedType, String expected)
     {
         functionAssertions.assertFunctionString(projection, expectedType, expected);


### PR DESCRIPTION
Add function to get last day of month #8477 

Hello,

This is my first pull request in open source project and hoping to get guidance on if I am following the right coding practices,... etc.

I did add functionality to fix[Add function to get last day of month #8477 ](https://github.com/prestodb/presto/issues/8477). Basically, i added 2 methods one that takes a timestamp and another taking date as input and in both cases, it returns last day of the month as a date

In order to fix this issue, I made two changes 
1) Added these 2 methods in DateTimeFunctions.java
```
@Description("time zone hour of the given timestamp")
    @ScalarFunction("last_day")
    @SqlType(StandardTypes.DATE)
    public static long lastDayOfMonthFromTimestamp(ConnectorSession session, @SqlType(StandardTypes.TIMESTAMP) long timestamp)
    {
        DateTime dateTime = new DateTime(getChronology(session.getTimeZoneKey()).millis().getMillis(timestamp));
        return MILLISECONDS.toDays(dateTime.dayOfMonth().withMaximumValue().getMillis());
    }

    @Description("time zone hour of the given date")
    @ScalarFunction("last_day")
    @SqlType(StandardTypes.DATE)
    public static long lastDayOfMonthFromDate(@SqlType(StandardTypes.DATE) long date)
    {
        DateTime dateTime2 = new DateTime(DAYS.toMillis(date));
        return MILLISECONDS.toDays(dateTime2.dayOfMonth().withMaximumValue().getMillis());
    }
```
2) Added a test case for the last_day method implemented above
```
@Test
    public void testLastDayOfMonth()
    {
        DateTime result = DATE.withDayOfMonth(31);
        assertFunction("last_day( " + DATE_LITERAL + ")", DateType.DATE, toDate(result));

        DateTime result2 = DATE.withDayOfMonth(30);
        assertFunction("last_day( " + TIMESTAMP_LITERAL + ")", DateType.DATE, toDate(result2));
    }
```
Can someone please review the changes and let me know if this looks good. 

Thanks
Sunil