### PR TITLE
Do not plan INNER join with just filter function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -366,7 +366,7 @@ public class PredicatePushDown
                         .collect(Collectors.toMap(key -> key, Symbol::toSymbolReference)));
 
                 // Create new projections for the new join clauses
-                ImmutableList.Builder<JoinNode.EquiJoinClause> joinConditionBuilder = ImmutableList.builder();
+                List<JoinNode.EquiJoinClause> equiJoinClauses = new ArrayList<>();
                 ImmutableList.Builder<Expression> joinFilterBuilder = ImmutableList.builder();
                 for (Expression conjunct : extractConjuncts(newJoinPredicate)) {
                     if (joinEqualityExpression(node.getLeft().getOutputSymbols()).test(conjunct)) {
@@ -386,7 +386,7 @@ public class PredicatePushDown
                             rightProjections.put(rightSymbol, rightExpression);
                         }
 
-                        joinConditionBuilder.add(new JoinNode.EquiJoinClause(leftSymbol, rightSymbol));
+                        equiJoinClauses.add(new JoinNode.EquiJoinClause(leftSymbol, rightSymbol));
                     }
                     else {
                         joinFilterBuilder.add(conjunct);
@@ -407,7 +407,7 @@ public class PredicatePushDown
                         leftSource,
                         rightSource,
                         newJoinFilter,
-                        joinConditionBuilder.build(),
+                        equiJoinClauses.build(),
                         node.getLeftHashSymbol(),
                         node.getRightHashSymbol(),
                         node.getDistributionType());

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2656,6 +2656,9 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT COUNT(*) FROM (VALUES 1, 2) t1(a) JOIN (VALUES 10, 11) t2(b) ON a > 2",
                 "VALUES (0)");
+        assertQuery(
+                "SELECT * FROM (VALUES 1, 2) t1(a) JOIN (VALUES 10, 11) t2(b) ON a+9 > b",
+                "VALUES (2, 10)");
     }
 
     @Test


### PR DESCRIPTION
We want to avoid having INNER JoinNode with just non-equality filter function.
In such case HashJoin execution is planned. And if we have CROSS join followed by
FILTER, NestedLoopsJoin is planned, which is much faster.