### PR TITLE
Storage Based Security plugin for Hive backend

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -114,7 +114,7 @@ public class HiveClientConfig
 
     private boolean writesToNonManagedTablesEnabled;
 
-    private String hiveMetastoreWarehouseDir = "/usr/hive/warehouse";
+    private String hiveMetastoreWarehouseDir = "./warehouse";
 
     public String getHiveMetastoreWarehouseDir()
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -114,6 +114,20 @@ public class HiveClientConfig
 
     private boolean writesToNonManagedTablesEnabled;
 
+    private String hiveMetastoreWarehouseDir = "/usr/hive/warehouse";
+
+    public String getHiveMetastoreWarehouseDir()
+    {
+        return hiveMetastoreWarehouseDir;
+    }
+
+    @Config("hive.metastore-warehouse-dir")
+    public HiveClientConfig setHiveMetastoreWarehouseDir(String hiveMetastoreWarehouseDir)
+    {
+        this.hiveMetastoreWarehouseDir = hiveMetastoreWarehouseDir;
+        return this;
+    }
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -41,6 +41,7 @@ public class HiveMetadataFactory
     private final boolean writesToNonManagedTablesEnabled;
     private final HiveStorageFormat defaultStorageFormat;
     private final long perTransactionCacheMaximumSize;
+    private final String metastoreWarehouseDir;
     private final ExtendedHiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final HivePartitionManager partitionManager;
@@ -82,6 +83,7 @@ public class HiveMetadataFactory
                 hiveClientConfig.getWritesToNonManagedTablesEnabled(),
                 hiveClientConfig.getHiveStorageFormat(),
                 hiveClientConfig.getPerTransactionMetastoreCacheMaximumSize(),
+                hiveClientConfig.getHiveMetastoreWarehouseDir(),
                 typeManager,
                 locationService,
                 tableParameterCodec,
@@ -105,6 +107,7 @@ public class HiveMetadataFactory
             boolean writesToNonManagedTablesEnabled,
             HiveStorageFormat defaultStorageFormat,
             long perTransactionCacheMaximumSize,
+            String metastoreWarehouseDir,
             TypeManager typeManager,
             LocationService locationService,
             TableParameterCodec tableParameterCodec,
@@ -122,6 +125,7 @@ public class HiveMetadataFactory
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
         this.defaultStorageFormat = requireNonNull(defaultStorageFormat, "defaultStorageFormat is null");
         this.perTransactionCacheMaximumSize = perTransactionCacheMaximumSize;
+        this.metastoreWarehouseDir = metastoreWarehouseDir;
 
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -162,6 +166,7 @@ public class HiveMetadataFactory
                 respectTableFormat,
                 bucketWritingEnabled,
                 writesToNonManagedTablesEnabled,
+                metastoreWarehouseDir,
                 defaultStorageFormat,
                 typeManager,
                 locationService,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -119,16 +119,7 @@ public class FileHiveMetastore
     @Override
     public synchronized void createDatabase(Database database)
     {
-        requireNonNull(database, "database is null");
-
-        if (database.getLocation().isPresent()) {
-            throw new PrestoException(HIVE_METASTORE_ERROR, "Database can not be created with a location set");
-        }
-
-        verifyDatabaseNotExists(database.getDatabaseName());
-
-        Path databaseMetadataDirectory = getDatabaseMetadataDirectory(database.getDatabaseName());
-        writeSchemaFile("database", databaseMetadataDirectory, databaseCodec, new DatabaseMetadata(database), false);
+        createDatabase(database, true);
     }
 
     @Override
@@ -171,6 +162,20 @@ public class FileHiveMetastore
         Path databaseMetadataDirectory = getDatabaseMetadataDirectory(databaseName);
         return readSchemaFile("database", databaseMetadataDirectory, databaseCodec)
                 .map(databaseMetadata -> databaseMetadata.toDatabase(databaseName, databaseMetadataDirectory.toString()));
+    }
+
+    protected void createDatabase(Database database, boolean checkLocation)
+    {
+        requireNonNull(database, "database is null");
+
+        if (checkLocation && database.getLocation().isPresent()) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, "Database can not be created with a location set");
+        }
+
+        verifyDatabaseNotExists(database.getDatabaseName());
+
+        Path databaseMetadataDirectory = getDatabaseMetadataDirectory(database.getDatabaseName());
+        writeSchemaFile("database", databaseMetadataDirectory, databaseCodec, new DatabaseMetadata(database), false);
     }
 
     private Database getRequiredDatabase(String databaseName)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/HiveSecurityModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/HiveSecurityModule.java
