### PR TITLE
Clear interrupt flag after exiting from pager

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -228,6 +228,8 @@ public class Query
             handler.processRows(client);
         }
         catch (RuntimeException | IOException e) {
+            // clear interrupt flag before throwing an exception
+            Thread.interrupted();
             if (userAbortedQuery.get() && !(e instanceof QueryAbortedException)) {
                 throw new QueryAbortedException(e);
             }


### PR DESCRIPTION
Http client is responsive for interrupts, therefore sometimes it happens
that the final "abort" request is not being executed