### PR TITLE
Add PruneOutputColumns rule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -42,6 +42,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneIndexSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinChildrenColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneMarkDistinctColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneOutputColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
@@ -144,6 +145,7 @@ public class PlanOptimizers
                 new PruneJoinChildrenColumns(),
                 new PruneJoinColumns(),
                 new PruneMarkDistinctColumns(),
+                new PruneOutputColumns(),
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),
                 new PruneValuesColumns(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOutputColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOutputColumns.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictChildOutputs;
+
+public class PruneOutputColumns
+        implements Rule
+{
+    private static final Pattern PATTERN = Pattern.typeOf(OutputNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Context context)
+    {
+        OutputNode outputNode = (OutputNode) node;
+
+        return restrictChildOutputs(
+                context.getIdAllocator(),
+                outputNode,
+                ImmutableSet.copyOf(outputNode.getOutputSymbols()));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneOutputColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneOutputColumns.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictOutput;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPruneOutputColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testNotAllOutputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneOutputColumns())
+                .on(p ->
+                {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.output(
+                            ImmutableList.of("B label"),
+                            ImmutableList.of(b),
+                            p.values(a, b));
+                })
+                .matches(
+                        strictOutput(
+                                ImmutableList.of("b"),
+                                strictProject(
+                                        ImmutableMap.of("b", expression("b")),
+                                        values("a", "b"))));
+    }
+
+    @Test
+    public void testAllOutputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneOutputColumns())
+                .on(p ->
+                {
+                    Symbol a = p.symbol("a");
+                    Symbol b = p.symbol("b");
+                    return p.output(
+                            ImmutableList.of("A label", "B label"),
+                            ImmutableList.of(a, b),
+                            p.values(a, b));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -46,6 +46,7 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
+import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
@@ -94,6 +95,15 @@ public class PlanBuilder
     {
         this.idAllocator = idAllocator;
         this.metadata = metadata;
+    }
+
+    public OutputNode output(List<String> columnNames, List<Symbol> outputs, PlanNode source)
+    {
+        return new OutputNode(
+                idAllocator.getNextId(),
+                source,
+                columnNames,
+                outputs);
     }
 
     public ValuesNode values(Symbol... columns)


### PR DESCRIPTION
Migrate PruneUnreferencedOutputs handling of OutputNode to the iterative
optimizer.  This rule adds an explicit project-off underneath an
OutputNode which doesn't use all of it's child's outputs, so that other
pruning rules will match against the pattern of a project over the
original child.