### PR TITLE
Adding TimestampStatistics for OrcReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -387,7 +387,7 @@ public class OrcWriter
 
         // the 0th column is a struct column for the whole row
         columnEncodings.put(0, new ColumnEncoding(DIRECT, 0));
-        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, null, null, null, null, null, null, null));
+        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, null, null, null, null, null, null, null, null));
 
         StripeFooter stripeFooter = new StripeFooter(allStreams, toDenseList(columnEncodings, orcTypes.size()));
         int footerLength = metadataWriter.writeStripeFooter(output, stripeFooter);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -207,6 +207,7 @@ public class DwrfMetadataReader
                 toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup),
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -26,6 +26,7 @@ import com.facebook.presto.orc.metadata.statistics.HiveBloomFilter;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
 import com.facebook.presto.orc.metadata.statistics.StringStatistics;
 import com.facebook.presto.orc.metadata.statistics.StripeStatistics;
+import com.facebook.presto.orc.metadata.statistics.TimestampStatistics;
 import com.facebook.presto.orc.proto.OrcProto;
 import com.facebook.presto.orc.proto.OrcProto.RowIndexEntry;
 import com.facebook.presto.orc.protobuf.CodedInputStream;
@@ -214,6 +215,7 @@ public class OrcMetadataReader
                 toDoubleStatistics(statistics.getDoubleStatistics()),
                 toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup),
                 toDateStatistics(hiveWriterVersion, statistics.getDateStatistics(), isRowGroup),
+                toTimestampStatistics(hiveWriterVersion, statistics.getTimestampStatistics(), isRowGroup),
                 toDecimalStatistics(statistics.getDecimalStatistics()),
                 null);
     }
@@ -397,6 +399,26 @@ public class OrcMetadataReader
         return new DateStatistics(
                 dateStatistics.hasMinimum() ? dateStatistics.getMinimum() : null,
                 dateStatistics.hasMaximum() ? dateStatistics.getMaximum() : null);
+    }
+
+    private static TimestampStatistics toTimestampStatistics(HiveWriterVersion hiveWriterVersion, OrcProto.TimestampStatistics timestampStatistics, boolean isRowGroup)
+    {
+        /*
+        Skip the file and stripe TimestampStatistics when the ORC File is written using old ORC Writer.
+        TimestampStatistics in ORC are fixed in this patch https://issues.apache.org/jira/browse/HIVE-8732.
+         */
+
+        if (hiveWriterVersion == ORIGINAL && !isRowGroup) {
+            return null;
+        }
+
+        if (!timestampStatistics.hasMinimum() && !timestampStatistics.hasMaximum()) {
+            return null;
+        }
+
+        return new TimestampStatistics(
+                timestampStatistics.hasMinimum() ? timestampStatistics.getMinimum() : null,
+                timestampStatistics.hasMaximum() ? timestampStatistics.getMaximum() : null);
     }
 
     private static OrcType toType(OrcProto.Type type)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
@@ -227,7 +227,12 @@ public class OrcMetadataWriter
                     .setMaximum(columnStatistics.getDateStatistics().getMax())
                     .build());
         }
