### PR TITLE
Avoid eager loading all pages in PageProcessor

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -14,13 +14,19 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.SequencePageBuilder;
+import com.facebook.presto.block.BlockAssertions;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.index.PageRecordSet;
 import com.facebook.presto.operator.project.PageProcessor;
+import com.facebook.presto.operator.project.TestPageProcessor.LazyPagePageProjection;
+import com.facebook.presto.operator.project.TestPageProcessor.SelectAllFilter;
+import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.RecordPageSource;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.relational.RowExpression;
@@ -38,6 +44,7 @@ import java.util.function.Supplier;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.operator.OperatorAssertion.toMaterializedResult;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.relational.Expressions.field;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
@@ -83,6 +90,42 @@ public class TestScanFilterAndProjectOperator
 
         MaterializedResult expected = toMaterializedResult(driverContext.getSession(), ImmutableList.of(VARCHAR), ImmutableList.of(input));
         MaterializedResult actual = toMaterializedResult(driverContext.getSession(), ImmutableList.of(VARCHAR), toPages(operator));
+
+        assertEquals(actual.getRowCount(), expected.getRowCount());
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPageSourceLazyLoad()
+            throws Exception
+    {
+        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 100);
+        // If column 1 is loaded, test will fail
+        Page input = new Page(100, inputBlock, new LazyBlock(100, lazyBlock -> {
+            throw new AssertionError("Lazy block should not be loaded");
+        }));
+        DriverContext driverContext = newDriverContext();
+
+        List<RowExpression> projections = ImmutableList.of(field(0, VARCHAR));
+        Supplier<CursorProcessor> cursorProcessor = expressionCompiler.compileCursorProcessor(Optional.empty(), projections, "key");
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new LazyPagePageProjection()));
+
+        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                new PlanNodeId("0"),
+                (session, split, columns) -> new SinglePagePageSource(input),
+                cursorProcessor,
+                () -> pageProcessor,
+                ImmutableList.of(),
+                ImmutableList.of(BIGINT));
+
+        SourceOperator operator = factory.createOperator(driverContext);
+        operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
+        operator.noMoreSplits();
+
+        MaterializedResult expected = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), ImmutableList.of(new Page(inputBlock)));
+        MaterializedResult actual = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), toPages(operator));
 
         assertEquals(actual.getRowCount(), expected.getRowCount());
         assertEquals(actual, expected);
@@ -147,5 +190,60 @@ public class TestScanFilterAndProjectOperator
         return createTaskContext(executor, TEST_SESSION)
                 .addPipelineContext(0, true, true)
                 .addDriverContext();
+    }
+
+    public class SinglePagePageSource
+            implements ConnectorPageSource
+    {
+        private Page page;
+
+        public SinglePagePageSource(Page page)
+        {
+            this.page = page;
+        }
+
+        @Override
+        public void close()
+        {
+            page = null;
+        }
+
+        @Override
+        public long getTotalBytes()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getCompletedBytes()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getReadTimeNanos()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getSystemMemoryUsage()
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            return page == null;
+        }
+
+        @Override
+        public Page getNextPage()
+        {
+            Page page = this.page;
+            this.page = null;
+            return page;
+        }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -244,6 +244,11 @@ public class LazyBlock
         this.block = requireNonNull(block, "block is null");
     }
 
+    public boolean isLoaded()
+    {
+        return block != null;
+    }
+
     @Override
     public void assureLoaded()
     {


### PR DESCRIPTION
LazyBlock size calls force the block to load, so add a special size
calculation for page projections.

Add tests to ensure lazy blocks are not eagerly loaded.