### PR TITLE
Add PruneTopNColumns Rule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -45,6 +45,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneMarkDistinctColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinFilteringSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneTopNColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
@@ -146,6 +147,7 @@ public class PlanOptimizers
                 new PruneMarkDistinctColumns(),
                 new PruneSemiJoinColumns(),
                 new PruneSemiJoinFilteringSourceColumns(),
+                new PruneTopNColumns(),
                 new PruneValuesColumns(),
                 new PruneTableScanColumns());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTopNColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTopNColumns.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.google.common.collect.Streams;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictChildOutputs;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class PruneTopNColumns
+        extends ProjectOffPushDownRule<TopNNode>
+{
+    public PruneTopNColumns()
+    {
+        super(TopNNode.class);
+    }
+
+    @Override
+    protected Optional<PlanNode> pushDownProjectOff(PlanNodeIdAllocator idAllocator, TopNNode topNNode, Set<Symbol> referencedOutputs)
+    {
+        Set<Symbol> prunedTopNInputs = Streams.concat(
+                referencedOutputs.stream(),
+                topNNode.getOrderBy().stream())
+                .collect(toImmutableSet());
+
+        return restrictChildOutputs(idAllocator, topNNode, prunedTopNInputs);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -41,6 +41,7 @@ import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
@@ -229,6 +230,11 @@ public final class PlanMatchPattern
     public static PlanMatchPattern sort(PlanMatchPattern source)
     {
         return node(SortNode.class, source);
+    }
+
+    public static PlanMatchPattern topN(long count, List<String> orderBy, PlanMatchPattern source)
+    {
+        return node(TopNNode.class, source).with(new TopNMatcher(count, toSymbolAliases(orderBy)));
     }
 
     public static PlanMatchPattern output(PlanMatchPattern source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TopNMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TopNMatcher.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PlanNodeCost;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class TopNMatcher
+        implements Matcher
+{
+    private final long count;
+    private final List<PlanTestSymbol> orderBySymbols;
+
+    public TopNMatcher(long count, List<PlanTestSymbol> orderBySymbols)
+    {
+        this.count = count;
+        this.orderBySymbols = ImmutableList.copyOf(orderBySymbols);
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof TopNNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, PlanNodeCost planNodeCost, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+        TopNNode topNNode = (TopNNode) node;
+
+        if (topNNode.getCount() != count) {
+            return NO_MATCH;
+        }
+
+        List<Symbol> expectedOrderBy = orderBySymbols.stream()
+                .map(alias -> alias.toSymbol(symbolAliases))
+                .collect(toImmutableList());
+
+        if (!topNNode.getOrderBy().equals(expectedOrderBy)) {
+            return NO_MATCH;
+        }
+
+        Map<Symbol, SortOrder> expectedOrderings = Maps.toMap(expectedOrderBy, Functions.constant(SortOrder.ASC_NULLS_FIRST));
+
+        if (!topNNode.getOrderings().equals(expectedOrderings)) {
+            return NO_MATCH;
+        }
+
+        return match();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("count", count)
+                .add("orderBySymbols", orderBySymbols)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneTopNColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneTopNColumns.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.function.Predicate;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topN;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class TestPruneTopNColumns
+        extends BaseRuleTest
+{
+    private static final long COUNT = 10;
+
+    @Test
+    public void testNotAllInputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneTopNColumns())
+                .on(p -> buildProjectedTopN(p, symbol -> symbol.getName().equals("b")))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("b", expression("b")),
+                                topN(
+                                        COUNT,
+                                        ImmutableList.of("b"),
+                                        strictProject(
+                                                ImmutableMap.of("b", expression("b")),
+                                                values("a", "b")))));
+    }
+
+    @Test
+    public void testAllInputsRereferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneTopNColumns())
+                .on(p -> buildProjectedTopN(p, symbol -> symbol.getName().equals("a")))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testAllOutputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneTopNColumns())
+                .on(p -> buildProjectedTopN(p, Predicates.alwaysTrue()))
+                .doesNotFire();
+    }
+
+    private ProjectNode buildProjectedTopN(PlanBuilder planBuilder, Predicate<Symbol> projectionTopN)
+    {
+        Symbol a = planBuilder.symbol("a");
+        Symbol b = planBuilder.symbol("b");
+        return planBuilder.project(
+                Assignments.identity(ImmutableList.of(a, b).stream().filter(projectionTopN).collect(toImmutableSet())),
+                planBuilder.topN(
+                        COUNT,
+                        ImmutableList.of(b),
+                        planBuilder.values(a, b)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -20,6 +20,7 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.ExpressionUtils;
@@ -53,16 +54,19 @@ import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
 import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
+import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Maps;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -122,6 +126,17 @@ public class PlanBuilder
     public MarkDistinctNode markDistinct(PlanNode source, Symbol markerSymbol, List<Symbol> distinctSymbols)
     {
         return new MarkDistinctNode(idAllocator.getNextId(), source, markerSymbol, distinctSymbols, Optional.empty());
+    }
+
+    public TopNNode topN(long count, List<Symbol> orderBy, PlanNode source)
+    {
+        return new TopNNode(
+                idAllocator.getNextId(),
+                source,
+                count,
+                orderBy,
+                Maps.toMap(orderBy, Functions.constant(SortOrder.ASC_NULLS_FIRST)),
+                TopNNode.Step.SINGLE);
     }
 
     public SampleNode sample(double sampleRatio, SampleNode.Type type, PlanNode source)


### PR DESCRIPTION
Migrate PruneUnreferencedOutputs handling of TopNNode to the iterative
optimizer.  This rule finds a TopNNode that's under a project, such that
the grandchild produces columns not needed by either the parent or the
child, and creates a new project grandchild to discard the unused
columns.  Subsequent rules may match the pattern of the new grandchild
(project) over the old grandchild, and do further pruning.