-
+        if (columnStatistics.getTimestampStatistics() != null) {
+            builder.setTimestampStatistics(OrcProto.TimestampStatistics.newBuilder()
+                    .setMinimum(columnStatistics.getTimestampStatistics().getMin())
+                    .setMaximum(columnStatistics.getTimestampStatistics().getMax())
+                    .build());
+        }
         if (columnStatistics.getDecimalStatistics() != null) {
             builder.setDecimalStatistics(OrcProto.DecimalStatistics.newBuilder()
                     .setMinimum(columnStatistics.getDecimalStatistics().getMin().toString())

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -59,6 +59,7 @@ public class BooleanStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
@@ -22,6 +22,7 @@ import static com.facebook.presto.orc.metadata.statistics.DoubleStatisticsBuilde
 import static com.facebook.presto.orc.metadata.statistics.IntegerStatisticsBuilder.mergeIntegerStatistics;
 import static com.facebook.presto.orc.metadata.statistics.LongDecimalStatisticsBuilder.mergeDecimalStatistics;
 import static com.facebook.presto.orc.metadata.statistics.StringStatisticsBuilder.mergeStringStatistics;
+import static com.facebook.presto.orc.metadata.statistics.TimestampStatisticsBuilder.mergeTimestampStatistics;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ColumnStatistics
@@ -33,6 +34,7 @@ public class ColumnStatistics
     private final StringStatistics stringStatistics;
     private final DateStatistics dateStatistics;
     private final DecimalStatistics decimalStatistics;
+    private final TimestampStatistics timestampStatistics;
     private final HiveBloomFilter bloomFilter;
 
     public ColumnStatistics(
@@ -42,6 +44,7 @@ public class ColumnStatistics
             DoubleStatistics doubleStatistics,
             StringStatistics stringStatistics,
             DateStatistics dateStatistics,
+            TimestampStatistics timestampStatistics,
             DecimalStatistics decimalStatistics,
             HiveBloomFilter bloomFilter)
     {
@@ -52,6 +55,7 @@ public class ColumnStatistics
         this.stringStatistics = stringStatistics;
         this.dateStatistics = dateStatistics;
         this.decimalStatistics = decimalStatistics;
+        this.timestampStatistics = timestampStatistics;
         this.bloomFilter = bloomFilter;
     }
 
@@ -95,6 +99,11 @@ public class ColumnStatistics
         return decimalStatistics;
     }
 
+    public TimestampStatistics getTimestampStatistics()
+    {
+        return timestampStatistics;
+    }
+
     public HiveBloomFilter getBloomFilter()
     {
         return bloomFilter;
@@ -109,6 +118,7 @@ public class ColumnStatistics
                 doubleStatistics,
                 stringStatistics,
                 dateStatistics,
+                timestampStatistics,
                 decimalStatistics,
                 bloomFilter);
     }
@@ -129,6 +139,7 @@ public class ColumnStatistics
                 Objects.equals(doubleStatistics, that.doubleStatistics) &&
                 Objects.equals(stringStatistics, that.stringStatistics) &&
                 Objects.equals(dateStatistics, that.dateStatistics) &&
+                Objects.equals(timestampStatistics, that.timestampStatistics) &&
                 Objects.equals(decimalStatistics, that.decimalStatistics) &&
                 Objects.equals(bloomFilter, that.bloomFilter);
     }
@@ -168,6 +179,7 @@ public class ColumnStatistics
                 mergeDoubleStatistics(stats).orElse(null),
                 mergeStringStatistics(stats).orElse(null),
                 mergeDateStatistics(stats).orElse(null),
+                mergeTimestampStatistics(stats).orElse(null),
                 mergeDecimalStatistics(stats).orElse(null),
                 null);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -69,6 +69,7 @@ public class DoubleStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
