### PR TITLE
Do not print configuration in tests to avoid Travis log limit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -235,6 +235,7 @@ public class TestingPrestoServer
                 .doNotInitializeLogging()
                 .setRequiredConfigurationProperties(serverProperties.build())
                 .setOptionalConfigurationProperties(optionalProperties)
+                .quiet()
                 .initialize();
 
         injector.getInstance(Announcer.class).start();

--- a/presto-main/src/test/java/com/facebook/presto/failureDetector/TestHeartbeatFailureDetector.java
+++ b/presto-main/src/test/java/com/facebook/presto/failureDetector/TestHeartbeatFailureDetector.java
@@ -82,6 +82,7 @@ public class TestHeartbeatFailureDetector
         Injector injector = app
                 .strictConfig()
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         ServiceSelector selector = injector.getInstance(Key.get(ServiceSelector.class, serviceType("presto")));

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -217,6 +217,7 @@ public class TestHttpRemoteTask
         Injector injector = app
                 .strictConfig()
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
         HandleResolver handleResolver = injector.getInstance(HandleResolver.class);
         handleResolver.addConnectorName("test", new TestingHandleResolver());

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestHttpBackupStore.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestHttpBackupStore.java
@@ -66,6 +66,7 @@ public class TestHttpBackupStore
                 .strictConfig()
                 .setRequiredConfigurationProperties(properties)
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         lifeCycleManager = injector.getInstance(LifeCycleManager.class);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingDiscoveryServer.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingDiscoveryServer.java
@@ -66,6 +66,7 @@ public class TestingDiscoveryServer
                 .strictConfig()
                 .doNotInitializeLogging()
                 .setRequiredConfigurationProperties(serverProperties)
+                .quiet()
                 .initialize();
 
         lifeCycleManager = injector.getInstance(LifeCycleManager.class);

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2ResourceGroupConfigurationManagerFactory.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2ResourceGroupConfigurationManagerFactory.java
@@ -58,6 +58,7 @@ public class H2ResourceGroupConfigurationManagerFactory
                     .strictConfig()
                     .doNotInitializeLogging()
                     .setRequiredConfigurationProperties(config)
+                    .quiet()
                     .initialize();
             return injector.getInstance(DbResourceGroupConfigurationManager.class);
         }


### PR DESCRIPTION
We're close to Travis log length limit of 4 MB in the build
configuration testing `presto-tests`.

This commits disables configuration printing during test setup.
Configuration printing is what takes a lot of the log space in
`presto-tests` tests.