### PR TITLE
Add rmiregistry port to deployment documentation

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -174,6 +174,9 @@ You may also wish to set the following properties:
 
 * ``query.queue-config-file``:
   Specifies the file to read the :doc:`/admin/queue` from.
+  
+* ``jmx.rmiregistry.port``:
+  Specifies the port for the JMX RMI registry. JMX clients should connect to this port.
 
 * ``jmx.rmiserver.port``:
   Specifies the port for the JMX RMI server. Presto exports many metrics


### PR DESCRIPTION
The JMX `rmiregistry` port is a required property to be able to connect to the JMX server. The documentation currently only mentions the `rmiserver` port, which the registry uses to redirect client requests, but clients actually connect to the `rmiregistry` port.

I have completed the Facebook CLA for this GitHub account, but this is my first contribution.