### PR TITLE
Fix potential native memory leak

### DIFF
--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/BufferedOutputStreamSliceOutput.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/BufferedOutputStreamSliceOutput.java
@@ -76,8 +76,12 @@ public class BufferedOutputStreamSliceOutput
     public void close()
             throws IOException
     {
-        flushBufferToOutputStream();
-        outputStream.close();
+        try {
+            flushBufferToOutputStream();
+        }
+        finally {
+            outputStream.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
Make sure we `close()` the output stream during writes.