### PR TITLE
Fix flaky TestQueues test

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
@@ -21,6 +21,8 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupInfo;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -37,7 +39,6 @@ import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.dashboa
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDao;
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDbConfigUrl;
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getSelectors;
-import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getSimpleQueryRunner;
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.rejectingSession;
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.waitForCompleteQueryCount;
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.waitForRunningQueryCount;
@@ -51,20 +52,37 @@ public class TestQueues
 {
     // Copy of TestQueues with tests for db reconfiguration of resource groups
     private static final String LONG_LASTING_QUERY = "SELECT COUNT(*) FROM lineitem";
+    private DistributedQueryRunner queryRunner;
+    private H2ResourceGroupsDao dao;
+
+    @BeforeMethod
+    public void setup()
+            throws Exception
+    {
+        String dbConfigUrl = getDbConfigUrl();
+        dao = getDao(dbConfigUrl);
+        queryRunner = createQueryRunner(dbConfigUrl, dao);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        queryManager.getAllQueryInfo().forEach(queryInfo -> queryManager.cancelQuery(queryInfo.getQueryId()));
+        queryRunner.close();
+    }
 
     @Test(timeOut = 60_000)
     public void testRunningQuery()
             throws Exception
     {
-        try (DistributedQueryRunner queryRunner = getSimpleQueryRunner()) {
-            queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
-            while (true) {
-                ResourceGroupInfo global = queryRunner.getCoordinator().getResourceGroupManager().get().getResourceGroupInfo(new ResourceGroupId(new ResourceGroupId("global"), "bi-user"));
-                if (global.getSoftMemoryLimit().toBytes() > 0) {
-                    break;
-                }
-                TimeUnit.SECONDS.sleep(2);
+        queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
+        while (true) {
+            ResourceGroupInfo global = queryRunner.getCoordinator().getResourceGroupManager().get().getResourceGroupInfo(new ResourceGroupId(new ResourceGroupId("global"), "bi-user"));
+            if (global.getSoftMemoryLimit().toBytes() > 0) {
+                break;
             }
+            TimeUnit.SECONDS.sleep(2);
         }
     }
 
@@ -72,159 +90,132 @@ public class TestQueues
     public void testBasic()
             throws Exception
     {
-        String dbConfigUrl = getDbConfigUrl();
-        H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner queryRunner = createQueryRunner(dbConfigUrl, dao)) {
-            // submit first "dashboard" query
-            QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-
-            // wait for the first "dashboard" query to start
-            waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
-            waitForRunningQueryCount(queryRunner, 1);
-            // submit second "dashboard" query
-            QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            MILLISECONDS.sleep(2000);
-            // wait for the second "dashboard" query to be queued ("dashboard.${USER}" queue strategy only allows one "dashboard" query to be accepted for execution)
-            waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
-            waitForRunningQueryCount(queryRunner, 1);
-            // Update db to allow for 1 more running query in dashboard resource group
-            dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, null, null, null, null, null, null, null, 1L);
-            dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, null, null, null, null, null, null, null, 3L);
-            waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
-            QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
-            waitForRunningQueryCount(queryRunner, 2);
-            // submit first non "dashboard" query
-            QueryId firstNonDashboardQuery = createQuery(queryRunner, adhocSession(), LONG_LASTING_QUERY);
-            // wait for the first non "dashboard" query to start
-            waitForQueryState(queryRunner, firstNonDashboardQuery, RUNNING);
-            waitForRunningQueryCount(queryRunner, 3);
-            // submit second non "dashboard" query
-            QueryId secondNonDashboardQuery = createQuery(queryRunner, adhocSession(), LONG_LASTING_QUERY);
-            // wait for the second non "dashboard" query to start
-            waitForQueryState(queryRunner, secondNonDashboardQuery, RUNNING);
-            waitForRunningQueryCount(queryRunner, 4);
-            // cancel first "dashboard" query, the second "dashboard" query and second non "dashboard" query should start running
-            cancelQuery(queryRunner, firstDashboardQuery);
-            waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
-            waitForQueryState(queryRunner, thirdDashboardQuery, RUNNING);
-            waitForRunningQueryCount(queryRunner, 4);
-            waitForCompleteQueryCount(queryRunner, 1);
-        }
+        // submit first "dashboard" query
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        // wait for the first "dashboard" query to start
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+        waitForRunningQueryCount(queryRunner, 1);
+        // submit second "dashboard" query
+        QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        MILLISECONDS.sleep(2000);
+        // wait for the second "dashboard" query to be queued ("dashboard.${USER}" queue strategy only allows one "dashboard" query to be accepted for execution)
+        waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
+        waitForRunningQueryCount(queryRunner, 1);
+        // Update db to allow for 1 more running query in dashboard resource group
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, null, null, null, null, null, null, null, 1L);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, null, null, null, null, null, null, null, 3L);
+        waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
+        QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
+        waitForRunningQueryCount(queryRunner, 2);
+        // submit first non "dashboard" query
+        QueryId firstNonDashboardQuery = createQuery(queryRunner, adhocSession(), LONG_LASTING_QUERY);
+        // wait for the first non "dashboard" query to start
+        waitForQueryState(queryRunner, firstNonDashboardQuery, RUNNING);
+        waitForRunningQueryCount(queryRunner, 3);
+        // submit second non "dashboard" query
+        QueryId secondNonDashboardQuery = createQuery(queryRunner, adhocSession(), LONG_LASTING_QUERY);
+        // wait for the second non "dashboard" query to start
+        waitForQueryState(queryRunner, secondNonDashboardQuery, RUNNING);
+        waitForRunningQueryCount(queryRunner, 4);
+        // cancel first "dashboard" query, the second "dashboard" query and second non "dashboard" query should start running
+        cancelQuery(queryRunner, firstDashboardQuery);
+        waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
+        waitForQueryState(queryRunner, thirdDashboardQuery, RUNNING);
+        waitForRunningQueryCount(queryRunner, 4);
+        waitForCompleteQueryCount(queryRunner, 1);
     }
 
     @Test(timeOut = 60_000)
     public void testTwoQueriesAtSameTime()
             throws Exception
     {
-        String dbConfigUrl = getDbConfigUrl();
-        H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner queryRunner = createQueryRunner(dbConfigUrl, dao)) {
-            QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
-            waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
-        }
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+        waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
     }
 
     @Test(timeOut = 90_000)
     public void testTooManyQueries()
             throws Exception
     {
-        String dbConfigUrl = getDbConfigUrl();
-        H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner queryRunner = createQueryRunner(dbConfigUrl, dao)) {
-            QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
 
-            QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
+        QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
 
-            QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, thirdDashboardQuery, FAILED);
+        QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, thirdDashboardQuery, FAILED);
 
