### PR TITLE
Update use of several deprecated methods/fields

### DIFF
--- a/presto-atop/src/main/java/com/facebook/presto/atop/AtopPageSource.java
+++ b/presto-atop/src/main/java/com/facebook/presto/atop/AtopPageSource.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
@@ -105,7 +104,7 @@ public class AtopPageSource
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
             try {
                 atop = atopFactory.create(table, date);

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
@@ -260,7 +260,7 @@ public class JdbcRecordCursor
             // do nothing
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
@@ -17,7 +17,6 @@ import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.client.StatementStats;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import io.airlift.discovery.client.ServiceDescriptor;
@@ -248,7 +247,7 @@ public class BenchmarkQueryRunner
         }
         catch (InterruptedException interruptedException) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(interruptedException);
+            throw new RuntimeException(interruptedException);
         }
     }
 

--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/PrestoBenchmarkDriver.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/PrestoBenchmarkDriver.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.benchmark.driver;
 
 import com.facebook.presto.client.ClientSession;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.airline.Command;
 import io.airlift.airline.HelpOption;
@@ -27,6 +26,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -162,7 +162,7 @@ public class PrestoBenchmarkDriver
             }
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
         finally {
             System.setOut(out);

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonAvgBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonAvgBenchmarkResultWriter.java
@@ -14,11 +14,11 @@
 package com.facebook.presto.benchmark;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Throwables;
 import io.airlift.json.JsonCodec;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -86,7 +86,7 @@ public class JsonAvgBenchmarkResultWriter
             outputStream.write(json.getBytes(UTF_8));
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/JsonBenchmarkResultWriter.java
@@ -16,10 +16,10 @@ package com.facebook.presto.benchmark;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.google.common.base.Throwables;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
@@ -38,7 +38,7 @@ public class JsonBenchmarkResultWriter
             jsonGenerator.writeArrayFieldStart("samples");
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -54,7 +54,7 @@ public class JsonBenchmarkResultWriter
             jsonGenerator.writeEndObject();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
         return this;
     }
@@ -68,7 +68,7 @@ public class JsonBenchmarkResultWriter
             jsonGenerator.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OdsBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OdsBenchmarkResultWriter.java
@@ -16,10 +16,10 @@ package com.facebook.presto.benchmark;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.google.common.base.Throwables;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
@@ -40,7 +40,7 @@ public class OdsBenchmarkResultWriter
             jsonGenerator.writeStartArray();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -58,7 +58,7 @@ public class OdsBenchmarkResultWriter
             }
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
         return this;
     }
@@ -71,7 +71,7 @@ public class OdsBenchmarkResultWriter
             jsonGenerator.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SimpleLineBenchmarkResultWriter.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SimpleLineBenchmarkResultWriter.java
@@ -14,11 +14,11 @@
 package com.facebook.presto.benchmark;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.Map;
 
@@ -44,7 +44,7 @@ public class SimpleLineBenchmarkResultWriter
             writer.flush();
         }
         catch (IOException e) {
-            Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
         return this;
     }

--- a/presto-bytecode/src/main/java/com/facebook/presto/bytecode/DynamicClassLoader.java
+++ b/presto-bytecode/src/main/java/com/facebook/presto/bytecode/DynamicClassLoader.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.bytecode;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
@@ -74,7 +73,7 @@ public class DynamicClassLoader
                 }
                 catch (ClassNotFoundException e) {
                     // this should never happen
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
             return classes;

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -20,7 +20,6 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.parser.StatementSplitter;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
 import io.airlift.airline.Command;
@@ -38,6 +37,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -382,7 +382,7 @@ public class Console
             logging.configure(config);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
         finally {
             System.setOut(out);

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -21,7 +21,6 @@ import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.client.StatementClient;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.airlift.log.Logger;
@@ -34,6 +33,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.List;
 import java.util.Map;
@@ -190,7 +190,7 @@ public class Query
             handler.processRows(client);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -204,7 +204,7 @@ public class Query
             client.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleClient.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleClient.java
@@ -16,7 +16,6 @@ package com.facebook.presto.example;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -26,6 +25,7 @@ import io.airlift.json.JsonCodec;
 import javax.inject.Inject;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
@@ -88,7 +88,7 @@ public class ExampleClient
                 return lookupSchemas(metadataUri, catalogCodec);
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         };
     }

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleRecordCursor.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleRecordCursor.java
@@ -17,13 +17,13 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.io.ByteSource;
 import com.google.common.io.CountingInputStream;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.List;
 
