### PR TITLE
Return VariableWidthBlock in slice direct reader

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -293,7 +293,8 @@ public class TestOrcPageSourceMemoryTracking
             // verify the stats are correctly recorded
             Distribution distribution = stats.getMaxCombinedBytesPerRow().getAllTime();
             assertEquals((int) distribution.getCount(), 1);
-            assertEquals((int) distribution.getMax(), Arrays.stream(dataColumns).mapToInt(GrowingTestColumn::getMaxSize).sum());
+            // the block is VariableWidthBlock that contains valueIsNull and offsets arrays as overhead
+            assertEquals((int) distribution.getMax(), Arrays.stream(dataColumns).mapToInt(GrowingTestColumn::getMaxSize).sum() + (Integer.BYTES + Byte.BYTES) * numColumns);
             pageSource.close();
         }
         finally {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayInputStream.java
@@ -33,14 +33,14 @@ public class ByteArrayInputStream
             throws IOException
     {
         byte[] data = new byte[length];
-        inputStream.readFully(data, 0, length);
+        next(data, 0, length);
         return data;
     }
 
-    public void next(int length, byte[] data)
+    public void next(byte[] data, int offset, int length)
             throws IOException
     {
-        inputStream.readFully(data, 0, length);
+        inputStream.readFully(data, offset, length);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Varchars.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Varchars.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
 import static io.airlift.slice.SliceUtf8.offsetOfCodePoint;
+import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public final class Varchars
@@ -52,17 +53,49 @@ public final class Varchars
         if (maxLength == 0) {
             return Slices.EMPTY_SLICE;
         }
+
+        return slice.slice(0, byteCount(slice, 0, slice.length(), maxLength));
+    }
+
+    /**
+     *  Get the byte count of a given {@param slice} with in range {@param offset} to {@param offset} + {@param length}
+     *  for at most {@param codePointCount} many code points
+     */
+    public static int byteCount(Slice slice, int offset, int length, int codePointCount)
+    {
+        requireNonNull(slice, "slice is null");
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be greater than or equal to zero");
+        }
+        if (offset < 0 || offset + length > slice.length()) {
+            throw new IllegalArgumentException("invalid offset/length");
+        }
+        if (codePointCount < 0) {
+            throw new IllegalArgumentException("codePointsCount must be greater than or equal to zero");
+        }
+        if (codePointCount == 0) {
+            return 0;
+        }
+
         // min codepoint size is 1 byte.
         // if size in bytes is less than the max length
         // we don't need to decode codepoints
-        int sizeInBytes = slice.length();
-        if (sizeInBytes <= maxLength) {
-            return slice;
+        if (codePointCount > length) {
+            return length;
         }
-        int indexEnd = offsetOfCodePoint(slice, maxLength);
-        if (indexEnd < 0) {
-            return slice;
+
+        // get the end index with respect to code point count
+        int endIndex = offsetOfCodePoint(slice, offset, codePointCount);
+        if (endIndex < 0) {
+            // end index runs over the slice's length
+            return length;
         }
-        return slice.slice(0, indexEnd);
+        if (offset > endIndex) {
+            throw new AssertionError("offset cannot be smaller than or equal to endIndex");
+        }
+
+        // end index could run over length because of large code points (e.g., 4-byte code points)
+        // or within length because of small code points (e.g., 1-byte code points)
+        return min(endIndex - offset, length);
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestChars.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestChars.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.Chars.byteCountWithoutTrailingSpace;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestChars
+{
+    @Test
+    public void testByteCountWithoutTrailingSpaces()
+            throws Exception
+    {
+        // single byte code points
+        assertByteCountWithoutTrailingSpace("abc def ", 1, 0, "");
+        assertByteCountWithoutTrailingSpace("abc def ", 0, 4, "abc");
+        assertByteCountWithoutTrailingSpace("abc def ", 1, 3, "bc");
+        assertByteCountWithoutTrailingSpace("abc def ", 0, 3, "abc");
+        assertByteCountWithoutTrailingSpace("abc def ", 1, 2, "bc");
+        assertByteCountWithoutTrailingSpace("abc def ", 0, 6, "abc de");
+        assertByteCountWithoutTrailingSpace("abc def ", 1, 7, "bc def");
+        assertByteCountWithoutTrailingSpace("abc def ", 0, 7, "abc def");
+        assertByteCountWithoutTrailingSpace("abc def ", 1, 6, "bc def");
+        assertByteCountWithoutTrailingSpace("abc  def ", 3, 1, "");
+        assertByteCountWithoutTrailingSpace("abc  def ", 3, 3, "  d");
+        assertByteCountWithoutTrailingSpace("abc  def ", 3, 4, "  de");
+        assertByteCountWithoutTrailingSpaceFailure("abc def ", 4, 9);
+        assertByteCountWithoutTrailingSpaceFailure("abc def ", 12, 1);
+        assertByteCountWithoutTrailingSpaceFailure("abc def ", -1, 1);
+        assertByteCountWithoutTrailingSpaceFailure("abc def ", 1, -1);
+        assertByteCountWithoutTrailingSpace("       ", 0, 4, "");
+        assertByteCountWithoutTrailingSpace("       ", 0, 0, "");
+
+        // invalid code points
+        assertByteCountWithoutTrailingSpace(new byte[]{(byte) 0x81, (byte) 0x81, (byte) 0x81}, 0, 2, new byte[]{(byte) 0x81, (byte) 0x81});
+        assertByteCountWithoutTrailingSpace(new byte[]{(byte) 0x81, (byte) 0x81, (byte) 0x81}, 0, 1, new byte[]{(byte) 0x81});
+        assertByteCountWithoutTrailingSpace(new byte[]{(byte) 0x81, (byte) 0x81, (byte) 0x81}, 0, 0, new byte[]{});
+    }
+
+    @Test
+    public void testByteCountWithoutTrailingSpacesWithCodePointLimit()
+            throws Exception
+    {
+        // single byte code points
+        assertByteCountWithoutTrailingSpace("abc def ", 1, 0, 1, "");
+        assertByteCountWithoutTrailingSpace("abc def ", 0, 3, 4, "abc");
+        assertByteCountWithoutTrailingSpace("abc def ", 0, 4, 4, "abc");
+        assertByteCountWithoutTrailingSpace("abc def ", 0, 4, 3, "abc");
+        assertByteCountWithoutTrailingSpace("abc def ", 0, 5, 4, "abc");
+
+        // invalid code points
+        assertByteCountWithoutTrailingSpace(new byte[]{(byte) 0x81, (byte) 0x81, (byte) ' ', (byte) 0x81}, 0, 3, 3, new byte[]{(byte) 0x81, (byte) 0x81});
+        assertByteCountWithoutTrailingSpace(new byte[]{(byte) 0x81, (byte) 0x81, (byte) ' ', (byte) 0x81}, 0, 2, 3, new byte[]{(byte) 0x81, (byte) 0x81});
+        assertByteCountWithoutTrailingSpace(new byte[]{(byte) 0x81, (byte) 0x81, (byte) ' ', (byte) 0x81}, 0, 0, 3, new byte[]{});
+    }
+
+    private static void assertByteCountWithoutTrailingSpaceFailure(String string, int offset, int maxLength)
+    {
+        try {
+            byteCountWithoutTrailingSpace(utf8Slice(string), offset, maxLength);
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException expected) {
+        }
+    }
+
+    private static void assertByteCountWithoutTrailingSpace(String actual, int offset, int length, String expected)
+    {
+        assertByteCountWithoutTrailingSpace(utf8Slice(actual).getBytes(), offset, length, utf8Slice(expected).getBytes());
+    }
+
+    private static void assertByteCountWithoutTrailingSpace(byte[] actual, int offset, int length, byte[] expected)
+    {
+        Slice slice = wrappedBuffer(actual);
+        int trimmedLength = byteCountWithoutTrailingSpace(slice, offset, length);
+        byte[] bytes = slice.getBytes(offset, trimmedLength);
+        assertEquals(bytes, expected);
+    }
+
+    private static void assertByteCountWithoutTrailingSpace(String actual, int offset, int length, int codePointCount, String expected)
+    {
+        assertByteCountWithoutTrailingSpace(utf8Slice(actual).getBytes(), offset, length, codePointCount, utf8Slice(expected).getBytes());
+    }
+
+    private static void assertByteCountWithoutTrailingSpace(byte[] actual, int offset, int length, int codePointCount, byte[] expected)
+    {
+        Slice slice = wrappedBuffer(actual);
+        int truncatedLength = byteCountWithoutTrailingSpace(slice, offset, length, codePointCount);
+        byte[] bytes = slice.getBytes(offset, truncatedLength);
+        assertEquals(bytes, expected);
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/VarcharsTest.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/VarcharsTest.java
@@ -13,12 +13,17 @@
  */
 package com.facebook.presto.spi.type;
 
+import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.type.Varchars.byteCount;
 import static com.facebook.presto.spi.type.Varchars.truncateToLength;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 public class VarcharsTest
 {
@@ -48,5 +53,87 @@ public class VarcharsTest
 
         assertEquals(truncateToLength(Slices.utf8Slice("abc"), createVarcharType(1)), Slices.utf8Slice("a"));
         assertEquals(truncateToLength(Slices.utf8Slice("abc"), (Type) createVarcharType(1)), Slices.utf8Slice("a"));
+    }
+
+    @Test
+    public void testByteCount()
+            throws Exception
+    {
+        // Single byte code points
+        assertByteCount("abc", 0, 0, 1, "");
+        assertByteCount("abc", 0, 1, 0, "");
+        assertByteCount("abc", 1, 1, 1, "b");
+        assertByteCount("abc", 1, 1, 2, "b");
+        assertByteCount("abc", 1, 2, 1, "b");
+        assertByteCount("abc", 1, 2, 2, "bc");
+        assertByteCount("abc", 1, 2, 3, "bc");
+        assertByteCount("abc", 0, 3, 1, "a");
+        assertByteCount("abc", 0, 3, 5, "abc");
+        assertByteCountFailure("abc", 4, 5, 1);
+        assertByteCountFailure("abc", 5, 0, 1);
+        assertByteCountFailure("abc", -1, 1, 1);
+        assertByteCountFailure("abc", 1, -1, 1);
+        assertByteCountFailure("abc", 1, 1, -1);
+
+        // 2 bytes code points
+        assertByteCount("абв", 0, 0, 1, "");
+        assertByteCount("абв", 0, 1, 0, "");
+        assertByteCount("абв", 0, 2, 1, "а");
+        assertByteCount("абв", 0, 4, 1, "а");
+        assertByteCount("абв", 0, 1, 1, utf8Slice("а").getBytes(0, 1));
+        assertByteCount("абв", 2, 2, 2, "б");
+        assertByteCount("абв", 2, 2, 0, "");
+        assertByteCount("абв", 0, 3, 5, utf8Slice("аб").getBytes(0, 3));
+        assertByteCountFailure("абв", 8, 5, 1);
+        // we do not check if the offset is in the middle of a code point
+        assertByteCount("абв", 1, 1, 5, utf8Slice("а").getBytes(1, 1));
+        assertByteCount("абв", 2, 1, 5, utf8Slice("б").getBytes(0, 1));
+
+        // 3 bytes code points
+        assertByteCount("\u6000\u6001\u6002\u6003", 0, 0, 2, "");
+        assertByteCount("\u6000\u6001\u6002\u6003", 0, 1, 1, utf8Slice("\u6000").getBytes(0, 1));
+        assertByteCount("\u6000\u6001\u6002\u6003", 0, 2, 1, utf8Slice("\u6000").getBytes(0, 2));
+        assertByteCount("\u6000\u6001\u6002\u6003", 0, 3, 1, "\u6000");
+        assertByteCount("\u6000\u6001\u6002\u6003", 0, 6, 1, "\u6000");
+        assertByteCount("\u6000\u6001\u6002\u6003", 6, 2, 4, utf8Slice("\u6002").getBytes(0, 2));
+        assertByteCount("\u6000\u6001\u6002\u6003", 0, 12, 6, "\u6000\u6001\u6002\u6003");
+        // we do not check if the offset is in the middle of a code point
+        assertByteCount("\u6000\u6001\u6002\u6003", 1, 6, 2, utf8Slice("\u6000\u6001\u6002").getBytes(1, 6));
+        assertByteCount("\u6000\u6001\u6002\u6003", 2, 6, 2, utf8Slice("\u6000\u6001\u6002").getBytes(2, 6));
+        assertByteCount("\u6000\u6001\u6002\u6003", 3, 6, 2, utf8Slice("\u6000\u6001\u6002").getBytes(3, 6));
+        assertByteCountFailure("\u6000\u6001\u6002\u6003", 21, 0, 1);
+
+        // invalid code points; always return the original lengths unless code point count is 0
+        assertByteCount(new byte[]{(byte) 0x81, (byte) 0x81, (byte) 0x81}, 0, 2, 0, new byte[]{});
+        assertByteCount(new byte[]{(byte) 0x81, (byte) 0x81, (byte) 0x81}, 0, 2, 1, new byte[]{(byte) 0x81, (byte) 0x81});
+        assertByteCount(new byte[]{(byte) 0x81, (byte) 0x81, (byte) 0x81}, 0, 2, 3, new byte[]{(byte) 0x81, (byte) 0x81});
+    }
+
+    private static void assertByteCountFailure(String string, int offset, int length, int codePointCount)
+    {
+        try {
+            byteCount(utf8Slice(string), offset, length, codePointCount);
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException expected) {
+        }
+    }
+
+    private static void assertByteCount(String actual, int offset, int length, int codePointCount, String expected)
+    {
+        assertByteCount(utf8Slice(actual).getBytes(), offset, length, codePointCount, utf8Slice(expected).getBytes());
+    }
+
+    private static void assertByteCount(String actual, int offset, int length, int codePointCount, byte[] expected)
+    {
+        assertByteCount(utf8Slice(actual).getBytes(), offset, length, codePointCount, expected);
+    }
+
+    private static void assertByteCount(byte[] actual, int offset, int length, int codePointCount, byte[] expected)
+    {
+        Slice slice = wrappedBuffer(actual);
+        int truncatedLength = byteCount(slice, offset, length, codePointCount);
+        byte[] bytes = slice.getBytes(offset, truncatedLength);
+        assertEquals(bytes, expected);
     }
 }


### PR DESCRIPTION
SliceArrayBlock creates huge overhead for each Slice created. Slice
array sometimes can contain 1M entries which leads to about 56M
overhead. This causes full GC issues in production. Switch to
VariableWidthBlock to save memory.