### PR TITLE
Preserve identifier quoting in AST

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.parser.StatementSplitter;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.Use;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
@@ -290,7 +291,7 @@ public class Console
     {
         if (parsedStatement instanceof Use) {
             Use use = (Use) parsedStatement;
-            session = withCatalogAndSchema(session, use.getCatalog().orElse(session.getCatalog()), use.getSchema());
+            session = withCatalogAndSchema(session, use.getCatalog().map(Identifier::getValue).orElse(session.getCatalog()), use.getSchema().getValue());
             session = withProperties(session, existingProperties);
             session = withPreparedStatements(session, existingPreparedStatements);
         }

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -834,9 +834,9 @@ public class TestPrestoDriver
                             "c_char_345 char(345), " +
                             "c_varbinary varbinary, " +
                             "c_time time, " +
-                            "c_time_with_time_zone \"time with time zone\", " +
+                            "c_time_with_time_zone time with time zone, " +
                             "c_timestamp timestamp, " +
-                            "c_timestamp_with_time_zone \"timestamp with time zone\", " +
+                            "c_timestamp_with_time_zone timestamp with time zone, " +
                             "c_date date, " +
                             "c_decimal_8_2 decimal(8,2), " +
                             "c_decimal_38_0 decimal(38,0), " +

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -225,7 +225,7 @@ public final class Session
 
     public String getPreparedStatementFromExecute(Execute execute)
     {
-        return getPreparedStatement(execute.getName());
+        return getPreparedStatement(execute.getName().getValue());
     }
 
     public String getPreparedStatement(String name)

--- a/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -69,11 +69,11 @@ public class AddColumnTask
         if ((type == null) || type.equals(UNKNOWN)) {
             throw new SemanticException(TYPE_MISMATCH, element, "Unknown type for column '%s' ", element.getName());
         }
-        if (columnHandles.containsKey(element.getName().toLowerCase(ENGLISH))) {
+        if (columnHandles.containsKey(element.getName().getValue().toLowerCase(ENGLISH))) {
             throw new SemanticException(COLUMN_ALREADY_EXISTS, statement, "Column '%s' already exists", element.getName());
         }
 
-        metadata.addColumn(session, tableHandle.get(), new ColumnMetadata(element.getName(), type));
+        metadata.addColumn(session, tableHandle.get(), new ColumnMetadata(element.getName().getValue(), type));
 
         return immediateFuture(null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -39,6 +39,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -99,14 +100,15 @@ public class CreateTableTask
         for (TableElement element : statement.getElements()) {
             if (element instanceof ColumnDefinition) {
                 ColumnDefinition column = (ColumnDefinition) element;
+                String name = column.getName().getValue().toLowerCase(Locale.ENGLISH);
                 Type type = metadata.getType(parseTypeSignature(column.getType()));
                 if ((type == null) || type.equals(UNKNOWN)) {
                     throw new SemanticException(TYPE_MISMATCH, column, "Unknown type for column '%s' ", column.getName());
                 }
-                if (columns.containsKey(column.getName().toLowerCase())) {
+                if (columns.containsKey(name)) {
                     throw new SemanticException(DUPLICATE_COLUMN_NAME, column, "Column name '%s' specified more than once", column.getName());
                 }
-                columns.put(column.getName().toLowerCase(), new ColumnMetadata(column.getName(), type, column.getComment().orElse(null), false));
+                columns.put(name, new ColumnMetadata(name, type, column.getComment().orElse(null), false));
             }
             else if (element instanceof LikeClause) {
                 LikeClause likeClause = (LikeClause) element;

--- a/presto-main/src/main/java/com/facebook/presto/execution/DeallocateTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DeallocateTask.java
@@ -36,7 +36,7 @@ public class DeallocateTask
     @Override
     public ListenableFuture<?> execute(Deallocate statement, TransactionManager transactionManager, Metadata metadata, AccessControl accessControl, QueryStateMachine stateMachine, List<Expression> parameters)
     {
-        String statementName = statement.getName();
+        String statementName = statement.getName().getValue();
         stateMachine.removePreparedStatement(statementName);
         return immediateFuture(null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropColumnTask.java
@@ -52,7 +52,7 @@ public class DropColumnTask
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
 
-        String column = statement.getColumn().toLowerCase(ENGLISH);
+        String column = statement.getColumn().getValue().toLowerCase(ENGLISH);
 
         if (!tableHandle.isPresent()) {
             throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);

--- a/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/GrantTask.java
@@ -68,10 +68,10 @@ public class GrantTask
 
         // verify current identity has permissions to grant permissions
         for (Privilege privilege : privileges) {
-            accessControl.checkCanGrantTablePrivilege(session.getRequiredTransactionId(), session.getIdentity(), privilege, tableName, statement.getGrantee(), statement.isWithGrantOption());
+            accessControl.checkCanGrantTablePrivilege(session.getRequiredTransactionId(), session.getIdentity(), privilege, tableName, statement.getGrantee().getValue(), statement.isWithGrantOption());
         }
 
-        metadata.grantTablePrivileges(session, tableName, privileges, statement.getGrantee(), statement.isWithGrantOption());
+        metadata.grantTablePrivileges(session, tableName, privileges, statement.getGrantee().getValue(), statement.isWithGrantOption());
         return immediateFuture(null);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PrepareTask.java
@@ -69,7 +69,7 @@ public class PrepareTask
         }
 
         String sql = getFormattedSql(statement, sqlParser, Optional.empty());
-        stateMachine.addPreparedStatement(prepare.getName(), sql);
+        stateMachine.addPreparedStatement(prepare.getName().getValue(), sql);
         return immediateFuture(null);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
@@ -52,8 +52,8 @@ public class RenameColumnTask
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
 
-        String source = statement.getSource().toLowerCase(ENGLISH);
-        String target = statement.getTarget().toLowerCase(ENGLISH);
+        String source = statement.getSource().getValue().toLowerCase(ENGLISH);
+        String target = statement.getTarget().getValue().toLowerCase(ENGLISH);
 
         if (!tableHandle.isPresent()) {
             throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameSchemaTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameSchemaTask.java
@@ -45,7 +45,7 @@ public class RenameSchemaTask
     {
         Session session = stateMachine.getSession();
         CatalogSchemaName source = createCatalogSchemaName(session, statement, Optional.of(statement.getSource()));
-        CatalogSchemaName target = new CatalogSchemaName(source.getCatalogName(), statement.getTarget());
+        CatalogSchemaName target = new CatalogSchemaName(source.getCatalogName(), statement.getTarget().getValue());
 
         if (!metadata.schemaExists(session, source)) {
             throw new SemanticException(MISSING_SCHEMA, statement, "Schema '%s' does not exist", source);
@@ -55,9 +55,9 @@ public class RenameSchemaTask
             throw new SemanticException(SCHEMA_ALREADY_EXISTS, statement, "Target schema '%s' already exists", target);
         }
 
-        accessControl.checkCanRenameSchema(session.getRequiredTransactionId(), session.getIdentity(), source, statement.getTarget());
+        accessControl.checkCanRenameSchema(session.getRequiredTransactionId(), session.getIdentity(), source, statement.getTarget().getValue());
 
-        metadata.renameSchema(session, source, statement.getTarget());
+        metadata.renameSchema(session, source, statement.getTarget().getValue());
 
         return immediateFuture(null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RevokeTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RevokeTask.java
@@ -68,10 +68,10 @@ public class RevokeTask
 
         // verify current identity has permissions to revoke permissions
         for (Privilege privilege : privileges) {
-            accessControl.checkCanRevokeTablePrivilege(session.getRequiredTransactionId(), session.getIdentity(), privilege, tableName, statement.getGrantee(), statement.isGrantOptionFor());
+            accessControl.checkCanRevokeTablePrivilege(session.getRequiredTransactionId(), session.getIdentity(), privilege, tableName, statement.getGrantee().getValue(), statement.isGrantOptionFor());
         }
 
-        metadata.revokeTablePrivileges(session, tableName, privileges, statement.getGrantee(), statement.isGrantOptionFor());
+        metadata.revokeTablePrivileges(session, tableName, privileges, statement.getGrantee().getValue(), statement.isGrantOptionFor());
         return immediateFuture(null);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
@@ -314,7 +314,7 @@ public final class ExpressionUtils
             @Override
             public Expression rewriteIdentifier(Identifier node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
-                return new SymbolReference(node.getName());
+                return new SymbolReference(node.getValue());
             }
 
             @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -361,14 +361,14 @@ public class ExpressionAnalyzer
         protected Type visitIdentifier(Identifier node, StackableAstVisitorContext<Context> context)
         {
             if (context.getContext().isInLambda()) {
-                LambdaArgumentDeclaration lambdaArgumentDeclaration = context.getContext().getNameToLambdaArgumentDeclarationMap().get(node.getName());
+                LambdaArgumentDeclaration lambdaArgumentDeclaration = context.getContext().getNameToLambdaArgumentDeclarationMap().get(node.getValue());
                 if (lambdaArgumentDeclaration != null) {
                     lambdaArgumentReferences.put(NodeRef.of(node), lambdaArgumentDeclaration);
                     Type result = getExpressionType(lambdaArgumentDeclaration);
                     return setExpressionType(node, result);
                 }
             }
-            return handleResolvedField(node, scope.resolveField(node, QualifiedName.of(node.getName())));
+            return handleResolvedField(node, scope.resolveField(node, QualifiedName.of(node.getValue())));
         }
 
         private Type handleResolvedField(Expression node, ResolvedField resolvedField)
@@ -410,7 +410,7 @@ public class ExpressionAnalyzer
 
             Type rowFieldType = null;
             for (RowField rowField : rowType.getFields()) {
-                if (node.getFieldName().equalsIgnoreCase(rowField.getName().orElse(null))) {
+                if (node.getField().getValue().equalsIgnoreCase(rowField.getName().orElse(null))) {
                     rowFieldType = rowField.getType();
                     break;
                 }
@@ -1074,7 +1074,7 @@ public class ExpressionAnalyzer
             }
             for (int i = 0; i < lambdaArguments.size(); i++) {
                 LambdaArgumentDeclaration lambdaArgument = lambdaArguments.get(i);
-                nameToLambdaArgumentDeclarationMap.put(lambdaArgument.getName(), lambdaArgument);
+                nameToLambdaArgumentDeclarationMap.put(lambdaArgument.getName().getValue(), lambdaArgument);
                 setExpressionType(lambdaArgument, types.get(i));
             }
             Type returnType = process(node.getBody(), new StackableAstVisitorContext<Context>(Context.inLambda(nameToLambdaArgumentDeclarationMap)));

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FreeLambdaReferenceExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FreeLambdaReferenceExtractor.java
@@ -67,7 +67,7 @@ public class FreeLambdaReferenceExtractor
         @Override
         protected Void visitIdentifier(Identifier node, Set<String> lambdaArgumentNames)
         {
-            if (analysis.getLambdaArgumentReferences().containsKey(NodeRef.of(node)) && !lambdaArgumentNames.contains(node.getName())) {
+            if (analysis.getLambdaArgumentReferences().containsKey(NodeRef.of(node)) && !lambdaArgumentNames.contains(node.getValue())) {
                 freeReferencesToLambdaArgument.add(node);
             }
             return null;
@@ -80,6 +80,7 @@ public class FreeLambdaReferenceExtractor
                     .addAll(lambdaArgumentNames)
                     .addAll(node.getArguments().stream()
                             .map(LambdaArgumentDeclaration::getName)
+                            .map(Identifier::getValue)
                             .collect(toImmutableSet()))
                     .build());
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Scope.java
@@ -117,7 +117,7 @@ public class Scope
     {
         QualifiedName name = null;
         if (expression instanceof Identifier) {
-            name = QualifiedName.of(((Identifier) expression).getName());
+            name = QualifiedName.of(((Identifier) expression).getValue());
         }
         else if (expression instanceof DereferenceExpression) {
             name = DereferenceExpression.getQualifiedName((DereferenceExpression) expression);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -302,6 +302,7 @@ class StatementAnalyzer
             List<String> insertColumns;
             if (insert.getColumns().isPresent()) {
                 insertColumns = insert.getColumns().get().stream()
+                        .map(Identifier::getValue)
                         .map(String::toLowerCase)
                         .collect(toImmutableList());
 
@@ -620,10 +621,10 @@ class StatementAnalyzer
             }
             Set<String> names = new HashSet<>();
             for (Identifier identifier : columnAliases) {
-                if (names.contains(identifier.getName().toLowerCase())) {
-                    throw new SemanticException(DUPLICATE_COLUMN_NAME, identifier, "Column name '%s' specified more than once", identifier.getName());
+                if (names.contains(identifier.getValue().toLowerCase(ENGLISH))) {
+                    throw new SemanticException(DUPLICATE_COLUMN_NAME, identifier, "Column name '%s' specified more than once", identifier.getValue());
                 }
-                names.add(identifier.getName().toLowerCase());
+                names.add(identifier.getValue().toLowerCase(ENGLISH));
             }
         }
 
@@ -711,17 +712,17 @@ class StatementAnalyzer
                     RelationType queryDescriptor = analysis.getOutputDescriptor(query);
 
                     List<Field> fields;
-                    Optional<List<String>> columnNames = withQuery.get().getColumnNames();
+                    Optional<List<Identifier>> columnNames = withQuery.get().getColumnNames();
                     if (columnNames.isPresent()) {
                         // if columns are explicitly aliased -> WITH cte(alias1, alias2 ...)
                         ImmutableList.Builder<Field> fieldBuilder = ImmutableList.builder();
 
                         int field = 0;
-                        for (String columnName : columnNames.get()) {
+                        for (Identifier columnName : columnNames.get()) {
                             Field inputField = queryDescriptor.getFieldByIndex(field);
                             fieldBuilder.add(Field.newQualified(
                                     QualifiedName.of(name),
-                                    Optional.of(columnName),
+                                    Optional.of(columnName.getValue()),
                                     inputField.getType(),
                                     false,
                                     inputField.getOriginTable(),
@@ -846,7 +847,15 @@ class StatementAnalyzer
                 }
             }
 
-            RelationType descriptor = relationType.withAlias(relation.getAlias(), relation.getColumnNames());
+            List<String> aliases = null;
+            if (relation.getColumnNames() != null) {
+                aliases = relation.getColumnNames().stream()
+                        .map(Identifier::getValue)
+                        .collect(Collectors.toList());
+            }
+
+            RelationType descriptor = relationType.withAlias(relation.getAlias().getValue(), aliases);
+
             return createAndAssignScope(relation, scope, descriptor);
         }
 
@@ -1090,12 +1099,12 @@ class StatementAnalyzer
 
             if (criteria instanceof JoinUsing) {
                 // TODO: implement proper "using" semantics with respect to output columns
-                List<String> columns = ((JoinUsing) criteria).getColumns();
+                List<Identifier> columns = ((JoinUsing) criteria).getColumns();
 
                 List<Expression> expressions = new ArrayList<>();
-                for (String column : columns) {
-                    Expression leftExpression = new Identifier(column);
-                    Expression rightExpression = new Identifier(column);
+                for (Identifier column : columns) {
+                    Expression leftExpression = new Identifier(column.getValue());
+                    Expression rightExpression = new Identifier(column.getValue());
 
                     ExpressionAnalysis leftExpressionAnalysis = analyzeExpression(leftExpression, left);
                     ExpressionAnalysis rightExpressionAnalysis = analyzeExpression(rightExpression, right);
@@ -1349,9 +1358,9 @@ class StatementAnalyzer
                 ImmutableMultimap.Builder<QualifiedName, Expression> byAliasBuilder = ImmutableMultimap.builder();
                 for (SelectItem item : node.getSelect().getSelectItems()) {
                     if (item instanceof SingleColumn) {
-                        Optional<String> alias = ((SingleColumn) item).getAlias();
+                        Optional<Identifier> alias = ((SingleColumn) item).getAlias();
                         if (alias.isPresent()) {
-                            byAliasBuilder.put(QualifiedName.of(alias.get()), ((SingleColumn) item).getExpression()); // TODO: need to know if alias was quoted
+                            byAliasBuilder.put(QualifiedName.of(alias.get().getValue()), ((SingleColumn) item).getExpression()); // TODO: need to know if alias was quoted
                         }
                     }
                 }
@@ -1364,7 +1373,7 @@ class StatementAnalyzer
                     if (expression instanceof Identifier) {
                         // if this is a simple name reference, try to resolve against output columns
 
-                        QualifiedName name = QualifiedName.of(((Identifier) expression).getName());
+                        QualifiedName name = QualifiedName.of(((Identifier) expression).getValue());
                         Collection<Expression> expressions = byAlias.get(name);
                         if (expressions.size() > 1) {
                             throw new SemanticException(AMBIGUOUS_ATTRIBUTE, expression, "'%s' in ORDER BY is ambiguous", name.getSuffix());
@@ -1424,12 +1433,12 @@ class StatementAnalyzer
             for (SelectItem item : node.getSelectItems()) {
                 if (item instanceof SingleColumn) {
                     SingleColumn column = (SingleColumn) item;
-                    Optional<String> alias = column.getAlias();
+                    Optional<Identifier> alias = column.getAlias();
                     if (alias.isPresent()) {
-                        assignments.put(QualifiedName.of(alias.get()), column.getExpression()); // TODO: need to know if alias was quoted
+                        assignments.put(QualifiedName.of(alias.get().getValue()), column.getExpression()); // TODO: need to know if alias was quoted
                     }
                     else if (column.getExpression() instanceof Identifier) {
-                        assignments.put(QualifiedName.of(((Identifier) column.getExpression()).getName()), column.getExpression());
+                        assignments.put(QualifiedName.of(((Identifier) column.getExpression()).getValue()), column.getExpression());
                     }
                 }
             }
@@ -1451,7 +1460,7 @@ class StatementAnalyzer
             public Expression rewriteIdentifier(Identifier reference, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
                 // if this is a simple name reference, try to resolve against output columns
-                QualifiedName name = QualifiedName.of(reference.getName());
+                QualifiedName name = QualifiedName.of(reference.getValue());
                 Set<Expression> expressions = assignments.get(name)
                         .stream()
                         .collect(Collectors.toSet());
@@ -1576,13 +1585,13 @@ class StatementAnalyzer
                     SingleColumn column = (SingleColumn) item;
 
                     Expression expression = column.getExpression();
-                    Optional<String> fieldName = column.getAlias();
+                    Optional<Identifier> field = column.getAlias();
 
                     Optional<QualifiedObjectName> originTable = Optional.empty();
                     QualifiedName name = null;
 
                     if (expression instanceof Identifier) {
-                        name = QualifiedName.of(((Identifier) expression).getName());
+                        name = QualifiedName.of(((Identifier) expression).getValue());
                     }
                     else if (expression instanceof DereferenceExpression) {
                         name = DereferenceExpression.getQualifiedName((DereferenceExpression) expression);
@@ -1595,13 +1604,13 @@ class StatementAnalyzer
                         }
                     }
 
-                    if (!fieldName.isPresent()) {
+                    if (!field.isPresent()) {
                         if (name != null) {
-                            fieldName = Optional.of(getLast(name.getOriginalParts()));
+                            field = Optional.of(new Identifier(getLast(name.getOriginalParts())));
                         }
                     }
 
-                    outputFields.add(Field.newUnqualified(fieldName, analysis.getType(expression), originTable, column.getAlias().isPresent())); // TODO don't use analysis as a side-channel. Use outputExpressions to look up the type
+                    outputFields.add(Field.newUnqualified(field.map(Identifier::getValue), analysis.getType(expression), originTable, column.getAlias().isPresent())); // TODO don't use analysis as a side-channel. Use outputExpressions to look up the type
                 }
                 else {
                     throw new IllegalArgumentException("Unsupported SelectItem type: " + item.getClass().getName());
@@ -1926,14 +1935,14 @@ class StatementAnalyzer
                 Query query = withQuery.getQuery();
                 process(query, withScopeBuilder.build());
 
-                String name = withQuery.getName();
+                String name = withQuery.getName().getValue().toLowerCase(ENGLISH);
                 if (withScopeBuilder.containsNamedQuery(name)) {
                     throw new SemanticException(DUPLICATE_RELATION, withQuery, "WITH query name '%s' specified more than once", name);
                 }
 
                 // check if all or none of the columns are explicitly alias
                 if (withQuery.getColumnNames().isPresent()) {
-                    List<String> columnNames = withQuery.getColumnNames().get();
+                    List<Identifier> columnNames = withQuery.getColumnNames().get();
                     RelationType queryDescriptor = analysis.getOutputDescriptor(query);
                     if (columnNames.size() != queryDescriptor.getVisibleFieldCount()) {
                         throw new SemanticException(MISMATCHED_COLUMN_ALIASES, withQuery, "WITH column alias list has %s entries but WITH query(%s) has %s columns", columnNames.size(), name, queryDescriptor.getVisibleFieldCount());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -404,7 +404,7 @@ public class ExpressionInterpreter
             }
 
             if (hasUnresolvedValue(base)) {
-                return new DereferenceExpression(toExpression(base, type), node.getFieldName());
+                return new DereferenceExpression(toExpression(base, type), node.getField());
             }
 
             RowType rowType = (RowType) type;
@@ -414,12 +414,12 @@ public class ExpressionInterpreter
             int index = -1;
             for (int i = 0; i < fields.size(); i++) {
                 RowField field = fields.get(i);
-                if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(node.getFieldName())) {
+                if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(node.getField().getValue())) {
                     checkArgument(index < 0, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
                     index = i;
                 }
             }
-            checkState(index >= 0, "could not find field name: %s", node.getFieldName());
+            checkState(index >= 0, "could not find field name: %s", node.getField());
             if (row.isNull(index)) {
                 return null;
             }
@@ -984,6 +984,7 @@ public class ExpressionInterpreter
             Expression body = node.getBody();
             List<String> argumentNames = node.getArguments().stream()
                     .map(LambdaArgumentDeclaration::getName)
+                    .map(Identifier::getValue)
                     .collect(toImmutableList());
             FunctionType functionType = (FunctionType) expressionTypes.get(NodeRef.<Expression>of(node));
             checkArgument(argumentNames.size() == functionType.getArgumentTypes().size());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionSymbolInliner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionSymbolInliner.java
@@ -69,14 +69,14 @@ public class ExpressionSymbolInliner
         public Expression rewriteLambdaExpression(LambdaExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
         {
             for (LambdaArgumentDeclaration argument : node.getArguments()) {
-                String argumentName = argument.getName();
+                String argumentName = argument.getName().getValue();
                 // Symbol names are unique. As a result, a symbol should never be excluded multiple times.
                 checkArgument(!excludedNames.contains(argumentName));
                 excludedNames.add(argumentName);
             }
             Expression result = treeRewriter.defaultRewrite(node, context);
             for (LambdaArgumentDeclaration argument : node.getArguments()) {
-                excludedNames.remove(argument.getName());
+                excludedNames.remove(argument.getName().getValue());
             }
             return result;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LambdaCaptureDesugaringRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LambdaCaptureDesugaringRewriter.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.tree.BindExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
 import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
@@ -79,6 +80,7 @@ public class LambdaCaptureDesugaringRewriter
 
             List<Symbol> lambdaArguments = node.getArguments().stream()
                     .map(LambdaArgumentDeclaration::getName)
+                    .map(Identifier::getValue)
                     .map(Symbol::new)
                     .collect(toImmutableList());
 
@@ -95,7 +97,7 @@ public class LambdaCaptureDesugaringRewriter
             for (Symbol captureSymbol : captureSymbols) {
                 Symbol extraSymbol = symbolAllocator.newSymbol(captureSymbol.getName(), symbolTypes.get(captureSymbol));
                 captureSymbolToExtraSymbol.put(captureSymbol, extraSymbol);
-                newLambdaArguments.add(new LambdaArgumentDeclaration(extraSymbol.getName()));
+                newLambdaArguments.add(new LambdaArgumentDeclaration(new Identifier(extraSymbol.getName())));
             }
             newLambdaArguments.addAll(node.getArguments());
             Expression rewrittenExpression = new LambdaExpression(newLambdaArguments.build(), replaceSymbols(rewrittenBody, captureSymbolToExtraSymbol.build()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -397,7 +397,7 @@ public class LogicalPlanner
         ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
         int aliasPosition = 0;
         for (Field field : plan.getDescriptor().getVisibleFields()) {
-            String columnName = columnAliases.isPresent() ? columnAliases.get().get(aliasPosition).getName() : field.getName().get();
+            String columnName = columnAliases.isPresent() ? columnAliases.get().get(aliasPosition).getValue() : field.getName().get();
             columns.add(new ColumnMetadata(columnName, field.getType()));
             aliasPosition++;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
@@ -105,7 +105,7 @@ public class SymbolAllocator
     {
         String nameHint = "expr";
         if (expression instanceof Identifier) {
-            nameHint = ((Identifier) expression).getName();
+            nameHint = ((Identifier) expression).getValue();
         }
         else if (expression instanceof FunctionCall) {
             nameHint = ((FunctionCall) expression).getName().getSuffix();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolsExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolsExtractor.java
@@ -126,7 +126,7 @@ public final class SymbolsExtractor
         @Override
         protected Void visitIdentifier(Identifier node, ImmutableSet.Builder<QualifiedName> builder)
         {
-            builder.add(QualifiedName.of(node.getName()));
+            builder.add(QualifiedName.of(node.getValue()));
             return null;
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
@@ -279,7 +279,7 @@ class TranslationMap
                 ImmutableList.Builder<LambdaArgumentDeclaration> newArguments = ImmutableList.builder();
                 for (LambdaArgumentDeclaration argument : node.getArguments()) {
                     Symbol symbol = lambdaDeclarationToSymbolMap.get(NodeRef.of(argument));
-                    newArguments.add(new LambdaArgumentDeclaration(symbol.getName()));
+                    newArguments.add(new LambdaArgumentDeclaration(new Identifier(symbol.getName())));
                 }
                 Expression rewrittenBody = treeRewriter.rewrite(node.getBody(), null);
                 return new LambdaExpression(newArguments.build(), rewrittenBody);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -45,6 +45,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GenericLiteral;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IfExpression;
 import com.facebook.presto.sql.tree.InListExpression;
 import com.facebook.presto.sql.tree.InPredicate;
@@ -345,6 +346,7 @@ public final class SqlToRowExpressionTranslator
             List<Type> argumentTypes = typeParameters.subList(0, typeParameters.size() - 1);
             List<String> argumentNames = node.getArguments().stream()
                     .map(LambdaArgumentDeclaration::getName)
+                    .map(Identifier::getValue)
                     .collect(toImmutableList());
 
             return new LambdaDefinitionExpression(argumentTypes, argumentNames, body);
@@ -554,12 +556,12 @@ public final class SqlToRowExpressionTranslator
             int index = -1;
             for (int i = 0; i < fields.size(); i++) {
                 RowField field = fields.get(i);
-                if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(node.getFieldName())) {
+                if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(node.getField().getValue())) {
                     checkArgument(index < 0, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
                     index = i;
                 }
             }
-            checkState(index >= 0, "could not find field name: %s", node.getFieldName());
+            checkState(index >= 0, "could not find field name: %s", node.getField());
             Type returnType = getType(node);
             return call(dereferenceSignature(returnType, rowType), returnType, process(node.getBase(), context), constant(index, INTEGER));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
@@ -95,7 +95,7 @@ final class DescribeInputRewrite
         protected Node visitDescribeInput(DescribeInput node, Void context)
                 throws SemanticException
         {
-            String sqlString = session.getPreparedStatement(node.getName());
+            String sqlString = session.getPreparedStatement(node.getName().getValue());
             Statement statement = parser.createStatement(sqlString);
 
             // create  analysis for the query we are describing.

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/DescribeOutputRewrite.java
@@ -91,7 +91,7 @@ final class DescribeOutputRewrite
         @Override
         protected Node visitDescribeOutput(DescribeOutput node, Void context)
         {
-            String sqlString = session.getPreparedStatement(node.getName());
+            String sqlString = session.getPreparedStatement(node.getName().getValue());
             Statement statement = parser.createStatement(sqlString);
 
             Analyzer analyzer = new Analyzer(session, metadata, parser, accessControl, queryExplainer, parameters);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCreateTableTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCreateTableTask.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringSessionProperty;
+import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
@@ -91,7 +92,7 @@ public class TestCreateTableTask
             throws Exception
     {
         CreateTable statement = new CreateTable(QualifiedName.of("test_table"),
-                ImmutableList.of(new ColumnDefinition("a", "BIGINT", Optional.empty())),
+                ImmutableList.of(new ColumnDefinition(identifier("a"), "BIGINT", Optional.empty())),
                 true,
                 ImmutableMap.of(),
                 Optional.empty());
@@ -105,7 +106,7 @@ public class TestCreateTableTask
             throws Exception
     {
         CreateTable statement = new CreateTable(QualifiedName.of("test_table"),
-                ImmutableList.of(new ColumnDefinition("a", "BIGINT", Optional.empty())),
+                ImmutableList.of(new ColumnDefinition(identifier("a"), "BIGINT", Optional.empty())),
                 false,
                 ImmutableMap.of(),
                 Optional.empty());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestDeallocateTask.java
@@ -21,6 +21,7 @@ import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.sql.tree.Deallocate;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.AfterClass;
@@ -81,7 +82,7 @@ public class TestDeallocateTask
         TransactionManager transactionManager = createTestTransactionManager();
         AccessControl accessControl = new AccessControlManager(transactionManager);
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, accessControl, executor, metadata);
-        Deallocate deallocate = new Deallocate(statementName);
+        Deallocate deallocate = new Deallocate(new Identifier(statementName));
         new DeallocateTask().execute(deallocate, transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList());
         return stateMachine.getDeallocatedPreparedStatements();
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestPrepareTask.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ExecutorService;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.sql.QueryUtil.selectList;
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
 import static com.facebook.presto.sql.QueryUtil.table;
@@ -87,7 +88,7 @@ public class TestPrepareTask
     @Test
     public void testPrepareInvalidStatement()
     {
-        Statement statement = new Execute("foo", emptyList());
+        Statement statement = new Execute(identifier("foo"), emptyList());
         String sqlString = "PREPARE my_query FROM EXECUTE foo";
         try {
             executePrepare("my_query", statement, sqlString, TEST_SESSION);
@@ -104,7 +105,7 @@ public class TestPrepareTask
         TransactionManager transactionManager = createTestTransactionManager();
         AccessControl accessControl = new AccessControlManager(transactionManager);
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), sqlString, session, URI.create("fake://uri"), false, transactionManager, accessControl, executor, metadata);
-        Prepare prepare = new Prepare(statementName, statement);
+        Prepare prepare = new Prepare(identifier(statementName), statement);
         new PrepareTask(new SqlParser()).execute(prepare, transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList());
         return stateMachine.getAddedPreparedStatements();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -245,17 +245,17 @@ public class TestAnalyzer
 
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:16: Subquery uses '\"u\".\"a\"' which must appear in GROUP BY clause",
+                "line 1:16: Subquery uses 'u.a' which must appear in GROUP BY clause",
                 "SELECT (SELECT u.a from (values 1) x(a)) FROM t1 u GROUP BY b");
 
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:16: Subquery uses '\"a\"' which must appear in GROUP BY clause",
+                "line 1:16: Subquery uses 'a' which must appear in GROUP BY clause",
                 "SELECT (SELECT a+2) FROM t1 GROUP BY a+1");
 
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:36: Subquery uses '\"u\".\"a\"' which must appear in GROUP BY clause",
+                "line 1:36: Subquery uses 'u.a' which must appear in GROUP BY clause",
                 "SELECT (SELECT 1 FROM t1 WHERE a = u.a) FROM t1 u GROUP BY b");
 
         // (t1.)a is not part of GROUP BY
@@ -278,17 +278,17 @@ public class TestAnalyzer
 
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:22: Subquery uses '\"u\".\"a\"' which must appear in GROUP BY clause",
+                "line 1:22: Subquery uses 'u.a' which must appear in GROUP BY clause",
                 "SELECT EXISTS(SELECT u.a from (values 1) x(a)) FROM t1 u GROUP BY b");
 
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:22: Subquery uses '\"a\"' which must appear in GROUP BY clause",
+                "line 1:22: Subquery uses 'a' which must appear in GROUP BY clause",
                 "SELECT EXISTS(SELECT a+2) FROM t1 GROUP BY a+1");
 
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:42: Subquery uses '\"u\".\"a\"' which must appear in GROUP BY clause",
+                "line 1:42: Subquery uses 'u.a' which must appear in GROUP BY clause",
                 "SELECT EXISTS(SELECT 1 FROM t1 WHERE a = u.a) FROM t1 u GROUP BY b");
 
         // (t1.)a is not part of GROUP BY
@@ -307,7 +307,7 @@ public class TestAnalyzer
 
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:16: Subquery uses '\"t\".\"a\"' which must appear in GROUP BY clause",
+                "line 1:16: Subquery uses 't.a' which must appear in GROUP BY clause",
                 "SELECT (SELECT t.a.someField) " +
                         "FROM (VALUES ROW(CAST(ROW(1) AS ROW(someField BIGINT)), 2)) t(a, b) " +
                         "GROUP BY b");
@@ -523,7 +523,7 @@ public class TestAnalyzer
 
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:46: Subquery uses '\"b\"' which must appear in GROUP BY clause",
+                "line 1:46: Subquery uses 'b' which must appear in GROUP BY clause",
                 "SELECT a FROM t1 GROUP BY a ORDER BY (SELECT b)");
 
         analyze("SELECT a AS b FROM t1 GROUP BY t1.a ORDER BY (SELECT b)");
@@ -1297,7 +1297,7 @@ public class TestAnalyzer
         // non-GROUP BY column captured in lambda
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:34: Subquery uses '\"a\"' which must appear in GROUP BY clause",
+                "line 1:34: Subquery uses 'a' which must appear in GROUP BY clause",
                 "SELECT (SELECT apply(0, x -> x + a) FROM (VALUES 1) x(c)) " +
                         "FROM t1 u GROUP BY b");
         // TODO #7784
@@ -1321,7 +1321,7 @@ public class TestAnalyzer
         analyze("SELECT count(*) AS output_column FROM t1 GROUP BY a ORDER BY (SELECT apply(0, x -> x + output_column))");
         assertFails(
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
-                "line 1:71: Subquery uses '\"b\"' which must appear in GROUP BY clause",
+                "line 1:71: Subquery uses 'b' which must appear in GROUP BY clause",
                 "SELECT count(*) FROM t1 GROUP BY a ORDER BY (SELECT apply(0, x -> x + b))");
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEqualityInference.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEqualityInference.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.GREATER_THAN;
 import static com.google.common.base.Predicates.not;
@@ -345,7 +346,7 @@ public class TestEqualityInference
                 new FunctionCall(QualifiedName.of("try"), ImmutableList.of(nameReference("b"))),
                 new NullIfExpression(nameReference("b"), number(1)),
                 new IfExpression(nameReference("b"), number(1), new NullLiteral()),
-                new DereferenceExpression(nameReference("b"), "x"),
+                new DereferenceExpression(nameReference("b"), identifier("x")),
                 new InPredicate(nameReference("b"), new InListExpression(ImmutableList.of(new NullLiteral()))),
                 new SearchedCaseExpression(ImmutableList.of(new WhenClause(new IsNotNullPredicate(nameReference("b")), new NullLiteral())), Optional.empty()),
                 new SimpleCaseExpression(nameReference("b"), ImmutableList.of(new WhenClause(number(1), new NullLiteral())), Optional.empty()),

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -433,14 +433,10 @@ qualifiedName
 
 identifier
     : IDENTIFIER             #unquotedIdentifier
-    | quotedIdentifier       #quotedIdentifierAlternative
+    | QUOTED_IDENTIFIER      #quotedIdentifier
     | nonReserved            #unquotedIdentifier
     | BACKQUOTED_IDENTIFIER  #backQuotedIdentifier
     | DIGIT_IDENTIFIER       #digitIdentifier
-    ;
-
-quotedIdentifier
-    : QUOTED_IDENTIFIER
     ;
 
 number

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -288,13 +288,18 @@ public final class ExpressionFormatter
         @Override
         protected String visitIdentifier(Identifier node, Void context)
         {
-            return formatIdentifier(node.getName());
+            if (!node.isDelimited()) {
+                return node.getValue();
+            }
+            else {
+                return '"' + node.getValue().replace("\"", "\"\"") + '"';
+            }
         }
 
         @Override
         protected String visitLambdaArgumentDeclaration(LambdaArgumentDeclaration node, Void context)
         {
-            return formatIdentifier(node.getName());
+            return formatExpression(node.getName(), parameters);
         }
 
         @Override
@@ -307,7 +312,7 @@ public final class ExpressionFormatter
         protected String visitDereferenceExpression(DereferenceExpression node, Void context)
         {
             String baseString = process(node.getBase(), context);
-            return baseString + "." + formatIdentifier(node.getFieldName());
+            return baseString + "." + process(node.getField());
         }
 
         private static String formatQualifiedName(QualifiedName name)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
@@ -52,9 +53,14 @@ public final class QueryUtil
 {
     private QueryUtil() {}
 
-    public static Expression identifier(String name)
+    public static Identifier identifier(String name)
     {
         return new Identifier(name);
+    }
+
+    public static Identifier quotedIdentifier(String name)
+    {
+        return new Identifier(name, true);
     }
 
     public static SelectItem unaliasedName(String name)
@@ -64,7 +70,7 @@ public final class QueryUtil
 
     public static SelectItem aliasedName(String name, String alias)
     {
-        return new SingleColumn(identifier(name), alias);
+        return new SingleColumn(identifier(name), identifier(alias));
     }
 
     public static Select selectList(Expression... expressions)
@@ -133,12 +139,17 @@ public final class QueryUtil
 
     public static Relation aliased(Relation relation, String alias, List<String> columnAliases)
     {
-        return new AliasedRelation(relation, alias, columnAliases);
+        return new AliasedRelation(
+                relation,
+                identifier(alias),
+                columnAliases.stream()
+                        .map(QueryUtil::identifier)
+                        .collect(Collectors.toList()));
     }
 
     public static SelectItem aliasedNullToEmpty(String column, String alias)
     {
-        return new SingleColumn(new CoalesceExpression(identifier(column), new StringLiteral("")), alias);
+        return new SingleColumn(new CoalesceExpression(identifier(column), new StringLiteral("")), identifier(alias));
     }
 
     public static OrderBy ordering(SortItem... items)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/TreePrinter.java
@@ -298,7 +298,7 @@ public class TreePrinter
                 if (resolved != null) {
                     resolvedName = "=>" + resolved.toString();
                 }
-                print(indentLevel, "Identifier[" + node.getName() + resolvedName + "]");
+                print(indentLevel, "Identifier[" + node.getValue() + resolvedName + "]");
                 return null;
             }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.sql.parser;
 
-import com.facebook.presto.sql.parser.SqlBaseParser.ColumnAliasesContext;
 import com.facebook.presto.sql.parser.SqlBaseParser.TablePropertiesContext;
 import com.facebook.presto.sql.parser.SqlBaseParser.TablePropertyContext;
 import com.facebook.presto.sql.tree.AddColumn;
@@ -197,7 +196,10 @@ class AstBuilder
     @Override
     public Node visitUse(SqlBaseParser.UseContext context)
     {
-        return new Use(getLocation(context), getTextIfPresent(context.catalog), context.schema.getText());
+        return new Use(
+                getLocation(context),
+                visitIfPresent(context.catalog, Identifier.class),
+                (Identifier) visit(context.schema));
     }
 
     @Override
@@ -226,7 +228,7 @@ class AstBuilder
         return new RenameSchema(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
-                context.identifier().getText());
+                (Identifier) visit(context.identifier()));
     }
 
     @Override
@@ -236,6 +238,12 @@ class AstBuilder
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
         }
+
+        Optional<List<Identifier>> columnAliases = Optional.empty();
+        if (context.columnAliases() != null) {
+            columnAliases = Optional.of(visit(context.columnAliases().identifier(), Identifier.class));
+        }
+
         return new CreateTableAsSelect(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -243,7 +251,7 @@ class AstBuilder
                 context.EXISTS() != null,
                 processTableProperties(context.tableProperties()),
                 context.NO() == null,
-                processColumnAliases(context.columnAliases()),
+                columnAliases,
                 comment);
     }
 
@@ -268,18 +276,6 @@ class AstBuilder
         return properties.build();
     }
 
-    private Optional<List<Identifier>> processColumnAliases(ColumnAliasesContext columnAliasesContext)
-    {
-        if (columnAliasesContext == null) {
-            return Optional.empty();
-        }
-        ImmutableList.Builder<Identifier> columnAliases = ImmutableList.builder();
-        for (SqlBaseParser.IdentifierContext identifierContext : columnAliasesContext.identifier()) {
-            columnAliases.add(new Identifier(getLocation(identifierContext), identifierContext.getText()));
-        }
-        return Optional.of(columnAliases.build());
-    }
-
     @Override
     public Node visitShowCreateTable(SqlBaseParser.ShowCreateTableContext context)
     {
@@ -301,9 +297,14 @@ class AstBuilder
     @Override
     public Node visitInsertInto(SqlBaseParser.InsertIntoContext context)
     {
+        Optional<List<Identifier>> columnAliases = Optional.empty();
+        if (context.columnAliases() != null) {
+            columnAliases = Optional.of(visit(context.columnAliases().identifier(), Identifier.class));
+        }
+
         return new Insert(
                 getQualifiedName(context.qualifiedName()),
-                Optional.ofNullable(getColumnAliases(context.columnAliases())),
+                columnAliases,
                 (Query) visit(context.query()));
     }
 
@@ -325,7 +326,11 @@ class AstBuilder
     @Override
     public Node visitRenameColumn(SqlBaseParser.RenameColumnContext context)
     {
-        return new RenameColumn(getLocation(context), getQualifiedName(context.tableName), context.from.getText(), context.to.getText());
+        return new RenameColumn(
+                getLocation(context),
+                getQualifiedName(context.tableName),
+                (Identifier) visit(context.from),
+                (Identifier) visit(context.to));
     }
 
     @Override
@@ -337,7 +342,7 @@ class AstBuilder
     @Override
     public Node visitDropColumn(SqlBaseParser.DropColumnContext context)
     {
-        return new DropColumn(getLocation(context), getQualifiedName(context.tableName), context.column.getText());
+        return new DropColumn(getLocation(context), getQualifiedName(context.tableName), (Identifier) visit(context.column));
     }
 
     @Override
@@ -416,36 +421,43 @@ class AstBuilder
     @Override
     public Node visitPrepare(SqlBaseParser.PrepareContext context)
     {
-        String name = context.identifier().getText();
-        return new Prepare(getLocation(context), name, (Statement) visit(context.statement()));
+        return new Prepare(
+                getLocation(context),
+                (Identifier) visit(context.identifier()),
+                (Statement) visit(context.statement()));
     }
 
     @Override
     public Node visitDeallocate(SqlBaseParser.DeallocateContext context)
     {
-        String name = context.identifier().getText();
-        return new Deallocate(getLocation(context), name);
+        return new Deallocate(
+                getLocation(context),
+                (Identifier) visit(context.identifier()));
     }
 
     @Override
     public Node visitExecute(SqlBaseParser.ExecuteContext context)
     {
-        String name = context.identifier().getText();
-        return new Execute(getLocation(context), name, visit(context.expression(), Expression.class));
+        return new Execute(
+                getLocation(context),
+                (Identifier) visit(context.identifier()),
+                visit(context.expression(), Expression.class));
     }
 
     @Override
     public Node visitDescribeOutput(SqlBaseParser.DescribeOutputContext context)
     {
-        String name = context.identifier().getText();
-        return new DescribeOutput(getLocation(context), name);
+        return new DescribeOutput(
+                getLocation(context),
+                (Identifier) visit(context.identifier()));
     }
 
     @Override
     public Node visitDescribeInput(SqlBaseParser.DescribeInputContext context)
     {
-        String name = context.identifier().getText();
-        return new DescribeInput(getLocation(context), name);
+        return new DescribeInput(
+                getLocation(context),
+                (Identifier) visit(context.identifier()));
     }
 
     // ********************** query expressions ********************
@@ -472,7 +484,16 @@ class AstBuilder
     @Override
     public Node visitNamedQuery(SqlBaseParser.NamedQueryContext context)
     {
-        return new WithQuery(getLocation(context), context.name.getText(), (Query) visit(context.query()), Optional.ofNullable(getColumnAliases(context.columnAliases())));
+        Optional<List<Identifier>> columns = Optional.empty();
+        if (context.columnAliases() != null) {
+            columns = Optional.of(visit(context.columnAliases().identifier(), Identifier.class));
+        }
+
+        return new WithQuery(
+                getLocation(context),
+                (Identifier) visit(context.name),
+                (Query) visit(context.query()),
+                columns);
     }
 
     @Override
@@ -563,7 +584,7 @@ class AstBuilder
     public Node visitRollup(SqlBaseParser.RollupContext context)
     {
         return new Rollup(getLocation(context), context.qualifiedName().stream()
-                .map(AstBuilder::getQualifiedName)
+                .map(this::getQualifiedName)
                 .collect(toList()));
     }
 
@@ -571,7 +592,7 @@ class AstBuilder
     public Node visitCube(SqlBaseParser.CubeContext context)
     {
         return new Cube(getLocation(context), context.qualifiedName().stream()
-                .map(AstBuilder::getQualifiedName)
+                .map(this::getQualifiedName)
                 .collect(toList()));
     }
 
@@ -580,7 +601,7 @@ class AstBuilder
     {
         return new GroupingSets(getLocation(context), context.groupingSet().stream()
                 .map(groupingSet -> groupingSet.qualifiedName().stream()
-                        .map(AstBuilder::getQualifiedName)
+                        .map(this::getQualifiedName)
                         .collect(toList()))
                 .collect(toList()));
     }
@@ -618,9 +639,10 @@ class AstBuilder
     @Override
     public Node visitSelectSingle(SqlBaseParser.SelectSingleContext context)
     {
-        Optional<String> alias = getTextIfPresent(context.identifier());
-
-        return new SingleColumn(getLocation(context), (Expression) visit(context.expression()), alias);
+        return new SingleColumn(
+                getLocation(context),
+                (Expression) visit(context.expression()),
+                visitIfPresent(context.identifier(), Identifier.class));
     }
 
     @Override
@@ -681,7 +703,7 @@ class AstBuilder
         return new ShowTables(
                 getLocation(context),
                 Optional.ofNullable(context.qualifiedName())
-                        .map(AstBuilder::getQualifiedName),
+                        .map(this::getQualifiedName),
                 getTextIfPresent(context.pattern)
                         .map(AstBuilder::unquote));
     }
@@ -691,7 +713,7 @@ class AstBuilder
     {
         return new ShowSchemas(
                 getLocation(context),
-                getTextIfPresent(context.identifier()),
+                visitIfPresent(context.identifier(), Identifier.class),
                 getTextIfPresent(context.pattern)
                         .map(AstBuilder::unquote));
     }
@@ -768,8 +790,6 @@ class AstBuilder
     @Override
     public Node visitGrant(SqlBaseParser.GrantContext context)
     {
-        String grantee = context.grantee.getText();
-
         Optional<List<String>> privileges;
         if (context.ALL() != null) {
             privileges = Optional.empty();
@@ -784,7 +804,7 @@ class AstBuilder
                 privileges,
                 context.TABLE() != null,
                 getQualifiedName(context.qualifiedName()),
-                grantee,
+                (Identifier) visit(context.grantee),
                 context.OPTION() != null);
     }
 
@@ -806,7 +826,7 @@ class AstBuilder
                 privileges,
                 context.TABLE() != null,
                 getQualifiedName(context.qualifiedName()),
-                context.grantee.getText());
+                (Identifier) visit(context.grantee));
     }
 
     @Override
@@ -866,12 +886,7 @@ class AstBuilder
                 criteria = new JoinOn((Expression) visit(context.joinCriteria().booleanExpression()));
             }
             else if (context.joinCriteria().USING() != null) {
-                List<String> columns = context.joinCriteria()
-                        .identifier().stream()
-                        .map(ParseTree::getText)
-                        .collect(toList());
-
-                criteria = new JoinUsing(columns);
+                criteria = new JoinUsing(visit(context.joinCriteria().identifier(), Identifier.class));
             }
             else {
                 throw new IllegalArgumentException("Unsupported join criteria");
@@ -920,7 +935,12 @@ class AstBuilder
             return child;
         }
 
-        return new AliasedRelation(getLocation(context), child, context.identifier().getText(), getColumnAliases(context.columnAliases()));
+        List<Identifier> aliases = null;
+        if (context.columnAliases() != null) {
+            aliases = visit(context.columnAliases().identifier(), Identifier.class);
+        }
+
+        return new AliasedRelation(getLocation(context), child, (Identifier) visit(context.identifier()), aliases);
     }
 
     @Override
@@ -1230,13 +1250,16 @@ class AstBuilder
     @Override
     public Node visitDereference(SqlBaseParser.DereferenceContext context)
     {
-        return new DereferenceExpression(getLocation(context), (Expression) visit(context.base), context.fieldName.getText());
+        return new DereferenceExpression(
+                getLocation(context),
+                (Expression) visit(context.base),
+                (Identifier) visit(context.fieldName));
     }
 
     @Override
     public Node visitColumnReference(SqlBaseParser.ColumnReferenceContext context)
     {
-        return new Identifier(getLocation(context), context.getText());
+        return visit(context.identifier());
     }
 
     @Override
@@ -1342,8 +1365,7 @@ class AstBuilder
     @Override
     public Node visitLambda(SqlBaseParser.LambdaContext context)
     {
-        List<LambdaArgumentDeclaration> arguments = context.identifier().stream()
-                .map(SqlBaseParser.IdentifierContext::getText)
+        List<LambdaArgumentDeclaration> arguments = visit(context.identifier(), Identifier.class).stream()
                 .map(LambdaArgumentDeclaration::new)
                 .collect(toList());
 
@@ -1380,7 +1402,11 @@ class AstBuilder
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
         }
-        return new ColumnDefinition(getLocation(context), context.identifier().getText(), getType(context.type()), comment);
+        return new ColumnDefinition(
+                getLocation(context),
+                (Identifier) visit(context.identifier()),
+                getType(context.type()),
+                comment);
     }
 
     @Override
@@ -1439,10 +1465,26 @@ class AstBuilder
     public Node visitGroupingOperation(SqlBaseParser.GroupingOperationContext context)
     {
         List<QualifiedName> arguments = context.qualifiedName().stream()
-                .map(AstBuilder::getQualifiedName)
+                .map(this::getQualifiedName)
                 .collect(toList());
 
         return new GroupingOperation(Optional.of(getLocation(context)), arguments);
+    }
+
+    @Override
+    public Node visitUnquotedIdentifier(SqlBaseParser.UnquotedIdentifierContext context)
+    {
+        return new Identifier(getLocation(context), context.getText(), false);
+    }
+
+    @Override
+    public Node visitQuotedIdentifier(SqlBaseParser.QuotedIdentifierContext context)
+    {
+        String token = context.getText();
+        String identifier = token.substring(1, token.length() - 1)
+                .replace("\"\"", "\"");
+
+        return new Identifier(getLocation(context), identifier, true);
     }
 
     // ************** literals **************
@@ -1696,12 +1738,11 @@ class AstBuilder
         throw new IllegalArgumentException("Unsupported LIKE option type: " + token.getText());
     }
 
-    private static QualifiedName getQualifiedName(SqlBaseParser.QualifiedNameContext context)
+    private QualifiedName getQualifiedName(SqlBaseParser.QualifiedNameContext context)
     {
-        List<String> parts = context
-                .identifier().stream()
-                .map(ParseTree::getText)
-                .collect(toList());
+        List<String> parts = visit(context.identifier(), Identifier.class).stream()
+                .map(Identifier::getValue) // TODO: preserve quotedness
+                .collect(Collectors.toList());
 
         return QualifiedName.of(parts);
     }
@@ -1733,18 +1774,6 @@ class AstBuilder
     {
         return Optional.ofNullable(token)
                 .map(Token::getText);
-    }
-
-    private static List<String> getColumnAliases(SqlBaseParser.ColumnAliasesContext columnAliasesContext)
-    {
-        if (columnAliasesContext == null) {
-            return null;
-        }
-
-        return columnAliasesContext
-                .identifier().stream()
-                .map(ParseTree::getText)
-                .collect(toList());
     }
 
     private static ArithmeticBinaryExpression.Type getArithmeticBinaryOperator(Token operator)
@@ -1933,7 +1962,7 @@ class AstBuilder
         throw new IllegalArgumentException("Unsupported quantifier: " + symbol.getText());
     }
 
-    private static String getType(SqlBaseParser.TypeContext type)
+    private String getType(SqlBaseParser.TypeContext type)
     {
         if (type.baseType() != null) {
             String signature = type.baseType().getText();
@@ -1945,7 +1974,7 @@ class AstBuilder
                 String typeParameterSignature = type
                         .typeParameter()
                         .stream()
-                        .map(AstBuilder::typeParameterToString)
+                        .map(this::typeParameterToString)
                         .collect(Collectors.joining(","));
                 signature += "(" + typeParameterSignature + ")";
             }
@@ -1966,7 +1995,7 @@ class AstBuilder
                 if (i != 0) {
                     builder.append(",");
                 }
-                builder.append(type.identifier(i).getText())
+                builder.append(visit(type.identifier(i)))
                         .append(" ")
                         .append(getType(type.type(i)));
             }
@@ -1977,7 +2006,7 @@ class AstBuilder
         throw new IllegalArgumentException("Unsupported type specification: " + type.getText());
     }
 
-    private static String typeParameterToString(SqlBaseParser.TypeParameterContext typeParameter)
+    private String typeParameterToString(SqlBaseParser.TypeParameterContext typeParameter)
     {
         if (typeParameter.INTEGER_VALUE() != null) {
             return typeParameter.INTEGER_VALUE().toString();

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParser.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParser.java
@@ -155,21 +155,6 @@ public class SqlParser
         }
 
         @Override
-        public void exitQuotedIdentifier(SqlBaseParser.QuotedIdentifierContext context)
-        {
-            // Remove quotes
-            context.getParent().removeLastChild();
-
-            Token token = (Token) context.getChild(0).getPayload();
-            context.getParent().addChild(new CommonToken(
-                    new Pair<>(token.getTokenSource(), token.getInputStream()),
-                    SqlBaseLexer.IDENTIFIER,
-                    token.getChannel(),
-                    token.getStartIndex() + 1,
-                    token.getStopIndex() - 1));
-        }
-
-        @Override
         public void exitNonReserved(SqlBaseParser.NonReservedContext context)
         {
             // we can't modify the tree during rule enter/exit event handling unless we're dealing with a terminal.

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AliasedRelation.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AliasedRelation.java
@@ -26,20 +26,20 @@ public class AliasedRelation
         extends Relation
 {
     private final Relation relation;
-    private final String alias;
-    private final List<String> columnNames;
+    private final Identifier alias;
+    private final List<Identifier> columnNames;
 
-    public AliasedRelation(Relation relation, String alias, List<String> columnNames)
+    public AliasedRelation(Relation relation, Identifier alias, List<Identifier> columnNames)
     {
         this(Optional.empty(), relation, alias, columnNames);
     }
 
-    public AliasedRelation(NodeLocation location, Relation relation, String alias, List<String> columnNames)
+    public AliasedRelation(NodeLocation location, Relation relation, Identifier alias, List<Identifier> columnNames)
     {
         this(Optional.of(location), relation, alias, columnNames);
     }
 
-    private AliasedRelation(Optional<NodeLocation> location, Relation relation, String alias, List<String> columnNames)
+    private AliasedRelation(Optional<NodeLocation> location, Relation relation, Identifier alias, List<Identifier> columnNames)
     {
         super(location);
         requireNonNull(relation, "relation is null");
@@ -55,12 +55,12 @@ public class AliasedRelation
         return relation;
     }
 
-    public String getAlias()
+    public Identifier getAlias()
     {
         return alias;
     }
 
-    public List<String> getColumnNames()
+    public List<Identifier> getColumnNames()
     {
         return columnNames;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ColumnDefinition.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ColumnDefinition.java
@@ -25,21 +25,21 @@ import static java.util.Objects.requireNonNull;
 public final class ColumnDefinition
         extends TableElement
 {
-    private final String name;
+    private final Identifier name;
     private final String type;
     private final Optional<String> comment;
 
-    public ColumnDefinition(String name, String type, Optional<String> comment)
+    public ColumnDefinition(Identifier name, String type, Optional<String> comment)
     {
         this(Optional.empty(), name, type, comment);
     }
 
-    public ColumnDefinition(NodeLocation location, String name, String type, Optional<String> comment)
+    public ColumnDefinition(NodeLocation location, Identifier name, String type, Optional<String> comment)
     {
         this(Optional.of(location), name, type, comment);
     }
 
-    private ColumnDefinition(Optional<NodeLocation> location, String name, String type, Optional<String> comment)
+    private ColumnDefinition(Optional<NodeLocation> location, Identifier name, String type, Optional<String> comment)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
@@ -47,7 +47,7 @@ public final class ColumnDefinition
         this.comment = requireNonNull(comment, "comment is null");
     }
 
-    public String getName()
+    public Identifier getName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Deallocate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Deallocate.java
@@ -25,25 +25,25 @@ import static java.util.Objects.requireNonNull;
 public class Deallocate
         extends Statement
 {
-    private final String name;
+    private final Identifier name;
 
-    public Deallocate(NodeLocation location, String name)
+    public Deallocate(NodeLocation location, Identifier name)
     {
         this(Optional.of(location), name);
     }
 
-    public Deallocate(String name)
+    public Deallocate(Identifier name)
     {
         this(Optional.empty(), name);
     }
 
-    private Deallocate(Optional<NodeLocation> location, String name)
+    private Deallocate(Optional<NodeLocation> location, Identifier name)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
     }
 
-    public String getName()
+    public Identifier getName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DereferenceExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DereferenceExpression.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -26,25 +27,25 @@ public class DereferenceExpression
         extends Expression
 {
     private final Expression base;
-    private final String fieldName;
+    private final Identifier field;
 
-    public DereferenceExpression(Expression base, String fieldName)
+    public DereferenceExpression(Expression base, Identifier field)
     {
-        this(Optional.empty(), base, fieldName);
+        this(Optional.empty(), base, field);
     }
 
-    public DereferenceExpression(NodeLocation location, Expression base, String fieldName)
+    public DereferenceExpression(NodeLocation location, Expression base, Identifier field)
     {
-        this(Optional.of(location), base, fieldName);
+        this(Optional.of(location), base, field);
     }
 
-    private DereferenceExpression(Optional<NodeLocation> location, Expression base, String fieldName)
+    private DereferenceExpression(Optional<NodeLocation> location, Expression base, Identifier field)
     {
         super(location);
         checkArgument(base != null, "base is null");
-        checkArgument(fieldName != null, "fieldName is null");
+        checkArgument(field != null, "fieldName is null");
         this.base = base;
-        this.fieldName = fieldName.toLowerCase();
+        this.field = field;
     }
 
     @Override
@@ -64,9 +65,9 @@ public class DereferenceExpression
         return base;
     }
 
-    public String getFieldName()
+    public Identifier getField()
     {
-        return fieldName;
+        return field;
     }
 
     /**
@@ -75,7 +76,7 @@ public class DereferenceExpression
      */
     public static QualifiedName getQualifiedName(DereferenceExpression expression)
     {
-        List<String> parts = tryParseParts(expression.base, expression.fieldName);
+        List<String> parts = tryParseParts(expression.base, expression.field.getValue().toLowerCase(Locale.ENGLISH));
         return parts == null ? null : QualifiedName.of(parts);
     }
 
@@ -88,7 +89,7 @@ public class DereferenceExpression
                 result = new Identifier(part);
             }
             else {
-                result = new DereferenceExpression(result, part);
+                result = new DereferenceExpression(result, new Identifier(part));
             }
         }
 
@@ -98,7 +99,7 @@ public class DereferenceExpression
     private static List<String> tryParseParts(Expression base, String fieldName)
     {
         if (base instanceof Identifier) {
-            return ImmutableList.of(((Identifier) base).getName(), fieldName);
+            return ImmutableList.of(((Identifier) base).getValue(), fieldName);
         }
         else if (base instanceof DereferenceExpression) {
             QualifiedName baseQualifiedName = getQualifiedName((DereferenceExpression) base);
@@ -122,12 +123,12 @@ public class DereferenceExpression
         }
         DereferenceExpression that = (DereferenceExpression) o;
         return Objects.equals(base, that.base) &&
-                Objects.equals(fieldName, that.fieldName);
+                Objects.equals(field, that.field);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(base, fieldName);
+        return Objects.hash(base, field);
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeInput.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeInput.java
@@ -24,25 +24,25 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 public class DescribeInput
         extends Statement
 {
-    private final String name;
+    private final Identifier name;
 
-    public DescribeInput(NodeLocation location, String name)
+    public DescribeInput(NodeLocation location, Identifier name)
     {
         this(Optional.of(location), name);
     }
 
-    public DescribeInput(String name)
+    public DescribeInput(Identifier name)
     {
         this(Optional.empty(), name);
     }
 
-    private DescribeInput(Optional<NodeLocation> location, String name)
+    private DescribeInput(Optional<NodeLocation> location, Identifier name)
     {
         super(location);
         this.name = name;
     }
 
-    public String getName()
+    public Identifier getName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeOutput.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeOutput.java
@@ -24,25 +24,25 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 public class DescribeOutput
         extends Statement
 {
-    private final String name;
+    private final Identifier name;
 
-    public DescribeOutput(NodeLocation location, String name)
+    public DescribeOutput(NodeLocation location, Identifier name)
     {
         this(Optional.of(location), name);
     }
 
-    public DescribeOutput(String name)
+    public DescribeOutput(Identifier name)
     {
         this(Optional.empty(), name);
     }
 
-    private DescribeOutput(Optional<NodeLocation> location, String name)
+    private DescribeOutput(Optional<NodeLocation> location, Identifier name)
     {
         super(location);
         this.name = name;
     }
 
-    public String getName()
+    public Identifier getName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropColumn.java
@@ -26,19 +26,19 @@ public class DropColumn
         extends Statement
 {
     private final QualifiedName table;
-    private final String column;
+    private final Identifier column;
 
-    public DropColumn(QualifiedName table, String column)
+    public DropColumn(QualifiedName table, Identifier column)
     {
         this(Optional.empty(), table, column);
     }
 
-    public DropColumn(NodeLocation location, QualifiedName table, String column)
+    public DropColumn(NodeLocation location, QualifiedName table, Identifier column)
     {
         this(Optional.of(location), table, column);
     }
 
-    private DropColumn(Optional<NodeLocation> location, QualifiedName table, String column)
+    private DropColumn(Optional<NodeLocation> location, QualifiedName table, Identifier column)
     {
         super(location);
         this.table = requireNonNull(table, "table is null");
@@ -50,7 +50,7 @@ public class DropColumn
         return table;
     }
 
-    public String getColumn()
+    public Identifier getColumn()
     {
         return column;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Execute.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Execute.java
@@ -25,27 +25,27 @@ import static java.util.Objects.requireNonNull;
 public class Execute
         extends Statement
 {
-    private final String name;
+    private final Identifier name;
     private final List<Expression> parameters;
 
-    public Execute(NodeLocation location, String name, List<Expression> parameters)
+    public Execute(NodeLocation location, Identifier name, List<Expression> parameters)
     {
         this(Optional.of(location), name, parameters);
     }
 
-    public Execute(String name, List<Expression> parameters)
+    public Execute(Identifier name, List<Expression> parameters)
     {
         this(Optional.empty(), name, parameters);
     }
 
-    private Execute(Optional<NodeLocation> location, String name, List<Expression> parameters)
+    private Execute(Optional<NodeLocation> location, Identifier name, List<Expression> parameters)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
         this.parameters = requireNonNull(ImmutableList.copyOf(parameters), "parameters is null");
     }
 
-    public String getName()
+    public Identifier getName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -756,7 +756,7 @@ public final class ExpressionTreeRewriter<C>
 
             Expression base = rewrite(node.getBase(), context.get());
             if (base != node.getBase()) {
-                return new DereferenceExpression(base, node.getFieldName());
+                return new DereferenceExpression(base, node.getField());
             }
 
             return node;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
@@ -28,20 +28,20 @@ public class Grant
     private final Optional<List<String>> privileges; // missing means ALL PRIVILEGES
     private final boolean table;
     private final QualifiedName tableName;
-    private final String grantee;
+    private final Identifier grantee;
     private final boolean withGrantOption;
 
-    public Grant(Optional<List<String>> privileges, boolean table, QualifiedName tableName, String grantee, boolean withGrantOption)
+    public Grant(Optional<List<String>> privileges, boolean table, QualifiedName tableName, Identifier grantee, boolean withGrantOption)
     {
         this(Optional.empty(), privileges, table, tableName, grantee, withGrantOption);
     }
 
-    public Grant(NodeLocation location, Optional<List<String>> privileges, boolean table, QualifiedName tableName, String grantee, boolean withGrantOption)
+    public Grant(NodeLocation location, Optional<List<String>> privileges, boolean table, QualifiedName tableName, Identifier grantee, boolean withGrantOption)
     {
         this(Optional.of(location), privileges, table, tableName, grantee, withGrantOption);
     }
 
-    private Grant(Optional<NodeLocation> location, Optional<List<String>> privileges, boolean table, QualifiedName tableName, String grantee, boolean withGrantOption)
+    private Grant(Optional<NodeLocation> location, Optional<List<String>> privileges, boolean table, QualifiedName tableName, Identifier grantee, boolean withGrantOption)
     {
         super(location);
         requireNonNull(privileges, "privileges is null");
@@ -67,7 +67,7 @@ public class Grant
         return tableName;
     }
 
-    public String getGrantee()
+    public Identifier getGrantee()
     {
         return grantee;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Identifier.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Identifier.java
@@ -18,31 +18,50 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class Identifier
         extends Expression
 {
-    private final String name;
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z_]([a-zA-Z0-9_:@])*");
 
-    public Identifier(String name)
+    private final String value;
+    private final boolean delimited;
+
+    public Identifier(NodeLocation location, String value, boolean delimited)
     {
-        this(Optional.empty(), name);
+        this(Optional.of(location), value, delimited);
     }
 
-    public Identifier(NodeLocation location, String name)
+    public Identifier(String value, boolean delimited)
     {
-        this(Optional.of(location), name);
+        this(Optional.empty(), value, delimited);
     }
 
-    private Identifier(Optional<NodeLocation> location, String name)
+    public Identifier(String value)
+    {
+        this(Optional.empty(), value, !NAME_PATTERN.matcher(value).matches());
+    }
+
+    private Identifier(Optional<NodeLocation> location, String value, boolean delimited)
     {
         super(location);
-        this.name = name;
+        this.value = value;
+        this.delimited = delimited;
+
+        checkArgument(delimited || NAME_PATTERN.matcher(value).matches(), "value contains illegal characters: %s", value);
     }
 
-    public String getName()
+    public String getValue()
     {
-        return name;
+        return value;
+    }
+
+    public boolean isDelimited()
+    {
+        return delimited;
     }
 
     @Override
@@ -68,12 +87,12 @@ public class Identifier
         }
 
         Identifier that = (Identifier) o;
-        return Objects.equals(name, that.name);
+        return Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode()
     {
-        return name.hashCode();
+        return value.hashCode();
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
@@ -27,14 +27,14 @@ public final class Insert
 {
     private final QualifiedName target;
     private final Query query;
-    private final Optional<List<String>> columns;
+    private final Optional<List<Identifier>> columns;
 
-    public Insert(QualifiedName target, Optional<List<String>> columns, Query query)
+    public Insert(QualifiedName target, Optional<List<Identifier>> columns, Query query)
     {
         this(Optional.empty(), columns, target, query);
     }
 
-    private Insert(Optional<NodeLocation> location, Optional<List<String>> columns, QualifiedName target, Query query)
+    private Insert(Optional<NodeLocation> location, Optional<List<Identifier>> columns, QualifiedName target, Query query)
     {
         super(location);
         this.target = requireNonNull(target, "target is null");
@@ -47,7 +47,7 @@ public final class Insert
         return target;
     }
 
-    public Optional<List<String>> getColumns()
+    public Optional<List<Identifier>> getColumns()
     {
         return columns;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/JoinUsing.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/JoinUsing.java
@@ -25,16 +25,16 @@ import static java.util.Objects.requireNonNull;
 public class JoinUsing
         extends JoinCriteria
 {
-    private final List<String> columns;
+    private final List<Identifier> columns;
 
-    public JoinUsing(List<String> columns)
+    public JoinUsing(List<Identifier> columns)
     {
         requireNonNull(columns, "columns is null");
         checkArgument(!columns.isEmpty(), "columns is empty");
         this.columns = ImmutableList.copyOf(columns);
     }
 
-    public List<String> getColumns()
+    public List<Identifier> getColumns()
     {
         return columns;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LambdaArgumentDeclaration.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LambdaArgumentDeclaration.java
@@ -22,15 +22,15 @@ import java.util.Optional;
 public class LambdaArgumentDeclaration
         extends Expression
 {
-    private final String name;
+    private final Identifier name;
 
-    public LambdaArgumentDeclaration(String name)
+    public LambdaArgumentDeclaration(Identifier name)
     {
         super(Optional.empty());
         this.name = name;
     }
 
-    public String getName()
+    public Identifier getName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Prepare.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Prepare.java
@@ -25,27 +25,27 @@ import static java.util.Objects.requireNonNull;
 public class Prepare
         extends Statement
 {
-    private final String name;
+    private final Identifier name;
     private final Statement statement;
 
-    public Prepare(NodeLocation location, String name, Statement statement)
+    public Prepare(NodeLocation location, Identifier name, Statement statement)
     {
         this(Optional.of(location), name, statement);
     }
 
-    public Prepare(String name, Statement statement)
+    public Prepare(Identifier name, Statement statement)
     {
         this(Optional.empty(), name, statement);
     }
 
-    private Prepare(Optional<NodeLocation> location, String name, Statement statement)
+    private Prepare(Optional<NodeLocation> location, Identifier name, Statement statement)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
         this.statement = requireNonNull(statement, "statement is null");
     }
 
-    public String getName()
+    public Identifier getName()
     {
         return name;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
@@ -26,20 +26,20 @@ public class RenameColumn
         extends Statement
 {
     private final QualifiedName table;
-    private final String source;
-    private final String target;
+    private final Identifier source;
+    private final Identifier target;
 
-    public RenameColumn(QualifiedName table, String source, String target)
+    public RenameColumn(QualifiedName table, Identifier source, Identifier target)
     {
         this(Optional.empty(), table, source, target);
     }
 
-    public RenameColumn(NodeLocation location, QualifiedName table, String source, String target)
+    public RenameColumn(NodeLocation location, QualifiedName table, Identifier source, Identifier target)
     {
         this(Optional.of(location), table, source, target);
     }
 
-    private RenameColumn(Optional<NodeLocation> location, QualifiedName table, String source, String target)
+    private RenameColumn(Optional<NodeLocation> location, QualifiedName table, Identifier source, Identifier target)
     {
         super(location);
         this.table = requireNonNull(table, "table is null");
@@ -52,12 +52,12 @@ public class RenameColumn
         return table;
     }
 
-    public String getSource()
+    public Identifier getSource()
     {
         return source;
     }
 
-    public String getTarget()
+    public Identifier getTarget()
     {
         return target;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameSchema.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameSchema.java
@@ -26,19 +26,19 @@ public final class RenameSchema
         extends Statement
 {
     private final QualifiedName source;
-    private final String target;
+    private final Identifier target;
 
-    public RenameSchema(QualifiedName source, String target)
+    public RenameSchema(QualifiedName source, Identifier target)
     {
         this(Optional.empty(), source, target);
     }
 
-    public RenameSchema(NodeLocation location, QualifiedName source, String target)
+    public RenameSchema(NodeLocation location, QualifiedName source, Identifier target)
     {
         this(Optional.of(location), source, target);
     }
 
-    private RenameSchema(Optional<NodeLocation> location, QualifiedName source, String target)
+    private RenameSchema(Optional<NodeLocation> location, QualifiedName source, Identifier target)
     {
         super(location);
         this.source = requireNonNull(source, "source is null");
@@ -50,7 +50,7 @@ public final class RenameSchema
         return source;
     }
 
-    public String getTarget()
+    public Identifier getTarget()
     {
         return target;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Revoke.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Revoke.java
@@ -29,19 +29,19 @@ public class Revoke
     private final Optional<List<String>> privileges; // missing means ALL PRIVILEGES
     private final boolean table;
     private final QualifiedName tableName;
-    private final String grantee;
+    private final Identifier grantee;
 
-    public Revoke(boolean grantOptionFor, Optional<List<String>> privileges, boolean table, QualifiedName tableName, String grantee)
+    public Revoke(boolean grantOptionFor, Optional<List<String>> privileges, boolean table, QualifiedName tableName, Identifier grantee)
     {
         this(Optional.empty(), grantOptionFor, privileges, table, tableName, grantee);
     }
 
-    public Revoke(NodeLocation location, boolean grantOptionFor, Optional<List<String>> privileges, boolean table, QualifiedName tableName, String grantee)
+    public Revoke(NodeLocation location, boolean grantOptionFor, Optional<List<String>> privileges, boolean table, QualifiedName tableName, Identifier grantee)
     {
         this(Optional.of(location), grantOptionFor, privileges, table, tableName, grantee);
     }
 
-    private Revoke(Optional<NodeLocation> location, boolean grantOptionFor, Optional<List<String>> privileges, boolean table, QualifiedName tableName, String grantee)
+    private Revoke(Optional<NodeLocation> location, boolean grantOptionFor, Optional<List<String>> privileges, boolean table, QualifiedName tableName, Identifier grantee)
     {
         super(location);
         this.grantOptionFor = grantOptionFor;
@@ -72,7 +72,7 @@ public class Revoke
         return tableName;
     }
 
-    public String getGrantee()
+    public Identifier getGrantee()
     {
         return grantee;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
@@ -25,27 +25,27 @@ import static java.util.Objects.requireNonNull;
 public class ShowSchemas
         extends Statement
 {
-    private final Optional<String> catalog;
+    private final Optional<Identifier> catalog;
     private final Optional<String> likePattern;
 
-    public ShowSchemas(Optional<String> catalog, Optional<String> likePattern)
+    public ShowSchemas(Optional<Identifier> catalog, Optional<String> likePattern)
     {
         this(Optional.empty(), catalog, likePattern);
     }
 
-    public ShowSchemas(NodeLocation location, Optional<String> catalog, Optional<String> likePattern)
+    public ShowSchemas(NodeLocation location, Optional<Identifier> catalog, Optional<String> likePattern)
     {
         this(Optional.of(location), catalog, likePattern);
     }
 
-    private ShowSchemas(Optional<NodeLocation> location, Optional<String> catalog, Optional<String> likePattern)
+    private ShowSchemas(Optional<NodeLocation> location, Optional<Identifier> catalog, Optional<String> likePattern)
     {
         super(location);
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.likePattern = requireNonNull(likePattern, "likePattern is null");
     }
 
-    public Optional<String> getCatalog()
+    public Optional<Identifier> getCatalog()
     {
         return catalog;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SingleColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SingleColumn.java
@@ -24,7 +24,7 @@ import static java.util.Objects.requireNonNull;
 public class SingleColumn
         extends SelectItem
 {
-    private final Optional<String> alias;
+    private final Optional<Identifier> alias;
     private final Expression expression;
 
     public SingleColumn(Expression expression)
@@ -32,22 +32,22 @@ public class SingleColumn
         this(Optional.empty(), expression, Optional.empty());
     }
 
-    public SingleColumn(Expression expression, Optional<String> alias)
+    public SingleColumn(Expression expression, Optional<Identifier> alias)
     {
         this(Optional.empty(), expression, alias);
     }
 
-    public SingleColumn(Expression expression, String alias)
+    public SingleColumn(Expression expression, Identifier alias)
     {
         this(Optional.empty(), expression, Optional.of(alias));
     }
 
-    public SingleColumn(NodeLocation location, Expression expression, Optional<String> alias)
+    public SingleColumn(NodeLocation location, Expression expression, Optional<Identifier> alias)
     {
         this(Optional.of(location), expression, alias);
     }
 
-    private SingleColumn(Optional<NodeLocation> location, Expression expression, Optional<String> alias)
+    private SingleColumn(Optional<NodeLocation> location, Expression expression, Optional<Identifier> alias)
     {
         super(location);
         requireNonNull(expression, "expression is null");
@@ -57,7 +57,7 @@ public class SingleColumn
         this.alias = alias;
     }
 
-    public Optional<String> getAlias()
+    public Optional<Identifier> getAlias()
     {
         return alias;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Use.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Use.java
@@ -25,20 +25,20 @@ import static java.util.Objects.requireNonNull;
 public final class Use
         extends Statement
 {
-    private final Optional<String> catalog;
-    private final String schema;
+    private final Optional<Identifier> catalog;
+    private final Identifier schema;
 
-    public Use(Optional<String> catalog, String schema)
+    public Use(Optional<Identifier> catalog, Identifier schema)
     {
         this(Optional.empty(), catalog, schema);
     }
 
-    public Use(NodeLocation location, Optional<String> catalog, String schema)
+    public Use(NodeLocation location, Optional<Identifier> catalog, Identifier schema)
     {
         this(Optional.of(location), catalog, schema);
     }
 
-    private Use(Optional<NodeLocation> location, Optional<String> catalog, String schema)
+    private Use(Optional<NodeLocation> location, Optional<Identifier> catalog, Identifier schema)
     {
         super(location);
         requireNonNull(catalog, "catalog is null");
@@ -47,12 +47,12 @@ public final class Use
         this.schema = schema;
     }
 
-    public Optional<String> getCatalog()
+    public Optional<Identifier> getCatalog()
     {
         return catalog;
     }
 
-    public String getSchema()
+    public Identifier getSchema()
     {
         return schema;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/WithQuery.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/WithQuery.java
@@ -25,29 +25,29 @@ import static java.util.Objects.requireNonNull;
 public class WithQuery
         extends Node
 {
-    private final String name;
+    private final Identifier name;
     private final Query query;
-    private final Optional<List<String>> columnNames;
+    private final Optional<List<Identifier>> columnNames;
 
-    public WithQuery(String name, Query query, Optional<List<String>> columnNames)
+    public WithQuery(Identifier name, Query query, Optional<List<Identifier>> columnNames)
     {
         this(Optional.empty(), name, query, columnNames);
     }
 
-    public WithQuery(NodeLocation location, String name, Query query, Optional<List<String>> columnNames)
+    public WithQuery(NodeLocation location, Identifier name, Query query, Optional<List<Identifier>> columnNames)
     {
         this(Optional.of(location), name, query, columnNames);
     }
 
-    private WithQuery(Optional<NodeLocation> location, String name, Query query, Optional<List<String>> columnNames)
+    private WithQuery(Optional<NodeLocation> location, Identifier name, Query query, Optional<List<Identifier>> columnNames)
     {
         super(location);
-        this.name = QualifiedName.of(requireNonNull(name, "name is null")).getParts().get(0);
+        this.name = name;
         this.query = requireNonNull(query, "query is null");
         this.columnNames = requireNonNull(columnNames, "columnNames is null");
     }
 
-    public String getName()
+    public Identifier getName()
     {
         return name;
     }
@@ -57,7 +57,7 @@ public class WithQuery
         return query;
     }
 
-    public Optional<List<String>> getColumnNames()
+    public Optional<List<Identifier>> getColumnNames()
     {
         return columnNames;
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -134,6 +134,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.sql.QueryUtil.query;
+import static com.facebook.presto.sql.QueryUtil.quotedIdentifier;
 import static com.facebook.presto.sql.QueryUtil.row;
 import static com.facebook.presto.sql.QueryUtil.selectList;
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
@@ -808,8 +809,8 @@ public class TestSqlParser
             throws Exception
     {
         assertStatement("SHOW SCHEMAS", new ShowSchemas(Optional.empty(), Optional.empty()));
-        assertStatement("SHOW SCHEMAS FROM foo", new ShowSchemas(Optional.of("foo"), Optional.empty()));
-        assertStatement("SHOW SCHEMAS IN foo LIKE '%'", new ShowSchemas(Optional.of("foo"), Optional.of("%")));
+        assertStatement("SHOW SCHEMAS FROM foo", new ShowSchemas(Optional.of(identifier("foo")), Optional.empty()));
+        assertStatement("SHOW SCHEMAS IN foo LIKE '%'", new ShowSchemas(Optional.of(identifier("foo")), Optional.of("%")));
     }
 
     @Test
@@ -943,10 +944,10 @@ public class TestSqlParser
                         Optional.empty(),
                         new QuerySpecification(
                                 selectList(
-                                        new DereferenceExpression(new Identifier("col1"), "f1"),
+                                        new DereferenceExpression(new Identifier("col1"), identifier("f1")),
                                         new Identifier("col2"),
                                         new DereferenceExpression(
-                                                new DereferenceExpression(new DereferenceExpression(new Identifier("col3"), "f1"), "f2"), "f3")),
+                                                new DereferenceExpression(new DereferenceExpression(new Identifier("col3"), identifier("f1")), identifier("f2")), identifier("f3"))),
                                 Optional.of(new Table(QualifiedName.of("table1"))),
                                 Optional.empty(),
                                 Optional.empty(),
@@ -961,9 +962,9 @@ public class TestSqlParser
                         Optional.empty(),
                         new QuerySpecification(
                                 selectList(
-                                        new SubscriptExpression(new DereferenceExpression(new Identifier("col1"), "f1"), new LongLiteral("0")),
+                                        new SubscriptExpression(new DereferenceExpression(new Identifier("col1"), identifier("f1")), new LongLiteral("0")),
                                         new Identifier("col2"),
-                                        new DereferenceExpression(new DereferenceExpression(new SubscriptExpression(new Identifier("col3"), new LongLiteral("2")), "f2"), "f3"),
+                                        new DereferenceExpression(new DereferenceExpression(new SubscriptExpression(new Identifier("col3"), new LongLiteral("2")), identifier("f2")), identifier("f3")),
                                         new SubscriptExpression(new Identifier("col4"), new LongLiteral("4"))),
                                 Optional.of(new Table(QualifiedName.of("table1"))),
                                 Optional.empty(),
@@ -979,7 +980,7 @@ public class TestSqlParser
                         Optional.empty(),
                         new QuerySpecification(
                                 selectList(
-                                        new DereferenceExpression(new Cast(new Row(Lists.newArrayList(new LongLiteral("11"), new LongLiteral("12"))), "ROW(COL0 INTEGER,COL1 INTEGER)"), "col0")),
+                                        new DereferenceExpression(new Cast(new Row(Lists.newArrayList(new LongLiteral("11"), new LongLiteral("12"))), "ROW(COL0 INTEGER,COL1 INTEGER)"), identifier("col0"))),
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
@@ -1184,13 +1185,13 @@ public class TestSqlParser
     public void testRenameSchema()
     {
         assertStatement("ALTER SCHEMA foo RENAME TO bar",
-                new RenameSchema(QualifiedName.of("foo"), "bar"));
+                new RenameSchema(QualifiedName.of("foo"), identifier("bar")));
 
         assertStatement("ALTER SCHEMA foo.bar RENAME TO baz",
-                new RenameSchema(QualifiedName.of("foo", "bar"), "baz"));
+                new RenameSchema(QualifiedName.of("foo", "bar"), identifier("baz")));
 
         assertStatement("ALTER SCHEMA \"awesome schema\".\"awesome table\" RENAME TO \"even more awesome table\"",
-                new RenameSchema(QualifiedName.of("awesome schema", "awesome table"), "even more awesome table"));
+                new RenameSchema(QualifiedName.of("awesome schema", "awesome table"), quotedIdentifier("even more awesome table")));
     }
 
     @Test
@@ -1235,15 +1236,15 @@ public class TestSqlParser
         assertStatement("CREATE TABLE foo (a VARCHAR, b BIGINT COMMENT 'hello world', c IPADDRESS)",
                 new CreateTable(QualifiedName.of("foo"),
                         ImmutableList.of(
-                                new ColumnDefinition("a", "VARCHAR", Optional.empty()),
-                                new ColumnDefinition("b", "BIGINT", Optional.of("hello world")),
-                                new ColumnDefinition("c", "IPADDRESS", Optional.empty())),
+                                new ColumnDefinition(identifier("a"), "VARCHAR", Optional.empty()),
+                                new ColumnDefinition(identifier("b"), "BIGINT", Optional.of("hello world")),
+                                new ColumnDefinition(identifier("c"), "IPADDRESS", Optional.empty())),
                         false,
                         ImmutableMap.of(),
                         Optional.empty()));
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP)",
                 new CreateTable(QualifiedName.of("bar"),
-                        ImmutableList.of(new ColumnDefinition("c", "TIMESTAMP", Optional.empty())),
+                        ImmutableList.of(new ColumnDefinition(identifier("c"), "TIMESTAMP", Optional.empty())),
                         true,
                         ImmutableMap.of(),
                         Optional.empty()));
@@ -1260,7 +1261,7 @@ public class TestSqlParser
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP, LIKE like_table)",
                 new CreateTable(QualifiedName.of("bar"),
                         ImmutableList.of(
-                                new ColumnDefinition("c", "TIMESTAMP", Optional.empty()),
+                                new ColumnDefinition(identifier("c"), "TIMESTAMP", Optional.empty()),
                                 new LikeClause(QualifiedName.of("like_table"),
                                         Optional.empty())),
                         true,
@@ -1269,10 +1270,10 @@ public class TestSqlParser
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP, LIKE like_table, d DATE)",
                 new CreateTable(QualifiedName.of("bar"),
                         ImmutableList.of(
-                                new ColumnDefinition("c", "TIMESTAMP", Optional.empty()),
+                                new ColumnDefinition(identifier("c"), "TIMESTAMP", Optional.empty()),
                                 new LikeClause(QualifiedName.of("like_table"),
                                         Optional.empty()),
-                                new ColumnDefinition("d", "DATE", Optional.empty())),
+                                new ColumnDefinition(identifier("d"), "DATE", Optional.empty())),
                         true,
                         ImmutableMap.of(),
                         Optional.empty()));
@@ -1287,7 +1288,7 @@ public class TestSqlParser
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP, LIKE like_table EXCLUDING PROPERTIES)",
                 new CreateTable(QualifiedName.of("bar"),
                         ImmutableList.of(
-                                new ColumnDefinition("c", "TIMESTAMP", Optional.empty()),
+                                new ColumnDefinition(identifier("c"), "TIMESTAMP", Optional.empty()),
                                 new LikeClause(QualifiedName.of("like_table"),
                                         Optional.of(LikeClause.PropertiesOption.EXCLUDING))),
                         true,
@@ -1296,7 +1297,7 @@ public class TestSqlParser
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP, LIKE like_table EXCLUDING PROPERTIES) COMMENT 'test'",
                 new CreateTable(QualifiedName.of("bar"),
                         ImmutableList.of(
-                                new ColumnDefinition("c", "TIMESTAMP", Optional.empty()),
+                                new ColumnDefinition(identifier("c"), "TIMESTAMP", Optional.empty()),
                                 new LikeClause(QualifiedName.of("like_table"),
                                         Optional.of(LikeClause.PropertiesOption.EXCLUDING))),
                         true,
@@ -1439,9 +1440,9 @@ public class TestSqlParser
         ImmutableMap<String, Expression> properties = ImmutableMap.<String, Expression>builder().build();
 
         Query query = new Query(Optional.of(new With(false, ImmutableList.of(
-                new WithQuery("t",
+                new WithQuery(identifier("t"),
                         query(new Values(ImmutableList.of(new LongLiteral("1")))),
-                        Optional.of(ImmutableList.of("x")))))),
+                        Optional.of(ImmutableList.of(identifier("x"))))))),
                 new Table(QualifiedName.of("t")),
                 Optional.empty(),
                 Optional.empty());
@@ -1488,7 +1489,7 @@ public class TestSqlParser
                 new Insert(table, Optional.empty(), query));
 
         assertStatement("INSERT INTO a (c1, c2) SELECT * FROM t",
-                new Insert(table, Optional.of(ImmutableList.of("c1", "c2")), query));
+                new Insert(table, Optional.of(ImmutableList.of(identifier("c1"), identifier("c2"))), query));
     }
 
     @Test
@@ -1514,22 +1515,22 @@ public class TestSqlParser
     public void testRenameColumn()
             throws Exception
     {
-        assertStatement("ALTER TABLE foo.t RENAME COLUMN a TO b", new RenameColumn(QualifiedName.of("foo", "t"), "a", "b"));
+        assertStatement("ALTER TABLE foo.t RENAME COLUMN a TO b", new RenameColumn(QualifiedName.of("foo", "t"), identifier("a"), identifier("b")));
     }
 
     @Test
     public void testAddColumn()
             throws Exception
     {
-        assertStatement("ALTER TABLE foo.t ADD COLUMN c bigint", new AddColumn(QualifiedName.of("foo", "t"), new ColumnDefinition("c", "bigint", Optional.empty())));
+        assertStatement("ALTER TABLE foo.t ADD COLUMN c bigint", new AddColumn(QualifiedName.of("foo", "t"), new ColumnDefinition(identifier("c"), "bigint", Optional.empty())));
     }
 
     @Test
     public void testDropColumn()
             throws Exception
     {
-        assertStatement("ALTER TABLE foo.t DROP COLUMN c", new DropColumn(QualifiedName.of("foo", "t"), "c"));
-        assertStatement("ALTER TABLE \"t x\" DROP COLUMN \"c d\"", new DropColumn(QualifiedName.of("t x"), "c d"));
+        assertStatement("ALTER TABLE foo.t DROP COLUMN c", new DropColumn(QualifiedName.of("foo", "t"), identifier("c")));
+        assertStatement("ALTER TABLE \"t x\" DROP COLUMN \"c d\"", new DropColumn(QualifiedName.of("t x"), quotedIdentifier("c d")));
     }
 
     @Test
@@ -1551,13 +1552,13 @@ public class TestSqlParser
             throws Exception
     {
         assertStatement("GRANT INSERT, DELETE ON t TO u",
-                new Grant(Optional.of(ImmutableList.of("INSERT", "DELETE")), false, QualifiedName.of("t"), "u", false));
+                new Grant(Optional.of(ImmutableList.of("INSERT", "DELETE")), false, QualifiedName.of("t"), identifier("u"), false));
         assertStatement("GRANT SELECT ON t TO PUBLIC WITH GRANT OPTION",
-                new Grant(Optional.of(ImmutableList.of("SELECT")), false, QualifiedName.of("t"), "PUBLIC", true));
+                new Grant(Optional.of(ImmutableList.of("SELECT")), false, QualifiedName.of("t"), identifier("PUBLIC"), true));
         assertStatement("GRANT ALL PRIVILEGES ON t TO u",
-                new Grant(Optional.empty(), false, QualifiedName.of("t"), "u", false));
+                new Grant(Optional.empty(), false, QualifiedName.of("t"), identifier("u"), false));
         assertStatement("GRANT taco ON t TO PUBLIC WITH GRANT OPTION",
-                new Grant(Optional.of(ImmutableList.of("taco")), false, QualifiedName.of("t"), "PUBLIC", true));
+                new Grant(Optional.of(ImmutableList.of("taco")), false, QualifiedName.of("t"), identifier("PUBLIC"), true));
     }
 
     @Test
@@ -1565,13 +1566,13 @@ public class TestSqlParser
             throws Exception
     {
         assertStatement("REVOKE INSERT, DELETE ON t FROM u",
-                new Revoke(false, Optional.of(ImmutableList.of("INSERT", "DELETE")), false, QualifiedName.of("t"), "u"));
+                new Revoke(false, Optional.of(ImmutableList.of("INSERT", "DELETE")), false, QualifiedName.of("t"), identifier("u")));
         assertStatement("REVOKE GRANT OPTION FOR SELECT ON t FROM PUBLIC",
-                new Revoke(true, Optional.of(ImmutableList.of("SELECT")), false, QualifiedName.of("t"), "PUBLIC"));
+                new Revoke(true, Optional.of(ImmutableList.of("SELECT")), false, QualifiedName.of("t"), identifier("PUBLIC")));
         assertStatement("REVOKE ALL PRIVILEGES ON TABLE t FROM u",
-                new Revoke(false, Optional.empty(), true, QualifiedName.of("t"), "u"));
+                new Revoke(false, Optional.empty(), true, QualifiedName.of("t"), identifier("u")));
         assertStatement("REVOKE taco ON TABLE t FROM u",
-                new Revoke(false, Optional.of(ImmutableList.of("taco")), true, QualifiedName.of("t"), "u"));
+                new Revoke(false, Optional.of(ImmutableList.of("taco")), true, QualifiedName.of("t"), identifier("u")));
     }
 
     @Test
@@ -1592,15 +1593,15 @@ public class TestSqlParser
     {
         assertStatement("WITH a (t, u) AS (SELECT * FROM x), b AS (SELECT * FROM y) TABLE z",
                 new Query(Optional.of(new With(false, ImmutableList.of(
-                        new WithQuery("a", simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("x"))), Optional.of(ImmutableList.of("t", "u"))),
-                        new WithQuery("b", simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("y"))), Optional.empty())))),
+                        new WithQuery(identifier("a"), simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("x"))), Optional.of(ImmutableList.of(identifier("t"), identifier("u")))),
+                        new WithQuery(identifier("b"), simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("y"))), Optional.empty())))),
                         new Table(QualifiedName.of("z")),
                         Optional.empty(),
                         Optional.empty()));
 
         assertStatement("WITH RECURSIVE a AS (SELECT * FROM x) TABLE y",
                 new Query(Optional.of(new With(true, ImmutableList.of(
-                        new WithQuery("a", simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("x"))), Optional.empty())))),
+                        new WithQuery(identifier("a"), simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("x"))), Optional.empty())))),
                         new Table(QualifiedName.of("y")),
                         Optional.empty(),
                         Optional.empty()));