@@ -63,7 +63,7 @@ public class ExampleRecordCursor
             totalBytes = input.getCount();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleRecordSet.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleRecordSet.java
@@ -16,7 +16,6 @@ package com.facebook.presto.example;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Resources;
@@ -48,7 +47,7 @@ public class ExampleRecordSet
             byteSource = Resources.asByteSource(split.getUri().toURL());
         }
         catch (MalformedURLException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -40,6 +39,7 @@ import org.apache.hadoop.mapred.RecordReader;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -526,7 +526,7 @@ class GenericHiveRecordCursor<K, V extends Writable>
             recordReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -27,10 +27,10 @@ import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.VarcharType;
-import com.google.common.base.Throwables;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.function.Function;
 
@@ -230,7 +230,7 @@ public class HivePageSource
             delegate.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -29,7 +29,6 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.compress.lzo.LzoCodec;
 import io.airlift.compress.lzo.LzopCodec;
@@ -290,7 +289,7 @@ public final class HiveUtil
             return (boolean) method.invoke(inputFormat, fileSystem, path);
         }
         catch (InvocationTargetException | IllegalAccessException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -307,7 +306,7 @@ public final class HiveUtil
             return (StructObjectInspector) inspector;
         }
         catch (SerDeException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RetryDriver.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.hive;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
@@ -156,7 +155,7 @@ public class RetryDriver
                 }
                 catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
-                    throw Throwables.propagate(ie);
+                    throw new RuntimeException(ie);
                 }
             }
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
@@ -25,6 +25,7 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -74,7 +75,7 @@ public class KerberosAuthentication
             return new KerberosPrincipal(getServerPrincipal(principal, InetAddress.getLocalHost().getCanonicalHostName()));
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.hive.authentication;
 
 import com.facebook.presto.hive.ForHiveMetastore;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.hive.thrift.client.TUGIAssumingTransport;
 import org.apache.hadoop.security.SaslRpcServer;
@@ -26,6 +25,7 @@ import javax.inject.Inject;
 import javax.security.sasl.Sasl;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -77,7 +77,7 @@ public class KerberosHiveMetastoreAuthentication
             return new TUGIAssumingTransport(saslTransport, authentication.getUserGroupInformation());
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/SimpleHadoopAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/SimpleHadoopAuthentication.java
@@ -13,10 +13,10 @@
  */
 package com.facebook.presto.hive.authentication;
 
-import com.google.common.base.Throwables;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 public class SimpleHadoopAuthentication
         implements HadoopAuthentication
@@ -28,7 +28,7 @@ public class SimpleHadoopAuthentication
             return UserGroupInformation.getCurrentUser();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
@@ -29,10 +29,10 @@ import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.LazyBlockLoader;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
@@ -174,7 +174,7 @@ public class OrcPageSource
             recordReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -27,7 +27,6 @@ import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
@@ -57,6 +56,7 @@ import parquet.schema.MessageType;
 import parquet.schema.PrimitiveType;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
@@ -304,7 +304,7 @@ public class ParquetHiveRecordCursor
             recordReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -371,7 +371,7 @@ public class ParquetHiveRecordCursor
             throwIfInstanceOf(e, PrestoException.class);
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
             String message = format("Error opening Hive split %s (offset=%s, length=%s): %s", path, start, length, e.getMessage());
             if (e.getClass().getSimpleName().equals("BlockMissingException")) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -26,12 +26,12 @@ import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import parquet.column.ColumnDescriptor;
 import parquet.schema.MessageType;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -241,7 +241,7 @@ public class ParquetPageSource
             parquetReader.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -79,6 +79,7 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
@@ -579,7 +580,7 @@ public class PrestoS3FileSystem
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         catch (Exception e) {
             throwIfInstanceOf(e, IOException.class);
@@ -599,7 +600,7 @@ public class PrestoS3FileSystem
             return new LocatedFileStatus(status, fakeLocation);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -835,7 +836,7 @@ public class PrestoS3FileSystem
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
             catch (Exception e) {
                 throwIfInstanceOf(e, IOException.class);
@@ -917,13 +918,13 @@ public class PrestoS3FileSystem
                                             throw new UnrecoverableS3OperationException(path, e);
                                     }
                                 }
