### PR TITLE
Make sure to call destroy() on close

### DIFF
--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileReader.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileReader.java
@@ -286,11 +286,14 @@ public class RcFileReader
         rowGroupPosition = 0;
         rowGroupRowCount = 0;
         currentChunkRowCount = 0;
-        input.close();
-        if (decompressor != null) {
-            decompressor.destroy();
+        try  {
+            input.close();
         }
-
+        finally {
+            if (decompressor != null) {
+                decompressor.destroy();
+            }
+        }
         if (writeChecksumBuilder.isPresent()) {
             WriteChecksum actualChecksum = writeChecksumBuilder.get().build();
             validateWrite(validation -> validation.getChecksum().getTotalRowCount() == actualChecksum.getTotalRowCount(), "Invalid row count");


### PR DESCRIPTION
`AircompressorDecompressor::destroy()` is a nop so for now this is not a problem, but
`destroy()` returns codecs to the pool for `HadoopDecompressor`s so it has to be called
to prevent leaks.