### PR TITLE
Fix config db outage

### DIFF
--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManager.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 
 import javax.annotation.PostConstruct;
@@ -58,6 +59,7 @@ import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 public class DbResourceGroupConfigurationManager
         extends AbstractResourceConfigurationManager
 {
+    private static final Logger log = Logger.get(DbResourceGroupConfigurationManager.class);
     private final ResourceGroupsDao dao;
     private final ConcurrentMap<ResourceGroupId, ResourceGroup> groups = new ConcurrentHashMap<>();
     @GuardedBy("this")
@@ -137,25 +139,30 @@ public class DbResourceGroupConfigurationManager
     @VisibleForTesting
     public synchronized void load()
     {
-        Map.Entry<ManagerSpec, Map<ResourceGroupIdTemplate, ResourceGroupSpec>> specsFromDb = buildSpecsFromDb();
-        ManagerSpec managerSpec = specsFromDb.getKey();
-        Map<ResourceGroupIdTemplate, ResourceGroupSpec> resourceGroupSpecs = specsFromDb.getValue();
-        Set<ResourceGroupIdTemplate> changedSpecs = new HashSet<>();
-        Set<ResourceGroupIdTemplate> deletedSpecs = Sets.difference(this.resourceGroupSpecs.keySet(), resourceGroupSpecs.keySet());
+        try {
+            Map.Entry<ManagerSpec, Map<ResourceGroupIdTemplate, ResourceGroupSpec>> specsFromDb = buildSpecsFromDb();
+            ManagerSpec managerSpec = specsFromDb.getKey();
+            Map<ResourceGroupIdTemplate, ResourceGroupSpec> resourceGroupSpecs = specsFromDb.getValue();
+            Set<ResourceGroupIdTemplate> changedSpecs = new HashSet<>();
+            Set<ResourceGroupIdTemplate> deletedSpecs = Sets.difference(this.resourceGroupSpecs.keySet(), resourceGroupSpecs.keySet());
 
-        for (Map.Entry<ResourceGroupIdTemplate, ResourceGroupSpec> entry : resourceGroupSpecs.entrySet()) {
-            if (!entry.getValue().sameConfig(this.resourceGroupSpecs.get(entry.getKey()))) {
-                changedSpecs.add(entry.getKey());
+            for (Map.Entry<ResourceGroupIdTemplate, ResourceGroupSpec> entry : resourceGroupSpecs.entrySet()) {
+                if (!entry.getValue().sameConfig(this.resourceGroupSpecs.get(entry.getKey()))) {
+                    changedSpecs.add(entry.getKey());
+                }
             }
+
+            this.resourceGroupSpecs = resourceGroupSpecs;
+            this.cpuQuotaPeriod.set(managerSpec.getCpuQuotaPeriod());
+            this.rootGroups.set(managerSpec.getRootGroups());
+            this.selectors.set(buildSelectors(managerSpec));
+
+            configureChangedGroups(changedSpecs);
+            disableDeletedGroups(deletedSpecs);
         }
-
-        this.resourceGroupSpecs = resourceGroupSpecs;
-        this.cpuQuotaPeriod.set(managerSpec.getCpuQuotaPeriod());
-        this.rootGroups.set(managerSpec.getRootGroups());
-        this.selectors.set(buildSelectors(managerSpec));
-
-        configureChangedGroups(changedSpecs);
-        disableDeletedGroups(deletedSpecs);
+        catch (Throwable e) {
+            log.error(e, "Error loading configuration from db");
+        }
     }
 
     // Populate temporary data structures to build resource group specs and selectors from db


### PR DESCRIPTION
Catch and log config db exceptions so that the task can continually retry until the issue is resolved.

Resolves #8565 