### PR TITLE
Improve detection of completely corrupt ORC files

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -257,7 +257,7 @@ public class OrcReader
             throws IOException
     {
         int magicLength = MAGIC.length();
-        if (postScriptSize < magicLength + 1) {
+        if ((postScriptSize < (magicLength + 1)) || (postScriptSize >= buffer.length)) {
             throw new OrcCorruptionException(source.getId(), "Invalid postscript length %s", postScriptSize);
         }
 


### PR DESCRIPTION
Validate that post script size is less than file size. This handles
the case of small files that are not ORC files.