### PR TITLE
Update to presto-maven-plugin 0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1166,9 +1166,9 @@
             </plugin>
 
             <plugin>
-                <groupId>io.takari.maven.plugins</groupId>
+                <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-maven-plugin</artifactId>
-                <version>0.1.12</version>
+                <version>0.2</version>
                 <extensions>true</extensions>
             </plugin>
 


### PR DESCRIPTION
This version preserves the exception when scanning for plugin classes fails.