@@ -64,6 +64,7 @@ public class IntegerStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -77,6 +77,7 @@ public class LongDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 buildDecimalStatistics().orElse(null),
                 null);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -60,6 +60,7 @@ public class ShortDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 buildDecimalStatistics().orElse(null),
                 null);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -81,6 +81,7 @@ public class StringStatisticsBuilder
                 buildStringStatistics().orElse(null),
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatistics.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class TimestampStatistics
+        implements RangeStatistics<Long>
+{
+    private final Long minimum;
+    private final Long maximum;
+
+    public TimestampStatistics(Long minimum, Long maximum)
+    {
+        checkArgument(minimum == null || maximum == null || minimum <= maximum, "minimum is not less than maximum");
+        this.minimum = minimum;
+        this.maximum = maximum;
+    }
+
+    @Override
+    public Long getMin()
+    {
+        return minimum;
+    }
+
+    @Override
+    public Long getMax()
+    {
+        return maximum;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TimestampStatistics that = (TimestampStatistics) o;
+        return Objects.equals(minimum, that.minimum) &&
+                Objects.equals(maximum, that.maximum);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(minimum, maximum);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("min", minimum)
+                .add("max", maximum)
+                .toString();
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatisticsBuilder.java
@@ -16,27 +16,25 @@ package com.facebook.presto.orc.metadata.statistics;
 import java.util.List;
 import java.util.Optional;
 
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
-public class DateStatisticsBuilder
+public class TimestampStatisticsBuilder
         implements LongValueStatisticsBuilder
 {
     private long nonNullValueCount;
-    private int minimum = Integer.MAX_VALUE;
-    private int maximum = Integer.MIN_VALUE;
+    private long minimum = Long.MAX_VALUE;
+    private long maximum = Long.MIN_VALUE;
 
     @Override
     public void addValue(long value)
     {
         nonNullValueCount++;
 
-        int intValue = toIntExact(value);
-        minimum = Math.min(intValue, minimum);
-        maximum = Math.max(intValue, maximum);
+        minimum = Math.min(value, minimum);
+        maximum = Math.max(value, maximum);
     }
 
-    private void addDateStatistics(long valueCount, DateStatistics value)
+    private void addTimestampStatistics(long valueCount, TimestampStatistics value)
     {
         requireNonNull(value, "value is null");
         requireNonNull(value.getMin(), "value.getMin() is null");
@@ -47,12 +45,12 @@ public class DateStatisticsBuilder
         maximum = Math.max(value.getMax(), maximum);
     }
 
-    private Optional<DateStatistics> buildDateStatistics()
+    private Optional<TimestampStatistics> buildTimestampStatistics()
     {
         if (nonNullValueCount == 0) {
             return Optional.empty();
         }
-        return Optional.of(new DateStatistics(minimum, maximum));
+        return Optional.of(new TimestampStatistics(minimum, maximum));
     }
 
     @Override
@@ -64,25 +62,25 @@ public class DateStatisticsBuilder
                 null,
                 null,
                 null,
-                buildDateStatistics().orElse(null),
                 null,
+                buildTimestampStatistics().orElse(null),
                 null,
                 null);
     }
 
-    public static Optional<DateStatistics> mergeDateStatistics(List<ColumnStatistics> stats)
+    public static Optional<TimestampStatistics> mergeTimestampStatistics(List<ColumnStatistics> stats)
     {
-        DateStatisticsBuilder dateStatisticsBuilder = new DateStatisticsBuilder();
+        TimestampStatisticsBuilder timestampStatisticsBuilder = new TimestampStatisticsBuilder();
         for (ColumnStatistics columnStatistics : stats) {
-            DateStatistics partialStatistics = columnStatistics.getDateStatistics();
+            TimestampStatistics partialStatistics = columnStatistics.getTimestampStatistics();
             if (columnStatistics.getNumberOfValues() > 0) {
                 if (partialStatistics == null) {
                     // there are non null values but no statistics, so we can not say anything about the data
                     return Optional.empty();
                 }
-                dateStatisticsBuilder.addDateStatistics(columnStatistics.getNumberOfValues(), partialStatistics);
+                timestampStatisticsBuilder.addTimestampStatistics(columnStatistics.getNumberOfValues(), partialStatistics);
             }
         }
-        return dateStatisticsBuilder.buildDateStatistics();
+        return timestampStatisticsBuilder.buildTimestampStatistics();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -108,7 +108,7 @@ public class ByteColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(column, statistics);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriters.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriters.java
@@ -18,6 +18,7 @@ import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.statistics.BinaryStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.DateStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatisticsBuilder;
+import com.facebook.presto.orc.metadata.statistics.TimestampStatisticsBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTimeZone;
@@ -69,7 +70,7 @@ public final class ColumnWriters
                 return new DecimalColumnWriter(columnIndex, type, compression, bufferSize, false);
 
             case TIMESTAMP:
-                return new TimestampColumnWriter(columnIndex, type, compression, bufferSize, isDwrf, hiveStorageTimeZone);
+                return new TimestampColumnWriter(columnIndex, type, compression, bufferSize, isDwrf, hiveStorageTimeZone, TimestampStatisticsBuilder::new);
 
             case BINARY:
                 return new SliceDirectColumnWriter(columnIndex, type, compression, bufferSize, isDwrf, BinaryStatisticsBuilder::new);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -135,7 +135,7 @@ public class ListColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -142,7 +142,7 @@ public class MapColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -134,7 +134,7 @@ public class StructColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -22,6 +22,7 @@ import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
+import com.facebook.presto.orc.metadata.statistics.TimestampStatisticsBuilder;
 import com.facebook.presto.orc.stream.LongOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStreamV1;
 import com.facebook.presto.orc.stream.LongOutputStreamV2;
@@ -40,6 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
@@ -67,14 +69,15 @@ public class TimestampColumnWriter
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
     private final long baseTimestampInSeconds;
-
-    private int nonNullValueCount;
+    private final Supplier<TimestampStatisticsBuilder> statisticsBuilderSupplier;
+    private TimestampStatisticsBuilder statisticsBuilder;
 
     private boolean closed;
 
-    public TimestampColumnWriter(int column, Type type, CompressionKind compression, int bufferSize, boolean isDwrf, DateTimeZone hiveStorageTimeZone)
+    public TimestampColumnWriter(int column, Type type, CompressionKind compression, int bufferSize, boolean isDwrf, DateTimeZone hiveStorageTimeZone, Supplier<TimestampStatisticsBuilder> statisticsBuilderSupplier)
     {
         checkArgument(column >= 0, "column is negative");
+        this.statisticsBuilderSupplier = statisticsBuilderSupplier;
         this.column = column;
         this.type = requireNonNull(type, "type is null");
         this.compressed = requireNonNull(compression, "compression is null") != NONE;
@@ -89,6 +92,7 @@ public class TimestampColumnWriter
         }
         this.presentStream = new PresentOutputStream(compression, bufferSize);
         this.baseTimestampInSeconds = new DateTime(2015, 1, 1, 0, 0, requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null")).getMillis() / MILLIS_PER_SECOND;
+        this.statisticsBuilder = this.statisticsBuilderSupplier.get();
     }
 
     @Override
@@ -135,7 +139,7 @@ public class TimestampColumnWriter
 
                 secondsStream.writeLong(seconds);
                 nanosStream.writeLong(encodedNanos);
-                nonNullValueCount++;
+                statisticsBuilder.addValue(value);
             }
         }
     }
