### PR TITLE
Dedup retained size for PageProcessor

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -188,11 +188,9 @@ public class LazyBlock
     @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
-        // do not support LazyBlock (for now) for the following two reasons:
-        // (1) the method is mainly used for inspecting the identity and size of each element to prevent over counting
-        // (2) the method should be non-recursive and only inspects blocks at the top level;
-        //     given LazyBlock is a wrapper for other blocks, it is not meaningful to only inspect the top-level elements
-        throw new UnsupportedOperationException(getClass().getName());
+        assureLoaded();
+        block.retainedBytesForEachPart(consumer);
+        consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
     @Override


### PR DESCRIPTION
PageProcessor can save previously computed results, which contribute to
its retained size. There are cases where the previous computed results
are the same as the blocks in the input page. We need to avoid double
counting the size for such cases.