@@ -31,6 +31,7 @@ public class HiveSecurityModule
         bindSecurityModule("file", new FileBasedAccessControlModule());
         bindSecurityModule("read-only", new ReadOnlySecurityModule());
         bindSecurityModule("sql-standard", new SqlStandardSecurityModule());
+        bindSecurityModule("storage-based", new StorageBasedSecurityModule());
     }
 
     private void bindSecurityModule(String name, Module module)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/StorageBasedAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/StorageBasedAccessControl.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.security;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveConnectorId;
+import com.facebook.presto.hive.HiveTransactionHandle;
+import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.security.AccessDeniedException;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
+import com.google.inject.Inject;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.security.AccessControlException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropSchema;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyDropView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyGrantTablePrivilege;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameColumn;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameSchema;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTablesMetadata;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class StorageBasedAccessControl
+        implements ConnectorAccessControl
+{
+    public static final String ADMIN_ROLE_NAME = "admin";
+    private static final String INFORMATION_SCHEMA_NAME = "information_schema";
+
+    private final String connectorId;
+    private final Function<HiveTransactionHandle, SemiTransactionalHiveMetastore> metastoreProvider;
+    private final ExtendedHiveMetastore metastore;
+    private final HdfsEnvironment hdfsEnvironment;
+
+    @Inject
+    public StorageBasedAccessControl(
+            HiveConnectorId connectorId,
+            Function<HiveTransactionHandle, SemiTransactionalHiveMetastore> metastoreProvider,
+            ExtendedHiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment)
+    {
+        this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
+        this.metastoreProvider = requireNonNull(metastoreProvider, "metastoreProvider is null");
+        this.metastore = metastore;
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+    }
+
+    @Override
+    public void checkCanCreateSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        // check if is admin or write at location ?
+    }
+
+    @Override
+    public void checkCanDropSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        if (!checkDatabaseFSAction(transactionHandle, identity, schemaName, FsAction.WRITE)) {
+            denyDropSchema(schemaName);
+        }
+    }
+
+    @Override
+    public void checkCanRenameSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName, String newSchemaName)
+    {
+        if (!checkDatabaseFSAction(transactionHandle, identity, schemaName, FsAction.WRITE)) {
+            denyRenameSchema(schemaName, newSchemaName);
+        }
+    }
+
+    @Override
+    public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
+    {
+        System.out.println("here was me Zwierzonka");
+    }
+
+    @Override
+    public Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
+    {
+        return schemaNames;
+    }
+
+    @Override
+    public void checkCanCreateTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkDatabaseFSAction(transaction, identity, tableName.getSchemaName(), FsAction.WRITE)) {
+            denyCreateTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanDropTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTableFSAction(transaction, identity, tableName, FsAction.WRITE)) {
+            denyDropTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanRenameTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName, SchemaTableName newTableName)
+    {
+        if (!checkTableFSAction(transaction, identity, tableName, FsAction.WRITE)) {
+            denyRenameTable(tableName.toString(), newTableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanShowTablesMetadata(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        if (!checkDatabaseFSAction(transactionHandle, identity, schemaName, FsAction.READ)) {
+            denyShowTablesMetadata(schemaName);
+        }
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
+    {
+        return tableNames;
+    }
+
+    @Override
+    public void checkCanAddColumn(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTableFSAction(transaction, identity, tableName, FsAction.WRITE)) {
+            denyAddColumn(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanRenameColumn(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTableFSAction(transaction, identity, tableName, FsAction.WRITE)) {
+            denyRenameColumn(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTableFSAction(transaction, identity, tableName, FsAction.READ)) {
+            denySelectTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTableFSAction(transaction, identity, tableName, FsAction.WRITE)) {
+            denyInsertTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTableFSAction(transaction, identity, tableName, FsAction.WRITE)) {
+            denyDeleteTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanCreateView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
+    {
+        if (!checkDatabaseFSAction(transaction, identity, viewName.getSchemaName(), FsAction.WRITE)) {
+            denyCreateView(viewName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanDropView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
+    {
+        // because view is not materialized checking for database credentials
+        if (!checkDatabaseFSAction(transaction, identity, viewName.getSchemaName(), FsAction.WRITE)) {
+            denyDropView(viewName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
+    {
+        // because view is not materialized checking for database credentials
+        if (!checkDatabaseFSAction(transaction, identity, viewName.getSchemaName(), FsAction.READ)) {
+            denySelectView(viewName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
+    {
+        if (!checkTableFSAction(transaction, identity, tableName, FsAction.READ)) {
+            denySelectTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
+    {
+        if (!checkDatabaseFSAction(transaction, identity, viewName.getSchemaName(), FsAction.READ)) {
+            denySelectView(viewName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
+    {
+        // TODO: when this is updated to have a transaction, use isAdmin()
+        if (!metastore.getRoles(identity.getUser()).contains(ADMIN_ROLE_NAME)) {
+            denySetCatalogSessionProperty(connectorId, propertyName);
+        }
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(ConnectorTransactionHandle transaction, Identity identity, Privilege privilege, SchemaTableName tableName, String grantee, boolean withGrantOption)
+    {
+        denyGrantTablePrivilege(tableName.toString(), "In storage based security mode grants are not allowed.");
+    }
+
+    @Override
+    public void checkCanRevokeTablePrivilege(ConnectorTransactionHandle transaction, Identity identity, Privilege privilege, SchemaTableName tableName, String revokee, boolean grantOptionFor)
+    {
+        denyRevokeTablePrivilege(tableName.toString(), "In storage based security mode grants are not allowed.");
+    }
+
+    private boolean checkDatabaseFSAction(ConnectorTransactionHandle transaction, Identity identity, String schemaName, FsAction action)
+    {
+        Optional<Database> target = metastoreProvider.apply(((HiveTransactionHandle) transaction)).getDatabase(schemaName);
+
+        if (!target.isPresent()) {
+            throw new AccessDeniedException(format("Database %s not found", schemaName));
+        }
+
+        String targetLocation = target.get().getLocation().get();
+        String user = identity.getUser();
+
+        return checkFSActionClassloader(user, targetLocation, action);
+    }
+
+    private boolean checkTableFSAction(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName, FsAction action)
+    {
+        if (INFORMATION_SCHEMA_NAME.equals(tableName.getSchemaName())) {
+            return true;
+        }
+
+        Optional<Table> target = metastoreProvider.apply(((HiveTransactionHandle) transaction)).getTable(tableName.getSchemaName(), tableName.getTableName());
+
+        if (!target.isPresent()) {
+            throw new AccessDeniedException(format("Table %s not found", tableName.getTableName()));
+        }
+
+        String targetLocation = target.get().getStorage().getLocation();
+        String user = identity.getUser();
+
+        return checkFSActionClassloader(user, targetLocation, action);
+    }
+
+    private boolean checkFSActionClassloader(String user, String targetLocation, FsAction action)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(this.getClass().getClassLoader())) {
+            return checkFSAction(user, targetLocation, action);
+        }
+    }
+
+    private boolean checkFSAction(String user, String targetLocation, FsAction action)
+    {
+        try {
+            Path targetPath = new Path(targetLocation);
+            FileSystem tableFS = this.hdfsEnvironment.getFileSystem(user, targetPath);
+            tableFS.access(targetPath, action);
+        }
+        catch (AccessControlException e) {
+            return false;
+        }
+        catch (FileNotFoundException e) {
+            throw new AccessDeniedException(
+                    format("Location %s does not exist. Details: %s", targetLocation, e.getMessage()));
+        }
+        catch (IOException e) {
+            throw new AccessDeniedException(
+                    format("IO error: %s", targetLocation, e.getMessage()));
+        }
+        return true;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/StorageBasedSecurityModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/StorageBasedSecurityModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.security;
+
+import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class StorageBasedSecurityModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(ConnectorAccessControl.class).to(StorageBasedAccessControl.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -527,6 +527,7 @@ public abstract class AbstractTestHiveClient
                 false,
                 HiveStorageFormat.RCBINARY,
                 1000,
+                "/usr/hive/warehouse",
                 TYPE_MANAGER,
                 locationService,
                 new TableParameterCodec(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -16,8 +16,8 @@ package com.facebook.presto.hive;
 import com.facebook.presto.Session;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.MockFileHiveMetastore;
 import com.facebook.presto.hive.metastore.PrincipalType;
-import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
@@ -88,11 +88,13 @@ public final class HiveQueryRunner
             File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
 
             HiveClientConfig hiveClientConfig = new HiveClientConfig();
+            hiveClientConfig.setHiveMetastoreWarehouseDir("/tmp/usr/hive/warehouse");
+
             HiveS3Config s3Config = new HiveS3Config();
-            HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig, s3Config));
+            HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new MockHdfsConfigurationUpdater(hiveClientConfig, s3Config));
             HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
 
-            FileHiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
+            MockFileHiveMetastore metastore = new MockFileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
             metastore.createDatabase(createDatabaseMetastoreObject(TPCH_SCHEMA));
             metastore.createDatabase(createDatabaseMetastoreObject(TPCH_BUCKETED_SCHEMA));
             queryRunner.installPlugin(new HivePlugin(HIVE_CATALOG, metastore));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/MockHdfsConfigurationUpdater.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/MockHdfsConfigurationUpdater.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.conf.Configuration;
+
+public class MockHdfsConfigurationUpdater extends HdfsConfigurationUpdater
+{
+    public MockHdfsConfigurationUpdater(HiveClientConfig hiveClientConfig, HiveS3Config s3Config)
+    {
+        super(hiveClientConfig, s3Config);
+    }
+
+    @Override
+    public void updateConfiguration(Configuration config)
+    {
+        super.updateConfiguration(config);
+        config.set("fs.file.impl", "com.facebook.presto.hive.filesystem.MockRawLocalFileSystem");
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -89,7 +89,8 @@ public class TestHiveClientConfig
                 .setBucketExecutionEnabled(true)
                 .setBucketWritingEnabled(true)
                 .setFileSystemMaxCacheSize(1000)
-                .setWritesToNonManagedTablesEnabled(false));
+                .setWritesToNonManagedTablesEnabled(false)
+                .setHiveMetastoreWarehouseDir("/usr/hive/warehouse"));
     }
 
     @Test
@@ -150,6 +151,7 @@ public class TestHiveClientConfig
                 .put("hive.bucket-writing", "false")
                 .put("hive.fs.cache.max-size", "1010")
                 .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.metastore-warehouse-dir", "/tmp/usr/hive/warehouse-test")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -206,7 +208,8 @@ public class TestHiveClientConfig
                 .setBucketExecutionEnabled(false)
                 .setBucketWritingEnabled(false)
                 .setFileSystemMaxCacheSize(1010)
-                .setWritesToNonManagedTablesEnabled(true);
+                .setWritesToNonManagedTablesEnabled(true)
+                .setHiveMetastoreWarehouseDir("/tmp/usr/hive/warehouse-test");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -90,7 +90,7 @@ public class TestHiveClientConfig
                 .setBucketWritingEnabled(true)
                 .setFileSystemMaxCacheSize(1000)
                 .setWritesToNonManagedTablesEnabled(false)
-                .setHiveMetastoreWarehouseDir("/usr/hive/warehouse"));
+                .setHiveMetastoreWarehouseDir("./warehouse"));
     }
 
     @Test

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -31,6 +31,7 @@ import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
+import io.airlift.testing.FileUtils;
 import org.apache.hadoop.fs.Path;
 import org.intellij.lang.annotations.Language;
 import org.joda.time.DateTime;
@@ -116,6 +117,9 @@ public class TestHiveIntegrationSmokeTest
     @Test
     public void testSchemaOperations()
     {
+        String defaultMetastoreWarehouseDir = new HiveClientConfig().getHiveMetastoreWarehouseDir();
+        FileUtils.deleteRecursively(new File(defaultMetastoreWarehouseDir + "/new_schema.db"));
+
         assertUpdate("CREATE SCHEMA new_schema");
 
         assertUpdate("CREATE TABLE new_schema.test (x bigint)");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/filesystem/MockRawLocalFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/filesystem/MockRawLocalFileSystem.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.filesystem;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.fs.permission.AclEntry;
+import org.apache.hadoop.fs.permission.AclStatus;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.security.AccessControlException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+
+public class MockRawLocalFileSystem extends RawLocalFileSystem
+{
+    @Override
+    public AclStatus getAclStatus(Path path) throws IOException
+    {
+        AclStatus.Builder builder = new AclStatus.Builder();
+        return builder
+                .owner("presto")
+                .group("presto")
+                .setPermission(FsPermission.getDefault())
+                .build();
+    }
+
+    @Override
+    public boolean mkdirs(Path f) throws IOException
+    {
+        try {
+            return super.mkdirs(f);
+        }
+        catch (IOException ex) {
+            return true;
+        }
+    }
+
+    @Override
+    public void access(Path path, FsAction mode) throws AccessControlException, FileNotFoundException, IOException
+    {
+    }
+
+    @Override
+    public void setOwner(Path p, String username, String groupname) throws IOException
+    {
+    }
+
+    @Override
+    public void modifyAclEntries(Path path, List<AclEntry> aclSpec) throws IOException
+    {
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/MockFileHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/MockFileHiveMetastore.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
+
+public class MockFileHiveMetastore extends FileHiveMetastore
+{
+    public MockFileHiveMetastore(HdfsEnvironment hdfsEnvironment, String catalogDirectory, String metastoreUser)
+    {
+        super(hdfsEnvironment, catalogDirectory, metastoreUser);
+    }
+
+    @Override
+    public synchronized void createDatabase(Database database)
+    {
+        super.createDatabase(database, false);
+    }
+}


### PR DESCRIPTION
Storage Based Security plugin analogous to Hive Metastore Storage based security plugin. All access control checks are delegated to HDFS. Plugin translates SQL DDL and DML commands to underneath HDFS read and write operations: https://github.com/prestodb/presto/issues/8522