### PR TITLE
Thrift Record Decoder

### DIFF
--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -82,6 +82,18 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
 
+        <!-- Thrift -->
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.5</version>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -94,5 +106,53 @@
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>javax.servlet</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.thrift.tools</groupId>
+                <artifactId>maven-thrift-plugin</artifactId>
+                <version>0.1.11</version>
+                <configuration>
+                    <thriftExecutable>/usr/local/bin/thrift</thriftExecutable>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>thrift-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>thrift-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/DecoderModule.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/DecoderModule.java
@@ -17,6 +17,7 @@ import com.facebook.presto.decoder.csv.CsvDecoderModule;
 import com.facebook.presto.decoder.dummy.DummyDecoderModule;
 import com.facebook.presto.decoder.json.JsonDecoderModule;
 import com.facebook.presto.decoder.raw.RawDecoderModule;
+import com.facebook.presto.decoder.thrift.ThriftDecoderModule;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -38,6 +39,7 @@ public class DecoderModule
         binder.install(new CsvDecoderModule());
         binder.install(new JsonDecoderModule());
         binder.install(new RawDecoderModule());
+        binder.install(new ThriftDecoderModule());
     }
 
     public static void bindRowDecoder(Binder binder, Class<? extends RowDecoder> decoderClass)

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/FieldValueProvider.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/FieldValueProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.decoder;
 
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
 import io.airlift.slice.Slice;
 
 /**
@@ -44,4 +45,9 @@ public abstract class FieldValueProvider
     }
 
     public abstract boolean isNull();
+
+    public Block getBlock()
+    {
+        throw new PrestoException(DecoderErrorCode.DECODER_CONVERSION_NOT_SUPPORTED, "conversion to block not supported");
+    }
 }

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/thrift/ThriftDecoderModule.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/thrift/ThriftDecoderModule.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.decoder.thrift;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.facebook.presto.decoder.DecoderModule.bindFieldDecoder;
+import static com.facebook.presto.decoder.DecoderModule.bindRowDecoder;
+
+public class ThriftDecoderModule implements Module
+{
+  @Override
+  public void configure(Binder binder)
+  {
+    bindRowDecoder(binder, ThriftRowDecoder.class);
+
+    bindFieldDecoder(binder, ThriftFieldDecoder.class);
+  }
+}

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/thrift/ThriftFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/thrift/ThriftFieldDecoder.java
@@ -1,0 +1,368 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.decoder.thrift;
+
+import com.facebook.presto.decoder.DecoderColumnHandle;
+import com.facebook.presto.decoder.FieldDecoder;
+import com.facebook.presto.decoder.FieldValueProvider;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.InterleavedBlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.joda.time.DateTimeZone;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
+import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
+import static com.facebook.presto.spi.type.Varchars.truncateToLength;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ThriftFieldDecoder
+        implements FieldDecoder<Object>
+{
+    @Override
+    public Set<Class<?>> getJavaTypes()
+    {
+        return ImmutableSet.of(boolean.class, long.class, double.class, Slice.class, Block.class);
+    }
+
+    @Override
+    public final String getRowDecoderName()
+    {
+        return ThriftRowDecoder.NAME;
+    }
+
+    @Override
+    public String getFieldDecoderName()
+    {
+        return FieldDecoder.DEFAULT_FIELD_DECODER_NAME;
+    }
+
+    @Override
+    public FieldValueProvider decode(Object value, DecoderColumnHandle columnHandle)
+    {
+        requireNonNull(columnHandle, "columnHandle is null");
+        return new ObjectValueProvider(value, columnHandle);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("FieldDecoder[%s/%s]", getRowDecoderName(), getFieldDecoderName());
+    }
+
+    public static class ObjectValueProvider
+            extends FieldValueProvider
+    {
+        protected final Object value;
+        protected final DecoderColumnHandle columnHandle;
+
+        public ObjectValueProvider(Object value, DecoderColumnHandle columnHandle)
+        {
+            this.columnHandle = requireNonNull(columnHandle, "columnHandle is null");
+            this.value = value;
+        }
+
+        @Override
+        public final boolean accept(DecoderColumnHandle columnHandle)
+        {
+            return this.columnHandle.equals(columnHandle);
+        }
+
+        @Override
+        public final boolean isNull()
+        {
+            return value == null;
+        }
+
+        @Override
+        public boolean getBoolean()
+        {
+            return isNull() ? false : (Boolean) value;
+        }
+
+        @Override
+        public long getLong()
+        {
+            return isNull() ? 0L : getLongExpressedValue(value);
+        }
+
+        private static long getLongExpressedValue(Object value)
+        {
+            if (value instanceof Date) {
+                long storageTime = ((Date) value).getTime();
+                // convert date from VM current time zone to UTC
+                long utcMillis = storageTime + DateTimeZone.getDefault().getOffset(storageTime);
+                return TimeUnit.MILLISECONDS.toDays(utcMillis);
+            }
+            if (value instanceof Timestamp) {
+                long parsedJvmMillis = ((Timestamp) value).getTime();
+                DateTimeZone jvmTimeZone = DateTimeZone.getDefault();
+                long convertedMillis = jvmTimeZone.convertUTCToLocal(parsedJvmMillis);
+
+                return convertedMillis;
+            }
+            if (value instanceof Float) {
+                return floatToRawIntBits(((Float) value));
+            }
+            return ((Number) value).longValue();
+        }
+
+        @Override
+        public double getDouble()
+        {
+            return isNull() ? 0.0d : (Double) value;
+        }
+
+        @Override
+        public Slice getSlice()
+        {
+            return isNull() ? EMPTY_SLICE : getSliceExpressedValue(value, columnHandle.getType());
+        }
+
+        private static Slice getSliceExpressedValue(Object value, Type type)
+        {
+            Slice sliceValue;
+            if (value instanceof String) {
+                sliceValue = Slices.utf8Slice((String) value);
+            }
+            else if (value instanceof byte[]) {
+                sliceValue = Slices.wrappedBuffer((byte[]) value);
+            }
+            else if (value instanceof Integer) {
+                sliceValue = Slices.utf8Slice(value.toString());
+            }
+            else {
+                throw new IllegalStateException("unsupported string field type: " + value.getClass().getName());
+            }
+            if (isVarcharType(type)) {
+                sliceValue = truncateToLength(sliceValue, type);
+            }
+            if (isCharType(type)) {
+                sliceValue = trimSpacesAndTruncateToLength(sliceValue, type);
+            }
+
+            return sliceValue;
+        }
+
+        @Override
+        public Block getBlock()
+        {
+            if (isNull()) {
+                return null;
+            }
+
+            Type type = columnHandle.getType();
+            return serializeObject(type, null, value);
+        }
+
+        private static Block serializeObject(Type type, BlockBuilder builder, Object object)
+        {
+            if (!isStructuralType(type)) {
+                serializePrimitive(type, builder, object);
+                return null;
+            }
+            else if (isArrayType(type)) {
+                return serializeList(type, builder, object);
+            }
+            else if (isMapType(type)) {
+                return serializeMap(type, builder, object);
+            }
+            else if (isRowType(type)) {
+                return serializeStruct(type, builder, object);
+            }
+            throw new RuntimeException("Unknown object type: " + type);
+        }
+
+        private static Block serializeList(Type type, BlockBuilder builder, Object object)
+        {
+            List<?> list = (List) object;
+            if (list == null) {
+                requireNonNull(builder, "parent builder is null").appendNull();
+                return null;
+            }
+
+            List<Type> typeParameters = type.getTypeParameters();
+            checkArgument(typeParameters.size() == 1, "list must have exactly 1 type parameter");
+            Type elementType = typeParameters.get(0);
+
+            BlockBuilder currentBuilder;
+            if (builder != null) {
+                currentBuilder = builder.beginBlockEntry();
+            }
+            else {
+                currentBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), list.size());
+            }
+
+            for (Object element : list) {
+                serializeObject(elementType, currentBuilder, element);
+            }
+
+            if (builder != null) {
+                builder.closeEntry();
+                return null;
+            }
+            else {
+                Block resultBlock = currentBuilder.build();
+                return resultBlock;
+            }
+        }
+
+        private static Block serializeMap(Type type, BlockBuilder builder, Object object)
+        {
+            Map<?, ?> map = (Map) object;
+            if (map == null) {
+                requireNonNull(builder, "parent builder is null").appendNull();
+                return null;
+            }
+
+            List<Type> typeParameters = type.getTypeParameters();
+            checkArgument(typeParameters.size() == 2, "map must have exactly 2 type parameter");
+            Type keyType = typeParameters.get(0);
+            Type valueType = typeParameters.get(1);
+
+            BlockBuilder currentBuilder;
+            if (builder != null) {
+                currentBuilder = builder.beginBlockEntry();
+            }
+            else {
+                currentBuilder = new InterleavedBlockBuilder(typeParameters, new BlockBuilderStatus(), map.size());
+            }
+
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                // Hive skips map entries with null keys
+                if (entry.getKey() != null) {
+                    serializeObject(keyType, currentBuilder, entry.getKey());
+                    serializeObject(valueType, currentBuilder, entry.getValue());
+                }
+            }
+
+            if (builder != null) {
+                builder.closeEntry();
+                return null;
+            }
+            else {
+                Block resultBlock = currentBuilder.build();
+                return resultBlock;
+            }
+        }
+
+        private static Block serializeStruct(Type type, BlockBuilder builder, Object object)
+        {
+            if (object == null) {
+                requireNonNull(builder, "parent builder is null").appendNull();
+                return null;
+            }
+
+            List<Type> typeParameters = type.getTypeParameters();
+            ThriftGenericRow structData = (ThriftGenericRow) object;
+            BlockBuilder currentBuilder;
+            if (builder != null) {
+                currentBuilder = builder.beginBlockEntry();
+            }
+            else {
+                currentBuilder = new InterleavedBlockBuilder(typeParameters, new BlockBuilderStatus(), typeParameters.size());
+            }
+
+            for (int i = 0; i < typeParameters.size(); i++) {
+                // TODO: Handle cases where ids are not consecutive
+                Object fieldValue = structData.getFieldValueForThriftId((short) (i + 1));
+                serializeObject(typeParameters.get(i), currentBuilder, fieldValue);
+            }
+
+            if (builder != null) {
+                builder.closeEntry();
+                return null;
+            }
+            else {
+                Block resultBlock = currentBuilder.build();
+                return resultBlock;
+            }
+        }
+
+        private static void serializePrimitive(Type type, BlockBuilder builder, Object object)
+        {
+            requireNonNull(builder, "parent builder is null");
+
+            if (object == null) {
+                builder.appendNull();
+                return;
+            }
+
+            if (BOOLEAN.equals(type)) {
+                BOOLEAN.writeBoolean(builder, (Boolean) object);
+            }
+            else if (BIGINT.equals(type) || INTEGER.equals(type) || SMALLINT.equals(type) || TINYINT.equals(type)
+                    || REAL.equals(type) || DATE.equals(type) || TIMESTAMP.equals(type)) {
+                type.writeLong(builder, getLongExpressedValue(object));
+            }
+            else if (DOUBLE.equals(type)) {
+                DOUBLE.writeDouble(builder, ((Number) object).doubleValue());
+            }
+            else if (isVarcharType(type) || VARBINARY.equals(type) || isCharType(type)) {
+                type.writeSlice(builder, getSliceExpressedValue(object, type));
+            }
+            else {
+                throw new UnsupportedOperationException("Unsupported primitive type: " + type);
+            }
+        }
+
+        public static boolean isArrayType(Type type)
+        {
+            return type.getTypeSignature().getBase().equals(StandardTypes.ARRAY);
+        }
+
+        public static boolean isMapType(Type type)
+        {
+            return type.getTypeSignature().getBase().equals(StandardTypes.MAP);
+        }
+
+        public static boolean isRowType(Type type)
+        {
+            return type.getTypeSignature().getBase().equals(StandardTypes.ROW);
+        }
+
+        public static boolean isStructuralType(Type type)
+        {
+            String baseName = type.getTypeSignature().getBase();
+            return baseName.equals(StandardTypes.MAP) || baseName.equals(StandardTypes.ARRAY) || baseName.equals(StandardTypes.ROW);
+        }
+    }
+}

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/thrift/ThriftGenericRow.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/thrift/ThriftGenericRow.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.decoder.thrift;
+
+import io.airlift.log.Logger;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TFieldIdEnum;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TField;
+import org.apache.thrift.protocol.TList;
+import org.apache.thrift.protocol.TMap;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TProtocolUtil;
+import org.apache.thrift.protocol.TSet;
+import org.apache.thrift.protocol.TType;
+import org.apache.thrift.transport.TMemoryInputTransport;
+import org.apache.thrift.transport.TTransport;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ThriftGenericRow implements TBase<ThriftGenericRow, ThriftGenericRow.Fields>
+{
+    private static final Logger log = Logger.get(ThriftGenericRow.class);
+    private final Map<Short, Object> values = new HashMap<>();
+    private byte[] buf = null;
+    private int off = 0;
+    private int len = 0;
+
+    public ThriftGenericRow() {}
+
+    public ThriftGenericRow(Map<Short, Object> values)
+    {
+        this.values.putAll(values);
+    }
+
+    public class Fields implements TFieldIdEnum
+    {
+        private final short thriftId;
+        private final String fieldName;
+
+        Fields(short thriftId, String fieldName)
+        {
+            this.thriftId = thriftId;
+            this.fieldName = fieldName;
+        }
+
+        public short getThriftFieldId()
+        {
+            return thriftId;
+        }
+
+        public String getFieldName()
+        {
+            return fieldName;
+        }
+    }
+
+    public void read(TProtocol iprot) throws TException
+    {
+        TTransport trans = iprot.getTransport();
+        buf = trans.getBuffer();
+        off = trans.getBufferPosition();
+        TProtocolUtil.skip(iprot, TType.STRUCT);
+        len = trans.getBufferPosition() - off;
+    }
+
+    public void parse() throws TException
+    {
+        parse(null);
+    }
+
+    public void parse(short[] thriftIds) throws TException
+    {
+        Set<Short> idSet = thriftIds == null ? null : new HashSet(Arrays.asList(ArrayUtils.toObject(thriftIds)));
+        TMemoryInputTransport trans = new TMemoryInputTransport(buf, off, len);
+        TBinaryProtocol iprot = new TBinaryProtocol(trans);
+        TField field;
+        iprot.readStructBegin();
+        while (true) {
+            field = iprot.readFieldBegin();
+            if (field.type == TType.STOP) {
+                break;
+            }
+            if (idSet != null && !idSet.remove(Short.valueOf(field.id))) {
+                TProtocolUtil.skip(iprot, field.type);
+            }
+            else {
+                values.put(field.id, readElem(iprot, field.type));
+            }
+            iprot.readFieldEnd();
+        }
+        iprot.readStructEnd();
+    }
+
+    private Object readElem(TProtocol iprot, byte type) throws TException
+    {
+        switch (type) {
+            case TType.BOOL:
+                return iprot.readBool();
+            case TType.BYTE:
+                return iprot.readByte();
+            case TType.I16:
+                return iprot.readI16();
+            case TType.ENUM:
+            case TType.I32:
+                return iprot.readI32();
+            case TType.I64:
+                return iprot.readI64();
+            case TType.DOUBLE:
+                return iprot.readDouble();
+            case TType.STRING:
+                return iprot.readString();
+            case TType.STRUCT:
+                return readStruct(iprot);
+            case TType.LIST:
+                return readList(iprot);
+            case TType.SET:
+                return readSet(iprot);
+            case TType.MAP:
+                return readMap(iprot);
+            default:
+                TProtocolUtil.skip(iprot, type);
+                return null;
+        }
+    }
+
+    private Object readStruct(TProtocol iprot) throws TException
+    {
+        ThriftGenericRow elem = new ThriftGenericRow();
+        elem.read(iprot);
+        elem.parse();
+        return elem;
+    }
+
+    private Object readList(TProtocol iprot) throws TException
+    {
+        TList ilist = iprot.readListBegin();
+        List<Object> listValue = new ArrayList<>();
+        for (int i = 0; i < ilist.size; ++i) {
+            listValue.add(readElem(iprot, ilist.elemType));
+        }
+        iprot.readListEnd();
+        return listValue;
+    }
+
+    private Object readSet(TProtocol iprot) throws TException
+    {
+        TSet iset = iprot.readSetBegin();
+        List<Object> setValue = new ArrayList<>();
+        for (int i = 0; i < iset.size; ++i) {
+            setValue.add(readElem(iprot, iset.elemType));
+        }
+        iprot.readSetEnd();
+        return setValue;
+    }
+
+    private Object readMap(TProtocol iprot) throws TException
+    {
+        TMap imap = iprot.readMapBegin();
+        Map<Object, Object> mapValue = new HashMap<>();
+        for (int i = 0; i < imap.size; ++i) {
+            mapValue.put(readElem(iprot, imap.keyType), readElem(iprot, imap.valueType));
+        }
+        iprot.readMapEnd();
+        return mapValue;
+    }
+
+    public Object getFieldValueForThriftId(short thriftId)
+    {
+        return values.get(thriftId);
+    }
+
+    public ThriftGenericRow deepCopy()
+    {
+        return new ThriftGenericRow(values);
+    }
+
+    public void clear() {}
+
+    public Fields fieldForId(int fieldId)
+    {
+        return new Fields((short) fieldId, "dummy");
+    }
+
+    public Object getFieldValue(Fields field)
+    {
+        return values.get(field.thriftId);
+    }
+
+    public boolean isSet(Fields field)
+    {
+        return values.containsKey(field.getThriftFieldId());
+    }
+
+    public void setFieldValue(Fields field, Object value)
+    {
+        values.put(field.getThriftFieldId(), value);
+    }
+
+    public void write(TProtocol oprot) throws TException
+    {
+        throw new UnsupportedOperationException("ThriftGenericRow.write is not supported.");
+    }
+
+    public Map<Short, Object> getValues()
+    {
+        return values;
+    }
+
+    public int compareTo(ThriftGenericRow other)
+    {
+        throw new UnsupportedOperationException("ThriftGenericRow.compareTo is not supported.");
+    }
+}

--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/thrift/ThriftRowDecoder.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/thrift/ThriftRowDecoder.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.decoder.thrift;
+
+import com.facebook.presto.decoder.DecoderColumnHandle;
+import com.facebook.presto.decoder.FieldDecoder;
+import com.facebook.presto.decoder.FieldValueProvider;
+import com.facebook.presto.decoder.RowDecoder;
+import com.google.common.base.Splitter;
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.TException;
+
+import javax.inject.Inject;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Thrift specific row decoder
+ */
+public class ThriftRowDecoder
+        implements RowDecoder
+{
+    public static final String NAME = "thrift";
+
+    @Inject
+    public ThriftRowDecoder()
+    {
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public boolean decodeRow(byte[] data,
+            Map<String, String> dataMap,
+            Set<FieldValueProvider> fieldValueProviders,
+            List<DecoderColumnHandle> columnHandles,
+            Map<DecoderColumnHandle, FieldDecoder<?>> fieldDecoders)
+    {
+        ThriftGenericRow row = new ThriftGenericRow();
+        try {
+            TDeserializer deser = new TDeserializer();
+            deser.deserialize(row, data);
+            row.parse();
+        }
+        catch (TException e) {
+            return true;
+        }
+
+        for (DecoderColumnHandle columnHandle : columnHandles) {
+            if (columnHandle.isInternal()) {
+                continue;
+            }
+
+            @SuppressWarnings("unchecked")
+            FieldDecoder<Object> decoder = (FieldDecoder<Object>) fieldDecoders.get(columnHandle);
+
+            if (decoder != null) {
+                Object node = locateNode(row.getValues(), columnHandle);
+                fieldValueProviders.add(decoder.decode(node, columnHandle));
+            }
+        }
+        return false;
+    }
+
+    private static Object locateNode(Map<Short, Object> map, DecoderColumnHandle columnHandle)
+    {
+        Map<Short, Object> currentLevel = map;
+        Object val = null;
+
+        Iterator<String> it = Splitter.on('/').omitEmptyStrings().split(columnHandle.getMapping()).iterator();
+        while (it.hasNext()) {
+            String pathElement = it.next();
+            Short key = Short.valueOf(pathElement);
+            val = currentLevel.get(key);
+
+            // could be because of optional fields
+            if (val == null) {
+                return null;
+            }
+
+            if (val instanceof ThriftGenericRow) {
+                currentLevel = ((ThriftGenericRow) val).getValues();
+            }
+            else if (it.hasNext()) {
+                throw new IllegalStateException("Invalid thrift field schema");
+            }
+        }
+
+        return val;
+    }
+}

--- a/presto-record-decoder/src/test/java/com/facebook/presto/decoder/thrift/TestThriftDecoder.java
+++ b/presto-record-decoder/src/test/java/com/facebook/presto/decoder/thrift/TestThriftDecoder.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.decoder.thrift;
+
+import com.facebook.presto.decoder.DecoderColumnHandle;
+import com.facebook.presto.decoder.DecoderTestColumnHandle;
+import com.facebook.presto.decoder.FieldDecoder;
+import com.facebook.presto.decoder.FieldValueProvider;
+import com.facebook.presto.decoder.thrift.tweep.Location;
+import com.facebook.presto.decoder.thrift.tweep.Tweet;
+import com.facebook.presto.decoder.thrift.tweep.TweetType;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.SmallintType;
+import com.facebook.presto.spi.type.TinyintType;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.transport.TMemoryBuffer;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.decoder.util.DecoderTestUtil.checkValue;
+import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestThriftDecoder
+{
+    private static final ThriftFieldDecoder DEFAULT_FIELD_DECODER = new ThriftFieldDecoder();
+
+    private static Map<DecoderColumnHandle, FieldDecoder<?>> buildMap(List<DecoderColumnHandle> columns)
+    {
+        ImmutableMap.Builder<DecoderColumnHandle, FieldDecoder<?>> map = ImmutableMap.builder();
+        for (DecoderColumnHandle column : columns) {
+            map.put(column, DEFAULT_FIELD_DECODER);
+        }
+        return map.build();
+    }
+
+    @Test
+    public void testSimple()
+            throws Exception
+    {
+        Tweet tweet = new Tweet(1, "newUser", "hello world")
+                .setLoc(new Location(1234, 5678))
+                .setAge((short) 26)
+                .setB((byte) 10)
+                .setIsDeleted(false)
+                .setTweetType(TweetType.REPLY)
+                .setFullId(1234567)
+                .setPic("abc".getBytes())
+                .setAttr(ImmutableMap.of("a", "a"));
+
+        ThriftRowDecoder rowDecoder = new ThriftRowDecoder();
+
+        // schema
+        DecoderTestColumnHandle col1 = new DecoderTestColumnHandle("", 1, "user_id", IntegerType.INTEGER,"1", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col2 = new DecoderTestColumnHandle("", 2, "username", createVarcharType(100), "2", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col3 = new DecoderTestColumnHandle("", 3, "text", createVarcharType(100), "3", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col4 = new DecoderTestColumnHandle("", 4, "loc.latitude", DoubleType.DOUBLE, "4/1", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col5 = new DecoderTestColumnHandle("", 5, "loc.longitude", DoubleType.DOUBLE, "4/2", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col6 = new DecoderTestColumnHandle("", 6, "tweet_type", BigintType.BIGINT, "5", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col7 = new DecoderTestColumnHandle("", 7, "is_deleted", BooleanType.BOOLEAN, "6", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col8 = new DecoderTestColumnHandle("", 8, "b", TinyintType.TINYINT, "7", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col9 = new DecoderTestColumnHandle("", 9, "age", SmallintType.SMALLINT, "8", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col10 = new DecoderTestColumnHandle("", 10, "full_id", BigintType.BIGINT, "9", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col11 = new DecoderTestColumnHandle("", 11, "pic", VarbinaryType.VARBINARY, "10", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col12 = new DecoderTestColumnHandle("", 12, "language", createVarcharType(100), "16", "thrift", null, false, false, false);
+
+        List<DecoderColumnHandle> columns = ImmutableList.of(col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12);
+        Set<FieldValueProvider> providers = new HashSet<>();
+
+        TMemoryBuffer transport = new TMemoryBuffer(4096);
+        TBinaryProtocol protocol = new TBinaryProtocol(transport);
+        tweet.write(protocol);
+
+        boolean corrupt = rowDecoder.decodeRow(transport.getArray(), null, providers, columns, buildMap(columns));
+        assertFalse(corrupt);
+        assertEquals(providers.size(), columns.size());
+
+        checkValue(providers, col1, 1);
+        checkValue(providers, col2, "newUser");
+        checkValue(providers, col3, "hello world");
+        checkValue(providers, col4, 1234);
+        checkValue(providers, col5, 5678);
+        checkValue(providers, col6, TweetType.REPLY.getValue());
+        checkValue(providers, col7, false);
+        checkValue(providers, col8, 10);
+        checkValue(providers, col9, 26);
+        checkValue(providers, col10, 1234567);
+        checkValue(providers, col11, "abc");
+        checkValue(providers, col12, "english");
+    }
+}

--- a/presto-record-decoder/src/test/java/com/facebook/presto/decoder/thrift/TestThriftDecoder.java
+++ b/presto-record-decoder/src/test/java/com/facebook/presto/decoder/thrift/TestThriftDecoder.java
@@ -73,7 +73,7 @@ public class TestThriftDecoder
         ThriftRowDecoder rowDecoder = new ThriftRowDecoder();
 
         // schema
-        DecoderTestColumnHandle col1 = new DecoderTestColumnHandle("", 1, "user_id", IntegerType.INTEGER,"1", "thrift", null, false, false, false);
+        DecoderTestColumnHandle col1 = new DecoderTestColumnHandle("", 1, "user_id", IntegerType.INTEGER, "1", "thrift", null, false, false, false);
         DecoderTestColumnHandle col2 = new DecoderTestColumnHandle("", 2, "username", createVarcharType(100), "2", "thrift", null, false, false, false);
         DecoderTestColumnHandle col3 = new DecoderTestColumnHandle("", 3, "text", createVarcharType(100), "3", "thrift", null, false, false, false);
         DecoderTestColumnHandle col4 = new DecoderTestColumnHandle("", 4, "loc.latitude", DoubleType.DOUBLE, "4/1", "thrift", null, false, false, false);

--- a/presto-record-decoder/src/test/thrift/tweep.thrift
+++ b/presto-record-decoder/src/test/thrift/tweep.thrift
@@ -1,0 +1,43 @@
+namespace java com.facebook.presto.decoder.thrift.tweep
+
+enum TweetType {
+    TWEET,
+    RETWEET = 2,
+    DM = 0xa,
+    REPLY
+}
+
+struct Location {
+    1: required double latitude;
+    2: required double longitude;
+}
+
+struct Tweet {
+    1: required i32 userId;
+    2: required string userName;
+    3: required string text;
+    4: optional Location loc;
+    5: optional TweetType tweetType = TweetType.TWEET;
+    6: optional bool isDeleted = false;
+    7: optional byte b;
+    8: optional i16 age;
+    9: optional i64 fullId;
+    10: optional binary pic;
+    11: optional map<string,string> attr;
+    12: optional list<string> items;
+    16: optional string language = "english";
+}
+
+typedef list<Tweet> TweetList
+typedef set<Tweet> TweetSet
+
+struct TweetSearchResult {
+    1: TweetList tweetList;
+    2: TweetSet tweetSet;
+}
+
+exception TwitterUnavailable {
+    1: string message;
+}
+
+const i32 MAX_RESULTS = 100;


### PR DESCRIPTION
We are working on enabling querying messages in Kafka topics through Presto. 

The message format in our Kafka topics are encoded in Thrift message format which is not currently supported in presto-record-decoder. This PR consists of a Thrift decoder that don't require reading a specific schema in advance. A thrift message will be parsed into a `ThriftGenericRow`. 

In addition, the thrift schema has nested structures. For now, I don't see any of the record decoders support nested structure. This PR works around it by adding a `getBlock` method in the `FieldValueProvider`. And hopefully this PR provides an example that could help resolving https://github.com/prestodb/presto/issues/7391