### PR TITLE
Merge tiny pages returned from PageProcessor

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -95,7 +95,7 @@ public abstract class AbstractOperatorBenchmark
 
     protected OperatorFactory createHashProjectOperator(int operatorId, PlanNodeId planNodeId, List<Type> types)
     {
-        return localQueryRunner.createHashProjectOperator(operatorId, planNodeId, types);
+        return localQueryRunner.createHashProjectOperator(session, operatorId, planNodeId, types);
     }
 
     protected abstract List<Driver> createDrivers(TaskContext taskContext);

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.util.DateTimeUtils;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 
 import java.util.List;
 import java.util.Optional;
@@ -43,6 +44,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.sql.relational.Expressions.field;
+import static io.airlift.units.DataSize.Unit.BYTE;
 
 public class HandTpchQuery6
         extends AbstractSimpleOperatorBenchmark
@@ -75,7 +77,9 @@ public class HandTpchQuery6
                 1,
                 new PlanNodeId("test"),
                 () -> new PageProcessor(Optional.of(new TpchQuery6Filter()), ImmutableList.of(projection.get())),
-                ImmutableList.of(DOUBLE));
+                ImmutableList.of(DOUBLE),
+                new DataSize(0, BYTE),
+                0);
 
         AggregationOperatorFactory aggregationOperator = new AggregationOperatorFactory(
                 2,

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/PredicateFilterBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/PredicateFilterBenchmark.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +36,7 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.field;
+import static io.airlift.units.DataSize.Unit.BYTE;
 
 public class PredicateFilterBenchmark
         extends AbstractSimpleOperatorBenchmark
@@ -60,7 +62,9 @@ public class PredicateFilterBenchmark
                 1,
                 new PlanNodeId("test"),
                 pageProcessor,
-                ImmutableList.of(DOUBLE));
+                ImmutableList.of(DOUBLE),
+                new DataSize(0, BYTE),
+                0);
 
         return ImmutableList.of(tableScanOperator, filterAndProjectOperator);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -385,7 +385,7 @@ public class TestOrcPageSourceMemoryTracking
         // done... in the current implementation finish is not set until output returns a null page
         assertNull(operator.getOutput());
         assertTrue(operator.isFinished());
-        assertEquals(driverContext.getSystemMemoryUsage(), 0);
+        assertBetweenInclusive(driverContext.getSystemMemoryUsage(), 0L, 500L);
     }
 
     private class TestPreparer
@@ -509,7 +509,9 @@ public class TestOrcPageSourceMemoryTracking
                     cursorProcessor,
                     pageProcessor,
                     columns.stream().map(columnHandle -> (ColumnHandle) columnHandle).collect(toList()),
-                    types);
+                    types,
+                    new DataSize(0, BYTE),
+                    0);
             SourceOperator operator = sourceOperatorFactory.createOperator(driverContext);
             operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
             return operator;

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -75,6 +75,8 @@ public final class SystemSessionProperties
     public static final String PUSH_AGGREGATION_THROUGH_JOIN = "push_aggregation_through_join";
     public static final String PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN = "push_partial_aggregation_through_join";
     public static final String FORCE_SINGLE_NODE_OUTPUT = "force_single_node_output";
+    public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE = "filter_and_project_min_output_page_size";
+    public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT = "filter_and_project_min_output_page_row_count";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -334,7 +336,21 @@ public final class SystemSessionProperties
                         FORCE_SINGLE_NODE_OUTPUT,
                         "Force single node output",
                         featuresConfig.isForceSingleNodeOutput(),