@@ -144,9 +148,9 @@ public class TimestampColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = statisticsBuilder.buildColumnStatistics();
         rowGroupColumnStatistics.add(statistics);
-        nonNullValueCount = 0;
+        statisticsBuilder = statisticsBuilderSupplier.get();
         return ImmutableMap.of(column, statistics);
     }
 
@@ -238,6 +242,6 @@ public class TimestampColumnWriter
         nanosStream.reset();
         presentStream.reset();
         rowGroupColumnStatistics.clear();
-        nonNullValueCount = 0;
+        statisticsBuilder = statisticsBuilderSupplier.get();
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
@@ -295,6 +295,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 toHiveBloomFilter(orcBloomFilter)));
 
         Map<Integer, ColumnStatistics> nonMatchingStatisticsByColumnIndex = ImmutableMap.of(0, new ColumnStatistics(
@@ -305,12 +306,14 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 toHiveBloomFilter(emptyOrcBloomFilter)));
 
         Map<Integer, ColumnStatistics> withoutBloomFilterStatisticsByColumnIndex = ImmutableMap.of(0, new ColumnStatistics(
                 null,
                 null,
                 new IntegerStatistics(10L, 2000L),
+                null,
                 null,
                 null,
                 null,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -20,6 +20,7 @@ import com.facebook.presto.orc.metadata.statistics.DecimalStatistics;
 import com.facebook.presto.orc.metadata.statistics.DoubleStatistics;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
 import com.facebook.presto.orc.metadata.statistics.StringStatistics;
+import com.facebook.presto.orc.metadata.statistics.TimestampStatistics;
 import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.Type;
@@ -46,6 +47,7 @@ import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.floatToRawIntBits;
@@ -86,7 +88,7 @@ public class TestTupleDomainOrcPredicate
         if (trueValueCount != null) {
             booleanStatistics = new BooleanStatistics(trueValueCount);
         }
-        return new ColumnStatistics(numberOfValues, booleanStatistics, null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, booleanStatistics, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -116,7 +118,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics integerColumnStats(Long numberOfValues, Long minimum, Long maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, new IntegerStatistics(minimum, maximum), null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, null, new IntegerStatistics(minimum, maximum), null, null, null, null, null, null);
     }
 
     @Test
@@ -146,7 +148,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics doubleColumnStats(Long numberOfValues, Double minimum, Double maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null);
+        return new ColumnStatistics(numberOfValues, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null);
     }
 
     @Test
@@ -238,7 +240,7 @@ public class TestTupleDomainOrcPredicate
     {
         Slice minimumSlice = minimum == null ? null : utf8Slice(minimum);
         Slice maximumSlice = maximum == null ? null : utf8Slice(maximum);
-        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minimumSlice, maximumSlice), null, null, null);
+        return new ColumnStatistics(numberOfValues, null, null, null, new StringStatistics(minimumSlice, maximumSlice), null, null, null, null);
     }
 
     @Test
