### PR TITLE
Fix humongous allocation when computing retained size for SliceArrayBlock

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
@@ -225,7 +225,7 @@ public class SliceArrayBlock
     private static long getSliceArrayRetainedSizeInBytes(Slice[] values)
     {
         long sizeInBytes = sizeOf(values);
-        Map<Object, Boolean> uniqueRetained = new IdentityHashMap<>(values.length);
+        Map<Object, Boolean> uniqueRetained = new IdentityHashMap<>();
         for (Slice value : values) {
             if (value == null) {
                 continue;


### PR DESCRIPTION

When computing the retained size of a SliceArrayBlock,
an IdentityHashMap will be created  with expected size set to
the number of slices. For a SliceArrayBlock contains 1 million slices,
the IdentityHashMap will contain an Object array with 4,194,304 entires
which will cause humongous allocation.

Most of the slices will share the same base byte array, and setting
such huge expected size is a waste. This commit changes to use the
default expected size. This aligns with other usage of IdentityHashMap
including SliceArrayBlock.deepCopyAndCompact.

![hugeobjectarray2](https://user-images.githubusercontent.com/799346/28351199-31f11664-6c03-11e7-8510-b503917c38a0.png)
