### PR TITLE
Add last_day function, to get last day of month

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -100,6 +100,10 @@ Date and Time Functions
 
     Returns ``timestamp`` as a UNIX timestamp.
 
+.. function:: last_day(date) -> date
+
+    Returns last day of the month that contains the date.
+
 .. note:: The following SQL-standard functions do not use parenthesis:
 
     - ``current_date``

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -953,6 +953,24 @@ public final class DateTimeFunctions
         return extractZoneOffsetMinutes(timestampWithTimeZone) / 60;
     }
 
+    @Description("last day of the month that contains timestamp")
+    @ScalarFunction("last_day")
+    @SqlType(StandardTypes.DATE)
+    public static long lastDayOfMonthFromTimestampWithTimeZone(ConnectorSession session, @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long timestampWithTimeZone)
+    {
+        DateTime dateTime = new DateTime(unpackChronology(timestampWithTimeZone).millis().getMillis(unpackMillisUtc(timestampWithTimeZone))).dayOfMonth().withMaximumValue();
+        return MILLISECONDS.toDays(dateTime.dayOfMonth().roundCeilingCopy().getMillis());
+    }
+
+    @Description("last day of the month that contains the date")
+    @ScalarFunction("last_day")
+    @SqlType(StandardTypes.DATE)
+    public static long lastDayOfMonthFromDate(@SqlType(StandardTypes.DATE) long date)
+    {
+        DateTime dateTime = new DateTime(DAYS.toMillis(date)).dayOfMonth().withMaximumValue();
+        return MILLISECONDS.toDays(dateTime.dayOfMonth().roundCeilingCopy().getMillis());
+    }
+
     @SuppressWarnings("fallthrough")
     public static DateTimeFormatter createDateTimeFormatter(Slice format)
     {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -951,6 +951,14 @@ public class TestDateTimeFunctions
         assertInvalidFunction("parse_duration('abc')", "duration is not a valid data duration string: abc");
     }
 
+    @Test
+    public void testLastDayOfMonth()
+    {
+        assertFunction("last_day( " + DATE_LITERAL + ")", DateType.DATE, toDate(DATE.withDayOfMonth(31)));
+        assertFunction("last_day( " + TIMESTAMP_LITERAL + ")", DateType.DATE, toDate(DATE.withDayOfMonth(31)));
+        assertFunction("last_day( " + WEIRD_TIMESTAMP_LITERAL + ")", DateType.DATE, toDate(DATE.withDayOfMonth(31)));
+    }
+
     private void assertFunctionString(String projection, Type expectedType, String expected)
     {
         functionAssertions.assertFunctionString(projection, expectedType, expected);


### PR DESCRIPTION
@raghavsethi 

I created this pull request for cleaner check-in (squash commits + better commit message) of [Add last_day function, to get last day of month #8545](https://github.com/prestodb/presto/pull/8545), This is to implement last_day function. I am closing https://github.com/prestodb/presto/pull/8545 pull request

Can you please take a look