-                                throw Throwables.propagate(e);
+                                throw e;
                             }
                         });
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
             catch (Exception e) {
                 throwIfInstanceOf(e, IOException.class);

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.jdbc;
 
-import com.google.common.base.Throwables;
 import okhttp3.OkHttpClient;
 
 import java.io.Closeable;
@@ -64,7 +63,7 @@ public class PrestoDriver
             DriverManager.registerDriver(new PrestoDriver());
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -62,7 +62,6 @@ import java.util.function.Consumer;
 
 import static com.facebook.presto.jdbc.ColumnInfo.setTypeInfo;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.google.common.base.Throwables.propagate;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Iterators.concat;
 import static com.google.common.collect.Iterators.transform;
@@ -1763,7 +1762,7 @@ public class PrestoResultSet
             while (client.isValid()) {
                 if (Thread.currentThread().isInterrupted()) {
                     client.close();
-                    throw propagate(new SQLException("ResultSet thread was interrupted"));
+                    throw new RuntimeException(new SQLException("ResultSet thread was interrupted"));
                 }
 
                 QueryStatusInfo results = client.currentStatusInfo();
@@ -1779,7 +1778,7 @@ public class PrestoResultSet
             progressCallback.accept(QueryStats.create(results.getId(), results.getStats()));
 
             if (client.isFailed()) {
-                throw propagate(resultsException(results));
+                throw new RuntimeException(resultsException(results));
             }
 
             return endOfData();

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableDescriptionSupplier.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableDescriptionSupplier.java
@@ -16,7 +16,6 @@ package com.facebook.presto.kafka;
 import com.facebook.presto.decoder.dummy.DummyRowDecoder;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -27,6 +26,7 @@ import javax.inject.Inject;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -112,7 +112,7 @@ public class KafkaTableDescriptionSupplier
         }
         catch (IOException e) {
             log.warn(e, "Error: ");
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileRecordCursor.java
+++ b/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileRecordCursor.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -38,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -130,7 +130,7 @@ public class LocalFileRecordCursor
             return new FilesReader(table.getTimestampColumn(), fileNames.iterator(), predicate);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -165,7 +165,7 @@ public class LocalFileRecordCursor
             return fields != null;
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -45,7 +45,6 @@ import com.facebook.presto.spi.eventlistener.StageCpuDistribution;
 import com.facebook.presto.transaction.TransactionId;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
@@ -247,7 +246,7 @@ public class QueryMonitor
             logQueryTimeline(queryInfo);
         }
         catch (JsonProcessingException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryQueueRuleFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryQueueRuleFactory.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.jgrapht.DirectedGraph;
@@ -35,6 +34,7 @@ import javax.inject.Provider;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +69,7 @@ public class QueryQueueRuleFactory
                 managerSpec = mapper.readValue(file, ManagerSpec.class);
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
             Map<String, QueryQueueDefinition> definitions = new HashMap<>();
             for (Map.Entry<String, QueueSpec> queue : managerSpec.getQueues().entrySet()) {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/AbstractTypedJacksonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/AbstractTypedJacksonModule.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.SimpleType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
@@ -71,7 +71,12 @@ public abstract class AbstractTypedJacksonModule<T>
         public InternalTypeDeserializer(Class<T> baseClass, TypeIdResolver typeIdResolver)
         {
             super(baseClass);
-            this.typeDeserializer = new AsPropertyTypeDeserializer(SimpleType.construct(baseClass), typeIdResolver, TYPE_PROPERTY, false, null);
+            this.typeDeserializer = new AsPropertyTypeDeserializer(
+                    TypeFactory.defaultInstance().constructType(baseClass),
+                    typeIdResolver,
+                    TYPE_PROPERTY,
+                    false,
+                    null);
         }
 
         @SuppressWarnings("unchecked")

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExplainAnalyzeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExplainAnalyzeOperator.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -171,7 +170,7 @@ public class ExplainAnalyzeOperator
                 TimeUnit.MILLISECONDS.sleep(100);
             }
             catch (InterruptedException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
         return isFinalStageInfo(stageInfo);

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator;
 import com.facebook.presto.execution.buffer.SerializedPage;
 import com.facebook.presto.server.remotetask.Backoff;
 import com.facebook.presto.spi.PrestoException;
-import com.google.common.base.Throwables;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.MediaType;
@@ -567,7 +566,7 @@ public final class HttpPageBufferClient
                     return createPagesResponse(taskInstanceId, token, nextToken, pages, complete);
                 }
                 catch (IOException e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
             catch (PageTransportErrorException e) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/PageSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PageSourceOperator.java
@@ -16,12 +16,12 @@ package com.facebook.presto.operator;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -63,7 +63,7 @@ public class PageSourceOperator
             pageSource.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -32,7 +32,6 @@ import com.facebook.presto.split.EmptySplit;
 import com.facebook.presto.split.EmptySplitPageSource;
 import com.facebook.presto.split.PageSourceProvider;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -40,6 +39,7 @@ import io.airlift.units.DataSize;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -172,7 +172,7 @@ public class ScanFilterAndProjectOperator
                 pageSource.close();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         }
         else if (cursor != null) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -24,13 +24,13 @@ import com.facebook.presto.split.EmptySplit;
 import com.facebook.presto.split.EmptySplitPageSource;
 import com.facebook.presto.split.PageSourceProvider;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -205,7 +205,7 @@ public class TableScanOperator
                 source.close();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
             systemMemoryContext.setBytes(source.getSystemMemoryUsage());
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
 import com.facebook.presto.spi.function.WindowIndex;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.reflect.Constructor;
@@ -92,7 +91,7 @@ public class GenericAccumulatorFactory
             accumulator = accumulatorConstructor.newInstance(stateSerializer, stateFactory, inputChannels, maskChannel);
         }
         catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         if (orderByChannels.isEmpty()) {
             return accumulator;
@@ -108,7 +107,7 @@ public class GenericAccumulatorFactory
             return accumulatorConstructor.newInstance(stateSerializer, stateFactory, ImmutableList.of(), Optional.empty());
         }
         catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -120,7 +119,7 @@ public class GenericAccumulatorFactory
             accumulator = groupedAccumulatorConstructor.newInstance(stateSerializer, stateFactory, inputChannels, maskChannel);
         }
         catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
 
         if (orderByChannels.isEmpty()) {
@@ -137,7 +136,7 @@ public class GenericAccumulatorFactory
             return groupedAccumulatorConstructor.newInstance(stateSerializer, stateFactory, ImmutableList.of(), maskChannel);
         }
         catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactoryBinder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactoryBinder.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