@@ -1771,7 +1772,7 @@ public class TestSqlParser
                         new Join(
                                 Join.Type.IMPLICIT,
                                 new Table(QualifiedName.of("t")),
-                                new AliasedRelation(lateralRelation, "a", ImmutableList.of("x")),
+                                new AliasedRelation(lateralRelation, identifier("a"), ImmutableList.of(identifier("x"))),
                                 Optional.empty())));
 
         assertStatement("SELECT * FROM t CROSS JOIN LATERAL (VALUES 1) ",
@@ -1872,11 +1873,11 @@ public class TestSqlParser
     {
         assertExpression("x -> sin(x)",
                 new LambdaExpression(
-                        ImmutableList.of(new LambdaArgumentDeclaration("x")),
+                        ImmutableList.of(new LambdaArgumentDeclaration(identifier("x"))),
                         new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(new Identifier("x")))));
         assertExpression("(x, y) -> mod(x, y)",
                 new LambdaExpression(
-                        ImmutableList.of(new LambdaArgumentDeclaration("x"), new LambdaArgumentDeclaration("y")),
+                        ImmutableList.of(new LambdaArgumentDeclaration(identifier("x")), new LambdaArgumentDeclaration(identifier("y"))),
                         new FunctionCall(
                                 QualifiedName.of("mod"),
                                 ImmutableList.of(new Identifier("x"), new Identifier("y")))));
@@ -1936,7 +1937,7 @@ public class TestSqlParser
     public void testPrepare()
     {
         assertStatement("PREPARE myquery FROM select * from foo",
-                new Prepare("myquery", simpleQuery(
+                new Prepare(identifier("myquery"), simpleQuery(
                         selectList(new AllColumns()),
                         table(QualifiedName.of("foo")))));
     }
@@ -1945,7 +1946,7 @@ public class TestSqlParser
     public void testPrepareWithParameters()
     {
         assertStatement("PREPARE myquery FROM SELECT ?, ? FROM foo",
-                new Prepare("myquery", simpleQuery(
+                new Prepare(identifier("myquery"), simpleQuery(
                         selectList(new Parameter(0), new Parameter(1)),
                         table(QualifiedName.of("foo")))));
     }
@@ -1953,20 +1954,20 @@ public class TestSqlParser
     @Test
     public void testDeallocatePrepare()
     {
-        assertStatement("DEALLOCATE PREPARE myquery", new Deallocate("myquery"));
+        assertStatement("DEALLOCATE PREPARE myquery", new Deallocate(identifier("myquery")));
     }
 
     @Test
     public void testExecute()
     {
-        assertStatement("EXECUTE myquery", new Execute("myquery", emptyList()));
+        assertStatement("EXECUTE myquery", new Execute(identifier("myquery"), emptyList()));
     }
 
     @Test
     public void testExecuteWithUsing()
     {
         assertStatement("EXECUTE myquery USING 1, 'abc', ARRAY ['hello']",
-                new Execute("myquery", ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new ArrayConstructor(ImmutableList.of(new StringLiteral("hello"))))));
+                new Execute(identifier("myquery"), ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new ArrayConstructor(ImmutableList.of(new StringLiteral("hello"))))));
     }
 
     @Test
@@ -2061,13 +2062,13 @@ public class TestSqlParser
     @Test
     public void testDescribeOutput()
     {
-        assertStatement("DESCRIBE OUTPUT myquery", new DescribeOutput("myquery"));
+        assertStatement("DESCRIBE OUTPUT myquery", new DescribeOutput(identifier("myquery")));
     }
 
     @Test
     public void testDescribeInput()
     {
-        assertStatement("DESCRIBE INPUT myquery", new DescribeInput("myquery"));
+        assertStatement("DESCRIBE INPUT myquery", new DescribeInput(identifier("myquery")));
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -518,7 +518,7 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "SELECT a.col0, count(*) FROM (VALUES ROW(cast(ROW(1, 1) as ROW(col0 integer, col1 integer)))) t(a)",
-                "line 1:8: '\"a\".\"col0\"' must be an aggregate expression or appear in GROUP BY clause");
+                "line 1:8: 'a.col0' must be an aggregate expression or appear in GROUP BY clause");
     }
 
     @Test
