### PR TITLE
Factor out Rule#isEnabled(Session)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -119,6 +119,11 @@ public class IterativeOptimizer
             Iterator<Rule> possiblyMatchingRules = ruleStore.getCandidates(node).iterator();
             while (possiblyMatchingRules.hasNext()) {
                 Rule rule = possiblyMatchingRules.next();
+
+                if (!rule.isEnabled(context.session)) {
+                    continue;
+                }
+
                 Optional<PlanNode> transformed;
 
                 if (!rule.getPattern().matches(node)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
@@ -33,6 +33,11 @@ public interface Rule
         return Pattern.any();
     }
 
+    default boolean isEnabled(Session session)
+    {
+        return true;
+    }
+
     Optional<PlanNode> apply(PlanNode node, Context context);
 
     interface Context

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
@@ -75,15 +75,17 @@ public class AddIntermediateAggregations
     }
 
     @Override
+    public boolean isEnabled(Session session)
+    {
+        return SystemSessionProperties.isEnableIntermediateAggregations(session);
+    }
+
+    @Override
     public Optional<PlanNode> apply(PlanNode node, Context context)
     {
         Lookup lookup = context.getLookup();
         PlanNodeIdAllocator idAllocator = context.getIdAllocator();
         Session session = context.getSession();
-
-        if (!SystemSessionProperties.isEnableIntermediateAggregations(session)) {
-            return Optional.empty();
-        }
 
         if (!(node instanceof AggregationNode)) {
             return Optional.empty();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
@@ -56,13 +57,15 @@ public class EliminateCrossJoins
     }
 
     @Override
+    public boolean isEnabled(Session session)
+    {
+        return SystemSessionProperties.isJoinReorderingEnabled(session);
+    }
+
+    @Override
     public Optional<PlanNode> apply(PlanNode node, Context context)
     {
         if (!(node instanceof JoinNode)) {
-            return Optional.empty();
-        }
-
-        if (!SystemSessionProperties.isJoinReorderingEnabled(context.getSession())) {
             return Optional.empty();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.sql.planner.ExpressionSymbolInliner;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
@@ -94,12 +95,14 @@ public class PushAggregationThroughOuterJoin
     }
 
     @Override
+    public boolean isEnabled(Session session)
+    {
+        return shouldPushAggregationThroughJoin(session);
+    }
+
+    @Override
     public Optional<PlanNode> apply(PlanNode node, Context context)
     {
-        if (!shouldPushAggregationThroughJoin(context.getSession())) {
-            return Optional.empty();
-        }
-
         if (!(node instanceof AggregationNode)) {
             return Optional.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolsExtractor;
@@ -52,12 +53,14 @@ public class PushPartialAggregationThroughJoin
     }
 
     @Override
+    public boolean isEnabled(Session session)
+    {
+        return isPushAggregationThroughJoin(session);
+    }
+
+    @Override
     public Optional<PlanNode> apply(PlanNode node, Context context)
     {
-        if (!isPushAggregationThroughJoin(context.getSession())) {
-            return Optional.empty();
-        }
-
         AggregationNode aggregationNode = (AggregationNode) node;
 
         if (aggregationNode.getStep() != PARTIAL || aggregationNode.getGroupingSets().size() != 1) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushTableWriteThroughUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushTableWriteThroughUnion.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -30,12 +31,14 @@ public class PushTableWriteThroughUnion
         implements Rule
 {
     @Override
+    public boolean isEnabled(Session session)
+    {
+        return isPushTableWriteThroughUnion(session);
+    }
+
+    @Override
     public Optional<PlanNode> apply(PlanNode node, Context context)
     {
-        if (!isPushTableWriteThroughUnion(context.getSession())) {
-            return Optional.empty();
-        }
-
         if (!(node instanceof TableWriterNode)) {
             return Optional.empty();
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -146,7 +146,7 @@ public class RuleAssert
         Memo memo = new Memo(idAllocator, plan);
         Lookup lookup = Lookup.from(memo::resolve);
 
-        if (!rule.getPattern().matches(plan)) {
+        if (!rule.isEnabled(session) || !rule.getPattern().matches(plan)) {
             return new RuleApplication(lookup, symbolAllocator.getTypes(), Optional.empty());
         }
 


### PR DESCRIPTION
This will help unclutter `Rule#apply` and allow for non-negated conditional logic.

In theory, we could fit this into the new pattern matcher - but that would feel like an overkill. Also, evaluating the Rule's pattern (or the rule itself, as it is now with the check in `Rule#apply`) is a bit late for checking if it's enabled.