@@ -58,7 +57,7 @@ public class GenericAccumulatorFactoryBinder
                     Optional.class);
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
@@ -39,7 +39,6 @@ import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.CallSiteBinder;
 import com.facebook.presto.sql.gen.SqlTypeBytecodeExpression;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -144,7 +143,7 @@ public class StateCompiler
                 return (AccumulatorStateSerializer<T>) metadata.stateSerializerClass().getConstructor().newInstance();
             }
             catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -169,7 +168,7 @@ public class StateCompiler
             return (AccumulatorStateSerializer<T>) serializerClass.newInstance();
         }
         catch (InstantiationException | IllegalAccessException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -311,7 +310,7 @@ public class StateCompiler
             return clazz.getMethod(field.getSetterName(), field.getType());
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -321,7 +320,7 @@ public class StateCompiler
             return clazz.getMethod(field.getGetterName());
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -343,7 +342,7 @@ public class StateCompiler
                 return (AccumulatorStateFactory<T>) metadata.stateFactoryClass().getConstructor().newInstance();
             }
             catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -391,7 +390,7 @@ public class StateCompiler
             return (AccumulatorStateFactory<T>) factoryClass.newInstance();
         }
         catch (InstantiationException | IllegalAccessException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
@@ -35,7 +35,6 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.gen.CallSiteBinder;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 
@@ -126,7 +125,7 @@ public final class ArrayConstructor
             methodHandle = lookup().unreflect(method);
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         return new ScalarFunctionImplementation(
                 false,

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonExtract.java
@@ -20,12 +20,12 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.io.SerializedString;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.util.JsonUtil.createJsonGenerator;
@@ -140,7 +140,7 @@ public final class JsonExtract
             return null;
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/ReflectionWindowFunctionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/ReflectionWindowFunctionSupplier.java
@@ -50,7 +50,7 @@ public class ReflectionWindowFunctionSupplier<T extends WindowFunction>
             }
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -66,7 +66,7 @@ public class ReflectionWindowFunctionSupplier<T extends WindowFunction>
             }
         }
         catch (InvocationTargetException e) {
-            throw Throwables.propagate(e.getCause());
+            throw new RuntimeException(e);
         }
         catch (Exception e) {
             throw Throwables.propagate(e);

--- a/presto-main/src/main/java/com/facebook/presto/server/PagesResponseWriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PagesResponseWriter.java
@@ -15,7 +15,6 @@ package com.facebook.presto.server;
 
 import com.facebook.presto.execution.buffer.SerializedPage;
 import com.facebook.presto.spi.Page;
-import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
 import io.airlift.slice.OutputStreamSliceOutput;
 import io.airlift.slice.SliceOutput;
@@ -51,7 +50,7 @@ public class PagesResponseWriter
             LIST_GENERIC_TOKEN = List.class.getMethod("get", int.class).getGenericReturnType();
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginDiscovery.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginDiscovery.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.server;
 
 import com.facebook.presto.spi.Plugin;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.objectweb.asm.ClassReader;
@@ -25,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
@@ -125,7 +125,7 @@ final class PluginDiscovery
             return new ClassReader(toByteArray(in));
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.server.security;
 
-import com.google.common.base.Throwables;
 import com.sun.security.auth.module.Krb5LoginModule;
 import io.airlift.log.Logger;
 import org.ietf.jgss.GSSContext;
@@ -101,7 +100,7 @@ public class KerberosAuthenticator
                     ACCEPT_ONLY));
         }
         catch (LoginException | UnknownHostException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -112,7 +111,7 @@ public class KerberosAuthenticator
             loginContext.logout();
         }
         catch (LoginException e) {
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -192,7 +191,7 @@ public class KerberosAuthenticator
                 return action.get();
             }
             catch (GSSException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         });
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapAuthenticator.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.server.security;
 
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -107,7 +106,7 @@ public class LdapAuthenticator
             closeContext(createDirContext(environment));
         }
         catch (NamingException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionCompiler.java
@@ -22,7 +22,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.operator.project.PageProjection;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.relational.RowExpression;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -84,7 +83,7 @@ public class ExpressionCompiler
                 return cursorProcessor.newInstance();
             }
             catch (ReflectiveOperationException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -824,7 +824,7 @@ public class JoinCompiler
                 constructor = joinHashSupplierClass.getConstructor(Session.class, PagesHashStrategy.class, LongArrayList.class, List.class, Optional.class, Optional.class, List.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -857,7 +857,7 @@ public class JoinCompiler
                 constructor = pagesHashStrategyClass.getConstructor(List.class, OptionalInt.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -34,7 +34,6 @@ import com.facebook.presto.sql.relational.CallExpression;
 import com.facebook.presto.sql.relational.LambdaDefinitionExpression;
 import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.sql.relational.RowExpressionVisitor;
-import com.google.common.base.Throwables;
 import com.google.common.base.VerifyException;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -347,7 +346,7 @@ public class JoinFilterFunctionCompiler
                 isolatedJoinFilterFunctionConstructor = isolatedJoinFilterFunction.getConstructor(InternalJoinFilterFunction.class, LongArrayList.class, List.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -359,7 +358,7 @@ public class JoinFilterFunctionCompiler
                 return isolatedJoinFilterFunctionConstructor.newInstance(internalJoinFilterFunction, addresses, channels);
             }
             catch (ReflectiveOperationException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
@@ -476,7 +476,7 @@ public class JoinProbeCompiler
                 constructor = joinProbeClass.getConstructor(Page.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -581,7 +581,7 @@ public class JoinProbeCompiler
                         PartitioningSpillerFactory.class);
             }
             catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaCapture.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaCapture.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.sql.gen;
 
-import com.google.common.base.Throwables;
-
 import java.lang.invoke.CallSite;
 import java.lang.invoke.LambdaConversionException;
 import java.lang.invoke.LambdaMetafactory;
@@ -34,7 +32,7 @@ public final class LambdaCapture
             LAMBDA_CAPTURE_METHOD = LambdaCapture.class.getMethod("lambdaCapture", MethodHandles.Lookup.class, String.class, MethodType.class, MethodType.class, MethodHandle.class, MethodType.class);
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
@@ -24,6 +24,7 @@ import libsvm.svm_problem;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.SortedMap;
@@ -62,7 +63,7 @@ public abstract class AbstractSvmModel
             return Files.readAllBytes(file.toPath());
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
         finally {
             if (file != null) {
@@ -87,7 +88,7 @@ public abstract class AbstractSvmModel
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         catch (Exception e) {
             throw Throwables.propagate(e);

--- a/presto-ml/src/main/java/com/facebook/presto/ml/EvaluateClassifierPredictionsStateSerializer.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/EvaluateClassifierPredictionsStateSerializer.java
@@ -20,13 +20,13 @@ import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.ObjectMapperProvider;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,7 +57,7 @@ public class EvaluateClassifierPredictionsStateSerializer
             VARCHAR.writeSlice(out, Slices.utf8Slice(OBJECT_MAPPER.writeValueAsString(jsonState)));
         }
         catch (JsonProcessingException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -70,7 +70,7 @@ public class EvaluateClassifierPredictionsStateSerializer
             jsonState = OBJECT_MAPPER.readValue(slice.getBytes(), new TypeReference<Map<String, Map<String, Integer>>>() {});
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
         state.addMemoryUsage(slice.length());
         state.getTruePositives().putAll(jsonState.getOrDefault(TRUE_POSITIVES, ImmutableMap.of()));

--- a/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
@@ -15,7 +15,6 @@ package com.facebook.presto.ml;
 
 import com.facebook.presto.spi.block.Block;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
@@ -154,7 +153,7 @@ public final class ModelUtils
             return (Model) deserialize.invoke(null, new Object[] {data});
         }
         catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-ml/src/main/java/com/facebook/presto/ml/SvmClassifier.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/SvmClassifier.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.ml;
 
 import com.facebook.presto.ml.type.ModelType;
-import com.google.common.base.Throwables;
 import libsvm.svm;
 import libsvm.svm_model;
 import libsvm.svm_parameter;
@@ -23,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 
 import static com.facebook.presto.ml.type.ClassifierType.BIGINT_CLASSIFIER;
 import static java.util.Objects.requireNonNull;
@@ -54,7 +54,7 @@ public class SvmClassifier
             return new SvmClassifier(model);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-ml/src/main/java/com/facebook/presto/ml/SvmRegressor.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/SvmRegressor.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.ml;
 
 import com.facebook.presto.ml.type.ModelType;
-import com.google.common.base.Throwables;
 import libsvm.svm;
 import libsvm.svm_model;
 import libsvm.svm_parameter;
@@ -23,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 
 import static com.facebook.presto.ml.type.RegressorType.REGRESSOR;
 import static java.util.Objects.requireNonNull;
@@ -54,7 +54,7 @@ public class SvmRegressor
             return new SvmRegressor(model);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientConfig.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientConfig.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.mongodb;
 
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
@@ -126,7 +125,7 @@ public class MongoClientConfig
                 }
             }
             catch (NumberFormatException e) {
-                throw Throwables.propagate(e);
+                throw e;
             }
         }
         return builder.build();

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.spi.type.Varchars;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.mysql.jdbc.Driver;
 import com.mysql.jdbc.Statement;
@@ -74,7 +73,7 @@ public class MySqlClient
             return schemaNames.build();
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -17,7 +17,6 @@ import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
 import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcOutputTableHandle;
-import com.google.common.base.Throwables;
 import org.postgresql.Driver;
 
 import javax.inject.Inject;
@@ -52,7 +51,7 @@ public class PostgreSqlClient
             execute(connection, sql.toString());
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TlsTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TlsTests.java
@@ -13,13 +13,13 @@
  */
 package com.facebook.presto.tests;
 
-import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.teradata.tempto.query.QueryResult;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -115,7 +115,7 @@ public class TlsTests
             return false;
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.tests.hive;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.assertions.QueryAssert.Row;
@@ -234,7 +233,7 @@ public class TestHiveStorageFormats
             }
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/querystats/HttpQueryStatsClient.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/querystats/HttpQueryStatsClient.java
@@ -16,7 +16,6 @@ package com.facebook.presto.tests.querystats;
 import com.facebook.presto.execution.QueryStats;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpStatus;
 import io.airlift.http.client.Request;
@@ -24,6 +23,7 @@ import io.airlift.http.client.Response;
 import io.airlift.http.client.ResponseHandler;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.Optional;
 
@@ -85,7 +85,7 @@ public class HttpQueryStatsClient
                 return Optional.of(queryStats);
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         }
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -680,7 +680,7 @@ public class DatabaseShardManager
             return existingShards.build();
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDaoUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDaoUtil.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.raptor.metadata;
 