-                        true));
+                        true),
+                new PropertyMetadata<>(
+                        FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE,
+                        "Experimental: Minimum output page size for filter and project operators",
+                        VARCHAR,
+                        DataSize.class,
+                        featuresConfig.getFilterAndProjectMinOutputPageSize(),
+                        false,
+                        value -> DataSize.valueOf((String) value),
+                        DataSize::toString),
+                integerSessionProperty(
+                        FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT,
+                        "Experimental: Minimum output page row count for filter and project operators",
+                        featuresConfig.getFilterAndProjectMinOutputPageRowCount(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -524,5 +540,15 @@ public final class SystemSessionProperties
     public static boolean isForceSingleNodeOutput(Session session)
     {
         return session.getSystemProperty(FORCE_SINGLE_NODE_OUTPUT, Boolean.class);
+    }
+
+    public static DataSize getFilterAndProjectMinOutputPageSize(Session session)
+    {
+        return session.getSystemProperty(FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE, DataSize.class);
+    }
+
+    public static int getFilterAndProjectMinOutputPageRowCount(Session session)
+    {
+        return session.getSystemProperty(FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT, Integer.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -17,6 +17,7 @@ import com.facebook.presto.memory.LocalMemoryContext;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.project.CursorProcessor;
 import com.facebook.presto.operator.project.CursorProcessorOutput;
+import com.facebook.presto.operator.project.MergingPageOutput;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.operator.project.PageProcessorOutput;
 import com.facebook.presto.spi.ColumnHandle;
@@ -35,6 +36,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.airlift.units.DataSize;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -43,7 +45,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-import static com.facebook.presto.operator.project.PageProcessorOutput.EMPTY_PAGE_PROCESSOR_OUTPUT;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static java.util.Objects.requireNonNull;
@@ -62,12 +63,12 @@ public class ScanFilterAndProjectOperator
     private final LocalMemoryContext pageSourceMemoryContext;
     private final LocalMemoryContext pageBuilderMemoryContext;
     private final SettableFuture<?> blocked = SettableFuture.create();
+    private final MergingPageOutput mergingOutput;
 
     private RecordCursor cursor;
     private ConnectorPageSource pageSource;
 
     private Split split;
-    private PageProcessorOutput currentOutput = EMPTY_PAGE_PROCESSOR_OUTPUT;
 
     private boolean finishing;
 
@@ -81,7 +82,8 @@ public class ScanFilterAndProjectOperator
             CursorProcessor cursorProcessor,
             PageProcessor pageProcessor,
             Iterable<ColumnHandle> columns,
-            Iterable<Type> types)
+            Iterable<Type> types,
+            MergingPageOutput mergingOutput)
     {
         this.cursorProcessor = requireNonNull(cursorProcessor, "cursorProcessor is null");
         this.pageProcessor = requireNonNull(pageProcessor, "pageProcessor is null");
@@ -92,6 +94,7 @@ public class ScanFilterAndProjectOperator
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.pageSourceMemoryContext = operatorContext.getSystemMemoryContext().newLocalMemoryContext();
         this.pageBuilderMemoryContext = operatorContext.getSystemMemoryContext().newLocalMemoryContext();
+        this.mergingOutput = requireNonNull(mergingOutput, "mergingOutput is null");
 
         this.pageBuilder = new PageBuilder(getTypes());
     }
@@ -143,6 +146,7 @@ public class ScanFilterAndProjectOperator
     {
         if (split == null) {
             finishing = true;
+            mergingOutput.finish();
         }
         blocked.set(null);
     }
@@ -175,12 +179,13 @@ public class ScanFilterAndProjectOperator
             cursor.close();
         }
         finishing = true;
+        mergingOutput.finish();
     }
 
     @Override
     public final boolean isFinished()
     {
-        return finishing && pageBuilder.isEmpty() && !currentOutput.hasNext();
+        return finishing && pageBuilder.isEmpty() && mergingOutput.isFinished();
     }
 
     @Override
@@ -245,7 +250,10 @@ public class ScanFilterAndProjectOperator
             operatorContext.recordGeneratedInput(bytesProcessed, output.getProcessedRows(), elapsedNanos);
             completedBytes = cursor.getCompletedBytes();
             readTimeNanos = cursor.getReadTimeNanos();
-            finishing = output.isNoMoreRows();
+            if (output.isNoMoreRows()) {
+                finishing = true;
+                mergingOutput.finish();
+            }
         }
 
         // only return a page if buffer is full or we are finishing
