### PR TITLE
Fix CORR for negative correlations

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
@@ -88,14 +88,14 @@ public final class AggregationUtils
 
     public static double getCorrelation(CorrelationState state)
     {
-        // Math comes from ISO9075-2:2011(E) 10.9 General Rules 7 c x
-        double dividend = state.getCount() * state.getSumXY() - state.getSumX() * state.getSumY();
-        dividend = dividend * dividend;
-        double divisor1 = state.getCount() * state.getSumXSquare() - state.getSumX() * state.getSumX();
-        double divisor2 = state.getCount() * state.getSumYSquare() - state.getSumY() * state.getSumY();
+        // This is defined as covariance(x, y) / (stdev(x) * stdev(y))
+        double covariance = state.getCount() * state.getSumXY() - state.getSumX() * state.getSumY();
+        double stdevX = Math.sqrt(state.getCount() * state.getSumXSquare() - state.getSumX() * state.getSumX());
+        double stdevY = Math.sqrt(state.getCount() * state.getSumYSquare() - state.getSumY() * state.getSumY());
 
-        // divisor1 and divisor2 deliberately not checked for zero because the result can be Infty or NaN even if they are both not zero
-        return dividend / divisor1 / divisor2; // When the left expression yields a finite value, dividend / (divisor1 * divisor2) can yield Infty or NaN.
+        // stdevX and stdevY deliberately not checked for zero because the result can be Infinity or NaN even
+        // if they are both not zero
+        return covariance / stdevX / stdevY;
     }
 
     public static void updateRegressionState(RegressionState state, double x, double y)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleCorrelationAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleCorrelationAggregation.java
@@ -50,7 +50,7 @@ public class DoubleCorrelationAggregation
     {
         double result = getCorrelation(state);
         if (Double.isFinite(result)) {
-            DOUBLE.writeDouble(out, Math.sqrt(result)); // sqrt cannot turn finite value to non-finite value
+            DOUBLE.writeDouble(out, result);
         }
         else {
             out.appendNull();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealCorrelationAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealCorrelationAggregation.java
@@ -50,7 +50,7 @@ public class RealCorrelationAggregation
     {
         double result = getCorrelation(state);
         if (Double.isFinite(result)) {
-            long resultBits = floatToRawIntBits((float) Math.sqrt(result)); // sqrt cannot turn finite value to non-finite value
+            long resultBits = floatToRawIntBits((float) result);
             REAL.writeLong(out, resultBits);
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleCorrelationAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleCorrelationAggregation.java
@@ -72,6 +72,12 @@ public class TestDoubleCorrelationAggregation
         testNonTrivialAggregation(new double[] {1, 2, 3, 4, 5}, new double[] {1, 4, 9, 16, 25});
     }
 
+    @Test
+    public void testInverseCorrelation()
+    {
+        testNonTrivialAggregation(new double[] {1, 2, 3, 4, 5}, new double[] {5, 4, 3, 2, 1});
+    }
+
     private void testNonTrivialAggregation(double[] y, double[] x)
     {
         PearsonsCorrelation corr = new PearsonsCorrelation();


### PR DESCRIPTION
The function is incorrectly implemented as:

    SQRT( COVAR(x,y)^2 / (VAR(x) * VAR(y)) )

due to a bug in the SQL spec (section 10.9.8.c.x.3). The correct formula is:

    COVAR(x, y) / SQRT(VAR(x) * VAR(y))

As a result, negative correlations are incorrectly indicated
as being positive.