-import com.google.common.base.Throwables;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.skife.jdbi.v2.Handle;
@@ -67,7 +66,7 @@ public final class SchemaDaoUtil
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
@@ -252,7 +251,7 @@ public class OrcFileWriter
             return constructor;
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -46,7 +46,6 @@ import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -340,7 +339,7 @@ public class OrcStorageManager
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
             catch (ExecutionException e) {
                 if (e.getCause() != null) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizerUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizerUtil.java
@@ -20,7 +20,6 @@ import com.facebook.presto.raptor.metadata.TableColumn;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimaps;
@@ -131,7 +130,7 @@ public class ShardOrganizerUtil
             }
         }
         catch (SQLException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         return indexInfoBuilder.build();
     }

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/AircompressorCompressor.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/AircompressorCompressor.java
@@ -13,12 +13,12 @@
  */
 package com.facebook.presto.rcfile;
 
-import com.google.common.base.Throwables;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -63,7 +63,7 @@ public class AircompressorCompressor
                 return new CompressedSliceOutput(compressionStream, compressedOutput, this, () -> {});
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         }
     }

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/HadoopCompressor.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/HadoopCompressor.java
@@ -13,13 +13,13 @@
  */
 package com.facebook.presto.rcfile;
 
-import com.google.common.base.Throwables;
 import org.apache.hadoop.io.compress.CodecPool;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -64,7 +64,7 @@ public class HadoopCompressor
                 return new CompressedSliceOutput(compressionStream, bufferedOutput, this, () -> CodecPool.returnCompressor(compressor));
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         }
     }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisTableDescriptionSupplier.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisTableDescriptionSupplier.java
