### PR TITLE
Improve Page splitting for Pages that hold certain types of Blocks

### DIFF
--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/PageSplitterUtil.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/PageSplitterUtil.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.execution.buffer;
+package com.facebook.presto.rcfile;
 
 import com.facebook.presto.spi.Page;
 import com.google.common.collect.ImmutableList;
@@ -20,6 +20,9 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+/**
+ * Copy of com.facebook.presto.execution.buffer.PageSplitterUtil
+ */
 public final class PageSplitterUtil
 {
     private PageSplitterUtil() {}


### PR DESCRIPTION
For Pages that hold certain types of Blocks, such as RLE blocks, the size in
bytes will remain constant through the recursion. For such cases the
recursion will only terminate when the positions in the Page is one, resulting
in potentially a large number of Pages of size one.