### PR TITLE
Dynamic Partition Pruning

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -16,19 +16,36 @@ package com.facebook.presto.hive;
 import com.facebook.presto.hive.util.AsyncQueue;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.DynamicFilterDescription;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.concurrent.MoreFutures;
+import org.joda.time.DateTimeZone;
 
 import java.io.FileNotFoundException;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.MoreFutures.failedFuture;
 
 class HiveSplitSource
@@ -37,12 +54,18 @@ class HiveSplitSource
     private final AsyncQueue<ConnectorSplit> queue;
     private final AtomicReference<Throwable> throwable = new AtomicReference<>();
     private final HiveSplitLoader splitLoader;
+    private final List<Future<DynamicFilterDescription>> filters;
+    private final DateTimeZone timeZone;
+    private final TypeManager typeManager;
     private volatile boolean closed;
 
-    HiveSplitSource(int maxOutstandingSplits, HiveSplitLoader splitLoader, Executor executor)
+    HiveSplitSource(int maxOutstandingSplits, HiveSplitLoader splitLoader, Executor executor, List<Future<DynamicFilterDescription>> dynamicFilters, DateTimeZone timeZone, TypeManager typeManager)
     {
         this.queue = new AsyncQueue<>(maxOutstandingSplits, executor);
         this.splitLoader = splitLoader;
+        this.filters = ImmutableList.copyOf(dynamicFilters);
+        this.timeZone = timeZone;
+        this.typeManager = typeManager;
     }
 
     @VisibleForTesting
@@ -104,7 +127,96 @@ class HiveSplitSource
             return failedFuture(throwable.get());
         }
 
-        return future;
+        return future.thenApply(this::dynamicallyFilterSplits);
+    }
+
+    private List<ConnectorSplit> dynamicallyFilterSplits(List<ConnectorSplit> splits)
+    {
+        List<DynamicFilterDescription> dynamicFilterDescriptions = getAvailableDynamicFilterDescriptions();
+
+        TupleDomain<HiveColumnHandle> runtimeTupleDomain = dynamicFilterDescriptions.stream()
+                .map(DynamicFilterDescription::getTupleDomain)
+                .map(domain -> domain.transform(HiveColumnHandle.class::cast))
+                .reduce(TupleDomain.all(), TupleDomain::columnWiseUnion);
+
+        Optional<Map<HiveColumnHandle, Domain>> domains = runtimeTupleDomain.getDomains();
+        if (!domains.isPresent() || domains.get().size() == 0) {
+            return splits;
+        }
+
+        DomainsCache domainsCache = new DomainsCache(domains.get());
+
+        Iterator<ConnectorSplit> iter = splits.iterator();
+        while (iter.hasNext()) {
+            HiveSplit hiveSplit = (HiveSplit) iter.next();
+            for (HivePartitionKey partitionKey : hiveSplit.getPartitionKeys()) {
+                String partitionKeyName = partitionKey.getName().toLowerCase(Locale.ENGLISH);
+                Collection<Domain> relevantDomains = domainsCache.getDomains(partitionKeyName);
+
+                boolean matched = false;
+                for (Domain predicateDomain : relevantDomains) {
+                    Type type = partitionKey.getHiveType().getType(typeManager);
+                    Object objectToWrite;
+                    try {
+                        objectToWrite = HiveUtil.parsePartitionValue(partitionKey.getName(), partitionKey.getValue(), type, timeZone).getValue();
+                    }
+                    catch (PrestoException e) {
+                        // if the type is not supported, skip pruning for that partition
+                        if (e.getErrorCode().equals(NOT_SUPPORTED)) {
+                            // TODO: log information about not supported type
+                            continue;
+                        }
+
+                        throw e;
+                    }
+                    if (predicateDomain.overlaps(Domain.singleValue(type, objectToWrite))) {
+                        matched = true;
+                        break;
+                    }
+                }
+                if (!matched) {
+                    // no relevant predicate matched, so remove that split
+                    iter.remove();
+                }
+            }
+        }
+        return splits;
+    }
+
+    class DomainsCache
+    {
+        private final Map<HiveColumnHandle, Domain> domains;
+        private final Map<String, Collection<Domain>> domainsCache = new HashMap<>();
+
+        public DomainsCache(Map<HiveColumnHandle, Domain> domains)
+        {
+            this.domains = ImmutableMap.copyOf(domains);
+        }
+
+        public Collection<Domain> getDomains(String partitionName)
+        {
+            String partitionNameLower = partitionName.toLowerCase(Locale.ENGLISH);
+            Collection<Domain> relevantDomains = domainsCache.get(partitionNameLower);
+            if (relevantDomains == null) {
+                relevantDomains = domains.entrySet().stream()
+                        .filter(entry -> entry.getKey().getName().equalsIgnoreCase(partitionNameLower))
+                        .map(Map.Entry::getValue)
+                        .collect(toImmutableList());
+                domainsCache.put(partitionNameLower, relevantDomains);
+            }
+
+            return relevantDomains;
+        }
+    }
+
+    private List<DynamicFilterDescription> getAvailableDynamicFilterDescriptions()
+    {
+        ImmutableList.Builder<DynamicFilterDescription> dynamicFilterDescriptionBuilder = ImmutableList.builder();
+        for (Future<DynamicFilterDescription> descriptionFuture : filters) {
+            Optional<DynamicFilterDescription> description = MoreFutures.tryGetFutureValue(descriptionFuture);
+            description.ifPresent(dynamicFilterDescriptionBuilder::add);
+        }
+        return dynamicFilterDescriptionBuilder.build();
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -50,6 +50,7 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.testing.TestingNodeManager;
+import com.facebook.presto.type.TypeRegistry;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -201,7 +202,9 @@ public abstract class AbstractTestHiveClientS3
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
                 hiveClientConfig.getMaxInitialSplits(),
-                hiveClientConfig.getRecursiveDirWalkerEnabled());
+                hiveClientConfig.getRecursiveDirWalkerEnabled(),
+                hiveClientConfig.getDateTimeZone(),
+                new TypeRegistry());
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(hiveClientConfig),
                 hdfsEnvironment,
@@ -242,7 +245,7 @@ public abstract class AbstractTestHiveClientS3
             List<ConnectorTableLayoutResult> tableLayoutResults = metadata.getTableLayouts(session, table, new Constraint<>(TupleDomain.all(), bindings -> true), Optional.empty());
             HiveTableLayoutHandle layoutHandle = (HiveTableLayoutHandle) getOnlyElement(tableLayoutResults).getTableLayout().getHandle();
             assertEquals(layoutHandle.getPartitions().get().size(), 1);
-            ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, layoutHandle);
+            ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, layoutHandle, ImmutableList.of());
 
             long sum = 0;
 
@@ -410,7 +413,7 @@ public abstract class AbstractTestHiveClientS3
             List<ConnectorTableLayoutResult> tableLayoutResults = metadata.getTableLayouts(session, tableHandle, new Constraint<>(TupleDomain.all(), bindings -> true), Optional.empty());
             HiveTableLayoutHandle layoutHandle = (HiveTableLayoutHandle) getOnlyElement(tableLayoutResults).getTableLayout().getHandle();
             assertEquals(layoutHandle.getPartitions().get().size(), 1);
-            ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, layoutHandle);
+            ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, layoutHandle, ImmutableList.of());
             ConnectorSplit split = getOnlyElement(getAllSplits(splitSource));
 
             try (ConnectorPageSource pageSource = pageSourceProvider.createPageSource(transaction.getTransactionHandle(), session, split, columnHandles)) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundSplitLoader.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.util.Progressable;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -214,7 +215,10 @@ public class TestBackgroundSplitLoader
         return new HiveSplitSource(
                 1,
                 backgroundHiveSplitLoader,
-                EXECUTOR);
+                EXECUTOR,
+                ImmutableList.of(),
+                DateTimeZone.UTC,
+                null); // type manager is used only in dynamic filtering, so null is fine for these tests
     }
 
     private static Table table(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -15,7 +15,10 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.SettableFuture;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -35,7 +38,7 @@ public class TestHiveSplitSource
     public void testOutstandingSplitCount()
             throws Exception
     {
-        HiveSplitSource hiveSplitSource = new HiveSplitSource(10, new TestingHiveSplitLoader(), Executors.newFixedThreadPool(5));
+        HiveSplitSource hiveSplitSource = new HiveSplitSource(10, new TestingHiveSplitLoader(), Executors.newFixedThreadPool(5), ImmutableList.of(), DateTimeZone.UTC, new TypeRegistry());
 
         // add 10 splits
         for (int i = 0; i < 10; i++) {
@@ -60,7 +63,7 @@ public class TestHiveSplitSource
     public void testFail()
             throws Exception
     {
-        HiveSplitSource hiveSplitSource = new HiveSplitSource(10, new TestingHiveSplitLoader(), Executors.newFixedThreadPool(5));
+        HiveSplitSource hiveSplitSource = new HiveSplitSource(10, new TestingHiveSplitLoader(), Executors.newFixedThreadPool(5), ImmutableList.of(), DateTimeZone.UTC, new TypeRegistry());
 
         // add some splits
         for (int i = 0; i < 5; i++) {
@@ -108,7 +111,7 @@ public class TestHiveSplitSource
     public void testReaderWaitsForSplits()
             throws Exception
     {
-        final HiveSplitSource hiveSplitSource = new HiveSplitSource(10, new TestingHiveSplitLoader(), Executors.newFixedThreadPool(5));
+        final HiveSplitSource hiveSplitSource = new HiveSplitSource(10, new TestingHiveSplitLoader(), Executors.newFixedThreadPool(5), ImmutableList.of(), DateTimeZone.UTC, new TypeRegistry());
 
         final SettableFuture<ConnectorSplit> splits = SettableFuture.create();
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -73,6 +73,7 @@ public final class SystemSessionProperties
     public static final String ENABLE_INTERMEDIATE_AGGREGATIONS = "enable_intermediate_aggregations";
     public static final String PUSH_AGGREGATION_THROUGH_JOIN = "push_aggregation_through_join";
     public static final String PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN = "push_partial_aggregation_through_join";
+    public static final String DYNAMIC_PARTITION_PRUNING = "dynamic_partition_pruning";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -318,6 +319,11 @@ public final class SystemSessionProperties
                         PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN,
                         "Push partial aggregations below joins",
                         false,
+                        false),
+                booleanSessionProperty(
+                        DYNAMIC_PARTITION_PRUNING,
+                        "Enable dynamic partition pruning",
+                        featuresConfig.isDynamicPartitionPruningEnabled(),
                         false));
     }
 
@@ -498,5 +504,10 @@ public final class SystemSessionProperties
     public static boolean isPushAggregationThroughJoin(Session session)
     {
         return session.getSystemProperty(PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN, Boolean.class);
+    }
+
+    public static boolean isDynamicPartitionPruningEnabled(Session session)
+    {
+        return session.getSystemProperty(DYNAMIC_PARTITION_PRUNING, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -29,6 +29,7 @@ import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.QueryType;
@@ -134,6 +135,7 @@ public final class SqlQueryExecution
     private final ExecutionPolicy executionPolicy;
     private final List<Expression> parameters;
     private final SplitSchedulerStats schedulerStats;
+    private final DynamicFilterService dynamicFilterService;
 
     public SqlQueryExecution(QueryId queryId,
             String query,
@@ -158,7 +160,8 @@ public final class SqlQueryExecution
             QueryExplainer queryExplainer,
             ExecutionPolicy executionPolicy,
             List<Expression> parameters,
-            SplitSchedulerStats schedulerStats)
+            SplitSchedulerStats schedulerStats,
+            DynamicFilterService dynamicFilterService)
     {
         try (SetThreadName ignored = new SetThreadName("Query-%s", queryId)) {
             this.statement = requireNonNull(statement, "statement is null");
@@ -178,6 +181,7 @@ public final class SqlQueryExecution
             this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
             this.parameters = requireNonNull(parameters);
             this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
+            this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
 
             checkArgument(scheduleSplitBatchSize > 0, "scheduleSplitBatchSize must be greater than 0");
             this.scheduleSplitBatchSize = scheduleSplitBatchSize;
@@ -438,7 +442,8 @@ public final class SqlQueryExecution
                 rootOutputBuffers,
                 nodeTaskMap,
                 executionPolicy,
-                schedulerStats);
+                schedulerStats,
+                dynamicFilterService);
 
         queryScheduler.set(scheduler);
 
@@ -627,6 +632,7 @@ public final class SqlQueryExecution
         private final FailureDetector failureDetector;
         private final NodeTaskMap nodeTaskMap;
         private final Map<String, ExecutionPolicy> executionPolicies;
+        private final DynamicFilterService dynamicFilterService;
 
         @Inject
         SqlQueryExecutionFactory(QueryManagerConfig config,
@@ -647,7 +653,8 @@ public final class SqlQueryExecution
                 NodeTaskMap nodeTaskMap,
                 QueryExplainer queryExplainer,
                 Map<String, ExecutionPolicy> executionPolicies,
-                SplitSchedulerStats schedulerStats)
+                SplitSchedulerStats schedulerStats,
+                DynamicFilterService dynamicFilterService)
         {
             requireNonNull(config, "config is null");
             this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
@@ -671,6 +678,7 @@ public final class SqlQueryExecution
             this.executionPolicies = requireNonNull(executionPolicies, "schedulerPolicies is null");
             this.costCalculator = requireNonNull(costCalculator, "cost calculator is null");
             this.planOptimizers = planOptimizers.get();
+            this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
         }
 
         @Override
@@ -704,7 +712,8 @@ public final class SqlQueryExecution
                     queryExplainer,
                     executionPolicy,
                     parameters,
-                    schedulerStats);
+                    schedulerStats,
+                    dynamicFilterService);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -402,7 +402,7 @@ public final class SqlQueryExecution
         long distributedPlanningStart = System.nanoTime();
 
         // plan the execution on the active nodes
-        DistributedExecutionPlanner distributedPlanner = new DistributedExecutionPlanner(splitManager);
+        DistributedExecutionPlanner distributedPlanner = new DistributedExecutionPlanner(splitManager, dynamicFilterService);
         StageExecutionPlan outputStageExecutionPlan = distributedPlanner.plan(plan.getRoot(), stateMachine.getSession());
         stateMachine.recordDistributedPlanningTime(distributedPlanningStart);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -25,6 +25,7 @@ import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.server.SessionSupplier;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
@@ -137,6 +138,8 @@ public class SqlQueryManager
 
     private final AtomicBoolean acceptQueries = new AtomicBoolean();
 
+    private final DynamicFilterService dynamicFilterService;
+
     @Inject
     public SqlQueryManager(
             SqlParser sqlParser,
@@ -152,7 +155,8 @@ public class SqlQueryManager
             SessionPropertyManager sessionPropertyManager,
             InternalNodeManager internalNodeManager,
             Map<Class<? extends Statement>, QueryExecutionFactory<?>> executionFactories,
-            Metadata metadata)
+            Metadata metadata,
+            DynamicFilterService dynamicFilterService)
     {
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
 
@@ -188,6 +192,7 @@ public class SqlQueryManager
         this.initializationRequiredWorkers = queryManagerConfig.getInitializationRequiredWorkers();
         this.initializationTimeout = queryManagerConfig.getInitializationTimeout();
         this.initialNanos = System.nanoTime();
+        this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
 
         queryManagementExecutor = Executors.newScheduledThreadPool(queryManagerConfig.getQueryManagerExecutorPoolSize(), threadsNamed("query-management-%s"));
         queryManagementExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) queryManagementExecutor);
@@ -430,6 +435,8 @@ public class SqlQueryManager
             finally {
                 // execution MUST be added to the expiration queue or there will be a leak
                 expirationQueue.add(execution);
+                // query MUST be removed from dynamic filter service or there will be a leak
+                dynamicFilterService.removeQuery(queryInfo.getQueryId().toString());
             }
 
             return queryInfo;
@@ -447,6 +454,8 @@ public class SqlQueryManager
             finally {
                 // execution MUST be added to the expiration queue or there will be a leak
                 expirationQueue.add(queryExecution);
+                // query MUST be removed from dynamic filter service or there will be a leak
+                dynamicFilterService.removeQuery(queryInfo.getQueryId().toString());
             }
         });
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -28,6 +28,7 @@ import com.facebook.presto.execution.StageId;
 import com.facebook.presto.execution.StageInfo;
 import com.facebook.presto.execution.StageState;
 import com.facebook.presto.failureDetector.FailureDetector;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.split.SplitSource;
@@ -99,6 +100,7 @@ public class SqlQueryScheduler
     private final SplitSchedulerStats schedulerStats;
     private final boolean summarizeTaskInfo;
     private final AtomicBoolean started = new AtomicBoolean();