@@ -261,16 +269,13 @@ public class ScanFilterAndProjectOperator
     private Page processPageSource()
     {
         DriverYieldSignal yieldSignal = operatorContext.getDriverContext().getYieldSignal();
-        if (!finishing && !currentOutput.hasNext() && !yieldSignal.isSet()) {
+        if (!finishing && mergingOutput.needsInput() && !yieldSignal.isSet()) {
             Page page = pageSource.getNextPage();
 
             finishing = pageSource.isFinished();
             pageSourceMemoryContext.setBytes(pageSource.getSystemMemoryUsage());
 
-            if (page == null) {
-                currentOutput = EMPTY_PAGE_PROCESSOR_OUTPUT;
-            }
-            else {
+            if (page != null) {
                 // update operator stats
                 long endCompletedBytes = pageSource.getCompletedBytes();
                 long endReadTimeNanos = pageSource.getReadTimeNanos();
@@ -278,12 +283,18 @@ public class ScanFilterAndProjectOperator
                 completedBytes = endCompletedBytes;
                 readTimeNanos = endReadTimeNanos;
 
-                currentOutput = pageProcessor.process(operatorContext.getSession().toConnectorSession(), yieldSignal, page);
+                PageProcessorOutput output = pageProcessor.process(operatorContext.getSession().toConnectorSession(), yieldSignal, page);
+                mergingOutput.addInput(output);
             }
-            pageBuilderMemoryContext.setBytes(currentOutput.getRetainedSizeInBytes());
+
+            if (finishing) {
+                mergingOutput.finish();
+            }
         }
 
-        return currentOutput.hasNext() ? currentOutput.next().orElse(null) : null;
+        Page result = mergingOutput.getOutput();
+        pageBuilderMemoryContext.setBytes(mergingOutput.getRetainedSizeInBytes());
+        return result;
     }
 
     public static class ScanFilterAndProjectOperatorFactory
@@ -297,6 +308,8 @@ public class ScanFilterAndProjectOperator
         private final PageSourceProvider pageSourceProvider;
         private final List<ColumnHandle> columns;
         private final List<Type> types;
+        private final DataSize minOutputPageSize;
+        private final int minOutputPageRowCount;
         private boolean closed;
 
         public ScanFilterAndProjectOperatorFactory(
@@ -307,7 +320,9 @@ public class ScanFilterAndProjectOperator
                 Supplier<CursorProcessor> cursorProcessor,
                 Supplier<PageProcessor> pageProcessor,
                 Iterable<ColumnHandle> columns,
-                List<Type> types)
+                List<Type> types,
+                DataSize minOutputPageSize,
+                int minOutputPageRowCount)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -317,6 +332,8 @@ public class ScanFilterAndProjectOperator
             this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
             this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
             this.types = requireNonNull(types, "types is null");
+            this.minOutputPageSize = requireNonNull(minOutputPageSize, "minOutputPageSize is null");
+            this.minOutputPageRowCount = minOutputPageRowCount;
         }
 
         @Override
@@ -343,7 +360,8 @@ public class ScanFilterAndProjectOperator
                     cursorProcessor.get(),
                     pageProcessor.get(),
                     columns,
-                    types);
+                    types,
+                    new MergingPageOutput(types, minOutputPageSize.toBytes(), minOutputPageRowCount));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.relational.Expressions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
+import io.airlift.units.DataSize;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +35,7 @@ import java.util.stream.IntStream;
 import static com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.Objects.requireNonNull;
 
 public class DynamicTupleFilterFactory
