### PR TITLE
Properly release native buffers when RcFileWriter is closed

### DIFF
--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileCompressor.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileCompressor.java
@@ -86,15 +86,23 @@ public interface RcFileCompressor
         public void close()
                 throws IOException
         {
-            closed = true;
-            super.close();
+            if (!closed) {
+                closed = true;
+                super.close();
+            }
         }
 
         public void destroy()
+                throws IOException
         {
             if (!destroyed) {
                 destroyed = true;
-                onDestroy.run();
+                try {
+                    close();
+                }
+                finally {
+                    onDestroy.run();
+                }
             }
         }
     }


### PR DESCRIPTION
When the RcFileWriter is closed it destroys the column encoders, which in turn
destroys the output stream. However, for the output streams created with `AircompressorCompressor` the on destroy action is nop resulting in a leak.