+    private final DynamicFilterService dynamicFilterService;
 
     public SqlQueryScheduler(QueryStateMachine queryStateMachine,
             LocationFactory locationFactory,
@@ -114,11 +116,13 @@ public class SqlQueryScheduler
             OutputBuffers rootOutputBuffers,
             NodeTaskMap nodeTaskMap,
             ExecutionPolicy executionPolicy,
-            SplitSchedulerStats schedulerStats)
+            SplitSchedulerStats schedulerStats,
+            DynamicFilterService dynamicFilterService)
     {
         this.queryStateMachine = requireNonNull(queryStateMachine, "queryStateMachine is null");
         this.executionPolicy = requireNonNull(executionPolicy, "schedulerPolicyFactory is null");
         this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
+        this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
         this.summarizeTaskInfo = summarizeTaskInfo;
 
         // todo come up with a better way to build this, or eliminate this map
@@ -218,7 +222,8 @@ public class SqlQueryScheduler
                 nodeTaskMap,
                 executor,
                 failureDetector,
-                schedulerStats);
+                schedulerStats,
+                dynamicFilterService);
 
         stages.add(stage);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClient.java
@@ -13,77 +13,10 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.execution.TaskId;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
-import io.airlift.http.client.HttpClient;
-import io.airlift.http.client.HttpClient.HttpResponseFuture;
-import io.airlift.http.client.HttpUriBuilder;
-import io.airlift.http.client.StatusResponseHandler.StatusResponse;
-import io.airlift.json.JsonCodec;
 
