### PR TITLE
Revert the code cache collection threshold to 70%

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CodeCacheGcConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CodeCacheGcConfig.java
@@ -27,7 +27,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class CodeCacheGcConfig
 {
     private Duration codeCacheCheckInterval = new Duration(20, SECONDS);
-    private int codeCacheCollectionThreshold = 40;
+    private int codeCacheCollectionThreshold = 70;
 
     @NotNull
     @MinDuration("1s")


### PR DESCRIPTION
Initially the threshold for triggering a full GC to workaround the code cache bug (in some JVM versions) was 70%. At some point the threshold was made configurable (in #6286) and the threshold was set to 40%, which is quite low and has caused issues for multiple users (and myself previously).

We don't know whether the latest JVM releases have this bug, but until we remove this workaround we can increase this threshold.