@@ -84,7 +86,7 @@ public class DynamicTupleFilterFactory
     {
         Page filterTuple = getFilterTuple(tuplePage);
         Supplier<PageProcessor> processor = createPageProcessor(filterTuple);
-        return new FilterAndProjectOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes);
+        return new FilterAndProjectOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes, new DataSize(0, BYTE), 0);
     }
 
     @VisibleForTesting

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/MergingPageOutput.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/MergingPageOutput.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.project;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+
+import static com.facebook.presto.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class is intended to be used right after the PageProcessor to ensure
+ * that the size of the pages returned by FilterAndProject and ScanFilterAndProject
+ * is big enough so it does not introduce considerable synchronization overhead.
+ * <p>
+ * As long as the input page contains more than {@link MergingPageOutput#minRowCount} rows
+ * or is bigger than {@link MergingPageOutput#minPageSizeInBytes} it is returned as is without
+ * additional memory copy.
+ * <p>
+ * The page data that has been buffered so far before receiving a "big" page is being flushed
+ * before transferring a "big" page.
+ * <p>
+ * Although it is still possible that the {@link MergingPageOutput} may return a tiny page,
+ * this situation is considered to be rare due to the assumption that filter selectivity may not
+ * vary a lot based on the particular input page.
+ * <p>
+ * Considering the CPU time required to process(filter, project) a full (~1MB) page returned by a
+ * connector, the CPU cost of memory copying (< 50kb, < 1024 rows) is supposed to be negligible.
+ */
+@NotThreadSafe
+public class MergingPageOutput
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(MergingPageOutput.class).instanceSize();
+    private static final int MAX_MIN_PAGE_SIZE = 1024 * 1024;
+
+    private final List<Type> types;
+    private final PageBuilder pageBuilder;
+    private final Queue<Page> outputQueue = new LinkedList<>();
+
+    private final long minPageSizeInBytes;
+    private final int minRowCount;
+
+    @Nullable
+    private PageProcessorOutput currentInput = null;
+    private boolean finishing = false;
+
+    public MergingPageOutput(Iterable<? extends Type> types, long minPageSizeInBytes, int minRowCount)
+    {
+        this(types, minPageSizeInBytes, minRowCount, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
+    }
+
+    public MergingPageOutput(Iterable<? extends Type> types, long minPageSizeInBytes, int minRowCount, int maxPageSizeInBytes)
+    {
+        this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        checkArgument(minPageSizeInBytes >= 0, "minPageSizeInBytes must be greater or equal than zero");
+        checkArgument(minRowCount >= 0, "minRowCount must be greater or equal than zero");
+        checkArgument(maxPageSizeInBytes > 0, "maxPageSizeInBytes must be greater than zero");
+        checkArgument(maxPageSizeInBytes >= minPageSizeInBytes, "maxPageSizeInBytes must be greater or equal than minPageSizeInBytes");
+        checkArgument(minPageSizeInBytes <= MAX_MIN_PAGE_SIZE, "minPageSizeInBytes must be less or equal than %d", MAX_MIN_PAGE_SIZE);
+        this.minPageSizeInBytes = minPageSizeInBytes;
+        this.minRowCount = minRowCount;
+        pageBuilder = PageBuilder.withMaxPageSize(maxPageSizeInBytes, this.types);
+    }
+
+    public boolean needsInput()
+    {
+        return currentInput == null && !finishing && outputQueue.isEmpty();
+    }
+
+    public void addInput(PageProcessorOutput input)
+    {
+        requireNonNull(input, "input is null");
+        checkState(!finishing, "output is in finishing state");
+        checkState(currentInput == null, "currentInput is present");
+        currentInput = input;
+    }
+
+    @Nullable
+    public Page getOutput()
+    {
+        if (!outputQueue.isEmpty()) {
+            return outputQueue.poll();
+        }
+
+        while (currentInput != null) {
+            if (!currentInput.hasNext()) {
+                currentInput = null;
+                break;
+            }
+
+            if (!outputQueue.isEmpty()) {
+                break;
+            }
+
+            Optional<Page> next = currentInput.next();
+            if (next.isPresent()) {
+                process(next.get());
+            }
+            else {
+                break;
+            }
+        }
+
+        if (currentInput == null && finishing) {
+            flush();
+        }
+
+        return outputQueue.poll();
+    }
+
+    public void finish()
+    {
+        finishing = true;
+    }
+
+    public boolean isFinished()
+    {
+        return finishing && currentInput == null && outputQueue.isEmpty() && pageBuilder.isEmpty();
+    }
+
+    private void process(Page page)
+    {
+        requireNonNull(page, "page is null");
+
+        // avoid memory copying for pages that are big enough
+        if (page.getSizeInBytes() >= minPageSizeInBytes || page.getPositionCount() >= minRowCount) {
+            flush();
+            outputQueue.add(page);
+            return;
+        }
+
+        buffer(page);
+    }
+
+    private void buffer(Page page)
+    {
+        pageBuilder.declarePositions(page.getPositionCount());
+        for (int channel = 0; channel < types.size(); channel++) {
+            Type type = types.get(channel);
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
+            }
+        }
+        if (pageBuilder.isFull()) {
+            flush();
+        }
+    }
+
+    private void flush()
+    {
+        if (!pageBuilder.isEmpty()) {
+            Page output = pageBuilder.build();
+            pageBuilder.reset();
+            outputQueue.add(output);
+        }
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        long retainedSizeInBytes = INSTANCE_SIZE;
+        retainedSizeInBytes += pageBuilder.getRetainedSizeInBytes();
+        if (currentInput != null) {
+            retainedSizeInBytes += currentInput.getRetainedSizeInBytes();
+        }
+        for (Page page : outputQueue) {
+            retainedSizeInBytes += page.getRetainedSizeInBytes();
+        }
+        return retainedSizeInBytes;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -20,6 +20,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.airlift.units.MaxDataSize;
 
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
@@ -31,6 +32,7 @@ import java.util.List;
 
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 @DefunctConfig({
@@ -76,6 +78,9 @@ public class FeaturesConfig
     private double memoryRevokingThreshold = 0.9;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
+
+    private DataSize filterAndProjectMinOutputPageSize = new DataSize(25, KILOBYTE);
+    private int filterAndProjectMinOutputPageRowCount = 256;
 
     public boolean isResourceGroupsEnabled()
     {
@@ -482,6 +487,32 @@ public class FeaturesConfig
     public FeaturesConfig setPagesIndexEagerCompactionEnabled(boolean pagesIndexEagerCompactionEnabled)
     {
         this.pagesIndexEagerCompactionEnabled = pagesIndexEagerCompactionEnabled;
+        return this;
+    }
+
+    @MaxDataSize("1MB")
+    public DataSize getFilterAndProjectMinOutputPageSize()
+    {
+        return filterAndProjectMinOutputPageSize;
+    }
+
+    @Config("experimental.filter-and-project-min-output-page-size")
+    public FeaturesConfig setFilterAndProjectMinOutputPageSize(DataSize filterAndProjectMinOutputPageSize)
+    {
+        this.filterAndProjectMinOutputPageSize = filterAndProjectMinOutputPageSize;
+        return this;
+    }
+
+    @Min(0)
+    public int getFilterAndProjectMinOutputPageRowCount()
+    {
+        return filterAndProjectMinOutputPageRowCount;
+    }
+
+    @Config("experimental.filter-and-project-min-output-page-row-count")
+    public FeaturesConfig setFilterAndProjectMinOutputPageRowCount(int filterAndProjectMinOutputPageRowCount)
+    {
+        this.filterAndProjectMinOutputPageRowCount = filterAndProjectMinOutputPageRowCount;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -184,6 +184,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.getAggregationOperatorUnspillMemoryLimit;
+import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMinOutputPageRowCount;
+import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMinOutputPageSize;
 import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
 import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
 import static com.facebook.presto.SystemSessionProperties.isExchangeCompressionEnabled;
@@ -1098,7 +1100,9 @@ public class LocalExecutionPlanner
                             cursorProcessor,
                             pageProcessor,
                             columns,
-                            getTypes(rewrittenProjections, expressionTypes));
+                            getTypes(rewrittenProjections, expressionTypes),
+                            getFilterAndProjectMinOutputPageSize(session),
+                            getFilterAndProjectMinOutputPageRowCount(session));
 
                     return new PhysicalOperation(operatorFactory, outputMappings);
                 }
@@ -1109,7 +1113,9 @@ public class LocalExecutionPlanner
                             context.getNextOperatorId(),
                             planNodeId,
                             pageProcessor,
-                            getTypes(rewrittenProjections, expressionTypes));
+                            getTypes(rewrittenProjections, expressionTypes),
+                            getFilterAndProjectMinOutputPageSize(session),
+                            getFilterAndProjectMinOutputPageRowCount(session));
 
                     return new PhysicalOperation(operatorFactory, outputMappings, source);
                 }
@@ -1150,7 +1156,9 @@ public class LocalExecutionPlanner
                         () -> cursorProcessor,
                         () -> pageProcessor,
                         columns,
-                        getTypes(rewrittenProjections, expressionTypes));
+                        getTypes(rewrittenProjections, expressionTypes),
+                        getFilterAndProjectMinOutputPageSize(session),
+                        getFilterAndProjectMinOutputPageRowCount(session));
 
                 return new PhysicalOperation(operatorFactory, outputMappings);
             }