-import java.net.URI;
-
-import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
-import static com.google.common.net.MediaType.JSON_UTF_8;
-import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
-import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
-import static io.airlift.http.client.Request.Builder.prepareGet;
-import static io.airlift.http.client.Request.Builder.preparePut;
-import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
-import static io.airlift.json.JsonCodec.jsonCodec;
-import static java.util.Objects.requireNonNull;
-
-public class DynamicFilterClient
+public interface DynamicFilterClient
 {
-    private final JsonCodec<DynamicFilterSummary> summaryJsonCodec;
-    private final URI coordinatorURI;
-    private final HttpClient httpClient;
-    private final TaskId taskId;
-    private final String source;
-    private final int driverId;
-    private final int expectedDriversCount;
-
-    public DynamicFilterClient(JsonCodec<DynamicFilterSummary> summaryJsonCodec, URI coordinatorURI, HttpClient httpClient, TaskId taskId, String source, int driverId, int expectedDriversCount)
-    {
-        this.summaryJsonCodec = requireNonNull(summaryJsonCodec, "summaryJsonCodec is null");
-        this.coordinatorURI = requireNonNull(coordinatorURI, "coordinatorURI is null");
-        this.httpClient = requireNonNull(httpClient, "httpClient is null");
-        this.taskId = requireNonNull(taskId, "taskId is null");
-        this.source = requireNonNull(source, "source is null");
-        this.driverId = driverId;
-        this.expectedDriversCount = expectedDriversCount;
-    }
-
-    public HttpResponseFuture<JsonResponse<DynamicFilterSummary>> getSummary()
-    {
-        return httpClient.executeAsync(
-                prepareGet()
-                        .setUri(HttpUriBuilder.uriBuilderFrom(coordinatorURI)
-                                .appendPath("/v1/dynamic-filter")
-                                .appendPath("/" + taskId.getQueryId())
-                                .appendPath("/" + source)
-                                .build())
-                        .build(),
-                createFullJsonResponseHandler(jsonCodec(DynamicFilterSummary.class)));
-    }
-
-    public ListenableFuture<StatusResponse> storeSummary(DynamicFilterSummary summary)
-    {
-        return httpClient.executeAsync(
-                preparePut()
-                        .setUri(HttpUriBuilder.uriBuilderFrom(coordinatorURI)
-                                .appendPath("/v1/dynamic-filter")
-                                .appendPath("/" + taskId.getQueryId())
-                                .appendPath("/" + source)
-                                .appendPath("/" + taskId.getStageId().getId())
-                                .appendPath("/" + taskId.getId())
-                                .appendPath("/" + driverId)
-                                .appendPath("/" + expectedDriversCount)
-                                .build())
-                        .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
-                        .setBodyGenerator(jsonBodyGenerator(summaryJsonCodec, summary))
-                        .build(),
-                createStatusResponseHandler());
-    }
+    ListenableFuture<?> getSummary();
+    ListenableFuture<?> storeSummary(DynamicFilterSummary summary);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClient.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.TaskId;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpClient.HttpResponseFuture;
+import io.airlift.http.client.HttpUriBuilder;
+import io.airlift.http.client.StatusResponseHandler.StatusResponse;
+import io.airlift.json.JsonCodec;
+
+import java.net.URI;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.Request.Builder.preparePut;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterClient
+{
+    private final JsonCodec<DynamicFilterSummary> summaryJsonCodec;
+    private final URI coordinatorURI;
+    private final HttpClient httpClient;
+    private final TaskId taskId;
+    private final String source;
+    private final int driverId;
+    private final int expectedDriversCount;
+
+    public DynamicFilterClient(JsonCodec<DynamicFilterSummary> summaryJsonCodec, URI coordinatorURI, HttpClient httpClient, TaskId taskId, String source, int driverId, int expectedDriversCount)
+    {
+        this.summaryJsonCodec = requireNonNull(summaryJsonCodec, "summaryJsonCodec is null");
+        this.coordinatorURI = requireNonNull(coordinatorURI, "coordinatorURI is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.source = requireNonNull(source, "source is null");
+        this.driverId = driverId;
+        this.expectedDriversCount = expectedDriversCount;
+    }
+
+    public HttpResponseFuture<JsonResponse<DynamicFilterSummary>> getSummary()
+    {
+        return httpClient.executeAsync(
+                prepareGet()
+                        .setUri(HttpUriBuilder.uriBuilderFrom(coordinatorURI)
+                                .appendPath("/v1/dynamic-filter")
+                                .appendPath("/" + taskId.getQueryId())
+                                .appendPath("/" + source)
+                                .build())
+                        .build(),
+                createFullJsonResponseHandler(jsonCodec(DynamicFilterSummary.class)));
+    }
+
+    public ListenableFuture<StatusResponse> storeSummary(DynamicFilterSummary summary)
+    {
+        return httpClient.executeAsync(
+                preparePut()
+                        .setUri(HttpUriBuilder.uriBuilderFrom(coordinatorURI)
+                                .appendPath("/v1/dynamic-filter")
+                                .appendPath("/" + taskId.getQueryId())
+                                .appendPath("/" + source)
+                                .appendPath("/" + taskId.getStageId().getId())
+                                .appendPath("/" + taskId.getId())
+                                .appendPath("/" + driverId)
+                                .appendPath("/" + expectedDriversCount)
+                                .build())
+                        .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                        .setBodyGenerator(jsonBodyGenerator(summaryJsonCodec, summary))
+                        .build(),
+                createStatusResponseHandler());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientFactory.java
@@ -44,6 +44,6 @@ public class DynamicFilterClientFactory
     @Override
     public DynamicFilterClient createClient(TaskId taskId, String source, int driverId, int expectedDriversCount)
     {
-        return new DynamicFilterClient(summaryJsonCodec, coordinatorURIProvider.get(), httpClient, taskId, source, driverId, expectedDriversCount);
+        return new HttpDynamicFilterClient(summaryJsonCodec, coordinatorURIProvider.get(), httpClient, taskId, source, driverId, expectedDriversCount);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.TaskId;
+import io.airlift.discovery.client.ForDiscoveryClient;
+import io.airlift.http.client.HttpClient;
+import io.airlift.json.JsonCodec;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.net.URI;
+
+public class DynamicFilterClientFactory
+        implements DynamicFilterClientSupplier
+{
+    private final Provider<URI> coordinatorURIProvider;
+    private final HttpClient httpClient;
+    private final JsonCodec<DynamicFilterSummary> summaryJsonCodec;
+
+    @Inject
+    public DynamicFilterClientFactory(
+            @ForDiscoveryClient Provider<URI> coordinatorURIProvider,
+            @ForDynamicFilterSummary HttpClient httpClient,
+            JsonCodec<DynamicFilterSummary> summaryJsonCodec)
+    {
+        this.coordinatorURIProvider = coordinatorURIProvider;
+        this.httpClient = httpClient;
+        this.summaryJsonCodec = summaryJsonCodec;
+    }
+
+    @Override
+    public DynamicFilterClient createClient(TaskId taskId, String source, int driverId, int expectedDriversCount)
+    {
+        return new DynamicFilterClient(summaryJsonCodec, coordinatorURIProvider.get(), httpClient, taskId, source, driverId, expectedDriversCount);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientSupplier.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.TaskId;
+
+public interface DynamicFilterClientSupplier
+{
+    DynamicFilterClient createClient(TaskId taskId, String source, int driverId, int expectedDriversCount);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeUtils;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterSourceOperator
+        implements Operator
+{
+    public static class DynamicFilterSourceOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final List<Type> types;
+        private final List<Integer> filterChannels;
+        private final List<String> filterDynamicFilterNames;
+        private final DynamicFilterClientSupplier dynamicFilterClientSupplier;
+        private final String sourceId;
+        private final int expectedDrivers;
+
+        private boolean closed;
+        private int driverId;
+
+        public DynamicFilterSourceOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<Type> types,
+                List<Integer> filterChannels,
+                List<String> filterDynamicFilterNames,
+                DynamicFilterClientSupplier dynamicFilterClientSupplier,
+                String sourceId,
+                int expectedDrivers)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.types = ImmutableList.copyOf(types);
+            this.filterChannels = ImmutableList.copyOf(filterChannels);
+            this.filterDynamicFilterNames = ImmutableList.copyOf(filterDynamicFilterNames);
+            this.dynamicFilterClientSupplier = requireNonNull(dynamicFilterClientSupplier, "dynamicFilterClientSupplier is null");
+            this.sourceId = requireNonNull(sourceId, "sourceId is null");
+            this.expectedDrivers = expectedDrivers;
+        }
+
+        @Override
+        public List<Type> getTypes()
+        {
+            return types;
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, DynamicFilterSourceOperator.class.getSimpleName());
+
+            return new DynamicFilterSourceOperator(operatorContext,
+                    types,
+                    filterChannels,
+                    filterDynamicFilterNames,
+                    dynamicFilterClientSupplier.createClient(driverContext.getPipelineContext().getTaskId(), sourceId, driverId++, expectedDrivers));
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            throw new UnsupportedOperationException("Parallel dynamic filter build can not be duplicated");
+        }
+    }
+
+    private static final int DEFAULT_POSITIONS_LIMIT = 1000;
+
+    private final OperatorContext operatorContext;
+    private final List<Type> types;
+    private final List<Integer> filterChannels;
+    private final List<String> filterDynamicFilterNames;
+    private final DynamicFilterClient client;
+    private final int positionsLimit;
+
+    private Page page;
+    private boolean finishing;
+    private long positionCount;
+    private List<ImmutableList.Builder<Object>> valuesBuilder;
+    private boolean[] nullsAllowed;
+
+    public DynamicFilterSourceOperator(
+            OperatorContext operatorContext,
+            List<Type> types,
+            List<Integer> filterChannels,
+            List<String> filterDynamicFilterNames,
+            DynamicFilterClient client)
+    {
+        this(operatorContext, types, filterChannels, filterDynamicFilterNames, client, DEFAULT_POSITIONS_LIMIT);
+    }
+
+    public DynamicFilterSourceOperator(
+            OperatorContext operatorContext,
+            List<Type> types,
+            List<Integer> filterChannels,
+            List<String> filterDynamicFilterNames,
+            DynamicFilterClient client,
+            int positionsLimit)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.types = ImmutableList.copyOf(types);
+        this.filterChannels = ImmutableList.copyOf(filterChannels);
+        this.filterDynamicFilterNames = ImmutableList.copyOf(filterDynamicFilterNames);
+        this.valuesBuilder = filterChannels.stream().map(channel -> ImmutableList.builder()).collect(toImmutableList());
+        this.client = requireNonNull(client, "client is null");
+        this.nullsAllowed = new boolean[filterChannels.size()];
+
+        checkArgument(positionsLimit > 0, "positionsLimit must be greater than zero");
+        this.positionsLimit = positionsLimit;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public List<Type> getTypes()
+    {
+        return types;
+    }
+
+    @Override
+    public void finish()
+    {
+        if (finishing) {
+            return;
+        }
+        finishing = true;
+        sendTupleDomain();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finishing && page == null;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finishing;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        this.page = page;
+        processPage();
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        Page page = this.page;
+        this.page = null;
+        return page;
+    }
+
+    private void processPage()
+    {
+        positionCount += page.getPositionCount();
+
+        // we don't want to filter if there're too many values
+        if (positionCount > positionsLimit) {
+            return;
+        }
+
+        for (int channelIndex = 0; channelIndex < filterChannels.size(); channelIndex++) {
+            Integer channel = filterChannels.get(channelIndex);
+            for (int position = 0; position < page.getBlock(channel).getPositionCount(); position++) {
+                Object value = TypeUtils.readNativeValue(types.get(channel), page.getBlock(channel), position);
+                if (value == null) {
+                    nullsAllowed[channelIndex] = true;
+                }
+                else {
+                    valuesBuilder.get(channelIndex).add(value);
+                }
+            }
+        }
+    }
+
+    private void sendTupleDomain()
+    {
+        // we don't want to filter if there're too many values
+        if (positionCount > positionsLimit) {
+            client.storeSummary(new DynamicFilterSummary(TupleDomain.all()));
+            return;
+        }
+
+        ImmutableMap.Builder<String, Domain> domainsBuilder = ImmutableMap.builder();
+        for (int channelIndex = 0; channelIndex < filterChannels.size(); channelIndex++) {
+            Integer channel = filterChannels.get(channelIndex);
+            List<Object> values = valuesBuilder.get(channelIndex).build();
+            Domain domain;
+            if (values.isEmpty()) {
+                domain = Domain.none(types.get(channel));
+            }
+            else {
+                domain = Domain.create(ValueSet.copyOf(types.get(channel), values), nullsAllowed[channelIndex]);
+            }
+            domainsBuilder.put(filterDynamicFilterNames.get(channelIndex).toString(), domain);
+        }
+
+        client.storeSummary(new DynamicFilterSummary(TupleDomain.withColumnDomains(domainsBuilder.build())));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSummary.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSummary.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import static com.facebook.presto.spi.predicate.TupleDomain.columnWiseUnion;
+
+@Immutable
+public class DynamicFilterSummary
+{
+    private final TupleDomain<String> tupleDomain;
+
+    @JsonCreator
+    public DynamicFilterSummary(@JsonProperty("tupleDomain") TupleDomain<String> tupleDomain)
+    {
+        this.tupleDomain = tupleDomain;
+    }
+
+    @JsonProperty
+    public TupleDomain<String> getTupleDomain()
+    {
+        return tupleDomain;
+    }
+
+    public DynamicFilterSummary mergeWith(DynamicFilterSummary other)
+    {
+        return new DynamicFilterSummary(columnWiseUnion(tupleDomain, other.tupleDomain));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ForDynamicFilterSummary.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ForDynamicFilterSummary.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForDynamicFilterSummary
+{
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpDynamicFilterClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpDynamicFilterClient.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.TaskId;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpUriBuilder;
+import io.airlift.http.client.StatusResponseHandler.StatusResponse;
+import io.airlift.json.JsonCodec;
+
+import java.net.URI;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.Request.Builder.preparePut;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.util.Objects.requireNonNull;
+
+public class HttpDynamicFilterClient
+        implements DynamicFilterClient
+{
+    private final JsonCodec<DynamicFilterSummary> summaryJsonCodec;
+    private final URI coordinatorURI;
+    private final HttpClient httpClient;
+    private final TaskId taskId;
+    private final String source;
+    private final int driverId;
+    private final int expectedDriversCount;
+
+    public HttpDynamicFilterClient(JsonCodec<DynamicFilterSummary> summaryJsonCodec, URI coordinatorURI, HttpClient httpClient, TaskId taskId, String source, int driverId, int expectedDriversCount)
+    {
+        this.summaryJsonCodec = requireNonNull(summaryJsonCodec, "summaryJsonCodec is null");
+        this.coordinatorURI = requireNonNull(coordinatorURI, "coordinatorURI is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.source = requireNonNull(source, "source is null");
+        this.driverId = driverId;
+        this.expectedDriversCount = expectedDriversCount;
+    }
+
+    @Override
+    public ListenableFuture<JsonResponse<DynamicFilterSummary>> getSummary()
+    {
+        return httpClient.executeAsync(
+                prepareGet()
+                        .setUri(HttpUriBuilder.uriBuilderFrom(coordinatorURI)
+                                .appendPath("/v1/dynamic-filter")
+                                .appendPath("/" + taskId.getQueryId())
+                                .appendPath("/" + source)
+                                .build())
+                        .build(),
+                createFullJsonResponseHandler(jsonCodec(DynamicFilterSummary.class)));
+    }
+
+    @Override
+    public ListenableFuture<StatusResponse> storeSummary(DynamicFilterSummary summary)
+    {
+        return httpClient.executeAsync(
+                preparePut()
+                        .setUri(HttpUriBuilder.uriBuilderFrom(coordinatorURI)
+                                .appendPath("/v1/dynamic-filter")
+                                .appendPath("/" + taskId.getQueryId())
+                                .appendPath("/" + source)
+                                .appendPath("/" + taskId.getStageId().getId())
+                                .appendPath("/" + taskId.getId())
+                                .appendPath("/" + driverId)
+                                .appendPath("/" + expectedDriversCount)
+                                .build())
+                        .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                        .setBodyGenerator(jsonBodyGenerator(summaryJsonCodec, summary))
+                        .build(),
+                createStatusResponseHandler());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/InMemoryDynamicFilterClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InMemoryDynamicFilterClient.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.server.DynamicFilterService;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.util.Objects.requireNonNull;
+
+public class InMemoryDynamicFilterClient
+        implements DynamicFilterClient
+{
+    private final DynamicFilterService service;
+    private final TaskId taskId;
+    private final String source;
+    private final int driverId;
+    private final int expectedDrviersCount;
+
+    public InMemoryDynamicFilterClient(DynamicFilterService service, TaskId taskId, String source, int driverId, int expectedDrviersCount)
+    {
+        this.service = requireNonNull(service, "dynamicFilterService is null");
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.source = requireNonNull(source, "source is null");
+        this.driverId = driverId;
+        this.expectedDrviersCount = expectedDrviersCount;
+    }
+
+    @Override
+    public ListenableFuture<DynamicFilterSummary> getSummary()
+    {
+        return service.getSummary(taskId.getQueryId().getId(), source);
+    }
+
+    @Override
+    public ListenableFuture<?> storeSummary(DynamicFilterSummary summary)
+    {
+        service.storeOrMergeSummary(taskId.getQueryId().getId(), source, taskId.getStageId().getId(), taskId.getId(), driverId, summary, expectedDrviersCount);
+        return immediateFuture(null);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/InMemoryDynamicFilterClientSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InMemoryDynamicFilterClientSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.server.DynamicFilterService;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class InMemoryDynamicFilterClientSupplier
+        implements DynamicFilterClientSupplier
+{
+    private final DynamicFilterService service;
+
+    @Inject
+    public InMemoryDynamicFilterClientSupplier(DynamicFilterService service)
+    {
+        this.service = requireNonNull(service, "dynamicFilterService is null");
+    }
+
+    @Override
+    public DynamicFilterClient createClient(TaskId taskId, String source, int driverId, int expectedDriversCount)
+    {
+        return new InMemoryDynamicFilterClient(service, taskId, source, driverId, expectedDriversCount);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/DynamicFilterResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/DynamicFilterResource.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.operator.DynamicFilterSummary;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import java.util.Optional;
+import java.util.concurrent.Future;
+
+import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+@Path("/v1/dynamic-filter/{queryId}/{source}")
+public class DynamicFilterResource
+{
+    private final DynamicFilterService service;
+
+    @Inject
+    public DynamicFilterResource(DynamicFilterService service)
+    {
+        this.service = service;
+    }
+
+    @PUT
+    @Path("/{stageId}/{taskId}/{driverId}/{expectedCount}")
+    @Consumes(APPLICATION_JSON)
+    @Produces(TEXT_PLAIN)
+    public Response storeOrMergeSummary(
+            @PathParam("queryId") String queryId,
+            @PathParam("source") String source,
+            @PathParam("stageId") int stageId,
+            @PathParam("taskId") int taskId,
+            @PathParam("driverId") int driverId,
+            @PathParam("expectedCount") int expectedCount,
+            DynamicFilterSummary dynamicFilterSummary)
+    {
+        service.storeOrMergeSummary(queryId, source, stageId, taskId, driverId, dynamicFilterSummary, expectedCount);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Response getSummary(
+            @PathParam("queryId") String queryId,
+            @PathParam("source") String source)
+    {
+        Future<DynamicFilterSummary> summaryFuture = service.getSummary(queryId, source);
+        Optional<DynamicFilterSummary> summary = tryGetFutureValue(summaryFuture);
+        if (!summary.isPresent()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        return Response.ok(summary.get()).build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/DynamicFilterService.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/DynamicFilterService.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.operator.DynamicFilterSummary;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class DynamicFilterService
+{
+    private final Map<SourceDescriptor, DynamicFilterSummaryWithSenders> dynamicFilterSummaries = new HashMap<>();
+    private final Map<SourceDescriptor, SettableFuture<DynamicFilterSummary>> futures = new ConcurrentHashMap<>();
+
+    public void storeOrMergeSummary(String queryId, String source, int stageId, int taskId, int driverId, DynamicFilterSummary dynamicFilterSummary, int expectedSummariesCount)
+    {
+        DynamicFilterSummary mergedSummary;
+        synchronized (this) {
+            DynamicFilterSummaryWithSenders dynamicFilterSummaryWithSenders = dynamicFilterSummaries.get(SourceDescriptor.of(queryId, source));
+            checkState(dynamicFilterSummaryWithSenders != null, "Cannot store summary for not pre-registered task");
+
+            mergedSummary = dynamicFilterSummaryWithSenders.addSummary(DynamicFilterSummaryWithSenders.StageTaskKey.of(stageId, taskId), driverId, dynamicFilterSummary, expectedSummariesCount);
+        }
+
+        if (mergedSummary != null) {
+            futures.get(SourceDescriptor.of(queryId, source)).set(mergedSummary);
+        }
+    }
+
+    public synchronized ListenableFuture<DynamicFilterSummary> getSummary(String queryId, String source)
+    {
+        SettableFuture<DynamicFilterSummary> future = futures.get(SourceDescriptor.of(queryId, source));
+        if (future == null) {
+            future = SettableFuture.create();
+            futures.put(SourceDescriptor.of(queryId, source), future);
+        }
+        DynamicFilterSummaryWithSenders dynamicFilterSummaryWithSenders = dynamicFilterSummaries.get(SourceDescriptor.of(queryId, source));
+        if (dynamicFilterSummaryWithSenders.getSummaryIfReady().isPresent()) {
+            future.set(dynamicFilterSummaryWithSenders.getSummaryIfReady().get());
+        }
+        return future;
+    }
+
+    public synchronized void removeQuery(String queryId)
+    {
+        dynamicFilterSummaries.entrySet().removeIf(entry -> entry.getKey().getQueryId().equals(queryId));
+        futures.entrySet().removeIf(entry -> entry.getKey().getQueryId().equals(queryId));
+    }
+
+    @Immutable
+    private static class SourceDescriptor
+    {
+        private final String queryId;
+        private final String source;
+
+        public static SourceDescriptor of(String queryId, String source)
+        {
+            return new SourceDescriptor(queryId, source);
+        }
+
+        private SourceDescriptor(String queryId, String source)
+        {
+            this.queryId = requireNonNull(queryId, "queryId is null");
+            this.source = requireNonNull(source, "source is null");
+        }
+
+        public String getQueryId()
+        {
+            return queryId;
+        }
+
+        public String getSource()
+        {
+            return source;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (other == this) {
+                return true;
+            }
+            if (other == null || !(other instanceof SourceDescriptor)) {
+                return false;
+            }
+
+            SourceDescriptor sourceDescriptor = (SourceDescriptor) other;
+
+            return Objects.equals(queryId, sourceDescriptor.queryId) &&
+                    Objects.equals(source, sourceDescriptor.source);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(queryId, source);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .addValue(queryId)
+                    .addValue(source)
+                    .toString();
+        }
+    }
+
+    @NotThreadSafe
+    static class DynamicFilterSummaryWithSenders
+    {
+        private final Map<StageTaskKey, SenderStats> senderStats = new HashMap<>();
+        private final Set<StageTaskKey> registeredTasks;
+        private DynamicFilterSummary dynamicFilterSummary;
+
+        DynamicFilterSummaryWithSenders(Set<StageTaskKey> senderStats)
+        {
+            this.registeredTasks = ImmutableSet.copyOf(senderStats);
+        }
+
+        public Optional<DynamicFilterSummary> getSummaryIfReady()
+        {
+            if (!senderStats.keySet().equals(registeredTasks)) {
+                return Optional.empty();
+            }
+
+            for (Map.Entry<StageTaskKey, SenderStats> entry : senderStats.entrySet()) {
+                if (!entry.getValue().isCompleted()) {
+                    return Optional.empty();
+                }
+            }
+
+            return Optional.of(dynamicFilterSummary);
+        }
+
+        public DynamicFilterSummary addSummary(StageTaskKey stageTaskId, int driverId, DynamicFilterSummary summary, int expectedSummariesCount)
+        {
+            SenderStats stats = senderStats.get(stageTaskId);
+            checkArgument(stats != null, "Cannot add summary to not pre-registered task");
+            checkState(stats.getExpectedSummariesCount() == expectedSummariesCount, "expected summaries count should not change between summaries");
+            stats.addSummary(driverId);
+
+            if (dynamicFilterSummary == null) {
+                dynamicFilterSummary = summary;
+            }
+            else {
+                dynamicFilterSummary = dynamicFilterSummary.mergeWith(summary);
+            }
+
+            if (stats.isCompleted()) {
+                return dynamicFilterSummary;
+            }
+
+            return null;
+        }
+
+        @NotThreadSafe
+        private static class SenderStats
+        {
+            // collection of driverIDs reported
+            private final Set<Integer> driverIDs = new HashSet<>();
+            private final int expectedSummariesCount;
+
+            SenderStats(int expectedSummariesCount)
+            {
+                this.expectedSummariesCount = expectedSummariesCount;
+            }
+
+            public int getExpectedSummariesCount()
+            {
+                return expectedSummariesCount;
+            }
+
+            public boolean isCompleted()
+            {
+                return driverIDs.size() == expectedSummariesCount;
+            }
+
+            public void addSummary(Integer driverId)
+            {
+                if (driverIDs.contains(driverId)) {
+                    // skip existing driver IDs in case of HTTP retries
+                    return;
+                }
+
+                checkState(driverIDs.size() < expectedSummariesCount, "cannot increase number of received summaries beyond the expected count");
+
+                driverIDs.add(driverId);
+            }
+        }
+
+        @Immutable
+        private static class StageTaskKey
+        {
+            private final int stageId;
+            private final int taskId;
+
+            static StageTaskKey of(TaskId taskId)
+            {
+                return of(taskId.getStageId().getId(), taskId.getId());
+            }
+
+            static StageTaskKey of(int stageId, int taskId)
+            {
+                return new StageTaskKey(stageId, taskId);
+            }
+
+            private StageTaskKey(int stageId, int taskId)
+            {
+                this.stageId = stageId;
+                this.taskId = taskId;
+            }
+
+            public int getStageId()
+            {
+                return stageId;
+            }
+
+            public int getTaskId()
+            {
+                return taskId;
+            }
+
+            @Override
+            public boolean equals(Object o)
+            {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+
+                StageTaskKey that = (StageTaskKey) o;
+
+                return Objects.equals(stageId, that.stageId) &&
+                        Objects.equals(taskId, that.taskId);
+            }
+
+            @Override
+            public int hashCode()
+            {
+                return Objects.hash(stageId, taskId);
+            }
+
+            @Override
+            public String toString()
+            {
+                return toStringHelper(this)
+                        .addValue(stageId)
+                        .addValue(taskId)
+                        .toString();
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -72,10 +72,13 @@ import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticCatalogStoreConfig;
 import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.operator.DynamicFilterClientFactory;
+import com.facebook.presto.operator.DynamicFilterClientSupplier;
 import com.facebook.presto.operator.DynamicFilterSummary;
 import com.facebook.presto.operator.ExchangeClientConfig;
 import com.facebook.presto.operator.ExchangeClientFactory;
 import com.facebook.presto.operator.ExchangeClientSupplier;
+import com.facebook.presto.operator.ForDynamicFilterSummary;
 import com.facebook.presto.operator.ForExchange;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.PagesIndex;
@@ -339,6 +342,16 @@ public class ServerMainModule
 
         // dynamic filter summary
         jsonCodecBinder(binder).bindJsonCodec(DynamicFilterSummary.class);
+        binder.bind(DynamicFilterService.class).in(Scopes.SINGLETON);
+        jaxrsBinder(binder).bind(DynamicFilterResource.class);
+
+        binder.bind(DynamicFilterClientSupplier.class).to(DynamicFilterClientFactory.class).in(Scopes.SINGLETON);
+        httpClientBinder(binder).bindHttpClient("dynamicFilter", ForDynamicFilterSummary.class)
+                .withTracing()
+                .withConfigDefaults(config -> {
+                    config.setIdleTimeout(new Duration(30, SECONDS));
+                    config.setRequestTimeout(new Duration(10, SECONDS));
+                });
 
         // memory manager
         jaxrsBinder(binder).bind(MemoryResource.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -72,6 +72,7 @@ import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticCatalogStoreConfig;
 import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.operator.DynamicFilterSummary;
 import com.facebook.presto.operator.ExchangeClientConfig;
 import com.facebook.presto.operator.ExchangeClientFactory;
 import com.facebook.presto.operator.ExchangeClientSupplier;
@@ -335,6 +336,9 @@ public class ServerMainModule
 
         // execution
         binder.bind(LocationFactory.class).to(HttpLocationFactory.class).in(Scopes.SINGLETON);
+
+        // dynamic filter summary
+        jsonCodecBinder(binder).bindJsonCodec(DynamicFilterSummary.class);
 
         // memory manager
         jaxrsBinder(binder).bind(MemoryResource.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -203,7 +203,7 @@ public class TestingPrestoServer
                 .add(new TestingJmxModule())
                 .add(new EventModule())
                 .add(new TraceTokenModule())
-                .add(new ServerMainModule(parserOptions))
+                .add(new ServerMainModule(parserOptions, discoveryUri == null))
                 .add(binder -> {
                     binder.bind(TestingAccessControlManager.class).in(Scopes.SINGLETON);
                     binder.bind(TestingEventListenerManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/split/SplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/SplitManager.java
@@ -19,12 +19,15 @@ import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.metadata.TableLayoutHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.DynamicFilterDescription;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 
 import javax.inject.Inject;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Future;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -53,14 +56,14 @@ public class SplitManager
         splitManagers.remove(connectorId);
     }
 
-    public SplitSource getSplits(Session session, TableLayoutHandle layout)
+    public SplitSource getSplits(Session session, TableLayoutHandle layout, List<Future<DynamicFilterDescription>> dynamicFilters)
     {
         ConnectorId connectorId = layout.getConnectorId();
         ConnectorSplitManager splitManager = getConnectorSplitManager(connectorId);
 
         ConnectorSession connectorSession = session.toConnectorSession(connectorId);
 
-        ConnectorSplitSource source = splitManager.getSplits(layout.getTransactionHandle(), connectorSession, layout.getConnectorHandle());
+        ConnectorSplitSource source = splitManager.getSplits(layout.getTransactionHandle(), connectorSession, layout.getConnectorHandle(), dynamicFilters);
 
         SplitSource splitSource = new ConnectorAwareSplitSource(connectorId, layout.getTransactionHandle(), source);
         if (minScheduleSplitBatchSize > 1) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/DynamicFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/DynamicFilter.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.ComparisonExpressionType;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
+import com.facebook.presto.sql.tree.Expression;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.DynamicFilterUtils.isDynamicFilter;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilter
+{
+    private final Expression sourceExpression;
+    private final String tupleDomainSourceId;
+    private final String tupleDomainName;
+    private final ComparisonExpressionType comparisonType;
+
+    public static Optional<DynamicFilter> getDynamicFilterOptional(Expression expression)
+    {
+        if (!isDynamicFilter(expression)) {
+            return Optional.empty();
+        }
+        return Optional.of(from(expression));
+    }
+
+    public static DynamicFilter from(Expression expression)
+    {
+        checkArgument(expression instanceof ComparisonExpression, "Unexpected expression: %s", expression);
+        ComparisonExpression comparison = (ComparisonExpression) expression;
+
+        Expression sourceExpression = null;
+        DeferredSymbolReference deferredReference = null;
+
+        checkState(comparison.getLeft() instanceof DeferredSymbolReference ^ comparison.getRight() instanceof DeferredSymbolReference, "Exactly one deferred symbol per expression is required");
+        if (comparison.getLeft() instanceof DeferredSymbolReference) {
+            sourceExpression = comparison.getRight();
+            deferredReference = (DeferredSymbolReference) comparison.getLeft();
+        }
+        else if (comparison.getRight() instanceof DeferredSymbolReference) {
+            sourceExpression = comparison.getLeft();
+            deferredReference = (DeferredSymbolReference) comparison.getRight();
+        }
+
+        return new DynamicFilter(
+                sourceExpression,
+                deferredReference.getSourceId(),
+                deferredReference.getSymbol(),
+                comparison.getType());
+    }
+
+    public DynamicFilter(Expression sourceExpression, String tupleDomainSourceId, String tupleDomainName, ComparisonExpressionType comparisonType)
+    {
+        this.sourceExpression = requireNonNull(sourceExpression, "symbol is null");
+        this.tupleDomainSourceId = requireNonNull(tupleDomainSourceId, "tupleDomainSourceId is null");
+        this.tupleDomainName = requireNonNull(tupleDomainName, "tupleDomainName is null");
+        this.comparisonType = requireNonNull(comparisonType, "comparisonType is null");
+    }
+
+    public Expression getSourceExpression()
+    {
+        return sourceExpression;
+    }
+
+    public String getTupleDomainSourceId()
+    {
+        return tupleDomainSourceId;
+    }
+
+    public String getTupleDomainName()
+    {
+        return tupleDomainName;
+    }
+
+    public ComparisonExpressionType getComparisonType()
+    {
+        return comparisonType;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("sourceExpression", sourceExpression)
+                .add("tupleDomainSourceId", tupleDomainSourceId)
+                .add("tupleDomainName", tupleDomainName)
+                .add("comparisonType", comparisonType)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DynamicFilter that = (DynamicFilter) o;
+        return Objects.equals(sourceExpression, that.sourceExpression) &&
+                Objects.equals(tupleDomainSourceId, that.tupleDomainSourceId) &&
+                Objects.equals(tupleDomainName, that.tupleDomainName) &&
+                comparisonType == that.comparisonType;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sourceExpression, tupleDomainSourceId, tupleDomainName, comparisonType);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/DynamicFilterUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/DynamicFilterUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
+import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterUtils
+{
+    private DynamicFilterUtils() {}
+
+    public static Expression stripDynamicFilters(Expression expression)
+    {
+        return combineConjuncts(extractConjuncts(expression)
+                .stream()
+                .filter(conjunct -> !isDynamicFilter(conjunct))
+                .collect(toImmutableList()));
+    }
+
+    public static boolean isDynamicFilter(Expression expression)
+    {
+        if (!(expression instanceof ComparisonExpression)) {
+            return false;
+        }
+
+        ComparisonExpression comparison = (ComparisonExpression) expression;
+        checkState(!(comparison.getLeft() instanceof DeferredSymbolReference && comparison.getRight() instanceof DeferredSymbolReference), "Dynamic filter cannot have DeferredSymbolReferences");
+        return comparison.getLeft() instanceof DeferredSymbolReference || comparison.getRight() instanceof DeferredSymbolReference;
+    }
+
+    public static ExtractDynamicFiltersResult extractDynamicFilters(Expression expression)
+    {
+        List<Expression> filters = extractConjuncts(expression);
+
+        List<Expression> staticFilters = new ArrayList<>(filters.size());
+        List<Expression> dynamicFilters = new ArrayList<>(filters.size());
+
+        for (Expression filter : filters) {
+            if (isDynamicFilter(filter)) {
+                dynamicFilters.add(filter);
+            }
+            else {
+                staticFilters.add(filter);
+            }
+        }
+
+        return new ExtractDynamicFiltersResult(
+                combineConjuncts(staticFilters),
+                dynamicFilters.stream().map(DynamicFilter::from).collect(toImmutableSet()));
+    }
+
+    public static class ExtractDynamicFiltersResult
+    {
+        private final Expression staticFilters;
+        private final Set<DynamicFilter> dynamicFilters;
+
+        public ExtractDynamicFiltersResult(Expression staticFilters, Set<DynamicFilter> dynamicFilters)
+        {
+            this.staticFilters = requireNonNull(staticFilters, "staticFilters is null");
+            this.dynamicFilters = ImmutableSet.copyOf(requireNonNull(dynamicFilters, "dynamicFilters is null"));
+        }
+
+        public Expression getStaticFilters()
+        {
+            return staticFilters;
+        }
+
+        public Set<DynamicFilter> getDynamicFilters()
+        {
+            return dynamicFilters;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.sql.DynamicFilter;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
@@ -127,6 +128,7 @@ import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.DynamicFilter.getDynamicFilterOptional;
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
 import static com.facebook.presto.sql.analyzer.Analyzer.verifyNoAggregateWindowOrGroupingFunctions;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.EXPRESSION_NOT_CONSTANT;
@@ -442,6 +444,11 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitComparisonExpression(ComparisonExpression node, StackableAstVisitorContext<Context> context)
         {
+            Optional<DynamicFilter> dynamicFilter = getDynamicFilterOptional(node);
+            dynamicFilter.ifPresent(filter -> {
+                expressionTypes.put(NodeRef.of(node.getLeft()), process(filter.getSourceExpression(), context));
+                expressionTypes.put(NodeRef.of(node.getRight()), process(filter.getSourceExpression(), context));
+            });
             OperatorType operatorType = OperatorType.valueOf(node.getType().name());
             return getOperator(context, node, operatorType, node.getLeft(), node.getRight());
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -74,6 +74,7 @@ public class FeaturesConfig
     private double memoryRevokingThreshold = 0.9;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
+    private boolean dynamicPartitionPruningEnabled = false;
 
     public boolean isResourceGroupsEnabled()
     {
@@ -408,6 +409,18 @@ public class FeaturesConfig
     public FeaturesConfig setSpillMaxUsedSpaceThreshold(double spillMaxUsedSpaceThreshold)
     {
         this.spillMaxUsedSpaceThreshold = spillMaxUsedSpaceThreshold;
+        return this;
+    }
+
+    public boolean isDynamicPartitionPruningEnabled()
+    {
+        return dynamicPartitionPruningEnabled;
+    }
+
+    @Config("experimental.dynamic-partition-pruning-enabled")
+    public FeaturesConfig setDynamicPartitionPruningEnabled(boolean value)
+    {
+        this.dynamicPartitionPruningEnabled = value;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
@@ -14,6 +14,12 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.operator.DynamicFilterSummary;
+import com.facebook.presto.server.DynamicFilterService;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.DynamicFilterDescription;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.split.SampledSplitSource;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.split.SplitSource;
@@ -53,9 +59,12 @@ import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.UnnestNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
 import io.airlift.log.Logger;
 
 import javax.inject.Inject;
@@ -65,7 +74,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Future;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
 
@@ -74,16 +85,18 @@ public class DistributedExecutionPlanner
     private static final Logger log = Logger.get(DistributedExecutionPlanner.class);
 
     private final SplitManager splitManager;
+    private final DynamicFilterService dynamicFilterService;
 
     @Inject
-    public DistributedExecutionPlanner(SplitManager splitManager)
+    public DistributedExecutionPlanner(SplitManager splitManager, DynamicFilterService dynamicFilterService)
     {
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
     }
 
     public StageExecutionPlan plan(SubPlan root, Session session)
     {
-        Visitor visitor = new Visitor(session);
+        Visitor visitor = new Visitor(session, new DynamicFilterDescriptionFutureSupplier(dynamicFilterService));
         try {
             return plan(root, visitor);
         }
@@ -127,10 +140,12 @@ public class DistributedExecutionPlanner
     {
         private final Session session;
         private final List<SplitSource> splitSources = new ArrayList<>();
+        private final DynamicFilterDescriptionFutureSupplier dynamicFilterDescriptionFutureSupplier;
 
-        private Visitor(Session session)
+        private Visitor(Session session, DynamicFilterDescriptionFutureSupplier dynamicFilterDescriptionFutureSupplier)
         {
             this.session = session;
+            this.dynamicFilterDescriptionFutureSupplier = dynamicFilterDescriptionFutureSupplier;
         }
 
         public List<SplitSource> getSplitSources()
@@ -158,13 +173,13 @@ public class DistributedExecutionPlanner
                     .map(ExtractDynamicFiltersResult::getDynamicFilters)
                     .orElse(ImmutableSet.of());
 
-            // TODO: use dynamic filters
+            List<Future<DynamicFilterDescription>> futuresList = ImmutableList.of();
             if (!dynamicFilters.isEmpty()) {
                 log.debug("Dynamic filters: %s", dynamicFilters);
+                futuresList = dynamicFilterDescriptionFutureSupplier.get(session.getQueryId().toString(), dynamicFilters, scan.getAssignments());
             }
 
-            // get dataSource for table
-            SplitSource splitSource = splitManager.getSplits(session, scan.getLayout().get());
+            SplitSource splitSource = splitManager.getSplits(session, scan.getLayout().get(), futuresList);
 
             splitSources.add(splitSource);
 
@@ -387,6 +402,61 @@ public class DistributedExecutionPlanner
         protected Map<PlanNodeId, SplitSource> visitPlan(PlanNode node, Void context)
         {
             throw new UnsupportedOperationException("not yet implemented: " + node.getClass().getName());
+        }
+    }
+
+    private static class DynamicFilterDescriptionFutureSupplier
+    {
+        private final DynamicFilterService dynamicFilterService;
+
+        public DynamicFilterDescriptionFutureSupplier(DynamicFilterService dynamicFilterService)
+        {
+            this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
+        }
+
+        public List<Future<DynamicFilterDescription>> get(String queryId, Set<DynamicFilter> dynamicFilters, Map<Symbol, ColumnHandle> columnHandles)
+        {
+            Set<String> sources = dynamicFilters.stream().map(DynamicFilter::getTupleDomainSourceId).collect(toImmutableSet());
+            ImmutableList.Builder<Future<DynamicFilterDescription>> futuresBuilder = ImmutableList.builder();
+            for (String source : sources) {
+                futuresBuilder.add(Futures.transform(dynamicFilterService.getSummary(queryId, source), summary -> translateSummaryIntoDescription(summary, dynamicFilters, columnHandles)));
+            }
+            return futuresBuilder.build();
+        }
+
+        private static DynamicFilterDescription translateSummaryIntoDescription(DynamicFilterSummary summary, Set<DynamicFilter> dynamicFilters, Map<Symbol, ColumnHandle> columnHandles)
+        {
+            if (!summary.getTupleDomain().getDomains().isPresent()) {
+                return new DynamicFilterDescription(TupleDomain.none());
+            }
+
+            Map<String, Symbol> sourceExpressionSymbols = extractSourceExpressionSymbols(dynamicFilters);
+            ImmutableMap.Builder<ColumnHandle, Domain> domainBuilder = ImmutableMap.builder();
+            for (Map.Entry<String, Domain> entry : summary.getTupleDomain().getDomains().get().entrySet()) {
+                Symbol actualSymbol = sourceExpressionSymbols.get(entry.getKey());
+                if (actualSymbol == null) {
+                    continue;
+                }
+                ColumnHandle columnHandle = columnHandles.get(actualSymbol);
+                if (columnHandle == null) {
+                    continue;
+                }
+                domainBuilder.put(columnHandle, entry.getValue());
+            }
+            return new DynamicFilterDescription(TupleDomain.withColumnDomains(domainBuilder.build()));
+        }
+
+        private static Map<String, Symbol> extractSourceExpressionSymbols(Set<DynamicFilter> dynamicFilters)
+        {
+            ImmutableMap.Builder<String, Symbol> resultBuilder = ImmutableMap.builder();
+            for (DynamicFilter dynamicFilter : dynamicFilters) {
+                Expression expression = dynamicFilter.getSourceExpression();
+                if (!(expression instanceof SymbolReference)) {
+                    continue;
+                }
+                resultBuilder.put(dynamicFilter.getTupleDomainName(), Symbol.from(expression));
+            }
+            return resultBuilder.build();
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.presto.sql.DynamicFilterUtils.isDynamicFilter;
 import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
 import static com.facebook.presto.sql.planner.DeterminismEvaluator.isDeterministic;
 import static com.facebook.presto.sql.planner.NullabilityAnalyzer.mayReturnNullOnNonNullInput;
@@ -258,7 +259,8 @@ public class EqualityInference
             expression = normalizeInPredicateToEquality(expression);
             if (expression instanceof ComparisonExpression &&
                     isDeterministic(expression) &&
-                    !mayReturnNullOnNonNullInput(expression)) {
+                    !mayReturnNullOnNonNullInput(expression) &&
+                    !isDynamicFilter(expression)) {
                 ComparisonExpression comparison = (ComparisonExpression) expression;
                 if (comparison.getType() == ComparisonExpressionType.EQUAL) {
                     // We should only consider equalities that have distinct left and right components

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
+import static com.facebook.presto.sql.planner.DeterminismEvaluator.isDeterministic;
+import static com.facebook.presto.sql.planner.NullabilityAnalyzer.mayReturnNullOnNonNullInput;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.not;
@@ -103,7 +105,7 @@ public class EqualityInference
      */
     public Expression rewriteExpression(Expression expression, Predicate<Symbol> symbolScope)
     {
-        checkArgument(DeterminismEvaluator.isDeterministic(expression), "Only deterministic expressions may be considered for rewrite");
+        checkArgument(isDeterministic(expression), "Only deterministic expressions may be considered for rewrite");
         return rewriteExpression(expression, symbolScope, true);
     }
 
@@ -254,7 +256,9 @@ public class EqualityInference
     {
         return expression -> {
             expression = normalizeInPredicateToEquality(expression);
-            if (expression instanceof ComparisonExpression && DeterminismEvaluator.isDeterministic(expression) && !NullabilityAnalyzer.mayReturnNullOnNonNullInput(expression)) {
+            if (expression instanceof ComparisonExpression &&
+                    isDeterministic(expression) &&
+                    !mayReturnNullOnNonNullInput(expression)) {
                 ComparisonExpression comparison = (ComparisonExpression) expression;
                 if (comparison.getType() == ComparisonExpressionType.EQUAL) {
                     // We should only consider equalities that have distinct left and right components
@@ -358,8 +362,8 @@ public class EqualityInference
         public Builder addEquality(Expression expression1, Expression expression2)
         {
             checkArgument(!expression1.equals(expression2), "Need to provide equality between different expressions");
-            checkArgument(DeterminismEvaluator.isDeterministic(expression1), "Expression must be deterministic: " + expression1);
-            checkArgument(DeterminismEvaluator.isDeterministic(expression2), "Expression must be deterministic: " + expression2);
+            checkArgument(isDeterministic(expression1), "Expression must be deterministic: " + expression1);
+            checkArgument(isDeterministic(expression2), "Expression must be deterministic: " + expression2);
 
             equalities.findAndUnion(expression1, expression2);
             return this;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -51,6 +51,7 @@ import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.ComparisonExpressionType;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.ExistsPredicate;
 import com.facebook.presto.sql.tree.Expression;
@@ -458,6 +459,12 @@ public class ExpressionInterpreter
         protected Object visitSymbolReference(SymbolReference node, Object context)
         {
             return ((SymbolResolver) context).getValue(Symbol.from(node));
+        }
+
+        @Override
+        protected Object visitDeferredSymbolReference(DeferredSymbolReference node, Object context)
+        {
+            return node;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -98,6 +98,9 @@ import com.facebook.presto.spiller.SpillerFactory;
 import com.facebook.presto.split.MappedRecordSet;
 import com.facebook.presto.split.PageSinkManager;
 import com.facebook.presto.split.PageSourceProvider;
+import com.facebook.presto.sql.DynamicFilter;
+import com.facebook.presto.sql.DynamicFilterUtils;
+import com.facebook.presto.sql.DynamicFilterUtils.ExtractDynamicFiltersResult;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -1057,9 +1060,19 @@ public class LocalExecutionPlanner
             }
             Map<Symbol, Integer> outputMappings = outputMappingsBuilder.build();
 
+            Optional<ExtractDynamicFiltersResult> extractDynamicFilterResult = filterExpression.map(DynamicFilterUtils::extractDynamicFilters);
+            Optional<Expression> staticFilters = extractDynamicFilterResult.map(ExtractDynamicFiltersResult::getStaticFilters);
+
+            // TODO: Process dynamic filters
+            Optional<Set<DynamicFilter>> dynamicFilters = extractDynamicFilterResult.map(ExtractDynamicFiltersResult::getDynamicFilters);
+
+            if (dynamicFilters.isPresent() && !dynamicFilters.get().isEmpty()) {
+                log.debug("[TableScan] Dynamic filters: %s", dynamicFilters);
+            }
+
             // compiler uses inputs instead of symbols, so rewrite the expressions first
             SymbolToInputRewriter symbolToInputRewriter = new SymbolToInputRewriter(sourceLayout);
-            Optional<Expression> rewrittenFilter = filterExpression.map(symbolToInputRewriter::rewrite);
+            Optional<Expression> rewrittenFilter = staticFilters.map(symbolToInputRewriter::rewrite);
 
             List<Expression> rewrittenProjections = new ArrayList<>();
             for (Symbol symbol : outputSymbols) {
@@ -1114,11 +1127,11 @@ public class LocalExecutionPlanner
                 }
 
                 // compilation failed, use interpreter
-                log.error(e, "Compile failed for filter=%s projections=%s sourceTypes=%s error=%s", filterExpression, assignments, sourceTypes, e);
+                log.error(e, "Compile failed for filter=%s projections=%s sourceTypes=%s error=%s", staticFilters, assignments, sourceTypes, e);
             }
 
             PageProcessor pageProcessor = createInterpretedColumnarPageProcessor(
-                    filterExpression,
+                    staticFilters,
                     outputSymbols.stream()
                             .map(assignments::get)
                             .collect(toImmutableList()),
@@ -1127,7 +1140,7 @@ public class LocalExecutionPlanner
                     context.getSession());
             if (columns != null) {
                 InterpretedCursorProcessor cursorProcessor = new InterpretedCursorProcessor(
-                        filterExpression,
+                        staticFilters,
                         outputSymbols.stream()
                                 .map(assignments::get)
                                 .collect(toImmutableList()),
@@ -1486,6 +1499,13 @@ public class LocalExecutionPlanner
             List<JoinNode.EquiJoinClause> clauses = node.getCriteria();
             if (node.isCrossJoin()) {
                 return createNestedLoopJoin(node, context);
+            }
+
+            Assignments dynamicFilters = node.getDynamicFilterAssignments();
+
+            // TODO handle pruning based on dynamic filters from joins above
+            if (!dynamicFilters.getMap().isEmpty()) {
+                log.debug("[Join] Dynamic filters: %s", dynamicFilters.getMap());
             }
 
             List<Symbol> leftSymbols = Lists.transform(clauses, JoinNode.EquiJoinClause::getLeft);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -28,6 +28,8 @@ import com.facebook.presto.operator.AggregationOperator.AggregationOperatorFacto
 import com.facebook.presto.operator.AssignUniqueIdOperator;
 import com.facebook.presto.operator.DeleteOperator.DeleteOperatorFactory;
 import com.facebook.presto.operator.DriverFactory;
+import com.facebook.presto.operator.DynamicFilterClientSupplier;
+import com.facebook.presto.operator.DynamicFilterSourceOperator.DynamicFilterSourceOperatorFactory;
 import com.facebook.presto.operator.EnforceSingleRowOperator;
 import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.operator.ExchangeOperator.ExchangeOperatorFactory;
@@ -209,6 +211,7 @@ import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BRO
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.CreateHandle;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.InsertHandle;
@@ -254,6 +257,7 @@ public class LocalExecutionPlanner
     private final PagesIndex.Factory pagesIndexFactory;
     private final JoinCompiler joinCompiler;
     private final LookupJoinOperators lookupJoinOperators;
+    private final DynamicFilterClientSupplier dynamicFilterClientSupplier;
 
     @Inject
     public LocalExecutionPlanner(
@@ -276,7 +280,8 @@ public class LocalExecutionPlanner
             BlockEncodingSerde blockEncodingSerde,
             PagesIndex.Factory pagesIndexFactory,
             JoinCompiler joinCompiler,
-            LookupJoinOperators lookupJoinOperators)
+            LookupJoinOperators lookupJoinOperators,
+            DynamicFilterClientSupplier dynamicFilterClientSupplier)
     {
         requireNonNull(compilerConfig, "compilerConfig is null");
         this.queryPerformanceFetcher = requireNonNull(queryPerformanceFetcher, "queryPerformanceFetcher is null");
@@ -300,6 +305,7 @@ public class LocalExecutionPlanner
         this.pagesIndexFactory = requireNonNull(pagesIndexFactory, "pagesIndexFactory is null");
         this.joinCompiler = requireNonNull(joinCompiler, "joinCompiler is null");
         this.lookupJoinOperators = requireNonNull(lookupJoinOperators, "lookupJoinOperators is null");
+        this.dynamicFilterClientSupplier = requireNonNull(dynamicFilterClientSupplier, "dynamicFitlerClientSupplier is null");
 
         interpreterEnabled = compilerConfig.isInterpreterEnabled();
     }
@@ -1572,9 +1578,24 @@ public class LocalExecutionPlanner
             PhysicalOperation probeSource = probeNode.accept(this, context);
 
             // Plan build
-            LookupSourceFactory lookupSourceFactory = createLookupSourceFactory(node, buildNode, buildSymbols, buildHashSymbol, probeSource.getLayout(), context);
+            LocalExecutionPlanContext buildContext = context.createSubContext();
+            PhysicalOperation buildSource = buildNode.accept(this, buildContext);
+            List<Integer> buildChannels = ImmutableList.copyOf(getChannelsForSymbols(buildSymbols, buildSource.getLayout()));
 
-            OperatorFactory operator = createLookupJoin(node, probeSource, probeSymbols, probeHashSymbol, lookupSourceFactory, context);
+            List<Symbol> filterSymbols = node.getDynamicFilterAssignments().getExpressions().stream().map(expression -> Symbol.from(expression)).collect(toImmutableList());
+            ImmutableList.Builder<String> dynamicFilterNamesBuilder = ImmutableList.builder();
+            for (Symbol filterSymbol : filterSymbols) {
+                Optional<Map.Entry<Symbol, Expression>> matchingEntry = node.getDynamicFilterAssignments().entrySet().stream().filter(entry -> Symbol.from(entry.getValue()).equals(filterSymbol)).findFirst();
+                dynamicFilterNamesBuilder.add(matchingEntry.get().getKey().toString());
+            }
+            List<String> dynamicFilterSymbolNames = dynamicFilterNamesBuilder.build();
+            List<Integer> filterChannels = ImmutableList.copyOf(getChannelsForSymbols(filterSymbols, buildSource.getLayout()));
+
+            Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
+
+            HashBuilderOperatorFactory hashBuilderOperatorFactory = createHashBuilderOperatorFactory(node, buildContext, buildSource, buildChannels, buildHashChannel, probeSource.getLayout(), context);
+
+            OperatorFactory lookupJoinOperator = createLookupJoin(node, probeSource, probeSymbols, probeHashSymbol, hashBuilderOperatorFactory.getLookupSourceFactory(), context);
 
             ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
             List<Symbol> outputSymbols = node.getOutputSymbols();
@@ -1583,25 +1604,55 @@ public class LocalExecutionPlanner
                 outputMappings.put(symbol, i);
             }
 
-            return new PhysicalOperation(operator, outputMappings.build(), probeSource);
+            // Dynamic filtering
+            if (SystemSessionProperties.isDynamicPartitionPruningEnabled(context.getSession()) && node.getType() == INNER && node.getCriteria().size() > 0) {
+                OperatorFactory dynamicFilterSource = new DynamicFilterSourceOperatorFactory(
+                        buildContext.getNextOperatorId(),
+                        node.getId(),
+                        buildSource.getTypes(),
+                        filterChannels,
+                        dynamicFilterSymbolNames,
+                        dynamicFilterClientSupplier,
+                        node.getId().toString(),
+                        buildContext.getDriverInstanceCount().orElse(1));
+
+                context.addDriverFactory(
+                        buildContext.isInputDriver(),
+                        false,
+                        ImmutableList.<OperatorFactory>builder()
+                                .addAll(buildSource.getOperatorFactories())
+                                .add(dynamicFilterSource)
+                                .add(hashBuilderOperatorFactory)
+                                .build(),
+                        buildContext.getDriverInstanceCount());
+            }
+            else {
+                context.addDriverFactory(
+                        buildContext.isInputDriver(),
+                        false,
+                        ImmutableList.<OperatorFactory>builder()
+                                .addAll(buildSource.getOperatorFactories())
+                                .add(hashBuilderOperatorFactory)
+                                .build(),
+                        buildContext.getDriverInstanceCount());
+            }
+
+            return new PhysicalOperation(lookupJoinOperator, outputMappings.build(), probeSource);
         }
 
-        private LookupSourceFactory createLookupSourceFactory(
+        private HashBuilderOperatorFactory createHashBuilderOperatorFactory(
                 JoinNode node,
-                PlanNode buildNode,
-                List<Symbol> buildSymbols,
-                Optional<Symbol> buildHashSymbol,
+                LocalExecutionPlanContext buildContext,
+                PhysicalOperation buildSource,
+                List<Integer> buildChannels,
+                Optional<Integer> buildHashChannel,
                 Map<Symbol, Integer> probeLayout,
                 LocalExecutionPlanContext context)
         {
-            LocalExecutionPlanContext buildContext = context.createSubContext();
-            PhysicalOperation buildSource = buildNode.accept(this, buildContext);
             List<Symbol> buildOutputSymbols = node.getOutputSymbols().stream()
                     .filter(symbol -> node.getRight().getOutputSymbols().contains(symbol))
                     .collect(toImmutableList());
             List<Integer> buildOutputChannels = ImmutableList.copyOf(getChannelsForSymbols(buildOutputSymbols, buildSource.getLayout()));
-            List<Integer> buildChannels = ImmutableList.copyOf(getChannelsForSymbols(buildSymbols, buildSource.getLayout()));
-            Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
 
             Optional<JoinFilterFunctionFactory> filterFunctionFactory = node.getFilter()
                     .map(filterExpression -> compileJoinFilterFunction(
@@ -1612,7 +1663,7 @@ public class LocalExecutionPlanner
                             context.getTypes(),
                             context.getSession()));
 
-            HashBuilderOperatorFactory hashBuilderOperatorFactory = new HashBuilderOperatorFactory(
+            return new HashBuilderOperatorFactory(
                     buildContext.getNextOperatorId(),
                     node.getId(),
                     buildSource.getTypes(),
@@ -1625,17 +1676,6 @@ public class LocalExecutionPlanner
                     10_000,
                     buildContext.getDriverInstanceCount().orElse(1),
                     pagesIndexFactory);
-
-            context.addDriverFactory(
-                    buildContext.isInputDriver(),
-                    false,
-                    ImmutableList.<OperatorFactory>builder()
-                            .addAll(buildSource.getOperatorFactories())
-                            .add(hashBuilderOperatorFactory)
-                            .build(),
-                    buildContext.getDriverInstanceCount());
-
-            return hashBuilderOperatorFactory.getLookupSourceFactory();
         }
 
         private JoinFilterFunctionFactory compileJoinFilterFunction(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -305,7 +305,8 @@ class RelationPlanner
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
 
         if (node.getType() != INNER) {
             for (Expression complexExpression : complexJoinExpressions) {
@@ -342,7 +343,8 @@ class RelationPlanner
                     Optional.of(rewrittenFilterCondition),
                     Optional.empty(),
                     Optional.empty(),
-                    Optional.empty());
+                    Optional.empty(),
+                    Assignments.of());
         }
 
         if (node.getType() == INNER) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ApplyDynamicFilters.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ApplyDynamicFilters.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.JoinNode.EquiJoinClause;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.isDynamicPartitionPruningEnabled;
+import static com.facebook.presto.matching.Pattern.typeOf;
+import static com.facebook.presto.matching.Property.property;
+import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class ApplyDynamicFilters
+        implements Rule<JoinNode>
+{
+    private static final Pattern<JoinNode> PATTERN = typeOf(JoinNode.class).with(property("type", JoinNode::getType).matching(INNER::equals));
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isDynamicPartitionPruningEnabled(session);
+    }
+
+    @Override
+    public Optional<PlanNode> apply(JoinNode node, Captures captures, Context context)
+    {
+        List<EquiJoinClause> criteria = node.getCriteria();
+        Assignments existingAssignments = node.getDynamicFilterAssignments();
+
+        List<EquiJoinClause> unprocessedClauses = criteria.stream()
+                .filter(c -> !existingAssignments.getExpressions().contains(c.getRight().toSymbolReference()))
+                .collect(toImmutableList());
+
+        if (unprocessedClauses.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Assignments.Builder assignments = Assignments.builder();
+        assignments.putAll(existingAssignments);
+        ImmutableList.Builder<Expression> predicates = ImmutableList.builder();
+
+        for (EquiJoinClause clause : unprocessedClauses) {
+            Symbol probeSymbol = clause.getLeft();
+            Symbol buildSymbol = clause.getRight();
+            Type buildSymbolType = requireNonNull(context.getSymbolAllocator().getTypes().get(buildSymbol));
+            Symbol assignedSymbol = context.getSymbolAllocator().newSymbol("df", buildSymbolType);
+            DeferredSymbolReference dynamicFilterReference = new DeferredSymbolReference(node.getId().toString(), assignedSymbol.getName());
+            predicates.add(new ComparisonExpression(EQUAL, probeSymbol.toSymbolReference(), dynamicFilterReference));
+            assignments.put(assignedSymbol, buildSymbol.toSymbolReference());
+        }
+
+        return Optional.of(
+                new JoinNode(
+                        node.getId(),
+                        node.getType(),
+                        new FilterNode(context.getIdAllocator().getNextId(), node.getLeft(), combineConjuncts(predicates.build())),
+                        node.getRight(),
+                        node.getCriteria(),
+                        node.getOutputSymbols(),
+                        node.getFilter(),
+                        node.getLeftHashSymbol(),
+                        node.getRightHashSymbol(),
+                        node.getDistributionType(),
+                        assignments.build()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -181,7 +181,8 @@ public class EliminateCrossJoins
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
-                    Optional.empty());
+                    Optional.empty(),
+                    Assignments.of());
         }
 
         List<Expression> filters = graph.getFilters();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -238,7 +238,8 @@ public class ExpressionRewriteRuleSet
                         filter,
                         joinNode.getLeftHashSymbol(),
                         joinNode.getRightHashSymbol(),
-                        joinNode.getDistributionType()));
+                        joinNode.getDistributionType(),
+                        joinNode.getDynamicFilterAssignments()));
             }
             return Optional.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneJoinColumns.java
@@ -50,6 +50,7 @@ public class PruneJoinColumns
                         joinNode.getFilter(),
                         joinNode.getLeftHashSymbol(),
                         joinNode.getRightHashSymbol(),
-                        joinNode.getDistributionType()));
+                        joinNode.getDistributionType(),
+                        joinNode.getDynamicFilterAssignments()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -148,7 +148,8 @@ public class PushAggregationThroughOuterJoin
                     join.getFilter(),
                     join.getLeftHashSymbol(),
                     join.getRightHashSymbol(),
-                    join.getDistributionType());
+                    join.getDistributionType(),
+                    join.getDynamicFilterAssignments());
         }
         else {
             rewrittenJoin = new JoinNode(
@@ -164,7 +165,8 @@ public class PushAggregationThroughOuterJoin
                     join.getFilter(),
                     join.getLeftHashSymbol(),
                     join.getRightHashSymbol(),
-                    join.getDistributionType());
+                    join.getDistributionType(),
+                    join.getDynamicFilterAssignments());
         }
 
         return Optional.of(coalesceWithNullAggregation(rewrittenAggregation, rewrittenJoin, context.getSymbolAllocator(), context.getIdAllocator(), context.getLookup()));
@@ -227,7 +229,8 @@ public class PushAggregationThroughOuterJoin
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
 
         // Add coalesce expressions for all aggregation functions
         Assignments.Builder assignmentsBuilder = Assignments.builder();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -180,7 +180,8 @@ public class PushPartialAggregationThroughJoin
                 child.getFilter(),
                 child.getLeftHashSymbol(),
                 child.getRightHashSymbol(),
-                child.getDistributionType());
+                child.getDistributionType(),
+                child.getDynamicFilterAssignments());
         return restrictOutputs(context.getIdAllocator(), joinNode, ImmutableSet.copyOf(aggregation.getOutputSymbols())).orElse(joinNode);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnsupportedDynamicFilters.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.DynamicFilter;
+import com.facebook.presto.sql.DynamicFilterUtils.ExtractDynamicFiltersResult;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.tree.Expression;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.sql.DynamicFilterUtils.extractDynamicFilters;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Dynamic filters are supported only right after TableScan
+ */
+public class RemoveUnsupportedDynamicFilters
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        return SimplePlanRewriter.rewriteWith(new RemoveUnsupportedDynamicFilters.Rewriter(), plan, new HashSet<>());
+    }
+
+    private class Rewriter
+            extends SimplePlanRewriter<Set<DynamicFilter>>
+    {
+        @Override
+        public PlanNode visitJoin(JoinNode node, RewriteContext<Set<DynamicFilter>> context)
+        {
+            JoinNode join = (JoinNode) context.defaultRewrite(node, context.get());
+
+            Optional<Expression> filterOptional = join.getFilter().map(filter -> {
+                Expression modified = removeDynamicFilters(filter, context.get());
+                if (TRUE_LITERAL.equals(modified)) {
+                    return null;
+                }
+                else if (!filter.equals(modified)) {
+                    return modified;
+                }
+                return filter;
+            });
+
+            Assignments assignments = join.getDynamicFilterAssignments();
+            Set<DynamicFilter> removedFilters = context.get();
+            if (!removedFilters.isEmpty()) {
+                Assignments originalAssignments = join.getDynamicFilterAssignments();
+                Assignments modifiedAssignments = cleanupAssignments(join.getId(), originalAssignments, removedFilters);
+                if (!originalAssignments.equals(modifiedAssignments)) {
+                    assignments = modifiedAssignments;
+                }
+            }
+
+            if (!filterOptional.equals(join.getFilter()) || !assignments.equals(join.getDynamicFilterAssignments())) {
+                return new JoinNode(
+                        join.getId(),
+                        join.getType(),
+                        join.getLeft(),
+                        join.getRight(),
+                        join.getCriteria(),
+                        join.getOutputSymbols(),
+                        filterOptional,
+                        join.getLeftHashSymbol(),
+                        join.getRightHashSymbol(),
+                        join.getDistributionType(),
+                        assignments);
+            }
+            return join;
+        }
+
+        private Assignments cleanupAssignments(PlanNodeId joinId, Assignments assignments, Set<DynamicFilter> removedFilters)
+        {
+            Map<Symbol, Expression> assignmentsMap = new HashMap<>(assignments.getMap());
+            Iterator<DynamicFilter> filtersIterator = removedFilters.iterator();
+            while (filtersIterator.hasNext()) {
+                DynamicFilter removedFilter = filtersIterator.next();
+                if (removedFilter.getTupleDomainSourceId().equals(joinId.toString())) {
+                    Symbol filterSymbol = new Symbol(removedFilter.getTupleDomainName());
+                    checkState(assignmentsMap.containsKey(filterSymbol), "Assignments map doesn't contain key '%s': %s", filterSymbol, assignmentsMap);
+                    assignmentsMap.remove(filterSymbol);
+                    filtersIterator.remove();
+                }
+            }
+            return new Assignments(assignmentsMap);
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, RewriteContext<Set<DynamicFilter>> context)
+        {
+            FilterNode filter = (FilterNode) context.defaultRewrite(node, context.get());
+            PlanNode source = filter.getSource();
+            if (source instanceof TableScanNode) {
+                return filter;
+            }
+
+            Expression original = node.getPredicate();
+            Expression modified = removeDynamicFilters(original, context.get());
+
+            if (original.equals(modified)) {
+                return filter;
+            }
+
+            if (TRUE_LITERAL.equals(modified)) {
+                return source;
+            }
+
+            return new FilterNode(node.getId(), node.getSource(), modified);
+        }
+
+        private Expression removeDynamicFilters(Expression expression, Set<DynamicFilter> removedFilters)
+        {
+            ExtractDynamicFiltersResult extractResult = extractDynamicFilters(expression);
+            if (extractResult.getDynamicFilters().isEmpty()) {
+                return expression;
+            }
+            removedFilters.addAll(extractResult.getDynamicFilters());
+            return extractResult.getStaticFilters();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -241,7 +241,8 @@ public class TransformCorrelatedInPredicateToJoin
                 Optional.of(joinExpression),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
     }
 
     private static AggregationNode.Aggregation countWithFilter(Expression condition)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformUncorrelatedLateralToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformUncorrelatedLateralToJoin.java
@@ -17,6 +17,7 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -56,6 +57,7 @@ public class TransformUncorrelatedLateralToJoin
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty()));
+                Optional.empty(),
+                Assignments.of()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -837,7 +837,8 @@ public class AddExchanges
                     node.getFilter(),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol(),
-                    node.getDistributionType());
+                    node.getDistributionType(),
+                    node.getDynamicFilterAssignments());
 
             return new PlanWithProperties(result, deriveProperties(result, ImmutableList.of(left.getProperties(), right.getProperties())));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CanonicalizeExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CanonicalizeExpressions.java
@@ -70,7 +70,8 @@ public class CanonicalizeExpressions
                             Optional.of(canonicalizedExpression),
                             node.getLeftHashSymbol(),
                             node.getRightHashSymbol(),
-                            node.getDistributionType());
+                            node.getDistributionType(),
+                            node.getDynamicFilterAssignments());
                 }
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
@@ -167,7 +167,8 @@ public class DesugaringOptimizer
                     filter,
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol(),
-                    node.getDistributionType());
+                    node.getDistributionType(),
+                    node.getDynamicFilterAssignments());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
@@ -73,7 +73,8 @@ public class DetermineJoinDistributionType
                     node.getFilter(),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol(),
-                    Optional.of(targetJoinDistributionType));
+                    Optional.of(targetJoinDistributionType),
+                    node.getDynamicFilterAssignments());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -350,7 +350,7 @@ public class HashGenerationOptimizer
 
             return new PlanWithProperties(
                     new JoinNode(
-                            idAllocator.getNextId(),
+                            node.getId(),
                             node.getType(),
                             left.getNode(),
                             right.getNode(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -359,7 +359,8 @@ public class HashGenerationOptimizer
                             node.getFilter(),
                             leftHashSymbol,
                             rightHashSymbol,
-                            node.getDistributionType()),
+                            node.getDistributionType(),
+                            node.getDynamicFilterAssignments()),
                     hashSymbolsWithParentPreferences);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -188,7 +188,7 @@ public class IndexJoinOptimizer
             }
 
             if (leftRewritten != node.getLeft() || rightRewritten != node.getRight()) {
-                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType());
+                return new JoinNode(node.getId(), node.getType(), leftRewritten, rightRewritten, node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType(), node.getDynamicFilterAssignments());
             }
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.sql.DynamicFilterUtils.stripDynamicFilters;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.stripNonDeterministicConjuncts;
@@ -583,6 +584,9 @@ public class PredicatePushDown
 
             leftEffectivePredicate = stripNonDeterministicConjuncts(leftEffectivePredicate);
             rightEffectivePredicate = stripNonDeterministicConjuncts(rightEffectivePredicate);
+
+            leftEffectivePredicate = stripDynamicFilters(leftEffectivePredicate);
+            rightEffectivePredicate = stripDynamicFilters(rightEffectivePredicate);
 
             // Generate equality inferences
             EqualityInference allInference = createEqualityInference(inheritedPredicate, leftEffectivePredicate, rightEffectivePredicate, joinPredicate);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -423,7 +423,8 @@ public class PredicatePushDown
                         newJoinFilter,
                         node.getLeftHashSymbol(),
                         node.getRightHashSymbol(),
-                        node.getDistributionType());
+                        node.getDistributionType(),
+                        node.getDynamicFilterAssignments());
             }
 
             if (!postJoinPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
@@ -714,11 +715,11 @@ public class PredicatePushDown
                     return node;
                 }
                 if (canConvertToLeftJoin && canConvertToRightJoin) {
-                    return new JoinNode(node.getId(), INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType());
+                    return new JoinNode(node.getId(), INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType(), node.getDynamicFilterAssignments());
                 }
                 else {
                     return new JoinNode(node.getId(), canConvertToLeftJoin ? LEFT : RIGHT,
-                            node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType());
+                            node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType(), node.getDynamicFilterAssignments());
                 }
             }
 
@@ -726,7 +727,7 @@ public class PredicatePushDown
                     node.getType() == JoinNode.Type.RIGHT && !canConvertOuterToInner(node.getLeft().getOutputSymbols(), inheritedPredicate)) {
                 return node;
             }
-            return new JoinNode(node.getId(), JoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType());
+            return new JoinNode(node.getId(), JoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getCriteria(), node.getOutputSymbols(), node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType(), node.getDynamicFilterAssignments());
         }
 
         private boolean canConvertOuterToInner(List<Symbol> innerSymbolsForOuterJoin, Expression inheritedPredicate)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -219,7 +219,7 @@ public class PruneUnreferencedOutputs
                         .collect(toImmutableList());
             }
 
-            return new JoinNode(node.getId(), node.getType(), left, right, node.getCriteria(), outputSymbols, node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType());
+            return new JoinNode(node.getId(), node.getType(), left, right, node.getCriteria(), outputSymbols, node.getFilter(), node.getLeftHashSymbol(), node.getRightHashSymbol(), node.getDistributionType(), node.getDynamicFilterAssignments());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -120,7 +120,8 @@ public class ScalarAggregationToJoinRewriter
                 joinExpression,
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
 
         Optional<AggregationNode> aggregationNode = createAggregationNode(
                 scalarAggregation,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SimplifyExpressions.java
@@ -143,7 +143,8 @@ public class SimplifyExpressions
                     node.getFilter().map(this::simplifyExpression),
                     node.getLeftHashSymbol(),
                     node.getRightHashSymbol(),
-                    node.getDistributionType());
+                    node.getDistributionType(),
+                    node.getDynamicFilterAssignments());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedNoAggregationSubqueryToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedNoAggregationSubqueryToJoin.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.optimizations.PlanNodeDecorrelator.DecorrelatedNode;
+import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -107,7 +108,8 @@ public class TransformCorrelatedNoAggregationSubqueryToJoin
                     source.get().getCorrelatedPredicates(),
                     Optional.empty(),
                     Optional.empty(),
-                    Optional.empty());
+                    Optional.empty(),
+                    Assignments.of());
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedLateralToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformUncorrelatedLateralToJoin.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -67,7 +68,8 @@ public class TransformUncorrelatedLateralToJoin
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        Optional.empty());
+                        Optional.empty(),
+                        Assignments.of());
             }
             return rewrittenNode;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
@@ -62,6 +62,7 @@ public class ApplyNode
      * <p>
      */
     private final Assignments subqueryAssignments;
+    private final List<Symbol> outputSymbols;
 
     /**
      * HACK!
@@ -95,6 +96,14 @@ public class ApplyNode
         this.subqueryAssignments = subqueryAssignments;
         this.correlation = ImmutableList.copyOf(correlation);
         this.originSubquery = originSubquery;
+
+        ImmutableList.Builder<Symbol> outputSymbols = ImmutableList.builder();
+        outputSymbols.addAll(input.getOutputSymbols());
+        subqueryAssignments.getOutputs()
+                .stream()
+                .filter(symbol -> !input.getOutputSymbols().contains(symbol))
+                .forEach(outputSymbols::add);
+        this.outputSymbols = outputSymbols.build();
     }
 
     private static boolean isSupportedSubqueryExpression(Expression expression)
@@ -144,10 +153,7 @@ public class ApplyNode
     @JsonProperty("outputSymbols")
     public List<Symbol> getOutputSymbols()
     {
-        return ImmutableList.<Symbol>builder()
-                .addAll(input.getOutputSymbols())
-                .addAll(subqueryAssignments.getOutputs())
-                .build();
+        return outputSymbols;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -59,7 +59,8 @@ public class JoinNode
     private final Assignments dynamicFilterAssignments;
 
     @JsonCreator
-    public JoinNode(@JsonProperty("id") PlanNodeId id,
+    public JoinNode(
+            @JsonProperty("id") PlanNodeId id,
             @JsonProperty("type") Type type,
             @JsonProperty("left") PlanNode left,
             @JsonProperty("right") PlanNode right,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LateralJoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LateralJoinNode.java
@@ -51,6 +51,7 @@ public class LateralJoinNode
      */
     private final List<Symbol> correlation;
     private final Type type;
+    private final List<Symbol> outputSymbols;
 
     /**
      * HACK!
@@ -80,6 +81,14 @@ public class LateralJoinNode
         this.correlation = ImmutableList.copyOf(correlation);
         this.type = type;
         this.originSubquery = originSubquery;
+
+        ImmutableList.Builder<Symbol> outputSymbols = ImmutableList.builder();
+        outputSymbols.addAll(input.getOutputSymbols());
+        subquery.getOutputSymbols()
+                .stream()
+                .filter(symbol -> !input.getOutputSymbols().contains(symbol))
+                .forEach(outputSymbols::add);
+        this.outputSymbols = outputSymbols.build();
     }
 
     @JsonProperty("input")
@@ -122,10 +131,7 @@ public class LateralJoinNode
     @JsonProperty("outputSymbols")
     public List<Symbol> getOutputSymbols()
     {
-        return ImmutableList.<Symbol>builder()
-                .addAll(input.getOutputSymbols())
-                .addAll(subquery.getOutputSymbols())
-                .build();
+        return outputSymbols;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/DynamicFiltersChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/DynamicFiltersChecker.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.SimplePlanVisitor;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.facebook.presto.sql.DynamicFilterUtils.extractDynamicFilters;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Sets.intersection;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFiltersChecker
+        implements PlanSanityChecker.Checker
+{
+    @Override
+    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
+    {
+        plan.accept(new SimplePlanVisitor<Set<Filter>>()
+        {
+            @Override
+            public Void visitJoin(JoinNode node, Set<Filter> expected)
+            {
+                ImmutableSet<Filter> currentJoinDynamicFilters = node.getDynamicFilterAssignments()
+                        .entrySet()
+                        .stream()
+                        .map(assignment -> new Filter(node.getId().toString(), assignment.getKey().getName()))
+                        .collect(toImmutableSet());
+
+                expected.addAll(currentJoinDynamicFilters);
+                node.getLeft().accept(this, expected);
+                checkState(intersection(currentJoinDynamicFilters, expected).isEmpty());
+                node.getRight().accept(this, expected);
+                return null;
+            }
+
+            @Override
+            public Void visitExchange(ExchangeNode node, Set<Filter> expected)
+            {
+                Set<Filter> filtersLeft = null;
+                for (PlanNode source : node.getSources()) {
+                    Set<Filter> copy = new HashSet<>(expected);
+                    source.accept(this, copy);
+                    if (filtersLeft == null) {
+                        filtersLeft = copy;
+                    }
+                    else {
+                        checkState(filtersLeft.equals(copy), "filters do not match: %s != %s", filtersLeft, copy);
+                    }
+                }
+                if (filtersLeft != null) {
+                    expected.clear();
+                    expected.addAll(filtersLeft);
+                }
+                return null;
+            }
+
+            @Override
+            public Void visitFilter(FilterNode node, Set<Filter> expected)
+            {
+                extractDynamicFilters(node.getPredicate())
+                        .getDynamicFilters()
+                        .stream()
+                        .map(dynamicFilter -> new Filter(dynamicFilter.getTupleDomainSourceId(), dynamicFilter.getTupleDomainName()))
+                        .forEach(expected::remove);
+                return node.getSource().accept(this, expected);
+            }
+        }, new HashSet<>());
+    }
+
+    private static class Filter
+    {
+        private final String source;
+        private final String name;
+
+        private Filter(String source, String name)
+        {
+            this.source = requireNonNull(source, "source is null");
+            this.name = requireNonNull(name, "name is null");
+        }
+
+        public String getSource()
+        {
+            return source;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Filter filter = (Filter) o;
+            return Objects.equals(source, filter.source) &&
+                    Objects.equals(name, filter.name);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(source, name);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("source", source)
+                    .add("name", name)
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
@@ -44,7 +44,8 @@ public final class PlanSanityChecker
                     new TypeValidator(),
                     new NoSubqueryExpressionLeftChecker(),
                     new VerifyOnlyOneOutputNode(),
-                    new VerifyNoFilteredAggregations())
+                    new VerifyNoFilteredAggregations(),
+                    new DynamicFiltersChecker())
             .build();
 
     private PlanSanityChecker() {}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -39,6 +39,7 @@ import com.facebook.presto.sql.tree.CharLiteral;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.DecimalLiteral;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.Expression;
@@ -334,6 +335,16 @@ public final class SqlToRowExpressionTranslator
         protected RowExpression visitSymbolReference(SymbolReference node, Void context)
         {
             return new VariableReferenceExpression(node.getName(), getType(node));
+        }
+
+        @Override
+        protected RowExpression visitDeferredSymbolReference(DeferredSymbolReference node, Void context)
+        {
+            // Hack!
+            // In order to make PushDown work for DynamicFilters, we have to make DeferredSymbolReferences comparable in context of ExpressionEquivalence
+            // To avoid implementing DeferredSymbolReference RowExpression we model DeferredSymbolReference as ConstantExpression,
+            // which for ExpressionEquivalence will work well enough.
+            return constant(node, getType(node));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -73,6 +73,7 @@ import com.facebook.presto.operator.Driver;
 import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.DriverFactory;
 import com.facebook.presto.operator.FilterAndProjectOperator;
+import com.facebook.presto.operator.InMemoryDynamicFilterClientSupplier;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.operator.OperatorContext;
@@ -85,6 +86,7 @@ import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.operator.project.InterpretedPageProjection;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorPageSource;
@@ -634,7 +636,8 @@ public class LocalQueryRunner
                 blockEncodingSerde,
                 new PagesIndex.TestingFactory(),
                 new JoinCompiler(),
-                new LookupJoinOperators(new JoinProbeCompiler()));
+                new LookupJoinOperators(new JoinProbeCompiler()),
+                new InMemoryDynamicFilterClientSupplier(new DynamicFilterService()));
 
         // plan query
         LocalExecutionPlan localExecutionPlan = executionPlanner.plan(

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -653,7 +653,7 @@ public class LocalQueryRunner
         for (TableScanNode tableScan : findTableScanNodes(subplan.getFragment().getRoot())) {
             TableLayoutHandle layout = tableScan.getLayout().get();
 
-            SplitSource splitSource = splitManager.getSplits(session, layout);
+            SplitSource splitSource = splitManager.getSplits(session, layout, ImmutableList.of());
 
             ImmutableSet.Builder<ScheduledSplit> scheduledSplits = ImmutableSet.builder();
             while (!splitSource.isFinished()) {
@@ -861,7 +861,7 @@ public class LocalQueryRunner
 
     private Split getLocalQuerySplit(Session session, TableLayoutHandle handle)
     {
-        SplitSource splitSource = splitManager.getSplits(session, handle);
+        SplitSource splitSource = splitManager.getSplits(session, handle, ImmutableList.of());
         List<Split> splits = new ArrayList<>();
         splits.addAll(getFutureValue(splitSource.getNextBatch(1000)));
         while (!splitSource.isFinished()) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -27,9 +27,11 @@ import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.operator.InMemoryDynamicFilterClientSupplier;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.spi.block.TestingBlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -144,7 +146,8 @@ public final class TaskTestUtils
                 new TestingBlockEncodingSerde(new TestingTypeManager()),
                 new PagesIndex.TestingFactory(),
                 new JoinCompiler(),
-                new LookupJoinOperators(new JoinProbeCompiler()));
+                new LookupJoinOperators(new JoinProbeCompiler()),
+                new InMemoryDynamicFilterClientSupplier(new DynamicFilterService()));
     }
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -204,7 +205,8 @@ public class TestPhasedExecutionSchedule
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.of(REPLICATED));
+                Optional.of(REPLICATED),
+                Assignments.of());
 
         return createFragment(join);
     }
@@ -226,7 +228,8 @@ public class TestPhasedExecutionSchedule
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.of(PARTITIONED));
+                Optional.of(PARTITIONED),
+                Assignments.of());
 
         return createFragment(planNode);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -43,6 +43,7 @@ import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.StageExecutionPlan;
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
@@ -460,7 +461,8 @@ public class TestSourcePartitionedScheduler
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        Optional.of(JoinNode.DistributionType.PARTITIONED)),
+                        Optional.of(JoinNode.DistributionType.PARTITIONED),
+                        Assignments.of()),
                 ImmutableMap.of(symbol, VARCHAR),
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(tableScanNodeId),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -28,6 +28,7 @@ import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.PrestoNode;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.server.NoOpFailureDetector;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
@@ -496,7 +497,8 @@ public class TestSourcePartitionedScheduler
                 nodeTaskMap,
                 executor,
                 new NoOpFailureDetector(),
-                new SplitSchedulerStats());
+                new SplitSchedulerStats(),
+                new DynamicFilterService());
 
         stage.setOutputBuffers(createInitialEmptyOutputBuffers(PARTITIONED)
                 .withBuffer(OUT, 0)

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionSerialization.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionSerialization.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonCodecFactory;
+import io.airlift.json.ObjectMapperProvider;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestExpressionSerialization
+{
+    private JsonCodecFactory jsonCodecFactory;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        ObjectMapperProvider mapperProvider = new ObjectMapperProvider();
+        mapperProvider.setJsonSerializers(ImmutableMap.of(Expression.class, new Serialization.ExpressionSerializer()));
+        mapperProvider.setJsonDeserializers(ImmutableMap.of(Expression.class, new Serialization.ExpressionDeserializer(new SqlParser())));
+        jsonCodecFactory = new JsonCodecFactory(mapperProvider);
+    }
+
+    @AfterClass
+    public void tearDown()
+            throws Exception
+    {
+        jsonCodecFactory = null;
+    }
+
+    @Test
+    public void testDeferredSymbolReference()
+            throws Exception
+    {
+        assertJsonSerialization(new DeferredSymbolReference("source", "name"));
+    }
+
+    @Test
+    public void testSymbolReference()
+            throws Exception
+    {
+        assertJsonSerialization(new SymbolReference("symbol"));
+    }
+
+    private void assertJsonSerialization(Expression expression)
+    {
+        JsonCodec<Expression> expressionCodec = jsonCodecFactory.jsonCodec(Expression.class);
+        assertEquals(expressionCodec.fromJson(expressionCodec.toJson(expression)), expression);
+        JsonCodec<ExpressionHolder> expressionHolderCodec = jsonCodecFactory.jsonCodec(ExpressionHolder.class);
+        assertEquals(expressionHolderCodec.fromJson(expressionHolderCodec.toJson(new ExpressionHolder(expression))), new ExpressionHolder(expression));
+        JsonCodec<List<Expression>> expressionListCodec = jsonCodecFactory.listJsonCodec(Expression.class);
+        assertEquals(expressionListCodec.fromJson(expressionListCodec.toJson(ImmutableList.of(expression))), ImmutableList.of(expression));
+        assertEquals(expressionListCodec.fromJson(expressionListCodec.toJson(ImmutableList.of(expression, expression))), ImmutableList.of(expression, expression));
+    }
+
+    public static class ExpressionHolder
+    {
+        private final Expression expression;
+
+        @JsonCreator
+        public ExpressionHolder(@JsonProperty("expression") Expression expression)
+        {
+            this.expression = requireNonNull(expression, "expression is null");
+        }
+
+        @JsonProperty("expression")
+        public Expression getExpression()
+        {
+            return expression;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ExpressionHolder that = (ExpressionHolder) o;
+            return Objects.equals(expression, that.expression);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(expression);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("expression", expression)
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -65,7 +65,8 @@ public class TestFeaturesConfig
                 .setIterativeOptimizerTimeout(new Duration(3, MINUTES))
                 .setExchangeCompressionEnabled(false)
                 .setEnableIntermediateAggregations(false)
-                .setPushAggregationThroughJoin(true));
+                .setPushAggregationThroughJoin(true)
+                .setDynamicPartitionPruningEnabled(false));
     }
 
     @Test
@@ -103,6 +104,7 @@ public class TestFeaturesConfig
                 .put("experimental.memory-revoking-target", "0.8")
                 .put("exchange.compression-enabled", "true")
                 .put("optimizer.enable-intermediate-aggregations", "true")
+                .put("experimental.dynamic-partition-pruning-enabled", "true")
                 .build();
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("experimental.resource-groups-enabled", "true")
@@ -136,6 +138,7 @@ public class TestFeaturesConfig
                 .put("experimental.memory-revoking-target", "0.8")
                 .put("exchange.compression-enabled", "true")
                 .put("optimizer.enable-intermediate-aggregations", "true")
+                .put("experimental.dynamic-partition-pruning-enabled", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -169,7 +172,8 @@ public class TestFeaturesConfig
                 .setMemoryRevokingTarget(0.8)
                 .setLegacyOrderBy(true)
                 .setExchangeCompressionEnabled(true)
-                .setEnableIntermediateAggregations(true);
+                .setEnableIntermediateAggregations(true)
+                .setDynamicPartitionPruningEnabled(true);
 
         assertFullMapping(properties, expected);
         assertDeprecatedEquivalence(FeaturesConfig.class, properties, propertiesLegacy);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -448,7 +448,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
 
@@ -512,7 +513,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
 
@@ -570,7 +572,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
 
@@ -631,7 +634,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
 
@@ -688,7 +692,8 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
 
         Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import static com.facebook.presto.SystemSessionProperties.DYNAMIC_PARTITION_PRUNING;
 import static com.facebook.presto.spi.predicate.Domain.singleValue;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
@@ -76,6 +77,12 @@ import static org.testng.Assert.assertFalse;
 public class TestLogicalPlanner
         extends BasePlanTest
 {
+    TestLogicalPlanner()
+    {
+        // in order to test testUncorrelatedSubqueries with Dynamic Filtering, enable it
+        super(ImmutableMap.of(DYNAMIC_PARTITION_PRUNING, "true"));
+    }
+
     @Test
     public void testDistinctLimitOverInequalityJoin()
             throws Exception
@@ -156,7 +163,7 @@ public class TestLogicalPlanner
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey",
                 anyTree(
                         join(INNER, ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                any(
+                                anyTree(
                                         tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
                                 anyTree(
                                         tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
@@ -168,7 +175,7 @@ public class TestLogicalPlanner
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey ORDER BY l.orderkey ASC, o.orderkey ASC",
                 anyTree(
                         join(INNER, ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                any(
+                                anyTree(
                                         tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
                                 anyTree(
                                         tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
@@ -181,7 +188,8 @@ public class TestLogicalPlanner
                 anyTree(
                         join(INNER, ImmutableList.of(equiJoinClause("X", "Y")),
                                 project(
-                                        tableScan("orders", ImmutableMap.of("X", "orderkey"))),
+                                        node(FilterNode.class,
+                                                tableScan("orders", ImmutableMap.of("X", "orderkey")))),
                                 project(
                                         node(EnforceSingleRowNode.class,
                                                 anyTree(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPlanMatchingFramework.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPlanMatchingFramework.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
-import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.columnReference;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
@@ -144,7 +143,7 @@ public class TestPlanMatchingFramework
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey",
                 anyTree(
                         join(INNER, ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                any(
+                                anyTree(
                                         tableScan("orders").withAlias("ORDERS_OK", columnReference("orders", "orderkey"))),
                                 anyTree(
                                         tableScan("lineitem").withAlias("LINEITEM_OK", columnReference("lineitem", "orderkey"))))));
@@ -156,7 +155,7 @@ public class TestPlanMatchingFramework
         assertPlan("SELECT l.orderkey FROM orders l, orders r WHERE l.orderkey = r.orderkey",
                 anyTree(
                         join(INNER, ImmutableList.of(equiJoinClause("L_ORDERS_OK", "R_ORDERS_OK")),
-                                any(
+                                anyTree(
                                         tableScan("orders").withAlias("L_ORDERS_OK", columnReference("orders", "orderkey"))),
                                 anyTree(
                                         tableScan("orders").withAlias("R_ORDERS_OK", columnReference("orders", "orderkey"))))));
@@ -244,7 +243,7 @@ public class TestPlanMatchingFramework
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey",
                 anyTree(
                         join(INNER, ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                any(
+                                anyTree(
                                         tableScan("orders").withAlias("ORDERS_OK", columnReference("orders", "orderkey"))),
                                 anyTree(
                                         tableScan("lineitem").withAlias("ORDERS_OK", columnReference("lineitem", "orderkey"))))));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
@@ -36,7 +35,7 @@ public class TestPredicatePushdown
         assertPlan("SELECT * FROM orders JOIN lineitem ON orders.orderkey = lineitem.orderkey AND cast(lineitem.linenumber AS varchar) = '2'",
                 anyTree(
                         join(INNER, ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
-                                any(
+                                anyTree(
                                         tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
                                 anyTree(
                                         filter("cast(LINEITEM_LINENUMBER as varchar) = cast('2' as varchar)",

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/DynamicFilterMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/DynamicFilterMatcher.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PlanNodeCost;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterMatcher
+        implements Matcher
+{
+    // LEFT_SYMBOL -> RIGHT_SYMBOL
+    private final Map<SymbolAlias, SymbolAlias> expectedDynamicFilters;
+    private final Map<String, String> joinExpectedMappings;
+    private final Map<String, String> filterExpectedMappings;
+
+    private JoinNode joinNode;
+    private SymbolAliases symbolAliases;
+    private FilterNode filterNode;
+
+    public DynamicFilterMatcher(Map<SymbolAlias, SymbolAlias> expectedDynamicFilters)
+    {
+        this.expectedDynamicFilters = requireNonNull(expectedDynamicFilters, "expectedDynamicFilters is null");
+        this.joinExpectedMappings = expectedDynamicFilters.values().stream()
+                .collect(toImmutableMap(rightSymbol -> rightSymbol.toString() + "_alias", SymbolAlias::toString));
+        this.filterExpectedMappings = expectedDynamicFilters.entrySet().stream()
+                .collect(toImmutableMap(entry -> entry.getKey().toString(), entry -> entry.getValue().toString() + "_alias"));
+    }
+
+    public MatchResult match(JoinNode joinNode, SymbolAliases symbolAliases)
+    {
+        checkState(this.joinNode == null, "joinNode must be null at this point");
+        this.joinNode = joinNode;
+        this.symbolAliases = symbolAliases;
+        return new MatchResult(match());
+    }
+
+    public MatchResult match(FilterNode filterNode, SymbolAliases symbolAliases)
+    {
+        checkState(this.filterNode == null, "filterNode must be null at this point");
+        this.filterNode = filterNode;
+        this.symbolAliases = symbolAliases;
+        return new MatchResult(match());
+    }
+
+    private boolean match()
+    {
+        checkState(symbolAliases != null, "symbolAliases is null");
+
+        // both nodes must be provided to do the matching
+        if (filterNode == null || joinNode == null) {
+            return true;
+        }
+
+        Map<Symbol, Symbol> leftToRightAliasMap = extractDynamicFilters(filterNode, joinNode.getId().toString());
+        Map<Symbol, Symbol> rightAliasToRightMap = extractDynamicFilters(joinNode);
+
+        if (leftToRightAliasMap == null) {
+            return false;
+        }
+
+        if (leftToRightAliasMap.size() != expectedDynamicFilters.size()) {
+            return false;
+        }
+
+        Map<Symbol, Symbol> actual = new HashMap<>();
+        for (Map.Entry<Symbol, Symbol> leftToRightAlias : leftToRightAliasMap.entrySet()) {
+            Symbol left = leftToRightAlias.getKey();
+            Symbol alias = leftToRightAlias.getValue();
+            Symbol right = rightAliasToRightMap.get(alias);
+            if (right == null) {
+                return false;
+            }
+            actual.put(left, right);
+        }
+
+        Map<Symbol, Symbol> expected = expectedDynamicFilters.entrySet().stream()
+                .collect(toImmutableMap(entry -> entry.getKey().toSymbol(symbolAliases), entry -> entry.getValue().toSymbol(symbolAliases)));
+
+        return expected.equals(actual);
+    }
+
+    /*
+     * LEFT_SYMBOL -> RIGHT_SYMBOL_DYNAMIC_FILTER_ALIAS
+     */
+    @Nullable
+    private static Map<Symbol, Symbol> extractDynamicFilters(FilterNode filterNode, String expectedSourceId)
+    {
+        List<Expression> conjuncts = extractConjuncts(filterNode.getPredicate());
+
+        List<ComparisonExpression> equalityComparisons = conjuncts.stream()
+                .filter(expression -> expression instanceof ComparisonExpression)
+                .map(ComparisonExpression.class::cast)
+                .filter(comparisonExpression -> comparisonExpression.getType() == EQUAL)
+                .collect(toImmutableList());
+
+        ImmutableMap.Builder<Symbol, Symbol> mappings = ImmutableMap.builder();
+        for (ComparisonExpression comparison : equalityComparisons) {
+            if (!(comparison.getLeft() instanceof SymbolReference) || !(comparison.getRight() instanceof DeferredSymbolReference)) {
+                continue;
+            }
+
+            Symbol left = Symbol.from(comparison.getLeft());
+            DeferredSymbolReference right = (DeferredSymbolReference) comparison.getRight();
+
+            if (!right.getSourceId().equals(expectedSourceId)) {
+                return null;
+            }
+
+            mappings.put(left, new Symbol(right.getSymbol()));
+        }
+
+        return mappings.build();
+    }
+
+    /*
+     * RIGHT_SYMBOL_DYNAMIC_FILTER_ALIAS -> RIGHT_SYMBOL
+     */
+    private static Map<Symbol, Symbol> extractDynamicFilters(JoinNode node)
+    {
+        return node.getDynamicFilterAssignments()
+                .getMap()
+                .entrySet()
+                .stream()
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> Symbol.from(entry.getValue())));
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof FilterNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, PlanNodeCost planNodeCost, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        if (!(node instanceof FilterNode)) {
+            return new MatchResult(false);
+        }
+        return match((FilterNode) node, symbolAliases);
+    }
+
+    public Map<String, String> getJoinExpectedMappings()
+    {
+        return joinExpectedMappings;
+    }
+
+    @Override
+    public String toString()
+    {
+        String predicate = Joiner.on("AND")
+                .join(filterExpectedMappings.entrySet().stream()
+                        .map(entry -> entry.getKey() + " = " + entry.getValue())
+                        .collect(toImmutableList()));
+        return toStringHelper(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
@@ -300,6 +301,12 @@ final class ExpressionVerifier
             return false;
         }
         return symbolAliases.get(((SymbolReference) expected).getName()).equals(actual);
+    }
+
+    @Override
+    protected Boolean visitDeferredSymbolReference(DeferredSymbolReference node, Node expected)
+    {
+        return expected instanceof DeferredSymbolReference;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
@@ -37,12 +37,14 @@ final class JoinMatcher
     private final JoinNode.Type joinType;
     private final List<ExpectedValueProvider<JoinNode.EquiJoinClause>> equiCriteria;
     private final Optional<Expression> filter;
+    private final Optional<DynamicFilterMatcher> dynamicFilter;
 
-    JoinMatcher(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> equiCriteria, Optional<Expression> filter)
+    JoinMatcher(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> equiCriteria, Optional<Expression> filter, Optional<DynamicFilterMatcher> dynamicFilter)
     {
         this.joinType = requireNonNull(joinType, "joinType is null");
         this.equiCriteria = requireNonNull(equiCriteria, "equiCriteria is null");
         this.filter = requireNonNull(filter, "filter can not be null");
+        this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
     }
 
     @Override
@@ -91,7 +93,15 @@ final class JoinMatcher
                         .map(maker -> maker.getExpectedValue(symbolAliases))
                         .collect(toImmutableSet());
 
-        return new MatchResult(expected.equals(actual));
+        if (!expected.equals(actual)) {
+            return NO_MATCH;
+        }
+
+        if (dynamicFilter.isPresent() && !dynamicFilter.get().match(joinNode, symbolAliases).isMatch()) {
+            return NO_MATCH;
+        }
+
+        return MatchResult.match();
     }
 
     @Override
@@ -101,6 +111,7 @@ final class JoinMatcher
                 .omitNullValues()
                 .add("equiCriteria", equiCriteria)
                 .add("filter", filter.orElse(null))
+                .add("dynamicFilter", dynamicFilter.map(DynamicFilterMatcher::getJoinExpectedMappings))
                 .toString();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestApplyDynamicFilters.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestApplyDynamicFilters.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.DYNAMIC_PARTITION_PRUNING;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static io.airlift.testing.Closeables.closeAllRuntimeException;
+
+public class TestApplyDynamicFilters
+{
+    private RuleTester tester;
+
+    @BeforeClass
+    public void setUp()
+    {
+        tester = new RuleTester(ImmutableMap.of(DYNAMIC_PARTITION_PRUNING, "true"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(tester);
+        tester = null;
+    }
+
+    @Test
+    public void testNotApplicable()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilters())
+                .on(p -> p.values(p.symbol("a", BIGINT)))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNonInnerJoin()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilters())
+                .on(p -> p.join(
+                        JoinNode.Type.LEFT,
+                        p.values(p.symbol("COL1", BIGINT)),
+                        p.values(p.symbol("COL2", BIGINT)),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
+                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testEmptyJoinCriteria()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilters())
+                .on(p -> p.join(
+                        INNER,
+                        p.values(p.symbol("COL1", BIGINT)),
+                        p.values(p.symbol("COL2", BIGINT)),
+                        ImmutableList.of(),
+                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testAlreadyProcessed()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilters())
+                .on(p -> p.join(
+                        INNER,
+                        p.values(p.symbol("COL1", BIGINT)),
+                        p.values(p.symbol("COL2", BIGINT)),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
+                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Assignments.of(new Symbol("COL2_ALIAS"), new SymbolReference("COL2"))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testSingleDynamicFilterCondition()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilters())
+                .on(p -> p.join(
+                        INNER,
+                        p.values(p.symbol("COL1", BIGINT)),
+                        p.values(p.symbol("COL2", BIGINT)),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(new Symbol("COL1"), new Symbol("COL2"))),
+                        ImmutableList.of(new Symbol("COL1"), new Symbol("COL2")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Assignments.of()))
+                .matches(
+                        join(
+                                INNER,
+                                ImmutableList.of(equiJoinClause("COL1", "COL2")),
+                                ImmutableMap.of("COL1", "COL2"),
+                                values("COL1"),
+                                values("COL2")));
+    }
+
+    @Test
+    public void testMultipleDynamicFilterConditions()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilters())
+                .on(p -> p.join(
+                        INNER,
+                        p.values(p.symbol("L_COL1", BIGINT), p.symbol("L_COL2", BIGINT)),
+                        p.values(p.symbol("R_COL1", BIGINT), p.symbol("R_COL2", BIGINT)),
+                        ImmutableList.of(
+                                new JoinNode.EquiJoinClause(new Symbol("L_COL1"), new Symbol("R_COL1")),
+                                new JoinNode.EquiJoinClause(new Symbol("L_COL2"), new Symbol("R_COL2"))),
+                        ImmutableList.of(new Symbol("L_COL1"), new Symbol("R_COL1")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Assignments.of()))
+                .matches(
+                        join(
+                                INNER,
+                                ImmutableList.of(
+                                        equiJoinClause("L_COL1", "R_COL1"),
+                                        equiJoinClause("L_COL2", "R_COL2")),
+                                ImmutableMap.of("L_COL1", "R_COL1", "L_COL2", "R_COL2"),
+                                values("L_COL1", "L_COL2"),
+                                values("R_COL1", "R_COL2")));
+    }
+
+    @Test
+    public void testMultipleEquiConditionsSingleDynamicFilterCondition()
+            throws Exception
+    {
+        tester.assertThat(new ApplyDynamicFilters())
+                .on(p -> p.join(
+                        INNER,
+                        p.values(p.symbol("L_COL1", BIGINT), p.symbol("L_COL2", BIGINT)),
+                        p.values(p.symbol("R_COL1", BIGINT), p.symbol("R_COL2", BIGINT)),
+                        ImmutableList.of(
+                                new JoinNode.EquiJoinClause(new Symbol("L_COL1"), new Symbol("R_COL1")),
+                                new JoinNode.EquiJoinClause(new Symbol("L_COL2"), new Symbol("R_COL2"))),
+                        ImmutableList.of(new Symbol("L_COL1"), new Symbol("R_COL1")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Assignments.of(new Symbol("R_COL2_ALIAS"), new Symbol("R_COL2").toSymbolReference())))
+                .matches(
+                        join(
+                                INNER,
+                                ImmutableList.of(
+                                        equiJoinClause("L_COL1", "R_COL1"),
+                                        equiJoinClause("L_COL2", "R_COL2")),
+                                ImmutableMap.of("L_COL1", "R_COL1"),
+                                values("L_COL1", "L_COL2"),
+                                values("R_COL1", "R_COL2")));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -280,7 +280,8 @@ public class TestEliminateCrossJoins
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
     }
 
     private ValuesNode values(String... symbols)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -495,7 +495,8 @@ public class PlanBuilder
                         .build(),
                 filter,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
     }
 
     public JoinNode join(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -508,7 +508,21 @@ public class PlanBuilder
             Optional<Symbol> leftHashSymbol,
             Optional<Symbol> rightHashSymbol)
     {
-        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.empty());
+        return join(type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Assignments.of());
+    }
+
+    public JoinNode join(
+            JoinNode.Type type,
+            PlanNode left,
+            PlanNode right,
+            List<JoinNode.EquiJoinClause> criteria,
+            List<Symbol> outputSymbols,
+            Optional<Expression> filter,
+            Optional<Symbol> leftHashSymbol,
+            Optional<Symbol> rightHashSymbol,
+            Assignments dynamicFilterAssignments)
+    {
+        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.empty(), dynamicFilterAssignments);
     }
 
     public PlanNode indexJoin(IndexJoinNode.Type type, TableScanNode probe, TableScanNode index)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -30,6 +30,7 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.Closeable;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -53,11 +54,21 @@ public class RuleTester
 
     public RuleTester()
     {
-        session = testSessionBuilder()
+        this(ImmutableMap.of());
+    }
+
+    public RuleTester(Map<String, String> properties)
+    {
+        Session.SessionBuilder sessionBuilder = testSessionBuilder()
                 .setCatalog(CATALOG_ID)
                 .setSchema("tiny")
-                .setSystemProperty("task_concurrency", "1") // these tests don't handle exchanges from local parallel
-                .build();
+                .setSystemProperty("task_concurrency", "1"); // these tests don't handle exchanges from local parallel
+
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            sessionBuilder.setSystemProperty(entry.getKey(), entry.getValue());
+        }
+
+        session = sessionBuilder.build();
 
         queryRunner = new LocalQueryRunner(session);
         queryRunner.createCatalog(session.getCatalog().get(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderJoins.java
@@ -59,7 +59,9 @@ public class TestReorderJoins
 
     public TestReorderJoins()
     {
-        super(ImmutableMap.of(SystemSessionProperties.REORDER_JOINS, "true"));
+        super(ImmutableMap.of(
+                SystemSessionProperties.REORDER_JOINS, "true",
+                SystemSessionProperties.DYNAMIC_PARTITION_PRUNING, "true"));
     }
 
     @Test
@@ -98,7 +100,7 @@ public class TestReorderJoins
                                 anyTree(
                                         join(INNER, ImmutableList.of(equiJoinClause("P_PARTKEY", "L_PARTKEY")), Optional.of("P_NAME < cast(L_COMMENT AS varchar(55))"),
                                                 anyTree(PART_WITH_NAME_TABLESCAN),
-                                                anyTree(filter("L_PARTKEY <> L_ORDERKEY", LINEITEM_WITH_COMMENT_TABLESCAN)))),
+                                                anyTree(filter("L_PARTKEY <> L_ORDERKEY AND L_ORDERKEY = \"$INTERNAL$DEFERRED_SYMBOL_REFERENCE\"(\"128\", \"dynamic_filter_orderkey\")", LINEITEM_WITH_COMMENT_TABLESCAN)))),
                                 anyTree(ORDERS_TABLESCAN))));
     }
 
@@ -111,7 +113,7 @@ public class TestReorderJoins
                         anyTree(
                                 join(INNER, ImmutableList.of(equiJoinClause("P_PARTKEY", "L_PARTKEY")),
                                         anyTree(PART_TABLESCAN),
-                                        anyTree(filter("L_RETURNFLAG = 'R'", LINEITEM_WITH_RETURNFLAG_TABLESCAN)))),
+                                        anyTree(filter("L_RETURNFLAG = 'R' AND L_ORDERKEY = \"$INTERNAL$DEFERRED_SYMBOL_REFERENCE\"(\"128\", \"dynamic_filter_orderkey\")", LINEITEM_WITH_RETURNFLAG_TABLESCAN)))),
                         anyTree(filter("O_SHIPPRIORITY >= 10", ORDERS_WITH_SHIPPRIORITY_TABLESCAN)))));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSimplifyExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSimplifyExpressions.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.SymbolsExtractor;