@@ -268,7 +270,37 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics dateColumnStats(Long numberOfValues, Integer minimum, Integer maximum)
     {
-        return new ColumnStatistics(numberOfValues, null, null, null, null, new DateStatistics(minimum, maximum), null, null);
+        return new ColumnStatistics(numberOfValues, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null);
+    }
+
+    @Test
+    public void testTimestamo()
+            throws Exception
+    {
+        assertEquals(getDomain(TIMESTAMP, 0, null), none(TIMESTAMP));
+        assertEquals(getDomain(TIMESTAMP, 10, null), all(TIMESTAMP));
+
+        assertEquals(getDomain(TIMESTAMP, 0, timeStampColumnStats(null, null, null)), none(TIMESTAMP));
+        assertEquals(getDomain(TIMESTAMP, 0, timeStampColumnStats(0L, null, null)), none(TIMESTAMP));
+        assertEquals(getDomain(TIMESTAMP, 0, timeStampColumnStats(0L, 100L, 100L)), none(TIMESTAMP));
+
+        assertEquals(getDomain(TIMESTAMP, 10, timeStampColumnStats(0L, null, null)), onlyNull(TIMESTAMP));
+        assertEquals(getDomain(TIMESTAMP, 10, timeStampColumnStats(10L, null, null)), notNull(TIMESTAMP));
+
+        assertEquals(getDomain(TIMESTAMP, 10, timeStampColumnStats(10L, 100L, 100L)), singleValue(TIMESTAMP, 100L));
+
+        assertEquals(getDomain(TIMESTAMP, 10, timeStampColumnStats(10L, 0L, 100L)), create(ValueSet.ofRanges(range(TIMESTAMP, 0L, true, 100L, true)), false));
+        assertEquals(getDomain(TIMESTAMP, 10, timeStampColumnStats(10L, null, 100L)), create(ValueSet.ofRanges(lessThanOrEqual(TIMESTAMP, 100L)), false));
+        assertEquals(getDomain(TIMESTAMP, 10, timeStampColumnStats(10L, 0L, null)), create(ValueSet.ofRanges(greaterThanOrEqual(TIMESTAMP, 0L)), false));
+
+        assertEquals(getDomain(TIMESTAMP, 10, timeStampColumnStats(5L, 0L, 100L)), create(ValueSet.ofRanges(range(TIMESTAMP, 0L, true, 100L, true)), true));
+        assertEquals(getDomain(TIMESTAMP, 10, timeStampColumnStats(5L, null, 100L)), create(ValueSet.ofRanges(lessThanOrEqual(TIMESTAMP, 100L)), true));
+        assertEquals(getDomain(TIMESTAMP, 10, timeStampColumnStats(5L, 0L, null)), create(ValueSet.ofRanges(greaterThanOrEqual(TIMESTAMP, 0L)), true));
+    }
+
+    private static ColumnStatistics timeStampColumnStats(Long numberOfValues, Long minimum, Long maximum)
+    {
+        return new ColumnStatistics(numberOfValues, null, null, null, null, null, new TimestampStatistics(minimum, maximum), null, null);
     }
 
     @Test
@@ -325,7 +357,7 @@ public class TestTupleDomainOrcPredicate
     {
         BigDecimal minimumDecimal = minimum == null ? null : new BigDecimal(minimum);
         BigDecimal maximumDecimal = maximum == null ? null : new BigDecimal(maximum);
-        return new ColumnStatistics(numberOfValues, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal), null);
+        return new ColumnStatistics(numberOfValues, null, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal), null);
     }
 
     private static Long shortDecimal(String value)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -199,7 +199,6 @@ public final class TestingOrcPredicate
             if (columnStatistics.getNumberOfValues() != Iterables.size(filter(chunk, notNull()))) {
                 return false;
             }
