### PR TITLE
Make SqlDate accept days as long

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -260,7 +260,7 @@ public class MaterializedResult
             type.writeSlice(blockBuilder, Slices.wrappedBuffer((byte[]) value));
         }
         else if (DATE.equals(type)) {
-            int days = ((SqlDate) value).getDays();
+            long days = ((SqlDate) value).getDays();
             type.writeLong(blockBuilder, days);
         }
         else if (TIME.equals(type)) {
@@ -337,7 +337,7 @@ public class MaterializedResult
             Object prestoValue = prestoRow.getField(field);
             Object jdbcValue;
             if (prestoValue instanceof SqlDate) {
-                int days = ((SqlDate) prestoValue).getDays();
+                long days = ((SqlDate) prestoValue).getDays();
                 jdbcValue = new Date(TimeUnit.DAYS.toMillis(days));
             }
             else if (prestoValue instanceof SqlTime) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1090,7 +1090,7 @@ public class OrcTester
             return ((SqlVarbinary) value).getBytes();
         }
         else if (type.equals(DATE)) {
-            int days = ((SqlDate) value).getDays();
+            long days = ((SqlDate) value).getDays();
             LocalDate localDate = LocalDate.ofEpochDay(days);
             ZonedDateTime zonedDateTime = localDate.atStartOfDay(ZoneId.systemDefault());
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -88,7 +88,7 @@ public final class TestingOrcPredicate
         if (DATE.equals(type)) {
             return new DateOrcPredicate(
                     expectedValues.stream()
-                            .map(value -> value == null ? null : (long) ((SqlDate) value).getDays())
+                            .map(value -> value == null ? null : ((SqlDate) value).getDays())
                             .collect(toList()),
                     format == DWRF);
         }

--- a/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
@@ -1039,7 +1039,7 @@ public class RcFileTester
             return ((SqlVarbinary) value).getBytes();
         }
         else if (type.equals(DATE)) {
-            int days = ((SqlDate) value).getDays();
+            long days = ((SqlDate) value).getDays();
             LocalDate localDate = LocalDate.ofEpochDay(days);
             ZonedDateTime zonedDateTime = localDate.atStartOfDay(ZoneId.systemDefault());
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlDate.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlDate.java
@@ -16,19 +16,17 @@ package com.facebook.presto.spi.type;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.time.LocalDate;
-import java.util.Objects;
 
 public final class SqlDate
 {
-    private final int days;
+    private final long days;
 
-    // TODO accept long
-    public SqlDate(int days)
+    public SqlDate(long days)
     {
         this.days = days;
     }
 
-    public int getDays()
+    public long getDays()
     {
         return days;
     }
@@ -36,7 +34,7 @@ public final class SqlDate
     @Override
     public int hashCode()
     {
-        return days;
+        return Long.hashCode(days);
     }
 
     @Override
@@ -49,7 +47,7 @@ public final class SqlDate
             return false;
         }
         SqlDate other = (SqlDate) obj;
-        return Objects.equals(days, other.days);
+        return days == other.days;
     }
 
     @JsonValue


### PR DESCRIPTION
Date data type has low-level representation of `long`, so `SqlDate`
should accept `long` in its constructor.