### PR TITLE
Reverse deprecation in PlanNodeSearcher

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
@@ -31,12 +31,16 @@ import static java.util.Objects.requireNonNull;
 
 public class PlanNodeSearcher
 {
-    @Deprecated
     public static PlanNodeSearcher searchFrom(PlanNode node)
     {
         return searchFrom(node, noLookup());
     }
 
+    /**
+     * Use it in optimizer {@link com.facebook.presto.sql.planner.iterative.Rule} only if you truly do not have a better option
+     *
+     * TODO: replace it with a support for plan (physical) properties in rules pattern matching
+     */
     public static PlanNodeSearcher searchFrom(PlanNode node, Lookup lookup)
     {
         return new PlanNodeSearcher(node, lookup);
@@ -47,7 +51,7 @@ public class PlanNodeSearcher
     private Predicate<PlanNode> where = alwaysTrue();
     private Predicate<PlanNode> recurseOnlyWhen = alwaysTrue();
 
-    public PlanNodeSearcher(PlanNode node, Lookup lookup)
+    private PlanNodeSearcher(PlanNode node, Lookup lookup)
     {
         this.node = requireNonNull(node, "node is null");
         this.lookup = requireNonNull(lookup, "lookup is null");


### PR DESCRIPTION
Reverse deprecation in PlanNodeSearcher

Using a plan node searcher without a lookup is completely fine, as it
requires to have accessible fully fledge plan node tree.

On the other side, using a plan node searcher with lookup enables
optimizer rules to overuse Lookup. Rule by design should not traverse
the tree. Hence, such plan node searcher usage should be replaced with
usage of traits and better pattern matching.