@@ -1159,7 +1167,9 @@ public class LocalExecutionPlanner
                         context.getNextOperatorId(),
                         planNodeId,
                         () -> pageProcessor,
-                        getTypes(rewrittenProjections, expressionTypes));
+                        getTypes(rewrittenProjections, expressionTypes),
+                        getFilterAndProjectMinOutputPageSize(session),
+                        getFilterAndProjectMinOutputPageRowCount(session));
                 return new PhysicalOperation(operatorFactory, outputMappings, source);
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -182,6 +182,8 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 
+import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMinOutputPageRowCount;
+import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMinOutputPageSize;
 import static com.facebook.presto.execution.SqlQueryManager.unwrapExecuteStatement;
 import static com.facebook.presto.execution.SqlQueryManager.validateParameters;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -828,7 +830,7 @@ public class LocalQueryRunner
         };
     }
 
-    public OperatorFactory createHashProjectOperator(int operatorId, PlanNodeId planNodeId, List<Type> columnTypes)
+    public OperatorFactory createHashProjectOperator(Session session, int operatorId, PlanNodeId planNodeId, List<Type> columnTypes)
     {
         ImmutableMap.Builder<Symbol, Type> symbolTypes = ImmutableMap.builder();
         ImmutableMap.Builder<Symbol, Integer> symbolToInputMapping = ImmutableMap.builder();
@@ -860,7 +862,9 @@ public class LocalQueryRunner
                 operatorId,
                 planNodeId,
                 () -> new PageProcessor(Optional.empty(), projections.build()),
-                ImmutableList.copyOf(Iterables.concat(columnTypes, ImmutableList.of(BIGINT))));
+                ImmutableList.copyOf(Iterables.concat(columnTypes, ImmutableList.of(BIGINT))),
+                getFilterAndProjectMinOutputPageSize(session),
+                getFilterAndProjectMinOutputPageRowCount(session));
     }
 
     private Split getLocalQuerySplit(Session session, TableLayoutHandle handle)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFilterAndProjectOperator.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.testing.MaterializedResult;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -39,6 +40,7 @@ import static com.facebook.presto.metadata.MetadataManager.createTestMetadataMan
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
 import static com.facebook.presto.spi.function.OperatorType.ADD;
 import static com.facebook.presto.spi.function.OperatorType.BETWEEN;
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
@@ -47,6 +49,8 @@ import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.field;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 
@@ -105,7 +109,9 @@ public class TestFilterAndProjectOperator
                 0,
                 new PlanNodeId("test"),
                 processor,
