### PR TITLE
Simple test for HiveMetadata.getTableStatistics()

### DIFF
--- a/presto-hive/src/test/sql/create-test.sql
+++ b/presto-hive/src/test/sql/create-test.sql
@@ -232,3 +232,8 @@ ALTER TABLE presto_test_partition_schema_change REPLACE COLUMNS (t_data DOUBLE);
 
 INSERT OVERWRITE TABLE presto_test_partition_schema_change_non_canonical PARTITION (t_boolean='0')
 SELECT 'test' FROM presto_test_sequence LIMIT 100;
+
+ANALYZE TABLE presto_test_unpartitioned COMPUTE STATISTICS;
+ANALYZE TABLE presto_test_unpartitioned COMPUTE STATISTICS FOR COLUMNS;
+ANALYZE TABLE presto_test_bucketed_by_string_int PARTITION(ds) COMPUTE STATISTICS;
+ANALYZE TABLE presto_test_bucketed_by_string_int PARTITION(ds) COMPUTE STATISTICS FOR COLUMNS;


### PR DESCRIPTION
Make sure that requesting stats for partitioned and unpartitioned Hive
tables returns stats for the correct set of columns.  Do not actually
validate the returned stats, which is complicated as they are floating
point numbers.