-            // Allow one more query to run and resubmit third query
-            dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, null, null, null, null, null, null, null, 1L);
-            dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, null, null, null, null, null, null, null, 3L);
+        // Allow one more query to run and resubmit third query
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, null, null, null, null, null, null, null, 1L);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, null, null, null, null, null, null, null, 3L);
 
-            InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
-            DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
-            // Trigger reload to make the test more deterministic
-            dbConfigurationManager.load();
-            waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
-            thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
+        // Trigger reload to make the test more deterministic
+        dbConfigurationManager.load();
+        waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
+        thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
 
-            // Lower running queries in dashboard resource groups and reload the config
-            dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, null, null, null, null, null, null, null, 3L);
-            dbConfigurationManager.load();
+        // Lower running queries in dashboard resource groups and reload the config
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, null, null, null, null, null, null, null, 3L);
+        dbConfigurationManager.load();
 
-            // Cancel query and verify that third query is still queued
-            cancelQuery(queryRunner, firstDashboardQuery);
-            waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
-            MILLISECONDS.sleep(2000);
-            waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
-        }
+        // Cancel query and verify that third query is still queued
+        cancelQuery(queryRunner, firstDashboardQuery);
+        waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
+        MILLISECONDS.sleep(2000);
+        waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
     }
 
     @Test(timeOut = 60_000)
     public void testRejection()
             throws Exception
     {
-        String dbConfigUrl = getDbConfigUrl();
-        H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner queryRunner = createQueryRunner(dbConfigUrl, dao)) {
-            // Verify the query cannot be submitted
-            QueryId queryId = createQuery(queryRunner, rejectingSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, queryId, FAILED);
-            QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-            assertEquals(queryManager.getQueryInfo(queryId).getErrorCode(), QUERY_REJECTED.toErrorCode());
-            int selectorCount = getSelectors(queryRunner).size();
-            dao.insertSelector(4, "user.*", "(?i).*reject.*");
-            assertEquals(dao.getSelectors().size(), selectorCount + 1);
-            while (getSelectors(queryRunner).size() == selectorCount) {
-                MILLISECONDS.sleep(500);
-            }
-            // Verify the query can be submitted
-            queryId = createQuery(queryRunner, rejectingSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, queryId, RUNNING);
-            dao.deleteSelector(4, "user.*", "(?i).*reject.*");
-            while (getSelectors(queryRunner).size() != selectorCount) {
-                MILLISECONDS.sleep(500);
-            }
-            // Verify the query cannot be submitted
-            queryId = createQuery(queryRunner, rejectingSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, queryId, FAILED);
-        }
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+        // Verify the query cannot be submitted
+        QueryId queryId = createQuery(queryRunner, rejectingSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, queryId, FAILED);
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        assertEquals(queryManager.getQueryInfo(queryId).getErrorCode(), QUERY_REJECTED.toErrorCode());
+        int selectorCount = getSelectors(queryRunner).size();
+        dao.insertSelector(4, "user.*", "(?i).*reject.*");
+        dbConfigurationManager.load();
+        assertEquals(dao.getSelectors().size(), selectorCount + 1);
+        // Verify the query can be submitted
+        queryId = createQuery(queryRunner, rejectingSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, queryId, RUNNING);
+        dao.deleteSelector(4, "user.*", "(?i).*reject.*");
+        dbConfigurationManager.load();
+        // Verify the query cannot be submitted
+        queryId = createQuery(queryRunner, rejectingSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, queryId, FAILED);
     }
 
     @Test(timeOut = 60_000)
     public void testRunningTimeLimit()
             throws Exception
     {
-        String dbConfigUrl = getDbConfigUrl();
-        H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner queryRunner = createQueryRunner(dbConfigUrl, dao)) {
-            dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, null, null, null, null, null, null, "3s", 3L);
-            QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
-        }
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, null, null, null, null, null, null, "3s", 3L);
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
     }
 
     @Test(timeOut = 60_000)
     public void testQueuedTimeLimit()
             throws Exception
     {
-        String dbConfigUrl = getDbConfigUrl();
-        H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner queryRunner = createQueryRunner(dbConfigUrl, dao)) {
-            dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, null, null, null, null, null, "5s", null, 3L);
-            QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
-            QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
-            waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
-            waitForQueryState(queryRunner, secondDashboardQuery, FAILED);
-        }
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, null, null, null, null, null, "5s", null, 3L);
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+        QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
+        waitForQueryState(queryRunner, secondDashboardQuery, FAILED);
     }
 }


### PR DESCRIPTION
Closing DistributedQueryRunner can take a variable amount of time
causing test timeouts. With this change I move the management of the runner
out of the unit tests to separate setup/tearDown methods to reduce the flakiness.

Should fix #8602, #8589.

Also includes #8650.