### PR TITLE
Require coalesce to have at least two arguments

### DIFF
--- a/presto-docs/src/main/sphinx/functions/conditional.rst
+++ b/presto-docs/src/main/sphinx/functions/conditional.rst
@@ -75,7 +75,7 @@ that is equivalent to the following ``CASE`` expression:
 COALESCE
 --------
 
-.. function:: coalesce(value[, ...])
+.. function:: coalesce(value1, value2[, ...])
 
     Returns the first non-null ``value`` in the argument list.
     Like a ``CASE`` expression, arguments are only evaluated if necessary.

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
@@ -43,7 +43,7 @@ public class TestSqlToRowExpressionTranslator
         ImmutableMap.Builder<NodeRef<Expression>, Type> types = ImmutableMap.builder();
         types.put(NodeRef.of(expression), BIGINT);
         for (int i = 0; i < 100; i++) {
-            expression = new CoalesceExpression(expression);
+            expression = new CoalesceExpression(expression, new LongLiteral("2"));
             types.put(NodeRef.of(expression), BIGINT);
         }
         SqlToRowExpressionTranslator.translate(expression, SCALAR, types.build(), functionRegistry, typeManager, TEST_SESSION, true);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1324,6 +1324,7 @@ class AstBuilder
                     (Expression) visit(context.expression(1)));
         }
         if (name.toString().equalsIgnoreCase("coalesce")) {
+            check(context.expression().size() >= 2, "The 'coalesce' function must have at least two arguments", context);
             check(!window.isPresent(), "OVER clause not valid for 'coalesce' function", context);
             check(!distinct, "DISTINCT not valid for 'coalesce' function", context);
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1313,6 +1313,7 @@ class AstBuilder
                     (Expression) visit(context.expression(1)),
                     elseExpression);
         }
+
         if (name.toString().equalsIgnoreCase("nullif")) {
             check(context.expression().size() == 2, "Invalid number of arguments for 'nullif' function", context);
             check(!window.isPresent(), "OVER clause not valid for 'nullif' function", context);
@@ -1323,6 +1324,7 @@ class AstBuilder
                     (Expression) visit(context.expression(0)),
                     (Expression) visit(context.expression(1)));
         }
+
         if (name.toString().equalsIgnoreCase("coalesce")) {
             check(context.expression().size() >= 2, "The 'coalesce' function must have at least two arguments", context);
             check(!window.isPresent(), "OVER clause not valid for 'coalesce' function", context);
@@ -1330,6 +1332,7 @@ class AstBuilder
 
             return new CoalesceExpression(getLocation(context), visit(context.expression(), Expression.class));
         }
+
         if (name.toString().equalsIgnoreCase("try")) {
             check(context.expression().size() == 1, "The 'try' function must have exactly one argument", context);
             check(!window.isPresent(), "OVER clause not valid for 'try' function", context);
@@ -1337,6 +1340,7 @@ class AstBuilder
 
             return new TryExpression(getLocation(context), (Expression) visit(getOnlyElement(context.expression())));
         }
+
         if (name.toString().equalsIgnoreCase("$internal$bind")) {
             check(context.expression().size() >= 1, "The '$internal$bind' function must have at least one arguments", context);
             check(!window.isPresent(), "OVER clause not valid for '$internal$bind' function", context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CoalesceExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CoalesceExpression.java
@@ -13,13 +13,13 @@
  */
 package com.facebook.presto.sql.tree;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class CoalesceExpression
@@ -27,9 +27,12 @@ public class CoalesceExpression
 {
     private final List<Expression> operands;
 
-    public CoalesceExpression(Expression... operands)
+    public CoalesceExpression(Expression first, Expression second, Expression... additional)
     {
-        this(Optional.empty(), ImmutableList.copyOf(operands));
+        this(Optional.empty(), ImmutableList.<Expression>builder()
+                .add(first, second)
+                .add(additional)
+                .build());
     }
 
     public CoalesceExpression(List<Expression> operands)
@@ -46,7 +49,7 @@ public class CoalesceExpression
     {
         super(location);
         requireNonNull(operands, "operands is null");
-        Preconditions.checkArgument(!operands.isEmpty(), "operands is empty");
+        checkArgument(operands.size() >= 2, "must have at least two operands");
 
         this.operands = ImmutableList.copyOf(operands);
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.tree.Call;
 import com.facebook.presto.sql.tree.CallArgument;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CharLiteral;
+import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ColumnDefinition;
 import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.sql.tree.ComparisonExpression;
@@ -405,6 +406,18 @@ public class TestSqlParser
 
         assertExpression("- - -9", negative(negative(negative(new LongLiteral("9")))));
         assertExpression("- - - 9", negative(negative(negative(new LongLiteral("9")))));
+    }
+
+    @Test
+    public void testCoalesce()
+    {
+        assertInvalidExpression("coalesce()", "The 'coalesce' function must have at least two arguments");
+        assertInvalidExpression("coalesce(5)", "The 'coalesce' function must have at least two arguments");
+        assertExpression("coalesce(13, 42)", new CoalesceExpression(new LongLiteral("13"), new LongLiteral("42")));
+        assertExpression("coalesce(6, 7, 8)", new CoalesceExpression(new LongLiteral("6"), new LongLiteral("7"), new LongLiteral("8")));
+        assertExpression("coalesce(13, null)", new CoalesceExpression(new LongLiteral("13"), new NullLiteral()));
+        assertExpression("coalesce(null, 13)", new CoalesceExpression(new NullLiteral(), new LongLiteral("13")));
+        assertExpression("coalesce(null, null)", new CoalesceExpression(new NullLiteral(), new NullLiteral()));
     }
 
     @Test


### PR DESCRIPTION
The SQL specification syntactically allows a single argument, but does
not contemplate it in the description of the semantics. Most commercial
databases require at least two arguments, which indicates that this is
a correct interpretation of the specification.