-
             return true;
         }
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
 {
     public enum StatisticsType
     {
-        NONE, BOOLEAN, INTEGER, DOUBLE, STRING, DATE, DECIMAL
+        NONE, BOOLEAN, INTEGER, DOUBLE, STRING, DATE, DECIMAL, TIMESTAMP
     }
 
     private final StatisticsType statisticsType;
@@ -147,7 +147,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
     static List<ColumnStatistics> insertEmptyColumnStatisticsAt(List<ColumnStatistics> statisticsList, int index, long numberOfValues)
     {
         List<ColumnStatistics> newStatisticsList = new ArrayList<>(statisticsList);
-        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, null, null, null, null, null, null, null));
+        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, null, null, null, null, null, null, null, null));
         return newStatisticsList;
     }
 
@@ -188,6 +188,13 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
         }
         else {
             assertNull(columnStatistics.getDateStatistics());
+        }
+
+        if (statisticsType == StatisticsType.TIMESTAMP && expectedNumberOfValues > 0) {
+            assertRangeStatistics(columnStatistics.getTimestampStatistics(), expectedMin, expectedMax);
+        }
+        else {
+            assertNull(columnStatistics.getTimestampStatistics());
         }
 
         if (statisticsType == StatisticsType.DECIMAL && expectedNumberOfValues > 0) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestTimestampStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestTimestampStatistics.java
@@ -13,35 +13,27 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
-import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
 
-import static java.util.Objects.requireNonNull;
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
 
-public class BinaryStatisticsBuilder
-        implements SliceColumnStatisticsBuilder
+public class TestTimestampStatistics
+        extends AbstractRangeStatisticsTest<TimestampStatistics, Long>
 {
-    private long nonNullValueCount;
-
     @Override
-    public void addValue(Slice value)
+    protected TimestampStatistics getCreateStatistics(Long min, Long max)
     {
-        requireNonNull(value, "value is null");
-
-        nonNullValueCount++;
+        return new TimestampStatistics(min, max);
     }
 
-    @Override
-    public ColumnStatistics buildColumnStatistics()
+    @Test
+    public void test()
     {
-        return new ColumnStatistics(
-                nonNullValueCount,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null);
+        assertMinMax(0L, 42L);
+        assertMinMax(42L, 42L);
+        assertMinMax(MIN_VALUE, 42L);
+        assertMinMax(42L, MAX_VALUE);
+        assertMinMax(MIN_VALUE, MAX_VALUE);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestTimestampStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestTimestampStatisticsBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.Range;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.TIMESTAMP;
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
+
+public class TestTimestampStatisticsBuilder
+        extends AbstractStatisticsBuilderTest<TimestampStatisticsBuilder, Long>
+{
+    public TestTimestampStatisticsBuilder()
+    {
+        super(TIMESTAMP, TimestampStatisticsBuilder::new, TimestampStatisticsBuilder::addValue);
+    }
+
+    @Test
+    public void testMinMaxValues()
+    {
+        assertMinMaxValues(0L, 0L);
+        assertMinMaxValues(42L, 42L);
+        assertMinMaxValues(MIN_VALUE, MIN_VALUE);
+        assertMinMaxValues(MAX_VALUE, MAX_VALUE);
+
+        assertMinMaxValues(0L, 42L);
+        assertMinMaxValues(42L, 42L);
+        assertMinMaxValues(MIN_VALUE, 42L);
+        assertMinMaxValues(42L, MAX_VALUE);
+        assertMinMaxValues(MIN_VALUE, MAX_VALUE);
+
+        assertValues(-42L, 0L, ContiguousSet.create(Range.closed(-42L, 0L), DiscreteDomain.longs()).asList());
+        assertValues(-42L, 42L, ContiguousSet.create(Range.closed(-42L, 42L), DiscreteDomain.longs()).asList());
+        assertValues(0L, 42L, ContiguousSet.create(Range.closed(0L, 42L), DiscreteDomain.longs()).asList());
+        assertValues(MIN_VALUE, MIN_VALUE + 42, ContiguousSet.create(Range.closed(MIN_VALUE, MIN_VALUE + 42), DiscreteDomain.longs()).asList());
+        assertValues(MAX_VALUE - 42L, MAX_VALUE, ContiguousSet.create(Range.closed(MAX_VALUE - 42L, MAX_VALUE), DiscreteDomain.longs()).asList());
+    }
+}


### PR DESCRIPTION
The Above PR adds support for skipping of stripes based on Timestamp statistics when we are reading from an ORC file. It was previously implemented in #7880
@dain I have updated to the latest code.
Thanks in advance.