### PR TITLE
Add PruneProjectColumns rule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -43,6 +43,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneJoinChildrenColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneMarkDistinctColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneOutputColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneProjectColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
@@ -147,6 +148,7 @@ public class PlanOptimizers
                 new PruneJoinColumns(),
                 new PruneMarkDistinctColumns(),
                 new PruneOutputColumns(),
+                new PruneProjectColumns(),
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),
                 new PruneTopNColumns(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneProjectColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneProjectColumns.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+
+import java.util.Optional;
+import java.util.Set;
+
+public class PruneProjectColumns
+        extends ProjectOffPushDownRule<ProjectNode>
+{
+    public PruneProjectColumns()
+    {
+        super(ProjectNode.class);
+    }
+
+    @Override
+    protected Optional<PlanNode> pushDownProjectOff(
+            PlanNodeIdAllocator idAllocator,
+            ProjectNode childProjectNode,
+            Set<Symbol> referencedOutputs)
+    {
+        return Optional.of(
+                new ProjectNode(
+                        childProjectNode.getId(),
+                        childProjectNode.getSource(),
+                        childProjectNode.getAssignments().filter(referencedOutputs)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneProjectColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneProjectColumns.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneProjectColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testNotAllOutputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneProjectColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(b),
+                            p.project(
+                                    Assignments.identity(a, b),
+                                    p.values(a, b)));
+                })
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("b", expression("b")),
+                                strictProject(
+                                        ImmutableMap.of("b", expression("b")),
+                                        values("a", "b"))));
+    }
+
+    @Test
+    public void testAllOutputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneProjectColumns())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.project(
+                            Assignments.identity(b),
+                            p.project(
+                                    Assignments.identity(b),
+                                    p.values(a, b)));
+                })
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
Migrate PruneUnreferencedOutputs handling of ProjectNode to
the iterative optimizer.  This rule finds a project that's under another
project, such that the parent doesn't use all the outputs of the child,
and drops the unused projections from the child.  Because the child is
a ProjectNode, it can trigger a subsequent rule to prune the grandchild.