### PR TITLE
Add Lookup#resolveGroup method and make Lookup#resolve depricated

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -76,7 +76,7 @@ public class IterativeOptimizer
         }
 
         Memo memo = new Memo(idAllocator, plan);
-        Lookup lookup = Lookup.from(memo::resolve);
+        Lookup lookup = Lookup.from(planNode -> ImmutableList.of(memo.resolve(planNode)));
         Matcher matcher = new PlanNodeMatcher(lookup);
 
         Duration timeout = SystemSessionProperties.getOptimizerTimeout(session);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
@@ -14,10 +14,13 @@
 package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableList;
 
+import java.util.List;
 import java.util.function.Function;
 
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Iterables.getOnlyElement;
 
 public interface Lookup
 {
@@ -28,7 +31,20 @@ public interface Lookup
      * If the node is not a GroupReference, it returns the
      * argument as is.
      */
-    PlanNode resolve(PlanNode node);
+    @Deprecated
+    default PlanNode resolve(PlanNode node)
+    {
+        return getOnlyElement(resolveGroup(node));
+    }
+
+    /**
+     * Resolves nodes by materializing GroupReference nodes
+     * representing symbolic references to other nodes.
+     * <p>
+     * If the node is not a GroupReference, it returns the
+     * singleton of the argument node.
+     */
+    List<PlanNode> resolveGroup(PlanNode node);
 
     /**
      * A Lookup implementation that does not perform lookup. It satisfies contract
@@ -38,18 +54,18 @@ public interface Lookup
     {
         return node -> {
             verify(!(node instanceof GroupReference), "Unexpected GroupReference");
-            return node;
+            return ImmutableList.of(node);
         };
     }
 
-    static Lookup from(Function<GroupReference, PlanNode> resolver)
+    static Lookup from(Function<GroupReference, List<PlanNode>> resolver)
     {
         return node -> {
             if (node instanceof GroupReference) {
                 return resolver.apply((GroupReference) node);
             }
 
-            return node;
+            return ImmutableList.of(node);
         };
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.collect.ImmutableList;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -92,7 +93,7 @@ public class Memo
 
     private PlanNode extract(PlanNode node)
     {
-        return resolveGroupReferences(node, Lookup.from(this::resolve));
+        return resolveGroupReferences(node, Lookup.from(planNode -> ImmutableList.of(this.resolve(planNode))));
     }
 
     public PlanNode replace(int group, PlanNode node, String reason)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
 import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Map;
@@ -146,7 +147,7 @@ public class RuleAssert
     {
         SymbolAllocator symbolAllocator = new SymbolAllocator(symbols);
         Memo memo = new Memo(idAllocator, plan);
-        Lookup lookup = Lookup.from(memo::resolve);
+        Lookup lookup = Lookup.from(planNode -> ImmutableList.of(memo.resolve(planNode)));
 
         PlanNode memoRoot = memo.getNode(memo.getRootGroup());
 


### PR DESCRIPTION
In the future, equivalence based memo would
store multiple plan nodes per group. Therefore
resolve() that returns singleton should be unused.

This is part of ongoing effort to introduce equivalence based memo and exploratory optimizer: https://github.com/prestodb/presto/issues/7169
It is natural step after `Support simple pattern matching with captures` that makes rule interface compatible with equivalence based memo.

FYI @martint @kokosing 