### PR TITLE
Fix handling of REAL type for MySQL and PostgreSQL

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -92,9 +92,9 @@ public class BaseJdbcClient
             .put(VARBINARY, "varbinary")
             .put(DATE, "date")
             .put(TIME, "time")
-            .put(TIME_WITH_TIME_ZONE, "time with timezone")
+            .put(TIME_WITH_TIME_ZONE, "time with time zone")
             .put(TIMESTAMP, "timestamp")
-            .put(TIMESTAMP_WITH_TIME_ZONE, "timestamp with timezone")
+            .put(TIMESTAMP_WITH_TIME_ZONE, "timestamp with time zone")
             .build();
 
     protected final String connectorId;

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -511,11 +512,12 @@ public class BaseJdbcClient
 
     protected String toSqlType(Type type)
     {
-        if (type instanceof VarcharType) {
-            if (((VarcharType) type).isUnbounded()) {
+        if (isVarcharType(type)) {
+            VarcharType varcharType = (VarcharType) type;
+            if (varcharType.isUnbounded()) {
                 return "varchar";
             }
-            return "varchar(" + ((VarcharType) type).getLength() + ")";
+            return "varchar(" + varcharType.getLengthSafe() + ")";
         }
         if (type instanceof CharType) {
             if (((CharType) type).getLength() == CharType.MAX_LENGTH) {

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -19,6 +19,7 @@ import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.spi.type.Varchars;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.mysql.jdbc.Driver;

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -19,7 +19,6 @@ import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
-import com.facebook.presto.spi.type.Varchars;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.mysql.jdbc.Driver;
@@ -35,6 +34,11 @@ import java.sql.SQLException;
 import java.util.Set;
 
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static java.util.Locale.ENGLISH;
 
 public class MySqlClient
@@ -120,31 +124,32 @@ public class MySqlClient
         if (REAL.equals(type)) {
             return "float";
         }
-
-        if (Varchars.isVarcharType(type)) {
+        if (VARBINARY.equals(type)) {
+            return "varbinary";
+        }
+        if (TIME_WITH_TIME_ZONE.equals(type)) {
+            return "time";
+        }
+        if (TIMESTAMP.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
+            return "datetime";
+        }
+        if (isVarcharType(type)) {
             VarcharType varcharType = (VarcharType) type;
-            if (varcharType.getLength() <= 255) {
+            if (varcharType.isUnbounded()) {
+                return "longtext";
+            }
+            if (varcharType.getLengthSafe() <= 255) {
                 return "tinytext";
             }
-            if (varcharType.getLength() <= 65535) {
+            if (varcharType.getLengthSafe() <= 65535) {
                 return "text";
             }
-            if (varcharType.getLength() <= 16777215) {
+            if (varcharType.getLengthSafe() <= 16777215) {
                 return "mediumtext";
             }
             return "longtext";
         }
 
-        String sqlType = super.toSqlType(type);
-        switch (sqlType) {
-            case "varbinary":
-                return "mediumblob";
-            case "time with timezone":
-                return "time";
-            case "timestamp":
-            case "timestamp with timezone":
-                return "datetime";
-        }
-        return sqlType;
+        return super.toSqlType(type);
     }
 }

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -34,6 +34,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Set;
 
+import static com.facebook.presto.spi.type.RealType.REAL;
 import static java.util.Locale.ENGLISH;
 
 public class MySqlClient
@@ -116,6 +117,10 @@ public class MySqlClient
     @Override
     protected String toSqlType(Type type)
     {
+        if (REAL.equals(type)) {
+            return "float";
+        }
+
         if (Varchars.isVarcharType(type)) {
             VarcharType varcharType = (VarcharType) type;
             if (varcharType.getLength() <= 255) {

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -13,44 +13,22 @@
  */
 package com.facebook.presto.plugin.mysql;
 
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.AbstractTestQueries;
-import com.facebook.presto.tests.datatype.CreateAndInsertDataSetup;
-import com.facebook.presto.tests.datatype.CreateAsSelectDataSetup;
-import com.facebook.presto.tests.datatype.DataSetup;
-import com.facebook.presto.tests.datatype.DataTypeTest;
-import com.facebook.presto.tests.sql.JdbcSqlExecutor;
-import com.facebook.presto.tests.sql.PrestoSqlExecutor;
 import io.airlift.testing.mysql.TestingMySqlServer;
 import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-
 import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
-import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
-import static com.facebook.presto.tests.datatype.DataType.charDataType;
-import static com.facebook.presto.tests.datatype.DataType.stringDataType;
-import static com.facebook.presto.tests.datatype.DataType.varcharDataType;
-import static com.google.common.base.Strings.repeat;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 @Test
 public class TestMySqlDistributedQueries
         extends AbstractTestQueries
 {
-    private static final String CHARACTER_SET_UTF8 = "CHARACTER SET utf8";
-
     private final TestingMySqlServer mysqlServer;
 
     public TestMySqlDistributedQueries()
@@ -70,116 +48,6 @@ public class TestMySqlDistributedQueries
     public final void destroy()
     {
         mysqlServer.close();
-    }
-
-    @Test
-    public void testDropTable()
-    {
-        assertUpdate("CREATE TABLE test_drop AS SELECT 123 x", 1);
-        assertTrue(getQueryRunner().tableExists(getSession(), "test_drop"));
-
-        assertUpdate("DROP TABLE test_drop");
-        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop"));
-    }
-
-    @Test
-    public void testViews()
-            throws SQLException
-    {
-        execute("CREATE OR REPLACE VIEW tpch.test_view AS SELECT * FROM tpch.orders");
-
-        assertQuery("SELECT orderkey FROM test_view", "SELECT orderkey FROM orders");
-
-        execute("DROP VIEW IF EXISTS tpch.test_view");
-    }
-
-    @Test
-    public void testPrestoCreatedParameterizedVarchar()
-    {
-        DataTypeTest.create()
-                .addRoundTrip(stringDataType("varchar(10)", createVarcharType(255)), "text_a")
-                .addRoundTrip(stringDataType("varchar(255)", createVarcharType(255)), "text_b")
-                .addRoundTrip(stringDataType("varchar(256)", createVarcharType(65535)), "text_c")
-                .addRoundTrip(stringDataType("varchar(65535)", createVarcharType(65535)), "text_d")
-                .addRoundTrip(stringDataType("varchar(65536)", createVarcharType(16777215)), "text_e")
-                .addRoundTrip(stringDataType("varchar(16777215)", createVarcharType(16777215)), "text_f")
-                .addRoundTrip(stringDataType("varchar(16777216)", createUnboundedVarcharType()), "text_g")
-                .addRoundTrip(stringDataType("varchar(" + VarcharType.MAX_LENGTH + ")", createUnboundedVarcharType()), "text_h")
-                .addRoundTrip(stringDataType("varchar", createUnboundedVarcharType()), "unbounded")
-                .execute(getQueryRunner(), prestoCreateAsSelect("presto_test_parameterized_varchar"));
-    }
-
-    @Test
-    public void testMySqlCreatedParameterizedVarchar()
-    {
-        DataTypeTest.create()
-                .addRoundTrip(stringDataType("tinytext", createVarcharType(255)), "a")
-                .addRoundTrip(stringDataType("text", createVarcharType(65535)), "b")
-                .addRoundTrip(stringDataType("mediumtext", createVarcharType(16777215)), "c")
-                .addRoundTrip(stringDataType("longtext", createUnboundedVarcharType()), "d")
-                .addRoundTrip(varcharDataType(32), "e")
-                .addRoundTrip(varcharDataType(20000), "f")
-                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar"));
-    }
-
-    @Test
-    public void testMySqlCreatedParameterizedVarcharUnicode()
-    {
-        String sampleUnicodeText = "\u653b\u6bbb\u6a5f\u52d5\u968a";
-        DataTypeTest.create()
-                .addRoundTrip(stringDataType("tinytext " + CHARACTER_SET_UTF8, createVarcharType(255)), sampleUnicodeText)
-                .addRoundTrip(stringDataType("text " + CHARACTER_SET_UTF8, createVarcharType(65535)), sampleUnicodeText)
-                .addRoundTrip(stringDataType("mediumtext " + CHARACTER_SET_UTF8, createVarcharType(16777215)), sampleUnicodeText)
-                .addRoundTrip(stringDataType("longtext " + CHARACTER_SET_UTF8, createUnboundedVarcharType()), sampleUnicodeText)
-                .addRoundTrip(varcharDataType(sampleUnicodeText.length(), CHARACTER_SET_UTF8), sampleUnicodeText)
-                .addRoundTrip(varcharDataType(32, CHARACTER_SET_UTF8), sampleUnicodeText)
-                .addRoundTrip(varcharDataType(20000, CHARACTER_SET_UTF8), sampleUnicodeText)
-                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar_unicode"));
-    }
-
-    @Test
-    public void testPrestoCreatedParameterizedChar()
-    {
-        mysqlCharTypeTest().execute(getQueryRunner(), prestoCreateAsSelect("mysql_test_parameterized_char"));
-    }
-
-    @Test
-    public void testMySqlCreatedParameterizedChar()
-    {
-        mysqlCharTypeTest().execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_parameterized_char"));
-    }
-
-    private DataTypeTest mysqlCharTypeTest()
-    {
-        return DataTypeTest.create()
-                .addRoundTrip(charDataType("char", 1), "")
-                .addRoundTrip(charDataType("char", 1), "a")
-                .addRoundTrip(charDataType(1), "")
-                .addRoundTrip(charDataType(1), "a")
-                .addRoundTrip(charDataType(8), "abc")
-                .addRoundTrip(charDataType(8), "12345678")
-                .addRoundTrip(charDataType(255), repeat("a", 255));
-    }
-
-    @Test
-    public void testMySqlCreatedParameterizedCharUnicode()
-    {
-        DataTypeTest.create()
-                .addRoundTrip(charDataType(1, CHARACTER_SET_UTF8), "\u653b")
-                .addRoundTrip(charDataType(5, CHARACTER_SET_UTF8), "\u653b\u6bbb")
-                .addRoundTrip(charDataType(5, CHARACTER_SET_UTF8), "\u653b\u6bbb\u6a5f\u52d5\u968a")
-                .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar"));
-    }
-
-    private DataSetup prestoCreateAsSelect(String tableNamePrefix)
-    {
-        return new CreateAsSelectDataSetup(new PrestoSqlExecutor(getQueryRunner()), tableNamePrefix);
-    }
-
-    private DataSetup mysqlCreateAndInsert(String tableNamePrefix)
-    {
-        JdbcSqlExecutor mysqlUnicodeExecutor = new JdbcSqlExecutor(mysqlServer.getJdbcUrl() + "&useUnicode=true&characterEncoding=utf8");
-        return new CreateAndInsertDataSetup(mysqlUnicodeExecutor, tableNamePrefix);
     }
 
     @Override
@@ -212,14 +80,5 @@ public class TestMySqlDistributedQueries
     public void testDescribeOutputNamedAndUnnamed()
     {
         // this connector uses a non-canonical type for varchar columns in tpch
-    }
-
-    private void execute(String sql)
-            throws SQLException
-    {
-        try (Connection connection = DriverManager.getConnection(mysqlServer.getJdbcUrl());
-                Statement statement = connection.createStatement()) {
-            statement.execute(sql);
-        }
     }
 }

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -17,6 +17,7 @@ import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
 import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcOutputTableHandle;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Throwables;
 import org.postgresql.Driver;
 
@@ -27,6 +28,8 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 
 public class PostgreSqlClient
         extends BaseJdbcClient
@@ -77,5 +80,15 @@ public class PostgreSqlClient
                 escapeNamePattern(schemaName, escape),
                 escapeNamePattern(tableName, escape),
                 new String[] {"TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE"});
+    }
+
+    @Override
+    protected String toSqlType(Type type)
+    {
+        if (VARBINARY.equals(type)) {
+            return "bytea";
+        }
+
+        return super.toSqlType(type);
     }
 }

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -14,29 +14,14 @@
 package com.facebook.presto.plugin.postgresql;
 
 import com.facebook.presto.tests.AbstractTestQueries;
-import com.facebook.presto.tests.datatype.CreateAndInsertDataSetup;
-import com.facebook.presto.tests.datatype.CreateAsSelectDataSetup;
-import com.facebook.presto.tests.datatype.DataSetup;
-import com.facebook.presto.tests.datatype.DataType;
-import com.facebook.presto.tests.datatype.DataTypeTest;
-import com.facebook.presto.tests.sql.JdbcSqlExecutor;
-import com.facebook.presto.tests.sql.PrestoSqlExecutor;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
 import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.function.Function;
 
 import static com.facebook.presto.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
-import static com.facebook.presto.tests.datatype.DataType.varcharDataType;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 @Test
 public class TestPostgreSqlDistributedQueries
@@ -70,108 +55,5 @@ public class TestPostgreSqlDistributedQueries
         // the PostgreSQL query fails with "stack depth limit exceeded"
         // TODO: fix QueryBuilder not to generate such a large query
         // https://github.com/prestodb/presto/issues/5752
-    }
-
-    @Test
-    public void testDropTable()
-    {
-        assertUpdate("CREATE TABLE test_drop AS SELECT 123 x", 1);
-        assertTrue(getQueryRunner().tableExists(getSession(), "test_drop"));
-
-        assertUpdate("DROP TABLE test_drop");
-        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop"));
-    }
-
-    @Test
-    public void testViews()
-            throws Exception
-    {
-        execute("CREATE OR REPLACE VIEW tpch.test_view AS SELECT * FROM tpch.orders");
-
-        assertQuery("SELECT orderkey FROM test_view", "SELECT orderkey FROM orders");
-
-        execute("DROP VIEW IF EXISTS tpch.test_view");
-    }
-
-    @Test
-    public void testPrestoCreatedParameterizedVarchar()
-    {
-        varcharDataTypeTest().execute(getQueryRunner(), prestoCreateAsSelect("presto_test_parameterized_varchar"));
-    }
-
-    @Test
-    public void testPostgreSqlCreatedParameterizedVarchar()
-    {
-        varcharDataTypeTest().execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar"));
-    }
-
-    private DataTypeTest varcharDataTypeTest()
-    {
-        return DataTypeTest.create()
-                .addRoundTrip(varcharDataType(10), "text_a")
-                .addRoundTrip(varcharDataType(255), "text_b")
-                .addRoundTrip(varcharDataType(65535), "text_d")
-                .addRoundTrip(varcharDataType(10485760), "text_f")
-                .addRoundTrip(varcharDataType(), "unbounded");
-    }
-
-    @Test
-    public void testPrestoCreatedParameterizedVarcharUnicode()
-    {
-        unicodeVarcharDateTypeTest().execute(getQueryRunner(), prestoCreateAsSelect("postgresql_test_parameterized_varchar_unicode"));
-    }
-
-    @Test
-    public void testPostgreSqlCreatedParameterizedVarcharUnicode()
-    {
-        unicodeVarcharDateTypeTest().execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar_unicode"));
-    }
-
-    @Test
-    public void testPrestoCreatedParameterizedCharUnicode()
-    {
-        unicodeDataTypeTest(DataType::charDataType).execute(getQueryRunner(), prestoCreateAsSelect("postgresql_test_parameterized_char_unicode"));
-    }
-
-    @Test
-    public void testPostgreSqlCreatedParameterizedCharUnicode()
-    {
-        unicodeDataTypeTest(DataType::charDataType).execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_parameterized_char_unicode"));
-    }
-
-    private DataTypeTest unicodeVarcharDateTypeTest()
-    {
-        return unicodeDataTypeTest(DataType::varcharDataType).addRoundTrip(varcharDataType(), "\u041d\u0443, \u043f\u043e\u0433\u043e\u0434\u0438!");
-    }
-
-    private DataTypeTest unicodeDataTypeTest(Function<Integer, DataType<String>> dataTypeFactory)
-    {
-        String sampleUnicodeText = "\u653b\u6bbb\u6a5f\u52d5\u968a";
-        String sampleFourByteUnicodeCharacter = "\uD83D\uDE02";
-
-        return DataTypeTest.create()
-                .addRoundTrip(dataTypeFactory.apply(sampleUnicodeText.length()), sampleUnicodeText)
-                .addRoundTrip(dataTypeFactory.apply(32), sampleUnicodeText)
-                .addRoundTrip(dataTypeFactory.apply(20000), sampleUnicodeText)
-                .addRoundTrip(dataTypeFactory.apply(1), sampleFourByteUnicodeCharacter);
-    }
-
-    private DataSetup prestoCreateAsSelect(String tableNamePrefix)
-    {
-        return new CreateAsSelectDataSetup(new PrestoSqlExecutor(getQueryRunner()), tableNamePrefix);
-    }
-
-    private DataSetup postgresCreateAndInsert(String tableNamePrefix)
-    {
-        return new CreateAndInsertDataSetup(new JdbcSqlExecutor(postgreSqlServer.getJdbcUrl()), tableNamePrefix);
-    }
-
-    private void execute(String sql)
-            throws SQLException
-    {
-        try (Connection connection = DriverManager.getConnection(postgreSqlServer.getJdbcUrl());
-                Statement statement = connection.createStatement()) {
-            statement.execute(sql);
-        }
     }
 }

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -28,6 +28,12 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.function.Function;
 
+import static com.facebook.presto.tests.datatype.DataType.bigintDataType;
+import static com.facebook.presto.tests.datatype.DataType.charDataType;
+import static com.facebook.presto.tests.datatype.DataType.doubleDataType;
+import static com.facebook.presto.tests.datatype.DataType.integerDataType;
+import static com.facebook.presto.tests.datatype.DataType.realDataType;
+import static com.facebook.presto.tests.datatype.DataType.smallintDataType;
 import static com.facebook.presto.tests.datatype.DataType.varcharDataType;
 import static io.airlift.tpch.TpchTable.ORDERS;
 import static org.testng.Assert.assertFalse;
@@ -78,6 +84,20 @@ public class TestPostgreSqlIntegrationSmokeTest
         assertUpdate("INSERT INTO test_insert VALUES (123, 'test')", 1);
         assertQuery("SELECT * FROM test_insert", "SELECT 123 x, 'test' y");
         assertUpdate("DROP TABLE test_insert");
+    }
+
+    @Test
+    public void testInsertTypes()
+    {
+        DataTypeTest.create()
+                .addRoundTrip(varcharDataType(), "hello world")
+                .addRoundTrip(charDataType(20), "hello world")
+                .addRoundTrip(bigintDataType(), 123_456_789_012L)
+                .addRoundTrip(integerDataType(), 1_234_567_890)
+                .addRoundTrip(smallintDataType(), (short) 32_456)
+                .addRoundTrip(doubleDataType(), 123.45d)
+                .addRoundTrip(realDataType(), 123.45f)
+                .execute(getQueryRunner(), prestoCreateAsSelect("test_insert_types"));
     }
 
     @Test

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -14,17 +14,23 @@
 package com.facebook.presto.plugin.postgresql;
 
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.facebook.presto.tests.datatype.CreateAndInsertDataSetup;
+import com.facebook.presto.tests.datatype.CreateAsSelectDataSetup;
+import com.facebook.presto.tests.datatype.DataSetup;
+import com.facebook.presto.tests.datatype.DataType;
+import com.facebook.presto.tests.datatype.DataTypeTest;
+import com.facebook.presto.tests.sql.JdbcSqlExecutor;
+import com.facebook.presto.tests.sql.PrestoSqlExecutor;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.util.function.Function;
 
+import static com.facebook.presto.tests.datatype.DataType.varcharDataType;
 import static io.airlift.tpch.TpchTable.ORDERS;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 @Test
@@ -55,6 +61,16 @@ public class TestPostgreSqlIntegrationSmokeTest
     }
 
     @Test
+    public void testDropTable()
+    {
+        assertUpdate("CREATE TABLE test_drop AS SELECT 123 x", 1);
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_drop"));
+
+        assertUpdate("DROP TABLE test_drop");
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop"));
+    }
+
+    @Test
     public void testInsert()
             throws Exception
     {
@@ -62,6 +78,16 @@ public class TestPostgreSqlIntegrationSmokeTest
         assertUpdate("INSERT INTO test_insert VALUES (123, 'test')", 1);
         assertQuery("SELECT * FROM test_insert", "SELECT 123 x, 'test' y");
         assertUpdate("DROP TABLE test_insert");
+    }
+
+    @Test
+    public void testViews()
+            throws Exception
+    {
+        execute("CREATE OR REPLACE VIEW tpch.test_view AS SELECT * FROM tpch.orders");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_view"));
+        assertQuery("SELECT orderkey FROM test_view", "SELECT orderkey FROM orders");
+        execute("DROP VIEW IF EXISTS tpch.test_view");
     }
 
     @Test
@@ -86,12 +112,87 @@ public class TestPostgreSqlIntegrationSmokeTest
         execute("DROP SERVER devnull");
     }
 
-    private void execute(String sql)
-            throws SQLException
+    @Test
+    public void testPrestoCreatedParameterizedVarchar()
     {
-        try (Connection connection = DriverManager.getConnection(postgreSqlServer.getJdbcUrl());
-                Statement statement = connection.createStatement()) {
-            statement.execute(sql);
-        }
+        varcharDataTypeTest().execute(getQueryRunner(), prestoCreateAsSelect("presto_test_parameterized_varchar"));
+    }
+
+    @Test
+    public void testPostgreSqlCreatedParameterizedVarchar()
+    {
+        varcharDataTypeTest().execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar"));
+    }
+
+    private static DataTypeTest varcharDataTypeTest()
+    {
+        return DataTypeTest.create()
+                .addRoundTrip(varcharDataType(10), "text_a")
+                .addRoundTrip(varcharDataType(255), "text_b")
+                .addRoundTrip(varcharDataType(65535), "text_d")
+                .addRoundTrip(varcharDataType(10485760), "text_f")
+                .addRoundTrip(varcharDataType(), "unbounded");
+    }
+
+    @Test
+    public void testPrestoCreatedParameterizedVarcharUnicode()
+    {
+        unicodeVarcharDateTypeTest().execute(getQueryRunner(), prestoCreateAsSelect("postgresql_test_parameterized_varchar_unicode"));
+    }
+
+    @Test
+    public void testPostgreSqlCreatedParameterizedVarcharUnicode()
+    {
+        unicodeVarcharDateTypeTest().execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_parameterized_varchar_unicode"));
+    }
+
+    @Test
+    public void testPrestoCreatedParameterizedCharUnicode()
+    {
+        unicodeDataTypeTest(DataType::charDataType).execute(getQueryRunner(), prestoCreateAsSelect("postgresql_test_parameterized_char_unicode"));
+    }
+
+    @Test
+    public void testPostgreSqlCreatedParameterizedCharUnicode()
+    {
+        unicodeDataTypeTest(DataType::charDataType).execute(getQueryRunner(), postgresCreateAndInsert("tpch.postgresql_test_parameterized_char_unicode"));
+    }
+
+    private static DataTypeTest unicodeVarcharDateTypeTest()
+    {
+        return unicodeDataTypeTest(DataType::varcharDataType)
+                .addRoundTrip(varcharDataType(), "\u041d\u0443, \u043f\u043e\u0433\u043e\u0434\u0438!");
+    }
+
+    private static DataTypeTest unicodeDataTypeTest(Function<Integer, DataType<String>> dataTypeFactory)
+    {
+        String sampleUnicodeText = "\u653b\u6bbb\u6a5f\u52d5\u968a";
+        String sampleFourByteUnicodeCharacter = "\uD83D\uDE02";
+
+        return DataTypeTest.create()
+                .addRoundTrip(dataTypeFactory.apply(sampleUnicodeText.length()), sampleUnicodeText)
+                .addRoundTrip(dataTypeFactory.apply(32), sampleUnicodeText)
+                .addRoundTrip(dataTypeFactory.apply(20000), sampleUnicodeText)
+                .addRoundTrip(dataTypeFactory.apply(1), sampleFourByteUnicodeCharacter);
+    }
+
+    private DataSetup prestoCreateAsSelect(String tableNamePrefix)
+    {
+        return new CreateAsSelectDataSetup(new PrestoSqlExecutor(getQueryRunner()), tableNamePrefix);
+    }
+
+    private DataSetup postgresCreateAndInsert(String tableNamePrefix)
+    {
+        return new CreateAndInsertDataSetup(postgresExecutor(), tableNamePrefix);
+    }
+
+    private void execute(String sql)
+    {
+        postgresExecutor().execute(sql);
+    }
+
+    private JdbcSqlExecutor postgresExecutor()
+    {
+        return new JdbcSqlExecutor(postgreSqlServer.getJdbcUrl());
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataType.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataType.java
@@ -111,9 +111,14 @@ public class DataType<T>
         return dataType(insertType, createCharType(length), DataType::quote, input -> padEnd(input, length, ' '));
     }
 
-    private static String quote(String value)
+    public static String quote(String value)
     {
-        return "'" + value + "'";
+        return "'" + value.replace("'", "''") + "'";
+    }
+
+    public static String quotedString(Object value)
+    {
+        return quote(String.valueOf(value));
     }
 
     public static <T> DataType<T> dataType(String insertType, Type prestoResultType)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataType.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataType.java
@@ -13,6 +13,12 @@
  */
 package com.facebook.presto.tests.datatype;
 
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.SmallintType;
+import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 
@@ -30,6 +36,36 @@ public class DataType<T>
     private Type prestoResultType;
     private Function<T, String> toLiteral;
     private Function<T, ?> toPrestoQueryResult;
+
+    public static DataType<Long> bigintDataType()
+    {
+        return dataType("bigint", BigintType.BIGINT);
+    }
+
+    public static DataType<Integer> integerDataType()
+    {
+        return dataType("integer", IntegerType.INTEGER);
+    }
+
+    public static DataType<Short> smallintDataType()
+    {
+        return dataType("smallint", SmallintType.SMALLINT);
+    }
+
+    public static DataType<Byte> tinyintDataType()
+    {
+        return dataType("tinyint", TinyintType.TINYINT);
+    }
+
+    public static DataType<Double> doubleDataType()
+    {
+        return dataType("double", DoubleType.DOUBLE);
+    }
+
+    public static DataType<Float> realDataType()
+    {
+        return dataType("real", RealType.REAL);
+    }
 
     public static DataType<String> varcharDataType(int size)
     {
@@ -78,6 +114,11 @@ public class DataType<T>
     private static String quote(String value)
     {
         return "'" + value + "'";
+    }
+
+    public static <T> DataType<T> dataType(String insertType, Type prestoResultType)
+    {
+        return new DataType<>(insertType, prestoResultType, Object::toString, Function.identity());
     }
 
     public static <T> DataType<T> dataType(String insertType, Type prestoResultType, Function<T, String> toLiteral, Function<T, ?> toPrestoQueryResult)


### PR DESCRIPTION
For both connectors, the data was inserted incorrectly. Additionally, for
MySQL, tables were created with the column type as double instead of real.