### PR TITLE
Test Join using stateful filter function

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.tests;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.testing.MaterializedResult;
@@ -911,5 +912,24 @@ public abstract class AbstractTestDistributedQueries
 
         assertAccessAllowed(nestedViewOwnerSession, "DROP VIEW test_nested_view_access");
         assertAccessAllowed(viewOwnerSession, "DROP VIEW test_view_access");
+    }
+
+    @Test
+    public void testJoinWithStatefulFilterFunction()
+    {
+        super.testJoinWithStatefulFilterFunction();
+
+        // Stateful function is placed in LEFT JOIN's ON clause and involves left & right symbols to prevent any kind of push down/pull down.
+        Session session = Session.builder(getSession())
+                // With broadcast join, lineitem would be source-distributed and not executed concurrently.
+                .setSystemProperty(SystemSessionProperties.DISTRIBUTED_JOIN, "true")
+                .build();
+        long joinOutputRowCount = 60175;
+        assertQuery(
+                session,
+                format(
+                        "SELECT count(*) FROM lineitem l LEFT OUTER JOIN orders o ON l.orderkey = o.orderkey AND stateful_sleeping_sum(%s, 100, l.linenumber, o.shippriority) > 0",
+                        10 * 1. / joinOutputRowCount),
+                format("VALUES %s", joinOutputRowCount));
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -86,6 +86,7 @@ import static com.facebook.presto.tests.QueryAssertions.assertContains;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
 import static com.facebook.presto.tests.QueryTemplate.parameter;
 import static com.facebook.presto.tests.QueryTemplate.queryTemplate;
+import static com.facebook.presto.tests.StatefulSleepingSum.STATEFUL_SLEEPING_SUM;
 import static com.facebook.presto.tests.StructuralTestUtil.mapType;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -109,7 +110,7 @@ public abstract class AbstractTestQueries
             .window(CustomRank.class)
             .scalars(CustomAdd.class)
             .scalars(CreateHll.class)
-            .functions(APPLY_FUNCTION, INVOKE_FUNCTION)
+            .functions(APPLY_FUNCTION, INVOKE_FUNCTION, STATEFUL_SLEEPING_SUM)
             .getFunctions();
 
     public static final List<PropertyMetadata<?>> TEST_SYSTEM_PROPERTIES = ImmutableList.of(

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StatefulSleepingSum.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StatefulSleepingSum.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.constructorMethodHandle;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Collections.nCopies;
+
+public class StatefulSleepingSum
+        extends SqlScalarFunction
+{
+    public static final StatefulSleepingSum STATEFUL_SLEEPING_SUM = new StatefulSleepingSum();
+
+    private StatefulSleepingSum()
+    {
+        super(new Signature(
+                "stateful_sleeping_sum",
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("bigint")),
+                ImmutableList.of(),
+                parseTypeSignature("bigint"),
+                ImmutableList.of(parseTypeSignature("double"), parseTypeSignature("bigint"), parseTypeSignature("bigint"), parseTypeSignature("bigint")),
+                false));
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "testing not thread safe function";
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        int args = 4;
+        return new ScalarFunctionImplementation(
+                false,
+                nCopies(args, false),
+                nCopies(args, false),
+                nCopies(args, Optional.empty()),
+                methodHandle(StatefulSleepingSum.class, "statefulSleepingSum", State.class, double.class, long.class, long.class, long.class),
+                Optional.of(constructorMethodHandle(State.class)),
+                true
+        );
+    }
+
+    public static long statefulSleepingSum(State state, double sleepProbability, long sleepDurationMillis, long a, long b)
+    {
+        int currentThreads = state.currentThreads.incrementAndGet();
+        try {
+            checkState(currentThreads == 1, "%s threads concurrently executing a stateful function", currentThreads);
+            if (ThreadLocalRandom.current().nextDouble() < sleepProbability) {
+                Thread.sleep(sleepDurationMillis);
+            }
+            return a + b;
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted", e);
+        }
+        finally {
+            state.currentThreads.decrementAndGet();
+        }
+    }
+
+    public static class State
+    {
+        private final AtomicInteger currentThreads = new AtomicInteger();
+    }
+}


### PR DESCRIPTION
Filter function is encapsulated in `LookupSource`. It's imperative that
`LookupJoinOperator`-s do not share `LookupSource` instances.