### PR TITLE
Don't ask Hive for statistics for hidden columns

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1055,6 +1055,52 @@ public abstract class AbstractTestHiveClient
     }
 
     @Test
+    public void testGetTableStatsBucketedStringInt()
+            throws Exception
+    {
+        assertTableStats(
+                tableBucketedStringInt,
+                ImmutableSet.of(
+                        "t_bigint",
+                        "t_boolean",
+                        "t_double",
+                        "t_float",
+                        "t_int",
+                        "t_smallint",
+                        "t_string",
+                        "t_tinyint",
+                        "ds"));
+    }
+
+    @Test
+    public void testGetTableStatsUnpartitioned()
+            throws Exception
+    {
+        assertTableStats(
+                tableUnpartitioned,
+                ImmutableSet.of("t_string", "t_tinyint"));
+    }
+
+    private void assertTableStats(
+            SchemaTableName tableName,
+            Set<String> expectedColumnStatsColumns)
+            throws Exception
+    {
+        try (Transaction transaction = newTransaction()) {
+            ConnectorMetadata metadata = transaction.getMetadata();
+            ConnectorSession session = newSession();
+            ConnectorTableHandle tableHandle = getTableHandle(metadata, tableName);
+
+            assertEquals(
+                    metadata
+                            .getTableStatistics(session, tableHandle, Constraint.alwaysTrue())
+                            .getColumnStatistics()
+                            .keySet(),
+                    expectedColumnStatsColumns);
+        }
+    }
+
+    @Test
     public void testGetPartitionSplitsBatch()
             throws Exception
     {

--- a/presto-hive/src/test/sql/create-test.sql
+++ b/presto-hive/src/test/sql/create-test.sql
@@ -232,3 +232,8 @@ ALTER TABLE presto_test_partition_schema_change REPLACE COLUMNS (t_data DOUBLE);
 
 INSERT OVERWRITE TABLE presto_test_partition_schema_change_non_canonical PARTITION (t_boolean='0')
 SELECT 'test' FROM presto_test_sequence LIMIT 100;
+
+ANALYZE TABLE presto_test_unpartitioned COMPUTE STATISTICS;
+ANALYZE TABLE presto_test_unpartitioned COMPUTE STATISTICS FOR COLUMNS;
+ANALYZE TABLE presto_test_bucketed_by_string_int PARTITION(ds) COMPUTE STATISTICS;
+ANALYZE TABLE presto_test_bucketed_by_string_int PARTITION(ds) COMPUTE STATISTICS FOR COLUMNS;


### PR DESCRIPTION
Hidden columns are internal to Presto.  Presto should not ask Hive for
statistics on them.  The code path for getting stats on an unpartitioned
table (inside MetastoreHiveStatisticsProvider.getPartitionsStatistics())
was asking Hive for stats on hidden columns, which for some
implementations of Hive (such as CDH 5.11.0) could throw an error.  This
patch hoists the check up to outside the HiveStatisticsProvider.

This solves #8380.