### PR TITLE
Add dedicated RowBlock 

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -20,7 +20,7 @@ import com.facebook.presto.hive.parquet.memory.AggregatedMemoryContext;
 import com.facebook.presto.hive.parquet.memory.LocalMemoryContext;
 import com.facebook.presto.spi.block.ArrayBlock;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.InterleavedBlock;
+import com.facebook.presto.spi.block.RowBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.NamedTypeSignature;
@@ -231,14 +231,13 @@ public class ParquetReader
             blocks[i] = readBlock(name, fieldType, path, new IntArrayList());
         }
 
-        InterleavedBlock interleavedBlock = new InterleavedBlock(blocks);
         int blockSize = blocks[0].getPositionCount();
         int[] offsets = new int[blockSize + 1];
         for (int i = 1; i < offsets.length; i++) {
             elementOffsets.add(parameters.size());
-            offsets[i] = i * parameters.size();
+            offsets[i] = i;
         }
-        return new ArrayBlock(blockSize, new boolean[blockSize], offsets, interleavedBlock);
+        return new RowBlock(0, blockSize, new boolean[blockSize], offsets, blocks);
     }
 
     public Block readPrimitive(ColumnDescriptor columnDescriptor, Type type)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/SerDeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/SerDeUtils.java
@@ -16,7 +16,6 @@ package com.facebook.presto.hive.util;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.InterleavedBlockBuilder;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.CharType;
@@ -252,25 +251,25 @@ public final class SerDeUtils
         List<? extends StructField> allStructFieldRefs = inspector.getAllStructFieldRefs();
         checkArgument(typeParameters.size() == allStructFieldRefs.size());
         BlockBuilder currentBuilder;
