### PR TITLE
Use timezone different Asia/Kathmandu timezone in product tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dep.slice.version>0.29</dep.slice.version>
         <dep.aws-sdk.version>1.11.30</dep.aws-sdk.version>
         <dep.okhttp.version>3.8.1</dep.okhttp.version>
-        <dep.tempto.version>1.33</dep.tempto.version>
+        <dep.tempto.version>1.35</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.nifty.version>0.15.1</dep.nifty.version>
         <dep.swift.version>0.15.2</dep.swift.version>

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -55,6 +55,8 @@ function run_product_tests() {
   mkdir -p "${REPORT_DIR}"
   run_in_application_runner_container \
     java "-Djava.util.logging.config.file=/docker/volumes/conf/tempto/logging.properties" \
+    -Duser.timezone=Asia/Kathmandu \
+    ${TLS_CERTIFICATE} \
     -jar "/docker/volumes/presto-product-tests/presto-product-tests-executable.jar" \
     --report-dir "/docker/volumes/test-reports" \
     --config-local "/docker/volumes/tempto/tempto-configuration-local.yaml" \

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -23,7 +23,7 @@ function export_canonical_path() {
 
 source ${BASH_SOURCE%/*}/../../../bin/locations.sh
 
-export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-20}
+export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-23}
 export HADOOP_MASTER_IMAGE=${HADOOP_MASTER_IMAGE:-"teradatalabs/hdp2.5-hive:${DOCKER_IMAGES_VERSION}"}
 
 # The following variables are defined to enable running product tests with arbitrary/downloaded jars

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -20,6 +20,7 @@ services:
       - '10000:10000'
       - '50070:50070'
       - '50075:50075'
+    command: bash -c "/root/change_timezone.sh Asia/Kathmandu && /root/startup.sh"
 
   presto-master:
     extends:

--- a/presto-product-tests/conf/presto/etc/jvm.config
+++ b/presto-product-tests/conf/presto/etc/jvm.config
@@ -16,6 +16,6 @@
 -XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M
 -DHADOOP_USER_NAME=hive
--Duser.timezone=UTC
+-Duser.timezone=Asia/Kathmandu
 -Xdebug 
 -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TemptoProductTestRunner.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TemptoProductTestRunner.java
@@ -16,9 +16,12 @@ package com.facebook.presto.tests;
 import com.teradata.tempto.internal.configuration.TestConfigurationFactory;
 import com.teradata.tempto.runner.TemptoRunner;
 import com.teradata.tempto.runner.TemptoRunnerCommandLineParser;
+import org.joda.time.DateTimeZone;
 
 public class TemptoProductTestRunner
 {
+    public static final DateTimeZone PRODUCT_TESTS_TIME_ZONE = DateTimeZone.forID("Asia/Kathmandu");
+
     public static void main(String[] args)
     {
         TemptoRunnerCommandLineParser parser = TemptoRunnerCommandLineParser

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/DataTypesTableDefinition.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/DataTypesTableDefinition.java
@@ -24,13 +24,14 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
-import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import static com.facebook.presto.tests.TemptoProductTestRunner.PRODUCT_TESTS_TIME_ZONE;
 import static com.facebook.presto.tests.cassandra.TestConstants.CONNECTOR_NAME;
 import static com.facebook.presto.tests.cassandra.TestConstants.KEY_SPACE;
+import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInLocalTime;
 
 public class DataTypesTableDefinition
 {
@@ -54,7 +55,7 @@ public class DataTypesTableDefinition
                                 BigDecimal.ZERO, Double.MIN_VALUE, Float.MIN_VALUE, ImmutableSet.of(0),
                                 Inet4Address.getByName("0.0.0.0"), Integer.MIN_VALUE, ImmutableList.of(0),
                                 ImmutableMap.of("a", 0, "\0", Integer.MIN_VALUE), ImmutableSet.of(0),
-                                "\0", new Timestamp(0),
+                                "\0", parseTimestampInLocalTime("1970-01-01 00:00:00", PRODUCT_TESTS_TIME_ZONE),
                                 UUID.fromString("d2177dd0-eaa2-11de-a572-001b779c76e3"),
                                 UUID.fromString("01234567-0123-0123-0123-0123456789ab"),
                                 "\0", BigInteger.valueOf(Long.MIN_VALUE)),
@@ -64,7 +65,7 @@ public class DataTypesTableDefinition
                                 Double.MAX_VALUE, Float.MAX_VALUE, ImmutableSet.of(4, 5, 6, 7),
                                 Inet4Address.getByName("255.255.255.255"), Integer.MAX_VALUE,
                                 ImmutableList.of(4, 5, 6), ImmutableMap.of("a", 1, "b", 2), ImmutableSet.of(4, 5, 6),
-                                "this is a text value", Timestamp.valueOf("9999-12-31 23:59:59"),
+                                "this is a text value", parseTimestampInLocalTime("9999-12-31 23:59:59", PRODUCT_TESTS_TIME_ZONE),
                                 UUID.fromString("d2177dd0-eaa2-11de-a572-001b779c76e3"),
                                 UUID.fromString("01234567-0123-0123-0123-0123456789ab"),
                                 "abc", BigInteger.valueOf(Long.MAX_VALUE)),

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/Select.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/Select.java
@@ -22,8 +22,8 @@ import com.teradata.tempto.query.QueryResult;
 import org.testng.annotations.Test;
 
 import java.sql.SQLException;
-import java.sql.Timestamp;
 
+import static com.facebook.presto.tests.TemptoProductTestRunner.PRODUCT_TESTS_TIME_ZONE;
 import static com.facebook.presto.tests.TestGroups.CASSANDRA;
 import static com.facebook.presto.tests.TpchTableResults.PRESTO_NATION_RESULT;
 import static com.facebook.presto.tests.cassandra.CassandraTpchTableDefinitions.CASSANDRA_NATION;
@@ -37,6 +37,7 @@ import static com.teradata.tempto.assertions.QueryAssert.Row.row;
 import static com.teradata.tempto.assertions.QueryAssert.assertThat;
 import static com.teradata.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static com.teradata.tempto.query.QueryExecutor.query;
+import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInLocalTime;
 import static java.lang.String.format;
 import static java.sql.JDBCType.BIGINT;
 import static java.sql.JDBCType.BOOLEAN;
@@ -181,13 +182,13 @@ public class Select
                 .containsOnly(
                         row("\0", Long.MIN_VALUE, Bytes.fromHexString("0x00").array(), false, 0f, Double.MIN_VALUE,
                                 Float.MIN_VALUE, "[0]", "0.0.0.0", Integer.MIN_VALUE, "[0]", "{\"\\u0000\":-2147483648,\"a\":0}",
-                                "[0]", "\0", Timestamp.valueOf("1970-01-01 00:00:00.0"),
+                                "[0]", "\0", parseTimestampInLocalTime("1970-01-01 00:00:00.0", PRODUCT_TESTS_TIME_ZONE),
                                 "d2177dd0-eaa2-11de-a572-001b779c76e3", "01234567-0123-0123-0123-0123456789ab",
                                 "\0", String.valueOf(Long.MIN_VALUE)),
                         row("the quick brown fox jumped over the lazy dog", 9223372036854775807L, "01234".getBytes(),
                                 true, new Double("99999999999999999999999999999999999999"), Double.MAX_VALUE,
                                 Float.MAX_VALUE, "[4,5,6,7]", "255.255.255.255", Integer.MAX_VALUE, "[4,5,6]",
-                                "{\"a\":1,\"b\":2}", "[4,5,6]", "this is a text value", Timestamp.valueOf("9999-12-31 23:59:59"),
+                                "{\"a\":1,\"b\":2}", "[4,5,6]", "this is a text value", parseTimestampInLocalTime("9999-12-31 23:59:59", PRODUCT_TESTS_TIME_ZONE),
                                 "d2177dd0-eaa2-11de-a572-001b779c76e3", "01234567-0123-0123-0123-0123456789ab",
                                 "abc", String.valueOf(Long.MAX_VALUE)),
                         row("def", null, null, null, null, null, null, null, null, null, null, null,

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestInsertIntoCassandraTable.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestInsertIntoCassandraTable.java
@@ -22,6 +22,7 @@ import com.teradata.tempto.query.QueryResult;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.tests.TemptoProductTestRunner.PRODUCT_TESTS_TIME_ZONE;
 import static com.facebook.presto.tests.TestGroups.CASSANDRA;
 import static com.facebook.presto.tests.cassandra.DataTypesTableDefinition.CASSANDRA_ALL_TYPES;
 import static com.facebook.presto.tests.cassandra.TestConstants.CONNECTOR_NAME;
@@ -33,7 +34,7 @@ import static com.teradata.tempto.fulfillment.table.MutableTableRequirement.Stat
 import static com.teradata.tempto.fulfillment.table.MutableTablesState.mutableTablesState;
 import static com.teradata.tempto.fulfillment.table.TableRequirements.mutableTable;
 import static com.teradata.tempto.query.QueryExecutor.query;
-import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInUTC;
+import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInLocalTime;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -103,7 +104,7 @@ public class TestInsertIntoCassandraTable
                         null,
                         null,
                         "text value",
-                        parseTimestampInUTC("9999-12-31 23:59:59"),
+                        parseTimestampInLocalTime("9999-12-31 23:59:59", PRODUCT_TESTS_TIME_ZONE),
                         null,
                         null,
                         "varchar value",

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAllDatatypesFromHiveConnector.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAllDatatypesFromHiveConnector.java
@@ -33,6 +33,7 @@ import java.sql.Connection;
 import java.sql.Date;
 import java.sql.SQLException;
 
+import static com.facebook.presto.tests.TemptoProductTestRunner.PRODUCT_TESTS_TIME_ZONE;
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.POST_HIVE_1_0_1;
 import static com.facebook.presto.tests.TestGroups.SMOKE;
@@ -52,7 +53,7 @@ import static com.teradata.tempto.fulfillment.table.TableHandle.tableHandle;
 import static com.teradata.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static com.teradata.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static com.teradata.tempto.query.QueryExecutor.query;
-import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInUTC;
+import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInLocalTime;
 import static java.lang.String.format;
 import static java.sql.JDBCType.BIGINT;
 import static java.sql.JDBCType.BOOLEAN;
@@ -138,7 +139,7 @@ public class TestAllDatatypesFromHiveConnector
                         234.567,
                         new BigDecimal("346"),
                         new BigDecimal("345.67800"),
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        parseTimestampInLocalTime("2015-05-10 12:15:35.123", PRODUCT_TESTS_TIME_ZONE),
                         Date.valueOf("2015-05-10"),
                         "ala ma kota",
                         "ala ma kot",
@@ -170,7 +171,7 @@ public class TestAllDatatypesFromHiveConnector
                         234.567,
                         new BigDecimal("346"),
                         new BigDecimal("345.67800"),
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        parseTimestampInLocalTime("2015-05-10 12:15:35.123", PRODUCT_TESTS_TIME_ZONE),
                         Date.valueOf("2015-05-10"),
                         "ala ma kota",
                         "ala ma kot",
@@ -202,7 +203,7 @@ public class TestAllDatatypesFromHiveConnector
                         234.567,
                         new BigDecimal("346"),
                         new BigDecimal("345.67800"),
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        parseTimestampInLocalTime("2015-05-10 12:15:35.123", PRODUCT_TESTS_TIME_ZONE),
                         Date.valueOf("2015-05-10"),
                         "ala ma kota",
                         "ala ma kot",
@@ -291,7 +292,7 @@ public class TestAllDatatypesFromHiveConnector
                 "234.567," +
                 "346," +
                 "345.67800," +
-                "'" + parseTimestampInUTC("2015-05-10 12:15:35.123").toString() + "'," +
+                "'" + parseTimestampInLocalTime("2015-05-10 12:15:35.123", PRODUCT_TESTS_TIME_ZONE).toString() + "'," +
                 "'ala ma kota'," +
                 "'ala ma kot'," +
                 "'ala ma    '," +
@@ -342,7 +343,7 @@ public class TestAllDatatypesFromHiveConnector
                         234.567,
                         new BigDecimal("346"),
                         new BigDecimal("345.67800"),
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        parseTimestampInLocalTime("2015-05-10 12:15:35.123", PRODUCT_TESTS_TIME_ZONE),
                         "ala ma kota",
                         "ala ma kot",
                         "ala ma    ",

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -265,24 +265,24 @@ public class TestHiveTableStatistics
                 row("c_boolean", null, null, null, null),
                 row("c_binary", null, null, null, null),
                 row(null, null, null, null, 1.0));
-
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
+        // SHOW STATS FORMAT: column_name, data_size, distinct_values_count, nulls_fraction, row_count
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
-                row("c_tinyint", null, 1.0, 0.0, null),
-                row("c_smallint", null, 1.0, 0.0, null),
-                row("c_int", null, 2.0, 0.0, null),
-                row("c_bigint", null, 1.0, 0.0, null),
-                row("c_float", null, 1.0, 0.0, null),
-                row("c_double", null, 1.0, 0.0, null),
-                row("c_decimal", null, 1.0, 0.0, null),
-                row("c_decimal_w_params", null, 1.0, 0.0, null),
-                row("c_timestamp", null, 1.0, 0.0, null),
-                row("c_date", null, 2.0, 0.0, null),
-                row("c_string", null, 1.0, 0.0, null),
-                row("c_varchar", null, 1.0, 0.0, null),
-                row("c_char", null, 1.0, 0.0, null),
-                row("c_boolean", null, 1.0, 0.0, null),
+                row("c_tinyint", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_smallint", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_int", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_bigint", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_float", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_double", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_decimal", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_decimal_w_params", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_timestamp", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_date", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_string", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_varchar", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_char", null, anyOf(1.0, 2.0), 0.0, null),
+                row("c_boolean", null, anyOf(1.0, 2.0), 0.0, null),
                 row("c_binary", null, null, 0.0, null),
                 row(null, null, null, null, 1.0));
     }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInsertIntoHiveTable.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInsertIntoHiveTable.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import java.math.BigDecimal;
 import java.sql.Date;
 
+import static com.facebook.presto.tests.TemptoProductTestRunner.PRODUCT_TESTS_TIME_ZONE;
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.POST_HIVE_1_0_1;
 import static com.facebook.presto.tests.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_TEXTFILE;
@@ -34,7 +35,7 @@ import static com.teradata.tempto.fulfillment.table.MutableTablesState.mutableTa
 import static com.teradata.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static com.teradata.tempto.fulfillment.table.TableRequirements.mutableTable;
 import static com.teradata.tempto.query.QueryExecutor.query;
-import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInUTC;
+import static com.teradata.tempto.util.DateTimeUtils.parseTimestampInLocalTime;
 
 public class TestInsertIntoHiveTable
         extends ProductTest
@@ -87,7 +88,7 @@ public class TestInsertIntoHiveTable
                         234.567,
                         new BigDecimal("346"),
                         new BigDecimal("345.67800"),
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        parseTimestampInLocalTime("2015-05-10 12:15:35.123", PRODUCT_TESTS_TIME_ZONE),
                         Date.valueOf("2015-05-10"),
                         "ala ma kota",
                         "ala ma kot",
@@ -113,7 +114,7 @@ public class TestInsertIntoHiveTable
                         234.567,
                         new BigDecimal("346"),
                         new BigDecimal("345.67800"),
-                        parseTimestampInUTC("2015-05-10 12:15:35.123"),
+                        parseTimestampInLocalTime("2015-05-10 12:15:35.123", PRODUCT_TESTS_TIME_ZONE),
                         Date.valueOf("2015-05-10"),
                         "ala ma kota",
                         "ala ma kot",

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_constant_from_table.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_constant_from_table.sql
@@ -1,7 +1,7 @@
 -- database: presto; groups: insert; mutable_tables: datatype|created; tables: datatype
 -- delimiter: |; ignoreOrder: true; 
 --!
-insert into ${mutableTables.hive.datatype} select 1, cast(2.2 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16 UTC' as timestamp), false, DECIMAL '123.22', DECIMAL '12345678901234567890.0123456789' from datatype;
+insert into ${mutableTables.hive.datatype} select 1, cast(2.2 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16' as timestamp), false, DECIMAL '123.22', DECIMAL '12345678901234567890.0123456789' from datatype;
 select * from ${mutableTables.hive.datatype}
 --!
 1|2.2|abc|2014-01-01|2015-01-01 03:15:16|false|123.22|12345678901234567890.0123456789|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_constant_no_from.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_constant_no_from.sql
@@ -1,7 +1,7 @@
 -- database: presto; groups: insert; mutable_tables: datatype|created
 -- delimiter: |; ignoreOrder: true; 
 --!
-insert into ${mutableTables.hive.datatype} select 1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16 UTC' as timestamp), FALSE, DECIMAL '123.22', DECIMAL '12345678901234567890.0123456789';
+insert into ${mutableTables.hive.datatype} select 1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16' as timestamp), FALSE, DECIMAL '123.22', DECIMAL '12345678901234567890.0123456789';
 select * from ${mutableTables.hive.datatype}
 --!
 1|2.1|abc|2014-01-01|2015-01-01 03:15:16|false|123.22|12345678901234567890.0123456789|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_from_group_by.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_from_group_by.sql
@@ -1,7 +1,7 @@
 -- database: presto; groups: insert; mutable_tables: datatype|created; tables: datatype
 -- delimiter: |; ignoreOrder: true; 
 --!
-insert into ${mutableTables.hive.datatype} select count(*), cast(1.1 as double), 'a', cast('2016-01-01' as date), cast('2015-01-01 03:15:16 UTC' as timestamp), FALSE, DECIMAL '-123.22', DECIMAL '-12345678901234567890.0123456789' from datatype group by c_bigint;
+insert into ${mutableTables.hive.datatype} select count(*), cast(1.1 as double), 'a', cast('2016-01-01' as date), cast('2015-01-01 03:15:16' as timestamp), FALSE, DECIMAL '-123.22', DECIMAL '-12345678901234567890.0123456789' from datatype group by c_bigint;
 select * from ${mutableTables.hive.datatype}
 --!
 1|1.1|a|2016-01-01|2015-01-01 03:15:16|false|-123.22|-12345678901234567890.0123456789|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_values_all_types.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_values_all_types.sql
@@ -1,7 +1,7 @@
 -- database: presto; groups: insert; mutable_tables: datatype|created
 -- delimiter: |; ignoreOrder: true; 
 --!
-insert into ${mutableTables.hive.datatype} values(1,cast(2.34567 as double),'a',cast('2014-01-01' as date), cast ('2015-01-01 03:15:16 UTC' as timestamp), TRUE, DECIMAL '123.22', DECIMAL '12345678901234567890.0123456789');
+insert into ${mutableTables.hive.datatype} values(1,cast(2.34567 as double),'a',cast('2014-01-01' as date), cast ('2015-01-01 03:15:16' as timestamp), TRUE, DECIMAL '123.22', DECIMAL '12345678901234567890.0123456789');
 select * from ${mutableTables.hive.datatype}
 --!
 1|2.34567|a|2014-01-01|2015-01-01 03:15:16|true|123.22|12345678901234567890.0123456789|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_values_const.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_values_const.sql
@@ -1,7 +1,7 @@
 -- database: presto; groups: insert; mutable_tables: datatype|created; 
 -- delimiter: |; ignoreOrder: true; 
 --!
-insert into ${mutableTables.hive.datatype} values(1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16 UTC' as timestamp), FALSE, DECIMAL '-123.22', DECIMAL '-12345678901234567890.0123456789');
+insert into ${mutableTables.hive.datatype} values(1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16' as timestamp), FALSE, DECIMAL '-123.22', DECIMAL '-12345678901234567890.0123456789');
 select * from ${mutableTables.hive.datatype}
 --!
 1|2.1|abc|2014-01-01|2015-01-01 03:15:16|false|-123.22|-12345678901234567890.0123456789|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_values_expression.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/insert/insert_values_expression.sql
@@ -2,7 +2,7 @@
 -- delimiter: |; ignoreOrder: true; 
 --!
 insert into ${mutableTables.hive.datatype}
-values(5 * 10, cast(4.1 + 5 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16 UTC' as timestamp), TRUE, DECIMAL '123.22', DECIMAL '12345678901234567890.0123456789');
+values(5 * 10, cast(4.1 + 5 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16' as timestamp), TRUE, DECIMAL '123.22', DECIMAL '12345678901234567890.0123456789');
 select * from ${mutableTables.hive.datatype}
 --!
 50|9.1|abc|2014-01-01|2015-01-01 03:15:16|true|123.22|12345678901234567890.0123456789|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/insert/multiple_inserts_one_table.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/insert/multiple_inserts_one_table.sql
@@ -1,9 +1,9 @@
 -- database: presto; groups: insert; mutable_tables: datatype|created; 
 -- delimiter: |; ignoreOrder: true; 
 --!
-insert into ${mutableTables.hive.datatype} values(1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16 UTC' as timestamp), FALSE, DECIMAL '-999.99', DECIMAL '-99999999999999999999.9999999999');
-insert into ${mutableTables.hive.datatype} values(1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16 UTC' as timestamp), FALSE, DECIMAL '999.99', DECIMAL '99999999999999999999.9999999999');
-insert into ${mutableTables.hive.datatype} values(1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16 UTC' as timestamp), FALSE, CAST(0 AS DECIMAL(5,2)), CAST(0 AS DECIMAL(30,10)));
+insert into ${mutableTables.hive.datatype} values(1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16' as timestamp), FALSE, DECIMAL '-999.99', DECIMAL '-99999999999999999999.9999999999');
+insert into ${mutableTables.hive.datatype} values(1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16' as timestamp), FALSE, DECIMAL '999.99', DECIMAL '99999999999999999999.9999999999');
+insert into ${mutableTables.hive.datatype} values(1, cast(2.1 as double), 'abc', cast('2014-01-01' as date), cast('2015-01-01 03:15:16' as timestamp), FALSE, CAST(0 AS DECIMAL(5,2)), CAST(0 AS DECIMAL(30,10)));
 select * from ${mutableTables.hive.datatype}
 --!
 1|2.1|abc|2014-01-01|2015-01-01 03:15:16|false|-999.99|-99999999999999999999.9999999999|


### PR DESCRIPTION
Product tests are using UTC for simplicity but it doesn't cover all scenarios that we are interested in which can (and did) cause bug to remain undetected.
This is especially important in the context of #7480 which will fail those tests at this point. Some adaptation and fixes are meant to be done in #7480 after rebasing it into those patches.

CC: @haozhun 