-                ImmutableList.of(VARCHAR, BIGINT));
+                ImmutableList.of(VARCHAR, BIGINT),
+                new DataSize(0, BYTE),
+                0);
 
         MaterializedResult expected = MaterializedResult.resultBuilder(driverContext.getSession(), VARCHAR, BIGINT)
                 .row("10", 15L)
@@ -118,6 +124,45 @@ public class TestFilterAndProjectOperator
                 .row("17", 22L)
                 .row("18", 23L)
                 .row("19", 24L)
+                .build();
+
+        assertOperatorEquals(operatorFactory, driverContext, input, expected);
+    }
+
+    @Test
+    public void testMergeOutput()
+            throws Exception
+    {
+        List<Page> input = rowPagesBuilder(VARCHAR, BIGINT)
+                .addSequencePage(100, 0, 0)
+                .addSequencePage(100, 0, 0)
+                .addSequencePage(100, 0, 0)
+                .addSequencePage(100, 0, 0)
+                .build();
+
+        RowExpression filter = call(
+                Signature.internalOperator(EQUAL, BOOLEAN.getTypeSignature(), ImmutableList.of(BIGINT.getTypeSignature(), BIGINT.getTypeSignature())),
+                BOOLEAN,
+                field(1, BIGINT),
+                constant(10L, BIGINT));
+
+        MetadataManager metadata = createTestMetadataManager();
+        ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
+        Supplier<PageProcessor> processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field(1, BIGINT)));
+
+        OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                processor,
+                ImmutableList.of(BIGINT),
+                new DataSize(64, KILOBYTE),
+                2);
+
+        List<Page> expected = rowPagesBuilder(BIGINT)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
                 .build();
 
         assertOperatorEquals(operatorFactory, driverContext, input, expected);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -41,6 +41,7 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.TestingSplit;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -49,18 +50,25 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.block.BlockAssertions.toValues;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.metadata.Signature.internalScalarFunction;
 import static com.facebook.presto.operator.OperatorAssertion.toMaterializedResult;
+import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.field;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -101,7 +109,9 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 ImmutableList.of(),
-                ImmutableList.of(VARCHAR));
+                ImmutableList.of(VARCHAR),
+                new DataSize(0, BYTE),
+                0);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -112,6 +122,55 @@ public class TestScanFilterAndProjectOperator
 
         assertEquals(actual.getRowCount(), expected.getRowCount());
         assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testPageSourceMergeOutput()
+            throws Exception
+    {
+        List<Page> input = rowPagesBuilder(BIGINT)
+                .addSequencePage(100, 0)
+                .addSequencePage(100, 0)
+                .addSequencePage(100, 0)
+                .addSequencePage(100, 0)
+                .build();
+
+        RowExpression filter = call(
+                Signature.internalOperator(EQUAL, BOOLEAN.getTypeSignature(), ImmutableList.of(BIGINT.getTypeSignature(), BIGINT.getTypeSignature())),
+                BOOLEAN,
+                field(0, BIGINT),
+                constant(10L, BIGINT));
+        List<RowExpression> projections = ImmutableList.of(field(0, BIGINT));
+        Supplier<CursorProcessor> cursorProcessor = expressionCompiler.compileCursorProcessor(Optional.of(filter), projections, "key");
+        Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(Optional.of(filter), projections);
+
+        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                new PlanNodeId("0"),
+                (session, split, columns) -> new FixedPageSource(input),
+                cursorProcessor,
+                pageProcessor,
+                ImmutableList.of(),
+                ImmutableList.of(BIGINT),
+                new DataSize(64, KILOBYTE),
+                2);
+
+        SourceOperator operator = factory.createOperator(newDriverContext());
+        operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
+        operator.noMoreSplits();
+
+        List<Page> actual = toPages(operator);
+        assertEquals(actual.size(), 1);
+
+        List<Page> expected = rowPagesBuilder(BIGINT)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .row(10L)
+                .build();
+
+        assertPageEquals(ImmutableList.of(BIGINT), actual.get(0), expected.get(0));
     }
 
     @Test
@@ -137,7 +196,9 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 () -> pageProcessor,
                 ImmutableList.of(),
