### PR TITLE
Add PruneWindowColumns Rule

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -52,6 +52,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinFilteringSour
 import com.facebook.presto.sql.planner.iterative.rule.PruneTableScanColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneTopNColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneWindowColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
@@ -158,6 +159,7 @@ public class PlanOptimizers
                 new PruneSemiJoinFilteringSourceColumns(),
                 new PruneTopNColumns(),
                 new PruneValuesColumns(),
+                new PruneWindowColumns(),
                 new PruneTableScanColumns());
 
         IterativeOptimizer inlineProjections = new IterativeOptimizer(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneWindowColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneWindowColumns.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolsExtractor;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
+import static com.facebook.presto.sql.planner.plan.Patterns.window;
+
+public class PruneWindowColumns
+        extends ProjectOffPushDownRule<WindowNode>
+{
+    public PruneWindowColumns()
+    {
+        super(window());
+    }
+
+    @Override
+    protected Optional<PlanNode> pushDownProjectOff(PlanNodeIdAllocator idAllocator, WindowNode windowNode, Set<Symbol> referencedOutputs)
+    {
+        Map<Symbol, WindowNode.Function> referencedFunctions = Maps.filterKeys(
+                windowNode.getWindowFunctions(),
+                referencedOutputs::contains);
+
+        if (referencedFunctions.isEmpty()) {
+            return Optional.of(windowNode.getSource());
+        }
+
+        ImmutableSet.Builder<Symbol> referencedInputs = ImmutableSet.<Symbol>builder()
+                .addAll(windowNode.getSource().getOutputSymbols().stream()
+                        .filter(referencedOutputs::contains)
+                        .iterator())
+                .addAll(windowNode.getPartitionBy())
+                .addAll(windowNode.getOrderBy());
+
+        windowNode.getHashSymbol().ifPresent(referencedInputs::add);
+
+        for (WindowNode.Function windowFunction : referencedFunctions.values()) {
+            referencedInputs.addAll(SymbolsExtractor.extractUnique(windowFunction.getFunctionCall()));
+            windowFunction.getFrame().getStartValue().ifPresent(referencedInputs::add);
+            windowFunction.getFrame().getEndValue().ifPresent(referencedInputs::add);
+        }
+
+        PlanNode prunedWindowNode = new WindowNode(
+                windowNode.getId(),
+                restrictOutputs(idAllocator, windowNode.getSource(), referencedInputs.build())
+                        .orElse(windowNode.getSource()),
+                windowNode.getSpecification(),
+                referencedFunctions,
+                windowNode.getHashSymbol(),
+                windowNode.getPrePartitionedInputs(),
+                windowNode.getPreSortedOrderPrefix());
+
+        if (prunedWindowNode.getOutputSymbols().size() == windowNode.getOutputSymbols().size()) {
+            // Neither function pruning nor input pruning was successful.
+            return Optional.empty();
+        }
+
+        return Optional.of(prunedWindowNode);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.WindowFrame;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.window;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.windowFrame;
+import static com.facebook.presto.sql.tree.FrameBound.Type.CURRENT_ROW;
+import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+import static com.google.common.base.Predicates.alwaysTrue;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class TestPruneWindowColumns
+        extends BaseRuleTest
+{
+    private static final Signature signature = new Signature(
+            "min",
+            FunctionKind.WINDOW,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            BIGINT.getTypeSignature(),
+            ImmutableList.of(BIGINT.getTypeSignature()),
+            false);
+
+    private static final List<String> inputSymbolNameList =
+            ImmutableList.of("orderKey", "partitionKey", "hash", "startValue1", "startValue2", "endValue1", "endValue2", "input1", "input2", "unused");
+    private static final Set<String> inputSymbolNameSet = ImmutableSet.copyOf(inputSymbolNameList);
+
+    private static final ExpectedValueProvider<WindowNode.Frame> frameProvider1 = windowFrame(
+            WindowFrame.Type.RANGE,
+            UNBOUNDED_PRECEDING,
+            Optional.of("startValue1"),
+            CURRENT_ROW,
+            Optional.of("endValue1"));
+
+    private static final ExpectedValueProvider<WindowNode.Frame> frameProvider2 = windowFrame(
+            WindowFrame.Type.RANGE,
+            UNBOUNDED_PRECEDING,
+            Optional.of("startValue2"),
+            CURRENT_ROW,
+            Optional.of("endValue2"));
+
+    @Test
+    public void testWindowNotNeeded()
+    {
+        tester().assertThat(new PruneWindowColumns())
+                .on(p -> buildProjectedWindow(p, symbol -> inputSymbolNameSet.contains(symbol.getName()), alwaysTrue()))
+                .matches(
+                        strictProject(
+                                Maps.asMap(inputSymbolNameSet, PlanMatchPattern::expression),
+                                values(inputSymbolNameList)));
+    }
+
+    @Test
+    public void testOneFunctionNotNeeded()
+    {
+        tester().assertThat(new PruneWindowColumns())
+                .on(p -> buildProjectedWindow(p,
+                        symbol -> symbol.getName().equals("output2") || symbol.getName().equals("unused"),
+                        alwaysTrue()))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of(
+                                        "output2", expression("output2"),
+                                        "unused", expression("unused")),
+                                window(windowBuilder -> windowBuilder
+                                                .prePartitionedInputs(ImmutableSet.of())
+                                                .specification(
+                                                        ImmutableList.of("partitionKey"),
+                                                        ImmutableList.of("orderKey"),
+                                                        ImmutableMap.of("orderKey", SortOrder.ASC_NULLS_FIRST))
+                                                .preSortedOrderPrefix(0)
+                                                .addFunction(
+                                                        "output2",
+                                                        functionCall("min", ImmutableList.of("input2")),
+                                                        signature,
+                                                        frameProvider2)
+                                                .hashSymbol("hash"),
+                                        strictProject(
+                                                Maps.asMap(
+                                                        Sets.difference(inputSymbolNameSet, ImmutableSet.of("input1", "startValue1", "endValue1")),
+                                                        PlanMatchPattern::expression),
+                                                values(inputSymbolNameList)))));
+    }
+
+    @Test
+    public void testAllColumnsNeeded()
+    {
+        tester().assertThat(new PruneWindowColumns())
+                .on(p -> buildProjectedWindow(p, alwaysTrue(), alwaysTrue()))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testUsedInputsNotNeeded()
+    {
+        // If the WindowNode needs all its inputs, we can't discard them from its child.
+        tester().assertThat(new PruneWindowColumns())
+                .on(p -> buildProjectedWindow(
+                        p,
+                        // only the window function outputs
+                        symbol -> !inputSymbolNameSet.contains(symbol.getName()),
+                        // only the used input symbols
+                        symbol -> !symbol.getName().equals("unused")))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testUnusedInputNotNeeded()
+    {
+        tester().assertThat(new PruneWindowColumns())
+                .on(p -> buildProjectedWindow(
+                        p,
+                        // only the window function outputs
+                        symbol -> !inputSymbolNameSet.contains(symbol.getName()),
+                        alwaysTrue()))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of(
+                                        "output1", expression("output1"),
+                                        "output2", expression("output2")),
+                                window(windowBuilder -> windowBuilder
+                                                .prePartitionedInputs(ImmutableSet.of())
+                                                .specification(
+                                                        ImmutableList.of("partitionKey"),
+                                                        ImmutableList.of("orderKey"),
+                                                        ImmutableMap.of("orderKey", SortOrder.ASC_NULLS_FIRST))
+                                                .preSortedOrderPrefix(0)
+                                                .addFunction(
+                                                        "output1",
+                                                        functionCall("min", ImmutableList.of("input1")),
+                                                        signature,
+                                                        frameProvider1)
+                                                .addFunction(
+                                                        "output2",
+                                                        functionCall("min", ImmutableList.of("input2")),
+                                                        signature,
+                                                        frameProvider2)
+                                                .hashSymbol("hash"),
+                                        strictProject(
+                                                Maps.asMap(
+                                                        Sets.filter(inputSymbolNameSet, symbolName -> !symbolName.equals("unused")),
+                                                        PlanMatchPattern::expression),
+                                                values(inputSymbolNameList)))));
+    }
+
+    private static PlanNode buildProjectedWindow(
+            PlanBuilder p,
+            Predicate<Symbol> projectionFilter,
+            Predicate<Symbol> sourceFilter)
+    {
+        Symbol orderKey = p.symbol("orderKey");
+        Symbol partitionKey = p.symbol("partitionKey");
+        Symbol hash = p.symbol("hash");
+        Symbol startValue1 = p.symbol("startValue1");
+        Symbol startValue2 = p.symbol("startValue2");
+        Symbol endValue1 = p.symbol("endValue1");
+        Symbol endValue2 = p.symbol("endValue2");
+        Symbol input1 = p.symbol("input1");
+        Symbol input2 = p.symbol("input2");
+        Symbol unused = p.symbol("unused");
+        Symbol output1 = p.symbol("output1");
+        Symbol output2 = p.symbol("output2");
+        List<Symbol> inputs = ImmutableList.of(orderKey, partitionKey, hash, startValue1, startValue2, endValue1, endValue2, input1, input2, unused);
+        List<Symbol> outputs = ImmutableList.<Symbol>builder().addAll(inputs).add(output1, output2).build();
+
+        return p.project(
+                Assignments.identity(
+                        outputs.stream()
+                                .filter(projectionFilter)
+                                .collect(toImmutableList())),
+                p.window(
+                        new WindowNode.Specification(
+                                ImmutableList.of(partitionKey),
+                                ImmutableList.of(orderKey),
+                                ImmutableMap.of(orderKey, SortOrder.ASC_NULLS_FIRST)),
+                        ImmutableMap.of(
+                                output1,
+                                new WindowNode.Function(
+                                        new FunctionCall(QualifiedName.of("min"), ImmutableList.of(input1.toSymbolReference())),
+                                        signature,
+                                        new WindowNode.Frame(
+                                                WindowFrame.Type.RANGE,
+                                                UNBOUNDED_PRECEDING,
+                                                Optional.of(startValue1),
+                                                CURRENT_ROW,
+                                                Optional.of(endValue1))),
+                                output2,
+                                new WindowNode.Function(
+                                        new FunctionCall(QualifiedName.of("min"), ImmutableList.of(input2.toSymbolReference())),
+                                        signature,
+                                        new WindowNode.Frame(
+                                                WindowFrame.Type.RANGE,
+                                                UNBOUNDED_PRECEDING,
+                                                Optional.of(startValue2),
+                                                CURRENT_ROW,
+                                                Optional.of(endValue2)))),
+                        hash,
+                        p.values(
+                                inputs.stream()
+                                        .filter(sourceFilter)
+                                        .collect(toImmutableList()),
+                                ImmutableList.of())));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -574,6 +574,18 @@ public class PlanBuilder
                 0);
     }
 
+    public WindowNode window(WindowNode.Specification specification, Map<Symbol, WindowNode.Function> functions, Symbol hashSymbol, PlanNode source)
+    {
+        return new WindowNode(
+                idAllocator.getNextId(),
+                source,
+                specification,
+                ImmutableMap.copyOf(functions),
+                Optional.of(hashSymbol),
+                ImmutableSet.of(),
+                0);
+    }
+
     public static Expression expression(String sql)
     {
         return ExpressionUtils.rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(sql));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
@@ -142,14 +142,15 @@ public class TestReorderWindows
                         window(windowMatcherBuilder -> windowMatcherBuilder
                                         .specification(windowAp)
                                         .addFunction(functionCall("min", commonFrame, ImmutableList.of(TAX_ALIAS))),
-                                window(windowMatcherBuilder -> windowMatcherBuilder
-                                                .specification(windowA)
-                                                .addFunction(functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
-                                        anyTree(
-                                                window(windowMatcherBuilder -> windowMatcherBuilder
-                                                                .specification(windowB)
-                                                                .addFunction(functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
-                                                        anyTree(LINEITEM_TABLESCAN_DOQPRSST))))));
+                                project(
+                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                        .specification(windowA)
+                                                        .addFunction(functionCall("sum", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
+                                                project(
+                                                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                                                        .specification(windowB)
+                                                                        .addFunction(functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),
+                                                                anyTree(LINEITEM_TABLESCAN_DOQPRSST)))))));
 
         assertPlan(sql, pattern);
     }


### PR DESCRIPTION
Migrate PruneUnreferencedOutputs handling of WindowNode to the iterative
optimizer.  This rule finds a WindowNode that's under a project, such
that the WindowNode defines a new column not needed by the parent, or
the grandchild produces columns not needed by either the parent or the
WindowNode, and remove any unneeded window functions, and creates a new
project grandchild to discard any unused columns.  Subsequent rules may
match the pattern of the new grandchild (project) over the old
grandchild, and do further pruning.

This PR contains a commit cherry-picked from https://github.com/prestodb/presto/pull/8507
which reviewers should ignore.  That commit enhances the window reorder / merge
optimizations so they aren't blocked by the project nodes introduced by
PruneWindowColumns.  PR https://github.com/prestodb/presto/pull/8507 needs to get merged before this one.