@@ -16,7 +16,6 @@ package com.facebook.presto.redis;
 import com.facebook.presto.decoder.dummy.DummyRowDecoder;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
@@ -26,6 +25,7 @@ import javax.inject.Inject;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -100,7 +100,7 @@ public class RedisTableDescriptionSupplier
         }
         catch (IOException e) {
             log.warn(e, "Error: ");
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManager.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.resourceGroups.ResourceGroupSelector;
 import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import com.google.common.base.Throwables;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
@@ -28,6 +27,7 @@ import io.airlift.units.Duration;
 import javax.inject.Inject;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -60,7 +60,7 @@ public class FileResourceGroupConfigurationManager
             managerSpec = CODEC.fromJson(Files.readAllBytes(Paths.get(config.getConfigFile())));
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
         catch (IllegalArgumentException e) {
             Throwable cause = e.getCause();

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -33,7 +33,6 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closer;
@@ -43,6 +42,7 @@ import io.airlift.units.Duration;
 import org.intellij.lang.annotations.Language;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -297,7 +297,7 @@ public class DistributedQueryRunner
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
         log.info("Announced catalog %s (%s) in %s", catalogName, connectorId, nanosSince(start));
@@ -398,7 +398,7 @@ public class DistributedQueryRunner
             closer.close();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/JsonEventClient.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/JsonEventClient.java
@@ -16,7 +16,6 @@ package com.facebook.presto.verifier;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.google.common.base.Throwables;
 import io.airlift.event.client.AbstractEventClient;
 import io.airlift.event.client.JsonEventSerializer;
 
@@ -26,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -56,7 +56,7 @@ public class JsonEventClient
             out.println(buffer.toString().trim());
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Validator.java
@@ -458,7 +458,7 @@ public class Validator
                 }
                 catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
                 catch (Exception e) {
                     throw Throwables.propagate(e);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/Verifier.java
@@ -16,7 +16,6 @@ package com.facebook.presto.verifier;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.event.client.EventClient;
 import io.airlift.log.Logger;
@@ -245,7 +244,7 @@ public class Verifier
             return completionService.take().get();
         }
         catch (ExecutionException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
This PR updates the use of four deprecated methods/fields:
- `Throwables.propagate`
    - I updated the use for **only** checked exceptions (as unchecked exceptions probably need a more case by case analysis). Currently for checked exceptions the behavior of `Throwables.propagate` is to simply throw a `RuntimeException` wrapping that. I did the same for all checked exceptions except `IOException`, where I used `UncheckedIOException`.
- `propagateIfInstanceOf`
- `JAVA_ISO_CONTROL`
- `SimpleType`