@@ -8520,7 +8520,7 @@ public abstract class AbstractTestQueries
             assertEquals(e.getCode(), MUST_BE_AGGREGATE_OR_GROUP_BY);
         }
         catch (RuntimeException e) {
-            assertEquals(e.getMessage(), "line 1:10: '(\"a\" + ?)' must be an aggregate expression or appear in GROUP BY clause");
+            assertEquals(e.getMessage(), "line 1:10: '(a + ?)' must be an aggregate expression or appear in GROUP BY clause");
         }
     }
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/TestShadowing.java
@@ -36,6 +36,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.verifier.QueryType.READ;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
@@ -81,8 +82,8 @@ public class TestShadowing
         assertEquals(PrestoVerifier.statementToQueryType(parser, rewrittenQuery.getQuery()), READ);
 
         Table table = new Table(createTableAs.getName());
-        SingleColumn column1 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new Identifier("column1"))));
-        SingleColumn column2 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new FunctionCall(QualifiedName.of("round"), ImmutableList.of(new Identifier("column2"), new LongLiteral("1"))))));
+        SingleColumn column1 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new Identifier("COLUMN1"))));
+        SingleColumn column2 = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new FunctionCall(QualifiedName.of("round"), ImmutableList.of(new Identifier("COLUMN2"), new LongLiteral("1"))))));
         Select select = new Select(false, ImmutableList.of(column1, column2));
         QuerySpecification querySpecification = new QuerySpecification(select, Optional.of(table), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         assertEquals(parser.createStatement(rewrittenQuery.getQuery()), new com.facebook.presto.sql.tree.Query(Optional.empty(), querySpecification, Optional.empty(), Optional.empty()));
@@ -126,7 +127,7 @@ public class TestShadowing
 
         Insert insert = (Insert) parser.createStatement(rewrittenQuery.getPreQueries().get(1));
         assertEquals(insert.getTarget(), createTable.getName());
-        assertEquals(insert.getColumns(), Optional.of(ImmutableList.of("b", "a", "c")));
+        assertEquals(insert.getColumns(), Optional.of(ImmutableList.of(identifier("b"), identifier("a"), identifier("c"))));
 
         Table table = new Table(createTable.getName());
         SingleColumn columnA = new SingleColumn(new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(new Identifier("A"))));


### PR DESCRIPTION
Track names that originate from identifiers in the grammar as
proper Identifier AST nodes and record whether they are to
be treated verbatim (i.e., they were originally quoted).
