### PR TITLE
Prune aggregation columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -36,6 +36,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
+import com.facebook.presto.sql.planner.iterative.rule.PruneAggregationSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCrossJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneIndexSourceColumns;
@@ -140,6 +141,7 @@ public class PlanOptimizers
 
         // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.
         Set<Rule> columnPruningRules = ImmutableSet.of(
+                new PruneAggregationSourceColumns(),
                 new PruneCrossJoinColumns(),
                 new PruneIndexSourceColumns(),
                 new PruneJoinChildrenColumns(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -36,6 +36,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithSort;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
+import com.facebook.presto.sql.planner.iterative.rule.PruneAggregationColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneAggregationSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCrossJoinColumns;
@@ -141,6 +142,7 @@ public class PlanOptimizers
 
         // TODO: Once we've migrated handling all the plan node types, replace uses of PruneUnreferencedOutputs with an IterativeOptimizer containing these rules.
         Set<Rule> columnPruningRules = ImmutableSet.of(
+                new PruneAggregationColumns(),
                 new PruneAggregationSourceColumns(),
                 new PruneCrossJoinColumns(),
                 new PruneIndexSourceColumns(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationColumns.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class PruneAggregationColumns
+        extends ProjectOffPushDownRule<AggregationNode>
+{
+    public PruneAggregationColumns()
+    {
+        super(AggregationNode.class);
+    }
+
+    @Override
+    protected Optional<PlanNode> pushDownProjectOff(
+            PlanNodeIdAllocator idAllocator,
+            AggregationNode aggregationNode,
+            Set<Symbol> referencedOutputs)
+    {
+        Map<Symbol, AggregationNode.Aggregation> prunedAggregations = Maps.filterKeys(
+                aggregationNode.getAggregations(),
+                referencedOutputs::contains);
+
+        if (prunedAggregations.size() == aggregationNode.getAggregations().size()) {
+            return Optional.empty();
+        }
+
+        // PruneAggregationSourceColumns will subsequently project off any newly unused inputs.
+        return Optional.of(
+                new AggregationNode(
+                        aggregationNode.getId(),
+                        aggregationNode.getSource(),
+                        prunedAggregations,
+                        aggregationNode.getGroupingSets(),
+                        aggregationNode.getStep(),
+                        aggregationNode.getHashSymbol(),
+                        aggregationNode.getGroupIdSymbol()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolsExtractor;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.Streams;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictChildOutputs;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class PruneAggregationSourceColumns
+        implements Rule
+{
+    private static final Pattern PATTERN = Pattern.typeOf(AggregationNode.class);
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNode> apply(PlanNode node, Context context)
+    {
+        AggregationNode aggregationNode = (AggregationNode) node;
+
+        Set<Symbol> requiredInputs = Streams.concat(
+                aggregationNode.getGroupingKeys().stream(),
+                aggregationNode.getHashSymbol().map(Stream::of).orElse(Stream.empty()),
+                aggregationNode.getAggregations().values().stream()
+                        .flatMap(PruneAggregationSourceColumns::getAggregationInputs))
+                .collect(toImmutableSet());
+
+        return restrictChildOutputs(context.getIdAllocator(), aggregationNode, requiredInputs);
+    }
+
+    private static Stream<Symbol> getAggregationInputs(AggregationNode.Aggregation aggregation)
+    {
+        return Streams.concat(
+                SymbolsExtractor.extractUnique(aggregation.getCall()).stream(),
+                aggregation.getMask().map(Stream::of).orElse(Stream.empty()));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneAggregationColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneAggregationColumns.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
+import static com.google.common.base.Predicates.alwaysTrue;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class TestPruneAggregationColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testNotAllInputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneAggregationColumns())
+                .on(p -> buildProjectedAggregation(p, symbol -> symbol.getName().equals("b")))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of("b", expression("b")),
+                                aggregation(
+                                        ImmutableList.of(ImmutableList.of("key")),
+                                        ImmutableMap.of(
+                                                Optional.of("b"),
+                                                functionCall("count", false, ImmutableList.of())),
+                                        ImmutableMap.of(),
+                                        Optional.empty(),
+                                        SINGLE,
+                                        values("key"))));
+    }
+
+    @Test
+    public void testAllOutputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneAggregationColumns())
+                .on(p -> buildProjectedAggregation(p, alwaysTrue()))
+                .doesNotFire();
+    }
+
+    private ProjectNode buildProjectedAggregation(PlanBuilder planBuilder, Predicate<Symbol> projectionFilter)
+    {
+        Symbol a = planBuilder.symbol("a");
+        Symbol b = planBuilder.symbol("b");
+        Symbol key = planBuilder.symbol("key");
+        return planBuilder.project(
+                Assignments.identity(ImmutableList.of(a, b).stream().filter(projectionFilter).collect(toImmutableSet())),
+                planBuilder.aggregation(aggregationBuilder -> aggregationBuilder
+                        .source(planBuilder.values(key))
+                        .addGroupingSet(key)
+                        .addAggregation(a, planBuilder.expression("count()"), ImmutableList.of())
+                        .addAggregation(b, planBuilder.expression("count()"), ImmutableList.of())));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneAggregationSourceColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneAggregationSourceColumns.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
+import static com.google.common.base.Predicates.alwaysTrue;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class TestPruneAggregationSourceColumns
+        extends BaseRuleTest
+{
+    @Test
+    public void testNotAllInputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneAggregationSourceColumns())
+                .on(p -> buildAggregation(p, alwaysTrue()))
+                .matches(
+                        aggregation(
+                                ImmutableList.of(ImmutableList.of("key")),
+                                ImmutableMap.of(
+                                        Optional.of("avg"),
+                                        functionCall("avg", ImmutableList.of("input"))),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                SINGLE,
+                                strictProject(
+                                        ImmutableMap.of(
+                                                "input", expression("input"),
+                                                "key", expression("key"),
+                                                "keyHash", expression("keyHash"),
+                                                "mask", expression("mask")),
+                                        values("input", "key", "keyHash", "mask", "unused"))));
+    }
+
+    @Test
+    public void testAllInputsReferenced()
+            throws Exception
+    {
+        tester().assertThat(new PruneAggregationSourceColumns())
+                .on(p -> buildAggregation(p, symbol -> !symbol.getName().equals("unused")))
+                .doesNotFire();
+    }
+
+    private AggregationNode buildAggregation(PlanBuilder planBuilder, Predicate<Symbol> sourceSymbolFilter)
+    {
+        Symbol avg = planBuilder.symbol("avg");
+        Symbol input = planBuilder.symbol("input");
+        Symbol key = planBuilder.symbol("key");
+        Symbol keyHash = planBuilder.symbol("keyHash");
+        Symbol mask = planBuilder.symbol("mask");
+        Symbol unused = planBuilder.symbol("unused");
+        List<Symbol> sourceSymbols = ImmutableList.of(input, key, keyHash, mask, unused);
+        return planBuilder.aggregation(aggregationBuilder -> aggregationBuilder
+                .addGroupingSet(key)
+                .addAggregation(avg, planBuilder.expression("avg(input)"), ImmutableList.of(BIGINT), mask)
+                .hashSymbol(keyHash)
+                .source(
+                        planBuilder.values(
+                                sourceSymbols.stream()
+                                        .filter(sourceSymbolFilter)
+                                        .collect(toImmutableList()),
+                                ImmutableList.of())));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -183,10 +183,20 @@ public class PlanBuilder
 
         public AggregationBuilder addAggregation(Symbol output, Expression expression, List<Type> inputTypes)
         {
+            return addAggregation(output, expression, inputTypes, Optional.empty());
+        }
+
+        public AggregationBuilder addAggregation(Symbol output, Expression expression, List<Type> inputTypes, Symbol mask)
+        {
+            return addAggregation(output, expression, inputTypes, Optional.of(mask));
+        }
+
+        private AggregationBuilder addAggregation(Symbol output, Expression expression, List<Type> inputTypes, Optional<Symbol> mask)
+        {
             checkArgument(expression instanceof FunctionCall);
             FunctionCall aggregation = (FunctionCall) expression;
             Signature signature = metadata.getFunctionRegistry().resolveFunction(aggregation.getName(), TypeSignatureProvider.fromTypes(inputTypes));
-            return addAggregation(output, new Aggregation(aggregation, signature, Optional.empty()));
+            return addAggregation(output, new Aggregation(aggregation, signature, mask));
         }
 
         public AggregationBuilder addAggregation(Symbol output, Aggregation aggregation)


### PR DESCRIPTION
Migrate PruneUnreferencedOutputs handling of AggregationNode to the iterative optimizer.
This patch adds two rules, one which looks for a project-off of AggregationNode outputs, and one which inserts a project-off below an AggregationNode, discarding unused inputs.  There are two rules because it may be possible to discard unused inputs even if there is no project-off above the AggregationNode.