-                ImmutableList.of(BIGINT));
+                ImmutableList.of(BIGINT),
+                new DataSize(0, BYTE),
+                0);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -169,7 +230,9 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 ImmutableList.of(),
-                ImmutableList.of(VARCHAR));
+                ImmutableList.of(VARCHAR),
+                new DataSize(0, BYTE),
+                0);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -219,7 +282,9 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 ImmutableList.of(),
-                ImmutableList.of(BIGINT));
+                ImmutableList.of(BIGINT),
+                new DataSize(0, BYTE),
+                0);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -277,7 +342,9 @@ public class TestScanFilterAndProjectOperator
                 cursorProcessor,
                 pageProcessor,
                 ImmutableList.of(),
-                ImmutableList.of(BIGINT));
+                ImmutableList.of(BIGINT),
+                new DataSize(0, BYTE),
+                0);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestMergingPageOutput.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestMergingPageOutput.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.project;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.SequencePageBuilder.createSequencePage;
+import static com.facebook.presto.execution.buffer.PageSplitterUtil.splitPage;
+import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.google.common.collect.Iterators.transform;
+import static java.lang.Math.toIntExact;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestMergingPageOutput
+{
+    private static final List<Type> TYPES = ImmutableList.of(BIGINT, REAL, DOUBLE);
+
+    @Test
+    public void testMinPageSizeThreshold()
+            throws Exception
+    {
+        Page page = createSequencePage(TYPES, 10);
+
+        MergingPageOutput output = new MergingPageOutput(TYPES, page.getSizeInBytes(), Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+        assertTrue(output.needsInput());
+        assertNull(output.getOutput());
+
+        output.addInput(createPageProcessorOutput(page));
+        assertFalse(output.needsInput());
+        assertSame(output.getOutput(), page);
+    }
+
+    @Test
+    public void testMinRowCountThreshold()
+            throws Exception
+    {
+        Page page = createSequencePage(TYPES, 10);
+
+        MergingPageOutput output = new MergingPageOutput(TYPES, 1024 * 1024, page.getPositionCount(), Integer.MAX_VALUE);
+
+        assertTrue(output.needsInput());
+        assertNull(output.getOutput());
+
+        output.addInput(createPageProcessorOutput(page));
+        assertFalse(output.needsInput());
+        assertSame(output.getOutput(), page);
+    }
+
+    @Test
+    public void testBufferSmallPages()
+            throws Exception
+    {
+        int singlePageRowCount = 10;
+        Page page = createSequencePage(TYPES, singlePageRowCount * 2);
+        List<Page> splits = splitPage(page, page.getSizeInBytes() / 2);
+
+        MergingPageOutput output = new MergingPageOutput(TYPES, page.getSizeInBytes() + 1, page.getPositionCount() + 1, Integer.MAX_VALUE);
+
+        assertTrue(output.needsInput());
+        assertNull(output.getOutput());
+
+        output.addInput(createPageProcessorOutput(splits.get(0)));
+        assertFalse(output.needsInput());
+        assertNull(output.getOutput());
+        assertTrue(output.needsInput());
+
+        output.addInput(createPageProcessorOutput(splits.get(1)));
+        assertFalse(output.needsInput());
+        assertNull(output.getOutput());
+
+        output.finish();
+
+        assertFalse(output.needsInput());
+        assertPageEquals(TYPES, output.getOutput(), page);
+    }
+
+    @Test
+    public void testFlushOnBigPage()
+            throws Exception
+    {
+        Page smallPage = createSequencePage(TYPES, 10);
+        Page bigPage = createSequencePage(TYPES, 100);
+
+        MergingPageOutput output = new MergingPageOutput(TYPES, bigPage.getSizeInBytes(), bigPage.getPositionCount(), Integer.MAX_VALUE);
+
+        assertTrue(output.needsInput());
+        assertNull(output.getOutput());
+
+        output.addInput(createPageProcessorOutput(smallPage));
+        assertFalse(output.needsInput());
+        assertNull(output.getOutput());
+        assertTrue(output.needsInput());
+
+        output.addInput(createPageProcessorOutput(bigPage));
+        assertFalse(output.needsInput());
+        assertPageEquals(TYPES, output.getOutput(), smallPage);
+        assertFalse(output.needsInput());
+        assertSame(output.getOutput(), bigPage);
+    }
+
+    @Test
+    public void testFlushOnFullPage()
+            throws Exception
+    {
+        int singlePageRowCount = 10;
+        List<Type> types = ImmutableList.of(BIGINT);
+        Page page = createSequencePage(types, singlePageRowCount * 2);
+        List<Page> splits = splitPage(page, page.getSizeInBytes() / 2);
+
+        MergingPageOutput output = new MergingPageOutput(types, page.getSizeInBytes() / 2 + 1, page.getPositionCount() / 2 + 1, toIntExact(page.getSizeInBytes()));
+
+        assertTrue(output.needsInput());
+        assertNull(output.getOutput());
+
+        output.addInput(createPageProcessorOutput(splits.get(0)));
+        assertFalse(output.needsInput());
+        assertNull(output.getOutput());
+        assertTrue(output.needsInput());
+
+        output.addInput(createPageProcessorOutput(splits.get(1)));
+        assertFalse(output.needsInput());
+        assertPageEquals(types, output.getOutput(), page);
+
+        output.addInput(createPageProcessorOutput(splits.get(0), splits.get(1)));
+        assertFalse(output.needsInput());
+        assertPageEquals(types, output.getOutput(), page);
+    }
+
+    private static PageProcessorOutput createPageProcessorOutput(Page... pages)
+    {
+        return createPageProcessorOutput(ImmutableList.copyOf(pages));
+    }
+
+    private static PageProcessorOutput createPageProcessorOutput(List<Page> pages)
+    {
+        long retainedSizeInBytes = pages.stream().mapToLong(Page::getRetainedSizeInBytes).sum();
+        return new PageProcessorOutput(() -> retainedSizeInBytes, transform(pages.iterator(), Optional::of));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -75,6 +75,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
@@ -121,6 +122,7 @@ import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.testing.Assertions.assertInstanceOf;
+import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -717,7 +719,9 @@ public final class FunctionAssertions
                 0,
                 new PlanNodeId("test"),
                 () -> processor,
-                ImmutableList.of(pageProjection.getType()));
+                ImmutableList.of(pageProjection.getType()),
+                new DataSize(0, BYTE),
+                0);
         return operatorFactory.createOperator(createDriverContext(session));
     }
 
