### PR TITLE
Fix flaky test TestPrestoDriver::testQueryTimeout()

### DIFF
--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -1497,7 +1497,7 @@ public class TestPrestoDriver
         });
 
         // make sure the query timed out
-        assertTrue(queryFinished.await(2, SECONDS));
+        queryFinished.await();
         assertNotNull(queryFailure.get());
         assertContains(queryFailure.get().getMessage(), "Query exceeded maximum time limit of 1.00s");
 


### PR DESCRIPTION
Hit this one again ([travis job](https://travis-ci.org/prestodb/presto/jobs/254646458), previously reported in #8272). 

I guess the reason for flakiness is that the `SqlQueryManager` thread that enforces the runtime limits run every second so it's easy to hit the timeout of 2 seconds.

Without the change I can easily repro this locally, and with the change I ran the test ~30 times and all passed. Note that the method has a timeout of 4 seconds.