### PR TITLE
Fix date constant in test

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -51,6 +51,7 @@ import org.testng.annotations.Test;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.FunctionRegistry.getMagicLiteralFunctionSignature;
@@ -149,7 +150,7 @@ public class TestDomainTranslator
             .build();
 
     private static final long TIMESTAMP_VALUE = new DateTime(2013, 3, 30, 1, 5, 0, 0, DateTimeZone.UTC).getMillis();
-    private static final long DATE_VALUE = new DateTime(2001, 1, 22, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
+    private static final long DATE_VALUE = TimeUnit.MILLISECONDS.toDays(new DateTime(2001, 1, 22, 0, 0, 0, 0, DateTimeZone.UTC).getMillis());
     private static final long COLOR_VALUE_1 = 1;
     private static final long COLOR_VALUE_2 = 2;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlDate.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlDate.java
@@ -22,6 +22,7 @@ public final class SqlDate
 {
     private final int days;
 
+    // TODO accept long
     public SqlDate(int days)
     {
         this.days = days;


### PR DESCRIPTION
The date constant needs to fit into an int, as `SqlDate` takes an int.
The constant value used in the test was clearly mistyped.