-        if (builder != null) {
-            currentBuilder = builder.beginBlockEntry();
+
+        boolean builderSynthesized = false;
+        if (builder == null) {
+            builderSynthesized = true;
+            builder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
         }
-        else {
-            currentBuilder = new InterleavedBlockBuilder(typeParameters, new BlockBuilderStatus(), typeParameters.size());
-        }
+        currentBuilder = builder.beginBlockEntry();
 
         for (int i = 0; i < typeParameters.size(); i++) {
             StructField field = allStructFieldRefs.get(i);
             serializeObject(typeParameters.get(i), currentBuilder, inspector.getStructFieldData(object, field), field.getFieldObjectInspector());
         }
 
-        if (builder != null) {
-            builder.closeEntry();
-            return null;
+        builder.closeEntry();
+        if (builderSynthesized) {
+            return (Block) type.getObject(builder, 0);
         }
         else {
-            Block resultBlock = currentBuilder.build();
-            return resultBlock;
+            return null;
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/block/BlockEncodingManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/block/BlockEncodingManager.java
@@ -24,9 +24,11 @@ import com.facebook.presto.spi.block.IntArrayBlockEncoding;
 import com.facebook.presto.spi.block.InterleavedBlockEncoding;
 import com.facebook.presto.spi.block.LongArrayBlockEncoding;
 import com.facebook.presto.spi.block.MapBlockEncoding;
+import com.facebook.presto.spi.block.RowBlockEncoding;
 import com.facebook.presto.spi.block.RunLengthBlockEncoding;
 import com.facebook.presto.spi.block.ShortArrayBlockEncoding;
 import com.facebook.presto.spi.block.SingleMapBlockEncoding;
+import com.facebook.presto.spi.block.SingleRowBlockEncoding;
 import com.facebook.presto.spi.block.SliceArrayBlockEncoding;
 import com.facebook.presto.spi.block.VariableWidthBlockEncoding;
 import com.facebook.presto.spi.type.TypeManager;
@@ -75,6 +77,8 @@ public final class BlockEncodingManager
         addBlockEncodingFactory(InterleavedBlockEncoding.FACTORY);
         addBlockEncodingFactory(MapBlockEncoding.FACTORY);
         addBlockEncodingFactory(SingleMapBlockEncoding.FACTORY);
+        addBlockEncodingFactory(RowBlockEncoding.FACTORY);
+        addBlockEncodingFactory(SingleRowBlockEncoding.FACTORY);
         addBlockEncodingFactory(RunLengthBlockEncoding.FACTORY);
 
         for (BlockEncodingFactory<?> factory : requireNonNull(blockEncodingFactories, "blockEncodingFactories is null")) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
@@ -32,7 +32,6 @@ import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.InterleavedBlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.gen.CachedInstanceBinder;
@@ -59,7 +58,6 @@ import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.withVariadicBound;
 import static com.facebook.presto.spi.function.OperatorType.CAST;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.facebook.presto.sql.gen.BytecodeUtils.loadConstant;
 import static com.facebook.presto.sql.gen.InvokeFunctionBytecodeExpression.invokeFunction;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
@@ -121,18 +119,20 @@ public class RowToRowCast
 
         Variable wasNull = scope.declareVariable(boolean.class, "wasNull");
         Variable blockBuilder = scope.createTempVariable(BlockBuilder.class);
+        Variable singleRowBlockWriter = scope.createTempVariable(BlockBuilder.class);
 
         body.append(wasNull.set(constantBoolean(false)));
 
         CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(definition, binder);
 
-        // create the interleave block builder
+        // create the row block builder
         body.append(blockBuilder.set(
-                newInstance(
-                        InterleavedBlockBuilder.class,
-                        loadConstant(binder.bind(toType.getTypeParameters(), List.class)),
+                constantType(binder, toType).invoke(
+                        "createBlockBuilder",
+                        BlockBuilder.class,
                         newInstance(BlockBuilderStatus.class),
-                        constantInt(toTypes.size()))));
+                        constantInt(1))));
+        body.append(singleRowBlockWriter.set(blockBuilder.invoke("beginBlockEntry", BlockBuilder.class)));
 
         // loop through to append member blocks
         for (int i = 0; i < toTypes.size(); i++) {
@@ -143,7 +143,7 @@ public class RowToRowCast
             ScalarFunctionImplementation function = functionRegistry.getScalarFunctionImplementation(signature);
             Type currentFromType = fromTypes.get(i);
             if (currentFromType.equals(UNKNOWN)) {
-                body.append(blockBuilder.invoke("appendNull", BlockBuilder.class).pop());
+                body.append(singleRowBlockWriter.invoke("appendNull", BlockBuilder.class).pop());
                 continue;
             }
             BytecodeExpression fromElement = constantType(binder, currentFromType).getValue(value, constantInt(i));
@@ -151,15 +151,18 @@ public class RowToRowCast
             IfStatement ifElementNull = new IfStatement("if the element in the row type is null...");
 
             ifElementNull.condition(value.invoke("isNull", boolean.class, constantInt(i)))
-                    .ifTrue(blockBuilder.invoke("appendNull", BlockBuilder.class).pop())
-                    .ifFalse(constantType(binder, toTypes.get(i)).writeValue(blockBuilder, toElement));
+                    .ifTrue(singleRowBlockWriter.invoke("appendNull", BlockBuilder.class).pop())
+                    .ifFalse(constantType(binder, toTypes.get(i)).writeValue(singleRowBlockWriter, toElement));
 
             body.append(ifElementNull);
         }
 
-        // call blockBuilder.build()
-        body.append(blockBuilder.invoke("build", Block.class))
-                .retObject();
+        // call blockBuilder.closeEntry() and return the single row block
+        body.append(blockBuilder.invoke("closeEntry", BlockBuilder.class).pop());
+        body.append(constantType(binder, toType)
+                .invoke("getObject", Object.class, blockBuilder.cast(Block.class), constantInt(0))
+                .cast(Block.class)
+                .ret());
 
         // create constructor
         MethodDefinition constructorDefinition = definition.declareConstructor(a(PUBLIC));

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.block;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.RowBlockBuilder;
+import com.facebook.presto.spi.block.SingleRowBlock;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestRowBlock
+        extends AbstractTestBlock
+{
+    @Test
+    void testWithVarcharBigint()
+    {
+        List<Type> fieldTypes = ImmutableList.of(VARCHAR, BIGINT);
+        List<Object>[] testRows = generateTestRows(fieldTypes, 100);
+
+        testWith(fieldTypes, testRows);
+        testWith(fieldTypes, (List<Object>[]) alternatingNullValues(testRows));
+    }
+
+    private void testWith(List<Type> fieldTypes, List<Object>[] expectedValues)
+    {
+        BlockBuilder blockBuilder = createBlockBuilderWithValues(fieldTypes, expectedValues);
+
+        assertBlock(blockBuilder, expectedValues);
+        assertBlock(blockBuilder.build(), expectedValues);
+
+        List<Integer> positionList = generatePositionList(expectedValues.length, expectedValues.length / 2);
+        assertBlockFilteredPositions(expectedValues, blockBuilder, positionList);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), positionList);
+    }
+
+    private BlockBuilder createBlockBuilderWithValues(List<Type> fieldTypes, List<Object>[] rows)
+    {
+        BlockBuilder rowBlockBuilder = new RowBlockBuilder(fieldTypes, new BlockBuilderStatus(), 1);
+        for (List<Object> row : rows) {
+            if (row == null) {
+                rowBlockBuilder.appendNull();
+            }
+            else {
+                BlockBuilder singleRowBlockWriter = rowBlockBuilder.beginBlockEntry();
+                for (Object fieldValue : row) {
+                    if (fieldValue == null) {
+                        singleRowBlockWriter.appendNull();
+                    }
+                    else {
+                        if (fieldValue instanceof Long) {
+                            BIGINT.writeLong(singleRowBlockWriter, ((Long) fieldValue).longValue());
+                        }
+                        else if (fieldValue instanceof String) {
+                            VARCHAR.writeSlice(singleRowBlockWriter, utf8Slice((String) fieldValue));
+                        }
+                        else {
+                            throw new IllegalArgumentException();
+                        }
+                    }
+                }
+                rowBlockBuilder.closeEntry();
+            }
+        }
+
+        return rowBlockBuilder;
+    }
+
+    @Override
+    protected <T> void assertPositionValue(Block block, int position, T expectedValue)
+    {
+        if (expectedValue instanceof List) {
+            assertValue(block, position, (List<Object>) expectedValue);
+            return;
+        }
+        super.assertPositionValue(block, position, expectedValue);
+    }
+
+    private void assertValue(Block rowBlock, int position, List<Object> row)
+    {
+        // null rows are handled by assertPositionValue
+        requireNonNull(row, "row is null");
+
+        assertFalse(rowBlock.isNull(position));
+        SingleRowBlock singleRowBlock = (SingleRowBlock) rowBlock.getObject(position, Block.class);
+        assertEquals(singleRowBlock.getPositionCount(), row.size());
+
+        for (int i = 0; i < row.size(); i++) {
+            Object fieldValue = row.get(i);
+            if (fieldValue == null) {
+                assertTrue(singleRowBlock.isNull(i));
+            }
+            else {
+                if (fieldValue instanceof Long) {
+                    assertEquals(BIGINT.getLong(singleRowBlock, i), ((Long) fieldValue).longValue());
+                }
+                else if (fieldValue instanceof String) {
+                    assertEquals(VARCHAR.getSlice(singleRowBlock, i), utf8Slice((String) fieldValue));
+                }
+                else {
+                    throw new IllegalArgumentException();
+                }
+            }
+        }
+    }
+
+    private List<Object>[] generateTestRows(List<Type> fieldTypes, int numRows)
+    {
+        List<Object>[] testRows = new List[numRows];
+        for (int i = 0; i < numRows; i++) {
+            List<Object> testRow = new ArrayList<>(fieldTypes.size());
+            for (int j = 0; j < fieldTypes.size(); j++) {
+                int cellId = i * fieldTypes.size() + j;
+                if (cellId % 7 == 3) {
+                    // Put null value for every 7 cells
+                    testRow.add(null);
+                }
+                else {
+                    if (fieldTypes.get(j) == BIGINT) {
+                        testRow.add(i * 100L + j);
+                    }
+                    else if (fieldTypes.get(j) == VARCHAR) {
+                        testRow.add(format("field(%s, %s)", i, j));
+                    }
+                    else {
+                        throw new IllegalArgumentException();
+                    }
+                }
+            }
+        }
+        return testRows;
+    }
+
+    private List<Integer> generatePositionList(int numRows, int numPositions)
+    {
+        List<Integer> positions = new ArrayList<>(numPositions);
+        for (int i = 0; i < numPositions; i++) {
+            positions.add((7 * i + 3) % numRows);
+        }
+        Collections.sort(positions);
+        return positions;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
@@ -13,10 +13,10 @@
  */
 package com.facebook.presto.type;
 
-import com.facebook.presto.spi.block.ArrayBlockBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.SingleArrayBlockWriter;
+import com.facebook.presto.spi.block.RowBlockBuilder;
+import com.facebook.presto.spi.block.SingleRowBlockWriter;
 import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
@@ -38,23 +38,23 @@ public class TestSimpleRowType
 
     private static Block createTestBlock()
     {
-        ArrayBlockBuilder blockBuilder = (ArrayBlockBuilder) TYPE.createBlockBuilder(new BlockBuilderStatus(), 3);
+        RowBlockBuilder blockBuilder = (RowBlockBuilder) TYPE.createBlockBuilder(new BlockBuilderStatus(), 3);
 
-        SingleArrayBlockWriter singleArrayBlockWriter;
+        SingleRowBlockWriter singleRowBlockWriter;
 
-        singleArrayBlockWriter = blockBuilder.beginBlockEntry();
-        BIGINT.writeLong(singleArrayBlockWriter, 1);
-        VARCHAR.writeSlice(singleArrayBlockWriter, utf8Slice("cat"));
+        singleRowBlockWriter = blockBuilder.beginBlockEntry();
+        BIGINT.writeLong(singleRowBlockWriter, 1);
+        VARCHAR.writeSlice(singleRowBlockWriter, utf8Slice("cat"));
         blockBuilder.closeEntry();
 
-        singleArrayBlockWriter = blockBuilder.beginBlockEntry();
-        BIGINT.writeLong(singleArrayBlockWriter, 2);
-        VARCHAR.writeSlice(singleArrayBlockWriter, utf8Slice("cats"));
+        singleRowBlockWriter = blockBuilder.beginBlockEntry();
+        BIGINT.writeLong(singleRowBlockWriter, 2);
+        VARCHAR.writeSlice(singleRowBlockWriter, utf8Slice("cats"));
         blockBuilder.closeEntry();
 
-        singleArrayBlockWriter = blockBuilder.beginBlockEntry();
-        BIGINT.writeLong(singleArrayBlockWriter, 3);
-        VARCHAR.writeSlice(singleArrayBlockWriter, utf8Slice("dog"));
+        singleRowBlockWriter = blockBuilder.beginBlockEntry();
+        BIGINT.writeLong(singleRowBlockWriter, 3);
+        VARCHAR.writeSlice(singleRowBlockWriter, utf8Slice("dog"));
         blockBuilder.closeEntry();
 
         return blockBuilder.build();
@@ -63,13 +63,13 @@ public class TestSimpleRowType
     @Override
     protected Object getGreaterValue(Object value)
     {
-        ArrayBlockBuilder blockBuilder = (ArrayBlockBuilder) TYPE.createBlockBuilder(new BlockBuilderStatus(), 1);
-        SingleArrayBlockWriter singleArrayBlockWriter;
+        RowBlockBuilder blockBuilder = (RowBlockBuilder) TYPE.createBlockBuilder(new BlockBuilderStatus(), 1);
+        SingleRowBlockWriter singleRowBlockWriter;
 
         Block block = (Block) value;
-        singleArrayBlockWriter = blockBuilder.beginBlockEntry();
-        BIGINT.writeLong(singleArrayBlockWriter, block.getSingleValueBlock(0).getLong(0, 0) + 1);
-        VARCHAR.writeSlice(singleArrayBlockWriter, block.getSingleValueBlock(1).getSlice(0, 0, 1));
+        singleRowBlockWriter = blockBuilder.beginBlockEntry();
+        BIGINT.writeLong(singleRowBlockWriter, block.getSingleValueBlock(0).getLong(0, 0) + 1);
+        VARCHAR.writeSlice(singleRowBlockWriter, block.getSingleValueBlock(1).getSlice(0, 0, 1));
         blockBuilder.closeEntry();
 
         return TYPE.getObject(blockBuilder.build(), 0);

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoPageSource.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoPageSource.java
@@ -19,8 +19,6 @@ import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.InterleavedBlockBuilder;
 import com.facebook.presto.spi.type.NamedTypeSignature;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
@@ -278,16 +276,6 @@ public class MongoPageSource
 
         // not a convertible value
         output.appendNull();
-    }
-
-    private BlockBuilder createParametersBlockBuilder(Type type, int size)
-    {
-        List<Type> params = type.getTypeParameters();
-        if (isArrayType(type)) {
-            return params.get(0).createBlockBuilder(new BlockBuilderStatus(), size);
-        }
-
-        return new InterleavedBlockBuilder(params, new BlockBuilderStatus(), size * params.size());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class AbstractRowBlock
+        implements Block
+{
+    protected final int numFields;
+
+    protected abstract Block[] getFieldBlocks();
+
+    protected abstract int[] getFieldBlockOffsets();
+
+    protected abstract int getOffsetBase();
+
+    protected abstract boolean[] getRowIsNull();
+
+    // the offset in each field block, it can also be viewed as the "entry-based" offset in the RowBlock
+    protected int getFieldBlockOffset(int position)
+    {
+        return getFieldBlockOffsets()[position + getOffsetBase()];
+    }
+
+    protected AbstractRowBlock(int numFields)
+    {
+        if (numFields <= 0) {
+            throw new IllegalArgumentException("Number of fields in RowBlock must be positive");
+        }
+        this.numFields = numFields;
+    }
+
+    @Override
+    public RowBlockEncoding getEncoding()
+    {
+        BlockEncoding[] fieldBlockEncodings = new BlockEncoding[numFields];
+        for (int i = 0; i < numFields; i++) {
+            fieldBlockEncodings[i] = getFieldBlocks()[i].getEncoding();
+        }
+        return new RowBlockEncoding(fieldBlockEncodings);
+    }
+
+    @Override
+    public Block copyPositions(List<Integer> positions)
+    {
+        int newPositionCount = positions.size();
+        int[] newOffsets = new int[newPositionCount + 1];
+        boolean[] newRowIsNull = new boolean[newPositionCount];
+
+        List<Integer> fieldBlockPositions = new ArrayList<>(newPositionCount);
+        for (int i = 0; i < newPositionCount; i++) {
+            int position = positions.get(i);
+            if (isNull(position)) {
+                newRowIsNull[i] = true;
+                newOffsets[i + 1] = newOffsets[i];
+            }
+            else {
+                newOffsets[i + 1] = newOffsets[i] + 1;
+                fieldBlockPositions.add(getFieldBlockOffset(position));
+            }
+        }
+
+        Block[] newBlocks = new Block[numFields];
+        for (int i = 0; i < numFields; i++) {
+            newBlocks[i] = getFieldBlocks()[i].copyPositions(fieldBlockPositions);
+        }
+        return new RowBlock(0, positions.size(), newRowIsNull, newOffsets, newBlocks);
+    }
+
+    @Override
+    public Block getRegion(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        if (position < 0 || length < 0 || position + length > positionCount) {
+            throw new IndexOutOfBoundsException("Invalid position " + position + " in block with " + positionCount + " positions");
+        }
+
+        if (position == 0 && length == positionCount) {
+            return this;
+        }
+
+        return new RowBlock(position + getOffsetBase(), length, getRowIsNull(), getFieldBlockOffsets(), getFieldBlocks());
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        if (position < 0 || length < 0 || position + length > positionCount) {
+            throw new IndexOutOfBoundsException("Invalid position " + position + " in block with " + positionCount + " positions");
+        }
+
+        int startFieldBlockOffset = getFieldBlockOffset(position);
+        int endFieldBlockOffset = getFieldBlockOffset(position + length);
+        int fieldBlockLength = endFieldBlockOffset - startFieldBlockOffset;
+
+        long regionSizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) length;
+        for (int i = 0; i < numFields; i++) {
+            regionSizeInBytes += getFieldBlocks()[i].getRegionSizeInBytes(startFieldBlockOffset, fieldBlockLength);
+        }
+        return regionSizeInBytes;
+    }
+
+    @Override
+    public Block copyRegion(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        if (position < 0 || length < 0 || position + length > positionCount) {
+            throw new IndexOutOfBoundsException("Invalid position " + position + " in block with " + positionCount + " positions");
+        }
+
+        int startFieldBlockOffset = getFieldBlockOffset(position);
+        int endFieldBlockOffset = getFieldBlockOffset(position + length);
+        int fieldBlockLength = endFieldBlockOffset - startFieldBlockOffset;
+        Block[] newBlocks = new Block[numFields];
+        for (int i = 0; i < numFields; i++) {
+            newBlocks[i] = getFieldBlocks()[i].copyRegion(startFieldBlockOffset, fieldBlockLength);
+        }
+
+        int[] newOffsets = new int[length + 1];
+        for (int i = 1; i < newOffsets.length; i++) {
+            newOffsets[i] = getFieldBlockOffset(position + i) - startFieldBlockOffset;
+        }
+        boolean[] newRowIsNull = Arrays.copyOfRange(getRowIsNull(), position + getOffsetBase(), position + getOffsetBase() + length);
+        return new RowBlock(0, length, newRowIsNull, newOffsets, newBlocks);
+    }
+
+    @Override
+    public <T> T getObject(int position, Class<T> clazz)
+    {
+        if (clazz != Block.class) {
+            throw new IllegalArgumentException("clazz must be Block.class");
+        }
+        checkReadablePosition(position);
+
+        return clazz.cast(new SingleRowBlock(getFieldBlockOffset(position) * numFields, getFieldBlocks()));
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+        int fieldBlockOffset = getFieldBlockOffset(position);
+        for (int i = 0; i < numFields; i++) {
+            if (getFieldBlocks()[i].isNull(fieldBlockOffset)) {
+                entryBuilder.appendNull();
+            }
+            else {
+                getFieldBlocks()[i].writePositionTo(fieldBlockOffset, entryBuilder);
+                entryBuilder.closeEntry();
+            }
+        }
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+
+        int startFieldBlockOffset = getFieldBlockOffset(position);
+        int endFieldBlockOffset = getFieldBlockOffset(position + 1);
+        int fieldBlockLength = endFieldBlockOffset - startFieldBlockOffset;
+        Block[] newBlocks = new Block[numFields];
+        for (int i = 0; i < numFields; i++) {
+            newBlocks[i] = getFieldBlocks()[i].copyRegion(startFieldBlockOffset, fieldBlockLength);
+        }
+        boolean[] newRowIsNull = new boolean[] {isNull(position)};
+        int[] newOffsets = new int[] {0, fieldBlockLength};
+
+        return new RowBlock(0, 1, newRowIsNull, newOffsets, newBlocks);
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return getRowIsNull()[position + getOffsetBase()];
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.block;
+
+import io.airlift.slice.Slice;
+
+import java.util.List;
+
+public abstract class AbstractSingleRowBlock
+        implements Block
+{
+    // in AbstractSingleRowBlock, offset is position-based (consider as cell-based), not entry-based.
+    protected final int startOffset;
+
+    protected final int numFields;
+
+    protected abstract Block getFieldBlock(int fieldIndex);
+
+    protected AbstractSingleRowBlock(int startOffset, int numFields)
+    {
+        this.startOffset = startOffset;
+        this.numFields = numFields;
+    }
+
+    private int getAbsolutePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+        return position + startOffset;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).isNull(position / numFields);
+    }
+
+    @Override
+    public byte getByte(int position, int offset)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).getByte(position / numFields, offset);
+    }
+
+    @Override
+    public short getShort(int position, int offset)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).getShort(position / numFields, offset);
+    }
+
+    @Override
+    public int getInt(int position, int offset)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).getInt(position / numFields, offset);
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).getLong(position / numFields, offset);
+    }
+
+    @Override
+    public Slice getSlice(int position, int offset, int length)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).getSlice(position / numFields, offset, length);
+    }
+
+    @Override
+    public int getSliceLength(int position)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).getSliceLength(position / numFields);
+    }
+
+    @Override
+    public int compareTo(int position, int offset, int length, Block otherBlock, int otherPosition, int otherOffset, int otherLength)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).compareTo(position / numFields, offset, length, otherBlock, otherPosition, otherOffset, otherLength);
+    }
+
+    @Override
+    public boolean bytesEqual(int position, int offset, Slice otherSlice, int otherOffset, int length)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).bytesEqual(position / numFields, offset, otherSlice, otherOffset, length);
+    }
+
+    @Override
+    public int bytesCompare(int position, int offset, int length, Slice otherSlice, int otherOffset, int otherLength)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).bytesCompare(position / numFields, offset, length, otherSlice, otherOffset, otherLength);
+    }
+
+    @Override
+    public void writeBytesTo(int position, int offset, int length, BlockBuilder blockBuilder)
+    {
+        position = getAbsolutePosition(position);
+        getFieldBlock(position % numFields).writeBytesTo(position / numFields, offset, length, blockBuilder);
+    }
+
+    @Override
+    public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).equals(position / numFields, offset, otherBlock, otherPosition, otherOffset, length);
+    }
+
+    @Override
+    public long hash(int position, int offset, int length)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).hash(position / numFields, offset, length);
+    }
+
+    @Override
+    public <T> T getObject(int position, Class<T> clazz)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).getObject(position / numFields, clazz);
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        position = getAbsolutePosition(position);
+        getFieldBlock(position % numFields).writePositionTo(position / numFields, blockBuilder);
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        position = getAbsolutePosition(position);
+        return getFieldBlock(position % numFields).getSingleValueBlock(position / numFields);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Block copyPositions(List<Integer> positions)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Block copyRegion(int position, int length)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlock.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.function.BiConsumer;
+
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RowBlock
+        extends AbstractRowBlock
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(RowBlock.class).instanceSize();
+
+    private final int startOffset;
+    private final int positionCount;
+
+    private final boolean[] rowIsNull;
+    private final int[] fieldBlockOffsets;
+    private final Block[] fieldBlocks;
+
+    private volatile long sizeInBytes;
+    private final long retainedSizeInBytes;
+
+    public RowBlock(int startOffset, int positionCount, boolean[] rowIsNull, int[] fieldBlockOffsets, Block[] fieldBlocks)
+    {
+        super(fieldBlocks.length);
+
+        this.startOffset = startOffset;
+        this.positionCount = positionCount;
+        this.rowIsNull = requireNonNull(rowIsNull, "rowIsNull is null");
+        this.fieldBlockOffsets = requireNonNull(fieldBlockOffsets, "fieldBlockOffsets is null");
+        this.fieldBlocks = requireNonNull(fieldBlocks, "fieldBlocks is null");
+        int firstFieldBlockPositionCount = fieldBlocks[0].getPositionCount();
+        for (int i = 1; i < fieldBlocks.length; i++) {
+            if (firstFieldBlockPositionCount != fieldBlocks[i].getPositionCount()) {
+                throw new IllegalArgumentException(format("length of field blocks differ: field 0: %s, block %s: %s", firstFieldBlockPositionCount, i, fieldBlocks[i].getPositionCount()));
+            }
+        }
+
+        this.sizeInBytes = -1;
+        long retainedSizeInBytes = INSTANCE_SIZE + sizeOf(fieldBlockOffsets) + sizeOf(rowIsNull);
+        for (Block fieldBlock : fieldBlocks) {
+            retainedSizeInBytes += fieldBlock.getRetainedSizeInBytes();
+        }
+        this.retainedSizeInBytes = retainedSizeInBytes;
+    }
+
+    @Override
+    protected Block[] getFieldBlocks()
+    {
+        return fieldBlocks;
+    }
+
+    @Override
+    protected int[] getFieldBlockOffsets()
+    {
+        return fieldBlockOffsets;
+    }
+
+    @Override
+    protected int getOffsetBase()
+    {
+        return startOffset;
+    }
+
+    @Override
+    protected boolean[] getRowIsNull()
+    {
+        return rowIsNull;
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        if (sizeInBytes < 0) {
+            calculateSize();
+        }
+        return sizeInBytes;
+    }
+
+    private void calculateSize()
+    {
+        int startFieldBlockOffset = fieldBlockOffsets[startOffset];
+        int endFieldBlockOffset = fieldBlockOffsets[startOffset + positionCount];
+        int fieldBlockLength = endFieldBlockOffset - startFieldBlockOffset;
+
+        long sizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) positionCount;
+        for (int i = 0; i < numFields; i++) {
+            sizeInBytes += fieldBlocks[i].getRegionSizeInBytes(startFieldBlockOffset, fieldBlockLength);
+        }
+        this.sizeInBytes = sizeInBytes;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        for (int i = 0; i < numFields; i++) {
+            consumer.accept(fieldBlocks[i], fieldBlocks[i].getRetainedSizeInBytes());
+        }
+        consumer.accept(fieldBlockOffsets, sizeOf(fieldBlockOffsets));
+        consumer.accept(rowIsNull, sizeOf(rowIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("RowBlock{numFields=%d, positionCount=%d}", numFields, getPositionCount());
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RowBlockBuilder
+        extends AbstractRowBlock
+        implements BlockBuilder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(RowBlockBuilder.class).instanceSize();
+
+    @Nullable
+    private final BlockBuilderStatus blockBuilderStatus;
+
+    private int positionCount;
+    private int[] fieldBlockOffsets;
+    private boolean[] rowIsNull;
+    private final BlockBuilder[] fieldBlockBuilders;
+
+    private boolean currentEntryOpened;
+
+    public RowBlockBuilder(List<Type> fieldTypes, BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        this(
+                blockBuilderStatus,
+                fieldTypes.stream()
+                        .map(type -> type.createBlockBuilder(blockBuilderStatus, expectedEntries))
+                        .toArray(BlockBuilder[]::new),
+                new int[expectedEntries + 1],
+                new boolean[expectedEntries]);
+    }
+
+    private RowBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, BlockBuilder[] fieldBlockBuilders, int[] fieldBlockOffsets, boolean[] rowIsNull)
+    {
+        super(fieldBlockBuilders.length);
+
+        this.blockBuilderStatus = blockBuilderStatus;
+        this.positionCount = 0;
+        this.fieldBlockOffsets = requireNonNull(fieldBlockOffsets, "fieldBlockOffsets is null");
+        this.rowIsNull = requireNonNull(rowIsNull, "rowIsNull is null");
+        this.fieldBlockBuilders = requireNonNull(fieldBlockBuilders, "fieldBlockBuilders is null");
+    }
+
+    @Override
+    protected Block[] getFieldBlocks()
+    {
+        return fieldBlockBuilders;
+    }
+
+    @Override
+    protected int[] getFieldBlockOffsets()
+    {
+        return fieldBlockOffsets;
+    }
+
+    @Override
+    protected int getOffsetBase()
+    {
+        return 0;
+    }
+
+    @Override
+    protected boolean[] getRowIsNull()
+    {
+        return rowIsNull;
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        long sizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) positionCount;
+        for (int i = 0; i < numFields; i++) {
+            sizeInBytes += fieldBlockBuilders[i].getSizeInBytes();
+        }
+        return sizeInBytes;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        long size = INSTANCE_SIZE + sizeOf(fieldBlockOffsets) + sizeOf(rowIsNull);
+        for (int i = 0; i < numFields; i++) {
+            size += fieldBlockBuilders[i].getRetainedSizeInBytes();
+        }
+        if (blockBuilderStatus != null) {
+            size += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+        return size;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        for (int i = 0; i < numFields; i++) {
+            consumer.accept(fieldBlockBuilders[i], fieldBlockBuilders[i].getRetainedSizeInBytes());
+        }
+        consumer.accept(fieldBlockOffsets, sizeOf(fieldBlockOffsets));
+        consumer.accept(rowIsNull, sizeOf(rowIsNull));
+        consumer.accept(this, (long) INSTANCE_SIZE);
+    }
+
+    @Override
+    public SingleRowBlockWriter beginBlockEntry()
+    {
+        if (currentEntryOpened) {
+            throw new IllegalStateException("Expected current entry to be closed but was opened");
+        }
+        currentEntryOpened = true;
+        return new SingleRowBlockWriter(fieldBlockBuilders[0].getPositionCount() * numFields, fieldBlockBuilders);
+    }
+
+    @Override
+    public BlockBuilder closeEntry()
+    {
+        if (!currentEntryOpened) {
+            throw new IllegalStateException("Expected entry to be opened but was closed");
+        }
+
+        entryAdded(false);
+        currentEntryOpened = false;
+        return this;
+    }
+
+    @Override
+    public BlockBuilder appendNull()
+    {
+        if (currentEntryOpened) {
+            throw new IllegalStateException("Current entry must be closed before a null can be written");
+        }
+
+        entryAdded(true);
+        return this;
+    }
+
+    private void entryAdded(boolean isNull)
+    {
+        if (rowIsNull.length <= positionCount) {
+            int newSize = BlockUtil.calculateNewArraySize(rowIsNull.length);
+            rowIsNull = Arrays.copyOf(rowIsNull, newSize);
+            fieldBlockOffsets = Arrays.copyOf(fieldBlockOffsets, newSize + 1);
+        }
+
+        if (isNull) {
+            fieldBlockOffsets[positionCount + 1] = fieldBlockOffsets[positionCount];
+        }
+        else {
+            fieldBlockOffsets[positionCount + 1] = fieldBlockOffsets[positionCount] + 1;
+        }
+        rowIsNull[positionCount] = isNull;
+        positionCount++;
+
+        for (int i = 0; i < numFields; i++) {
+            if (fieldBlockBuilders[i].getPositionCount() != fieldBlockOffsets[positionCount]) {
+                throw new IllegalStateException(format("field %s has unexpected position count. Expected: %s, actual: %s", i, fieldBlockOffsets[positionCount], fieldBlockBuilders[i].getPositionCount()));
+            }
+        }
+
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Integer.BYTES + Byte.BYTES);
+        }
+    }
+
+    @Override
+    public Block build()
+    {
+        if (currentEntryOpened) {
+            throw new IllegalStateException("Current entry must be closed before the block can be built");
+        }
+        Block[] fieldBlocks = new Block[numFields];
+        for (int i = 0; i < numFields; i++) {
+            fieldBlocks[i] = fieldBlockBuilders[i].build();
+        }
+        return new RowBlock(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("RowBlockBuilder{numFields=%d, positionCount=%d", numFields, getPositionCount());
+    }
+
+    @Override
+    public BlockBuilder writeObject(Object value)
+    {
+        if (currentEntryOpened) {
+            throw new IllegalStateException("Expected current entry to be closed but was opened");
+        }
+        currentEntryOpened = true;
+
+        Block block = (Block) value;
+        int blockPositionCount = block.getPositionCount();
+        if (blockPositionCount != numFields) {
+            throw new IllegalArgumentException(format("block position count (%s) is not equal to number of fields (%s)", blockPositionCount, numFields));
+        }
+        for (int i = 0; i < blockPositionCount; i++) {
+            if (block.isNull(i)) {
+                fieldBlockBuilders[i].appendNull();
+            }
+            else {
+                block.writePositionTo(i, fieldBlockBuilders[i]);
+                fieldBlockBuilders[i].closeEntry();
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        int newSize = calculateBlockResetSize(getPositionCount());
+        BlockBuilder[] newBlockBuilders = new BlockBuilder[numFields];
+        for (int i = 0; i < numFields; i++) {
+            newBlockBuilders[i] = fieldBlockBuilders[i].newBlockBuilderLike(blockBuilderStatus);
+        }
+        return new RowBlockBuilder(blockBuilderStatus, newBlockBuilders, new int[newSize + 1], new boolean[newSize]);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.type.TypeManager;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static io.airlift.slice.Slices.wrappedIntArray;
+import static java.util.Objects.requireNonNull;
+
+public class RowBlockEncoding
+        implements BlockEncoding
+{
+    public static final BlockEncodingFactory<RowBlockEncoding> FACTORY = new RowBlockEncodingFactory();
+    private static final String NAME = "ROW";
+
+    private final BlockEncoding[] fieldBlockEncodings;
+
+    public RowBlockEncoding(BlockEncoding[] fieldBlockEncodings)
+    {
+        this.fieldBlockEncodings = requireNonNull(fieldBlockEncodings, "fieldBlockEncodings is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void writeBlock(SliceOutput sliceOutput, Block block)
+    {
+        AbstractRowBlock rowBlock = (AbstractRowBlock) block;
+
+        if (rowBlock.numFields != fieldBlockEncodings.length) {
+            throw new IllegalArgumentException(
+                    "argument block differs in length (" + rowBlock.numFields + ") with this encoding (" + fieldBlockEncodings.length + ")");
+        }
+
+        int positionCount = rowBlock.getPositionCount();
+
+        int offsetBase = rowBlock.getOffsetBase();
+        int[] fieldBlockOffsets = rowBlock.getFieldBlockOffsets();
+
+        int startFieldBlockOffset = fieldBlockOffsets[offsetBase];
+        int endFieldBlockOffset = fieldBlockOffsets[offsetBase + positionCount];
+        for (int i = 0; i < fieldBlockEncodings.length; i++) {
+            fieldBlockEncodings[i].writeBlock(sliceOutput, rowBlock.getFieldBlocks()[i].getRegion(startFieldBlockOffset, endFieldBlockOffset - startFieldBlockOffset));
+        }
+
+        sliceOutput.appendInt(positionCount);
+        for (int position = 0; position < positionCount + 1; position++) {
+            sliceOutput.writeInt(fieldBlockOffsets[offsetBase + position] - startFieldBlockOffset);
+        }
+        EncoderUtil.encodeNullsAsBits(sliceOutput, block);
+    }
+
+    @Override
+    public Block readBlock(SliceInput sliceInput)
+    {
+        Block[] fieldBlocks = new Block[fieldBlockEncodings.length];
+        for (int i = 0; i < fieldBlockEncodings.length; i++) {
+            fieldBlocks[i] = fieldBlockEncodings[i].readBlock(sliceInput);
+        }
+
+        int positionCount = sliceInput.readInt();
+        int[] fieldBlockOffsets = new int[positionCount + 1];
+        sliceInput.readBytes(wrappedIntArray(fieldBlockOffsets));
+        boolean[] rowIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
+        return new RowBlock(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
+    }
+
+    @Override
+    public BlockEncodingFactory getFactory()
+    {
+        return FACTORY;
+    }
+
+    public static class RowBlockEncodingFactory
+            implements BlockEncodingFactory<RowBlockEncoding>
+    {
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public RowBlockEncoding readEncoding(TypeManager typeManager, BlockEncodingSerde serde, SliceInput input)
+        {
+            int numFields = input.readInt();
+            BlockEncoding[] fieldBlockEncodings = new BlockEncoding[numFields];
+            for (int i = 0; i < numFields; i++) {
+                fieldBlockEncodings[i] = serde.readBlockEncoding(input);
+            }
+            return new RowBlockEncoding(fieldBlockEncodings);
+        }
+
+        @Override
+        public void writeEncoding(BlockEncodingSerde serde, SliceOutput output, RowBlockEncoding blockEncoding)
+        {
+            output.appendInt(blockEncoding.fieldBlockEncodings.length);
+            for (BlockEncoding fieldBlockEncoding : blockEncoding.fieldBlockEncodings) {
+                serde.writeBlockEncoding(output, fieldBlockEncoding);
+            }
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlock.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.block;
+
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.function.BiConsumer;
+
+import static java.lang.String.format;
+
+public class SingleRowBlock
+        extends AbstractSingleRowBlock
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleRowBlock.class).instanceSize();
+
+    private final Block[] fieldBlocks;
+
+    SingleRowBlock(int cellOffset, Block[] fieldBlocks)
+    {
+        super(cellOffset, fieldBlocks.length);
+        this.fieldBlocks = fieldBlocks;
+    }
+
+    @Override
+    protected Block getFieldBlock(int fieldIndex)
+    {
+        return fieldBlocks[fieldIndex];
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return numFields;
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        long sizeInBytes = 0;
+        for (int i = 0; i < numFields; i++) {
+            sizeInBytes += getFieldBlock(i).getSizeInBytes();
+        }
+        return sizeInBytes;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        long retainedSizeInBytes = INSTANCE_SIZE;
+        for (int i = 0; i < numFields; i++) {
+            retainedSizeInBytes += getFieldBlock(i).getRetainedSizeInBytes();
+        }
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        for (int i = 0; i < numFields; i++) {
+            consumer.accept(fieldBlocks[i], fieldBlocks[i].getRetainedSizeInBytes());
+        }
+        consumer.accept(this, (long) INSTANCE_SIZE);
+    }
+
+    @Override
+    public BlockEncoding getEncoding()
+    {
+        BlockEncoding[] fieldBlockEncodings = new BlockEncoding[numFields];
+        for (int i = 0; i < numFields; i++) {
+            fieldBlockEncodings[i] = fieldBlocks[i].getEncoding();
+        }
+        return new SingleRowBlockEncoding(fieldBlockEncodings);
+    }
+
+    public int getOffset()
+    {
+        return startOffset;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("SingleRowBlock{numFields=%d}", numFields);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockEncoding.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.type.TypeManager;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static java.util.Objects.requireNonNull;
+
+public class SingleRowBlockEncoding
+        implements BlockEncoding
+{
+    public static final BlockEncodingFactory<SingleRowBlockEncoding> FACTORY = new SingleRowBlockEncodingFactory();
+    private static final String NAME = "ROW_ELEMENT";
+
+    private final BlockEncoding[] fieldBlockEncodings;
+
+    public SingleRowBlockEncoding(BlockEncoding[] fieldBlockEncodings)
+    {
+        this.fieldBlockEncodings = requireNonNull(fieldBlockEncodings, "fieldBlockEncodings is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void writeBlock(SliceOutput sliceOutput, Block block)
+    {
+        SingleRowBlock singleRowBlock = (SingleRowBlock) block;
+        int fieldOffset = singleRowBlock.getOffset() / fieldBlockEncodings.length;
+        for (int i = 0; i < fieldBlockEncodings.length; i++) {
+            fieldBlockEncodings[i].writeBlock(sliceOutput, singleRowBlock.getFieldBlock(i).getRegion(fieldOffset, 1));
+        }
+    }
+
+    @Override
+    public Block readBlock(SliceInput sliceInput)
+    {
+        Block[] fieldBlocks = new Block[fieldBlockEncodings.length];
+        for (int i = 0; i < fieldBlocks.length; i++) {
+            fieldBlocks[i] = fieldBlockEncodings[i].readBlock(sliceInput);
+        }
+        return new SingleRowBlock(0, fieldBlocks);
+    }
+
+    @Override
+    public BlockEncodingFactory getFactory()
+    {
+        return FACTORY;
+    }
+
+    public static class SingleRowBlockEncodingFactory
+            implements BlockEncodingFactory<SingleRowBlockEncoding>
+    {
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public SingleRowBlockEncoding readEncoding(TypeManager typeManager, BlockEncodingSerde serde, SliceInput input)
+        {
+            int numFields = input.readInt();
+            BlockEncoding[] fieldBlockEncodings = new BlockEncoding[numFields];
+            for (int i = 0; i < numFields; i++) {
+                fieldBlockEncodings[i] = serde.readBlockEncoding(input);
+            }
+            return new SingleRowBlockEncoding(fieldBlockEncodings);
+        }
+
+        @Override
+        public void writeEncoding(BlockEncodingSerde serde, SliceOutput output, SingleRowBlockEncoding blockEncoding)
+        {
+            output.appendInt(blockEncoding.fieldBlockEncodings.length);
+            for (BlockEncoding fieldBlockEncoding : blockEncoding.fieldBlockEncodings) {
+                serde.writeBlockEncoding(output, fieldBlockEncoding);
+            }
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import io.airlift.slice.Slice;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.function.BiConsumer;
+
+import static java.lang.String.format;
+
+public class SingleRowBlockWriter
+        extends AbstractSingleRowBlock
+        implements BlockBuilder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleRowBlockWriter.class).instanceSize();
+
+    private final BlockBuilder[] fieldBlockBuilders;
+    private final long initialBlockBuilderSize;
+    private int positionsWritten;
+
+    private int currentFieldIndexToWrite;
+
+    SingleRowBlockWriter(int startOffset, BlockBuilder[] fieldBlockBuilders)
+    {
+        super(startOffset, fieldBlockBuilders.length);
+        this.fieldBlockBuilders = fieldBlockBuilders;
+        long initialBlockBuilderSize = 0;
+        for (int i = 0; i < fieldBlockBuilders.length; i++) {
+            initialBlockBuilderSize += fieldBlockBuilders[i].getSizeInBytes();
+        }
+        this.initialBlockBuilderSize = initialBlockBuilderSize;
+    }
+
+    @Override
+    protected Block getFieldBlock(int fieldIndex)
+    {
+        return fieldBlockBuilders[fieldIndex];
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        long currentBlockBuilderSize = 0;
+        for (int i = 0; i < numFields; i++) {
+            currentBlockBuilderSize += fieldBlockBuilders[i].getSizeInBytes();
+        }
+        return currentBlockBuilderSize - initialBlockBuilderSize;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        long size = INSTANCE_SIZE;
+        for (int i = 0; i < numFields; i++) {
+            size += fieldBlockBuilders[i].getRetainedSizeInBytes();
+        }
+        return size;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        for (int i = 0; i < numFields; i++) {
+            consumer.accept(fieldBlockBuilders[i], fieldBlockBuilders[i].getRetainedSizeInBytes());
+        }
+        consumer.accept(this, (long) INSTANCE_SIZE);
+    }
+
+    @Override
+    public BlockBuilder writeByte(int value)
+    {
+        checkFieldIndexToWrite();
+        fieldBlockBuilders[currentFieldIndexToWrite].writeByte(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeShort(int value)
+    {
+        checkFieldIndexToWrite();
+        fieldBlockBuilders[currentFieldIndexToWrite].writeShort(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeInt(int value)
+    {
+        checkFieldIndexToWrite();
+        fieldBlockBuilders[currentFieldIndexToWrite].writeInt(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeLong(long value)
+    {
+        checkFieldIndexToWrite();
+        fieldBlockBuilders[currentFieldIndexToWrite].writeLong(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeBytes(Slice source, int sourceIndex, int length)
+    {
+        checkFieldIndexToWrite();
+        fieldBlockBuilders[currentFieldIndexToWrite].writeBytes(source, sourceIndex, length);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeObject(Object value)
+    {
+        checkFieldIndexToWrite();
+        fieldBlockBuilders[currentFieldIndexToWrite].writeObject(value);
+        return this;
+    }
+
+    @Override
+    public BlockBuilder beginBlockEntry()
+    {
+        checkFieldIndexToWrite();
+        return fieldBlockBuilders[currentFieldIndexToWrite].beginBlockEntry();
+    }
+
+    @Override
+    public BlockBuilder appendNull()
+    {
+        checkFieldIndexToWrite();
+        fieldBlockBuilders[currentFieldIndexToWrite].appendNull();
+        entryAdded();
+        return this;
+    }
+
+    @Override
+    public BlockBuilder closeEntry()
+    {
+        checkFieldIndexToWrite();
+        fieldBlockBuilders[currentFieldIndexToWrite].closeEntry();
+        entryAdded();
+        return this;
+    }
+
+    private void entryAdded()
+    {
+        currentFieldIndexToWrite++;
+        positionsWritten++;
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionsWritten;
+    }
+
+    @Override
+    public BlockEncoding getEncoding()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Block build()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("RowBlock{SingleRowBlockWriter=%d, positionCount=%d", numFields, getPositionCount());
+    }
+
+    private void checkFieldIndexToWrite()
+    {
+        if (currentFieldIndexToWrite >= numFields) {
+            throw new IllegalStateException("currentFieldIndexToWrite is not valid");
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
@@ -16,11 +16,10 @@ package com.facebook.presto.spi.type;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.StandardErrorCode;
-import com.facebook.presto.spi.block.ArrayBlockBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
-import com.facebook.presto.spi.block.InterleavedBlockBuilder;
+import com.facebook.presto.spi.block.RowBlockBuilder;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -73,19 +72,13 @@ public class RowType
     @Override
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
-        return new ArrayBlockBuilder(
-                new InterleavedBlockBuilder(getTypeParameters(), blockBuilderStatus, expectedEntries * getTypeParameters().size(), expectedBytesPerEntry),
-                blockBuilderStatus,
-                expectedEntries);
+        return new RowBlockBuilder(getTypeParameters(), blockBuilderStatus, expectedEntries);
     }
 
     @Override
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
-        return new ArrayBlockBuilder(
-                new InterleavedBlockBuilder(getTypeParameters(), blockBuilderStatus, expectedEntries * getTypeParameters().size()),
-                blockBuilderStatus,
-                expectedEntries);
+        return new RowBlockBuilder(getTypeParameters(), blockBuilderStatus, expectedEntries);
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarRow.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarRow.java
@@ -136,9 +136,6 @@ public class TestColumnarRow
 
     private static BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
-        return new ArrayBlockBuilder(
-                new InterleavedBlockBuilder(Collections.nCopies(FIELD_COUNT, VARCHAR), blockBuilderStatus, expectedEntries * FIELD_COUNT, expectedBytesPerEntry),
-                blockBuilderStatus,
-                expectedEntries);
+        return new RowBlockBuilder(Collections.nCopies(FIELD_COUNT, VARCHAR), blockBuilderStatus, expectedEntries);
     }
 }


### PR DESCRIPTION
Ready for review.
Note the final 3 migration commits are somewhat separated arbitrarily. We can probably merge them into one given they are not too large.

    The current internal representation of a row type in Presto is an
    interleaved block wrapped by an array block. A dedicated RowBlock is
    easier to understand.