+import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
@@ -158,7 +159,8 @@ public class TestSimplifyExpressions
                 Optional.of(expression),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                Assignments.of());
         JoinNode simplifiedNode = (JoinNode) SIMPLIFIER.optimize(
                 joinNode,
                 TEST_SESSION,

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.CurrentTime;
 import com.facebook.presto.sql.tree.DecimalLiteral;
+import com.facebook.presto.sql.tree.DeferredSymbolReference;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.ExistsPredicate;
@@ -306,6 +307,14 @@ public final class ExpressionFormatter
         protected String visitSymbolReference(SymbolReference node, Void context)
         {
             return formatIdentifier(node.getName());
+        }
+
+        @Override
+        protected String visitDeferredSymbolReference(DeferredSymbolReference node, Void context)
+        {
+            return "\"$INTERNAL$DEFERRED_SYMBOL_REFERENCE\"(" +
+                    formatIdentifier(node.getSourceId()) + ", " +
+                    formatIdentifier(node.getSymbol()) + ")";
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -677,6 +677,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitDeferredSymbolReference(DeferredSymbolReference node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, C context)
     {
         return visitExpression(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DeferredSymbolReference.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DeferredSymbolReference.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class DeferredSymbolReference
+        extends Expression
+{
+    private final String sourceId;
+    private final String symbol;
+
+    public DeferredSymbolReference(String sourceId, String symbol)
+    {
+        super(Optional.empty());
+        this.sourceId = requireNonNull(sourceId, "sourceId is null");
+        this.symbol = requireNonNull(symbol, "symbol is null");
+    }
+
+    public String getSourceId()
+    {
+        return sourceId;
+    }
+
+    public String getSymbol()
+    {
+        return symbol;
+    }
+
+    @Override
+    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitDeferredSymbolReference(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DeferredSymbolReference reference = (DeferredSymbolReference) o;
+        return Objects.equals(sourceId, reference.sourceId) &&
+                Objects.equals(symbol, reference.symbol);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sourceId, symbol);
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
@@ -195,6 +195,11 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
+    public Expression rewriteDeferredSymbolReference(DeferredSymbolReference node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
+
     public Expression rewriteParameter(Parameter node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -840,6 +840,19 @@ public final class ExpressionTreeRewriter<C>
         }
 
         @Override
+        protected Expression visitDeferredSymbolReference(DeferredSymbolReference node, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                Expression result = rewriter.rewriteDeferredSymbolReference(node, context.get(), ExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            return node;
+        }
+
+        @Override
         protected Expression visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/DynamicFilterDescription.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/DynamicFilterDescription.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.facebook.presto.spi.predicate.TupleDomain;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterDescription
+{
+    private final TupleDomain<ColumnHandle> tupleDomain;
+
+    public DynamicFilterDescription(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
+    }
+
+    public TupleDomain<ColumnHandle> getTupleDomain()
+    {
+        return tupleDomain;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorSplitManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorSplitManager.java
@@ -16,9 +16,19 @@ package com.facebook.presto.spi.connector;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.DynamicFilterDescription;
+
+import java.util.List;
+import java.util.concurrent.Future;
 
 public interface ConnectorSplitManager
 {
+    default ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, List<Future<DynamicFilterDescription>> dynamicFilters)
+    {
+        return getSplits(transactionHandle, session, layout);
+    }
+
+    @Deprecated
     default ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout)
     {
         throw new UnsupportedOperationException("not yet implemented");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorSplitManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorSplitManager.java
@@ -16,9 +16,13 @@ package com.facebook.presto.spi.connector.classloader;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.DynamicFilterDescription;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import java.util.List;
+import java.util.concurrent.Future;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,6 +36,14 @@ public final class ClassLoaderSafeConnectorSplitManager
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, List<Future<DynamicFilterDescription>> dynamicFilters)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSplits(transactionHandle, session, layout, dynamicFilters);
+        }
     }
 
     @Override


### PR DESCRIPTION
The Dynamic Partition Pruning is a feature to speed up joins (or at least more conservatively manage resources used in join operator) by postponing execution of probe side of the join until we've seen the values on the build side. Then, knowing what are the only possible values to join, we can prune them as low in the plan as possible (preferably on the table scan level, or even on split level).
It helps reducing the amount of tuples to be processed by all operators between table scan and the join (on the probe side), can also lower the memory consumption in some operators (like `TopNRowNumberOperator` or `WindowOperator`) because there will be less data to process.

---

This is achieved by collecting information into the `TupleDomain` by new `DynamicFilterSourceOperator` which is injected after the `HashBuilderOperator` on the build side of the join.
Then, such `TupleDomain` is sent to the coordinator to the new `DynamicFilterResource`.
Each `TupleDomain` is uniquely identified on the coordinator by (QueryId, Join.NodeId, stageId, taskId, driverId).
Once all `TupleDomains` for the same (QueryId, Join.NodeId) are received, they are merged and delivered to the `SplitManager` which can pass them further to the `SplitSource` where they may be used to prune unnecessary splits (i.e. based on partition keys, in case of Hive connector).