@@ -726,7 +730,7 @@ public final class FunctionAssertions
         try {
             Supplier<PageProcessor> processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of());
 
-            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of());
+            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(), new DataSize(0, BYTE), 0);
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {
@@ -740,7 +744,7 @@ public final class FunctionAssertions
     {
         try {
             Supplier<PageProcessor> processor = compiler.compilePageProcessor(filter, ImmutableList.of(projection));
-            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(projection.getType()));
+            return new FilterAndProjectOperatorFactory(0, new PlanNodeId("test"), processor, ImmutableList.of(projection.getType()), new DataSize(0, BYTE), 0);
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {
@@ -770,7 +774,9 @@ public final class FunctionAssertions
                     cursorProcessor,
                     pageProcessor,
                     ImmutableList.of(),
-                    ImmutableList.of(projection.getType()));
+                    ImmutableList.of(projection.getType()),
+                    new DataSize(0, BYTE),
+                    0);
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -25,6 +25,8 @@ import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.RE2J;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -66,7 +68,9 @@ public class TestFeaturesConfig
                 .setEnableIntermediateAggregations(false)
                 .setPushAggregationThroughJoin(true)
                 .setForceSingleNodeOutput(true)
-                .setPagesIndexEagerCompactionEnabled(false));
+                .setPagesIndexEagerCompactionEnabled(false)
+                .setFilterAndProjectMinOutputPageSize(new DataSize(25, KILOBYTE))
+                .setFilterAndProjectMinOutputPageRowCount(256));
     }
 
     @Test
@@ -106,6 +110,8 @@ public class TestFeaturesConfig
                 .put("optimizer.enable-intermediate-aggregations", "true")
                 .put("optimizer.force-single-node-output", "false")
                 .put("pages-index.eager-compaction-enabled", "true")
+                .put("experimental.filter-and-project-min-output-page-size", "1MB")
+                .put("experimental.filter-and-project-min-output-page-row-count", "2048")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -141,7 +147,9 @@ public class TestFeaturesConfig
                 .setExchangeCompressionEnabled(true)
                 .setEnableIntermediateAggregations(true)
                 .setForceSingleNodeOutput(false)
-                .setPagesIndexEagerCompactionEnabled(true);
+                .setPagesIndexEagerCompactionEnabled(true)
+                .setFilterAndProjectMinOutputPageSize(new DataSize(1, MEGABYTE))
+                .setFilterAndProjectMinOutputPageRowCount(2048);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
FilterAndProject and ScanFilterAndProject operators may produce
tiny pages (few rows) in case of highly selective filter.

Such tiny pages introduce considerable synchronization overhead
in subsequent operators. In particular HashBuilderOperator
does memory reservations for every single page. Considering that
memory manager is all the way synchronized - most of the time spent
by worker thread is just waiting for a lock.