### PR TITLE
Connector unit tests junit5/2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
         <dep.nifty.version>0.15.1</dep.nifty.version>
         <dep.swift.version>0.15.2</dep.swift.version>
 
+        <!-- Remove once Presto is on airbase >= 67 -->
+        <dep.junit-jupiter.version>5.0.0-RC2</dep.junit-jupiter.version>
+        <dep.junit-platform.version>1.0.0-RC2</dep.junit-platform.version>
+
         <!-- use a fractional hour timezone offset for tests -->
         <air.test.timezone>Asia/Katmandu</air.test.timezone>
         <air.test.parallel>methods</air.test.parallel>
@@ -1013,6 +1017,29 @@
                             </exception>
                         </exceptions>
                     </configuration>
+                </plugin>
+
+                <!-- Remove once Presto is on airbase >= 67 -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-testng</artifactId>
+                            <version>2.19.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-surefire-provider</artifactId>
+                            <version>${dep.junit-platform.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-engine</artifactId>
+                            <version>${dep.junit-jupiter.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
 
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <module>presto-thrift-testing-server</module>
         <module>presto-thrift-connector</module>
         <module>presto-matching</module>
+        <module>presto-connector-tests</module>
     </modules>
 
     <dependencyManagement>
@@ -337,6 +338,12 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-sqlserver</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-connector-tests</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -932,6 +939,24 @@
                 <groupId>com.facebook.presto.cassandra</groupId>
                 <artifactId>cassandra-driver</artifactId>
                 <version>3.1.4-1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${dep.junit-jupiter.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>${dep.junit-platform.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${dep.junit-jupiter.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-connector-tests/pom.xml
+++ b/presto-connector-tests/pom.xml
@@ -27,6 +27,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpch</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-connector-tests/pom.xml
+++ b/presto-connector-tests/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.184-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-connector-tests</artifactId>
+    <description>Tests for Presto Connectors</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+    </dependencies>
+</project>

--- a/presto-connector-tests/pom.xml
+++ b/presto-connector-tests/pom.xml
@@ -35,5 +35,11 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.testng</groupId>
+			<artifactId>testng</artifactId>
+            <scope>test</scope>
+		</dependency>
     </dependencies>
 </project>

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/meta/ConnectorFeature.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/meta/ConnectorFeature.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+public enum ConnectorFeature
+{
+    READ_DATA,
+    WRITE_DATA,
+    CREATE_SCHEMA,
+    DROP_SCHEMA,
+    RENAME_SCHEMA,
+    CREATE_TABLE,
+    CREATE_TABLE_AS,
+    DROP_TABLE,
+    RENAME_TABLE,
+    ADD_COLUMN,
+    RENAME_COLUMN;
+}

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/meta/RequiredFeatures.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/meta/RequiredFeatures.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/*
+ * This can be applied to test methods and test interfaces/classes. See
+ * SupportedTestCondition for an explanation of how the requirements of a test
+ * method are determined from the class hierarchy.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiredFeatures
+{
+    ConnectorFeature[] value();
+}

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/meta/SupportedFeatures.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/meta/SupportedFeatures.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/*
+ * This almost certainly only makes sense when applied to a leaf class that
+ * provides the infrastructure needed to run tests specified in various test
+ * interfaces implemented by that class.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SupportedFeatures
+{
+    ConnectorFeature[] value();
+}

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/meta/SupportedTestCondition.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/meta/SupportedTestCondition.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import com.google.common.base.Joiner;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+/*
+ * Determines whether a test method should run based on the @SupportedFeatures
+ * and @RequiredFeatures of the test method and the connector the test is being
+ * run against.
+ *
+ * Consider the following class hierarchy:
+ * BaseTest @RequiredFeatures({FEATURE1})
+ * |   test0
+ * `-- SubTest @RequiredFeatures({FEATURE2})
+ *     |   test1
+ *     |   test2 @RequiredFeatures({FEATURE3})
+ *     |-- ConnectorTest1 @SupportedFeatures({FEATURE1, FEATURE2, FEATURE3})
+ *     `-- ConnectorTest2 @SupportedFeatures({FEATURE1, FEATURE2})
+ *
+ * SupportedTestCondition only looks for a @SupportedFeatures annotation that
+ * is directly present on the test class.
+ *
+ * ConnectorTest1.testN has supported features {FEATURE1, FEATURE2, FEATURE3}
+ * ConnectorTest2.testN has supported features {FEATURE1, FEATURE2}
+ *
+ * Required features are gathered from the test method, its declaring class,
+ * and all of the super classes of its declaring class, recursively .
+ *
+ * ConnectorTestN.test0 has required features {FEATURE1}
+ * ConnectorTestN.test1 has required features {FEATURE1, FEATURE2}
+ * ConnectorTestN.test2 has required features {FEATURE1, FEATURE2, FEATURE3}
+ *
+ * A test is disabled if the test method has required features not contained in
+ * its supported features.
+ *
+ * Gathering required features for tests in inner classes is not supported.
+ * Feel free to add support if needed.
+ *
+ * Test interfaces can extend multiple other test interfaces. Required features
+ * are correctly gathered from all extended interfaces.
+ *
+ * BaseTest1 @RequiredFeatures({FEATURE1})     BaseTest2 @RequiredFeatures({FEATURE2})
+ *                                         \ /
+ *                                       SubTest
+ *                                           testMethod()
+ *
+ * The required features of SubTest.testMethod are {FEATURE1, FEATURE2}
+ */
+public class SupportedTestCondition
+        implements ExecutionCondition
+{
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext)
+    {
+        Optional<Method> testMethod = extensionContext.getTestMethod();
+
+        if (!testMethod.isPresent()) {
+            return enabled("");
+        }
+
+        Class<?> testClass = extensionContext.getRequiredTestClass();
+
+        Optional<RequiredFeatures> methodRequires = testMethod.map(method -> method.getAnnotation(RequiredFeatures.class));
+        List<RequiredFeatures> classRequires = getClassRequiredFeatures(testMethod.get().getDeclaringClass());
+        Optional<SupportedFeatures> classSupports = Optional.ofNullable(testClass.getAnnotation(SupportedFeatures.class));
+
+        Set<ConnectorFeature> requiredFeatures = Stream.concat(
+                streamOfRequired(methodRequires),
+                classRequires.stream().flatMap(r -> Arrays.stream(r.value())))
+                .distinct()
+                .collect(Collectors.toCollection(HashSet::new));
+
+        Set<ConnectorFeature> supportedFeatures = streamOfSupported(classSupports)
+                .distinct()
+                .collect(toImmutableSet());
+
+        requiredFeatures.removeAll(supportedFeatures);
+
+        return requiredFeatures.isEmpty() ?
+                enabled("All required features present") :
+                disabled("Missing required features: " + Joiner.on(", ").join(requiredFeatures));
+    }
+
+    private static List<RequiredFeatures> getClassRequiredFeatures(Class<?> testClass)
+    {
+        assertNull(testClass.getEnclosingClass(), "Add support (and tests!) if you need it");
+        Class<?>[] interfaces = testClass.getInterfaces();
+        Optional<RequiredFeatures> requiredFeatures = Optional.ofNullable(testClass.getAnnotation(RequiredFeatures.class));
+
+        return Stream.concat(
+                requiredFeatures.map(Stream::of).orElse(Stream.empty()),
+                Arrays.stream(interfaces)
+                        .map(SupportedTestCondition::getClassRequiredFeatures)
+                        .flatMap(List::stream))
+                .collect(toImmutableList());
+    }
+
+    private static Stream<ConnectorFeature> streamOfRequired(Optional<RequiredFeatures> requiredFeatures)
+    {
+        return requiredFeatures.map(required -> Arrays.stream(required.value()))
+                .orElse(Stream.empty());
+    }
+
+    private static Stream<ConnectorFeature> streamOfSupported(Optional<SupportedFeatures> supportedFeatures)
+    {
+        return supportedFeatures.map(supported -> Arrays.stream(supported.value()))
+                .orElse(Stream.empty());
+    }
+}

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/BaseMetadataTest.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/BaseMetadataTest.java
@@ -58,6 +58,11 @@ public interface BaseMetadataTest
         return ImmutableList.of();
     }
 
+    default List<SchemaTableName> systemTables()
+    {
+        return ImmutableList.of();
+    }
+
     /*
      * Connectors that add columns containing connector metadata to a table, like Hive,
      * should return a List containing the metadata for all of the expectedColumns and the connector-specific columns added in the appropriate positions.
@@ -142,7 +147,7 @@ public interface BaseMetadataTest
         withMetadata(
                 ImmutableList.of(
                         metadata -> assertEquals(metadata.listSchemaNames(session), systemSchemas()),
-                        metadata -> assertEquals(metadata.listTables(session, null), ImmutableList.of())));
+                        metadata -> assertEquals(metadata.listTables(session, null), systemTables())));
     }
 
     /*

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/BaseMetadataTest.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/BaseMetadataTest.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.unittest;
+
+import com.facebook.presto.connector.meta.RequiredFeatures;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_TABLE;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_TABLE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public interface BaseMetadataTest
+        extends SPITest
+{
+    Map<String, Object> getTableProperties();
+
+    default List<ColumnMetadata> withSystemColumns(List<ColumnMetadata> expectedColumns)
+    {
+        return expectedColumns;
+    }
+
+    default List<String> systemSchemas()
+    {
+        return ImmutableList.of();
+    }
+
+    default SchemaTableName schemaTableName(String tableName)
+    {
+        return new SchemaTableName("default_schema", tableName);
+    }
+
+    default SchemaTableName schemaTableName(String schemaName, String tableName)
+    {
+        return new SchemaTableName(schemaName, tableName);
+    }
+
+    @Test
+    default void testEmptyMetadata()
+    {
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+
+        run(ImmutableList.of(
+                metadata -> assertEquals(metadata.listSchemaNames(session), systemSchemas()),
+                metadata -> assertEquals(metadata.listTables(session, null), ImmutableList.of())));
+    }
+
+    @Test
+    @RequiredFeatures({CREATE_TABLE, DROP_TABLE})
+    default void testCreateDropTable()
+            throws Exception
+    {
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        String tableName = "table";
+        SchemaTableName schemaTableName = schemaTableName(tableName);
+
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(
+                schemaTableName,
+                ImmutableList.of(
+                        new ColumnMetadata("bigint_column", BIGINT),
+                        new ColumnMetadata("double_column", DOUBLE)),
+                getTableProperties());
+
+        try (AllCloser cleanup = AllCloser.of(new Schema(this, session, schemaTableName.getSchemaName()))) {
+            run(ImmutableList.of(
+                    metadata -> metadata.createTable(session, tableMetadata),
+                    metadata -> assertEquals(getOnlyElement(metadata.listTables(session, schemaTableName.getSchemaName())), schemaTableName),
+                    metadata -> metadata.dropTable(session, metadata.getTableHandle(session, schemaTableName))));
+        }
+    }
+
+    default List<String> schemaNamesOf(SchemaTableName... schemaTableNames)
+    {
+        return Arrays.stream(schemaTableNames)
+                .map(SchemaTableName::getSchemaName)
+                .collect(toImmutableList());
+    }
+
+    default List<String> schemaNamesOf(List<ConnectorTableMetadata> tables)
+    {
+        return tables.stream()
+                .map(ConnectorTableMetadata::getTable)
+                .map(SchemaTableName::getSchemaName)
+                .distinct()
+                .collect(toImmutableList());
+    }
+
+    default SchemaTablePrefix prefixOfSchemaName(SchemaTableName schemaTableName)
+    {
+        return new SchemaTablePrefix(schemaTableName.getSchemaName());
+    }
+
+    default SchemaTablePrefix prefixOf(SchemaTableName schemaTableName)
+    {
+        return new SchemaTablePrefix(schemaTableName.getSchemaName(), schemaTableName.getTableName());
+    }
+
+    default void run(List<Consumer<ConnectorMetadata>> consumers)
+    {
+        consumers.forEach(this::withMetadata);
+    }
+
+    default void withMetadata(Consumer<ConnectorMetadata> consumer)
+    {
+        Connector connector = getConnector();
+        ConnectorTransactionHandle transaction = connector.beginTransaction(IsolationLevel.READ_UNCOMMITTED, true);
+        ConnectorMetadata metadata = connector.getMetadata(transaction);
+        consumer.accept(metadata);
+        connector.commit(transaction);
+    }
+
+    class AllCloser
+            implements AutoCloseable
+    {
+        List<AutoCloseable> items;
+
+        public AllCloser(List<AutoCloseable> items)
+        {
+            this.items = items;
+        }
+
+        static AllCloser of(AutoCloseable... elements)
+        {
+            return new AllCloser(ImmutableList.copyOf(elements));
+        }
+
+        @Override
+        public void close()
+                throws Exception
+        {
+            for (int i = items.size() - 1; i >= 0; --i) {
+                items.get(i).close();
+            }
+        }
+    }
+
+    class Schema
+            implements AutoCloseable
+    {
+        private final BaseMetadataTest test;
+        private final ConnectorSession session;
+        private final String name;
+
+        public Schema(BaseMetadataTest test, ConnectorSession session, String name)
+        {
+            this.test = test;
+            this.session = session;
+            this.name = name;
+
+            test.withMetadata(metadata -> metadata.createSchema(session, name, ImmutableMap.of()));
+        }
+
+        @Override
+        public void close()
+                throws Exception
+        {
+            test.withMetadata(metadata -> metadata.dropSchema(session, name));
+        }
+    }
+
+    default List<AutoCloseable> withSchemas(ConnectorSession session, List<String> schemaNames)
+    {
+        return schemaNames.stream()
+                .distinct()
+                .map(schemaName -> new Schema(this, session, schemaName))
+                .collect(toImmutableList());
+    }
+
+    class Table
+            implements AutoCloseable
+    {
+        private final BaseMetadataTest test;
+        private final ConnectorSession session;
+        private final ConnectorTableMetadata tableMetadata;
+
+        public Table(BaseMetadataTest test, ConnectorSession session, ConnectorTableMetadata tableMetadata)
+        {
+            this.test = test;
+            this.session = session;
+            this.tableMetadata = tableMetadata;
+
+            test.withMetadata(metadata -> {
+                ConnectorOutputTableHandle handle = metadata.beginCreateTable(session, tableMetadata, Optional.empty());
+                metadata.finishCreateTable(session, handle, ImmutableList.of());
+            });
+        }
+
+        @Override
+        public void close()
+                throws Exception
+        {
+            test.withMetadata(metadata -> {
+                ConnectorTableHandle handle = metadata.getTableHandle(session, tableMetadata.getTable());
+                metadata.dropTable(session, handle);
+            });
+        }
+    }
+
+    default AllCloser withTables(ConnectorSession session, ConnectorTableMetadata... tables)
+    {
+        List<ConnectorTableMetadata> tableList = Arrays.asList(tables);
+        return new AllCloser(Streams.concat(
+                withSchemas(session, schemaNamesOf(tableList)).stream(),
+                tableList.stream()
+                        .map(table -> new Table(this, session, table)))
+                .collect(toImmutableList()));
+    }
+}

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/MetadataSchemaTest.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/MetadataSchemaTest.java
@@ -38,32 +38,36 @@ public interface MetadataSchemaTest
 
     @Test
     default void testCreateDropSchema()
+            throws Exception
     {
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         String schemaName = "testCreateSchema";
 
-        run(ImmutableList.of(
-                metadata -> metadata.createSchema(session, schemaName, ImmutableMap.of()),
-                metadata -> assertEquals(getOnlyElement(metadata.listSchemaNames(session)), schemaName),
-                metadata -> assertEquals(metadata.listTables(session, schemaName).size(), 0),
-                metadata -> assertEquals(metadata.listTables(session, null).size(), 0),
-                metadata -> metadata.dropSchema(session, schemaName)));
+        withMetadata(
+                ImmutableList.of(
+                        metadata -> metadata.createSchema(session, schemaName, ImmutableMap.of()),
+                        metadata -> assertEquals(getOnlyElement(metadata.listSchemaNames(session)), schemaName),
+                        metadata -> assertEquals(metadata.listTables(session, schemaName).size(), 0),
+                        metadata -> assertEquals(metadata.listTables(session, null).size(), 0),
+                        metadata -> metadata.dropSchema(session, schemaName)));
     }
 
     @Test
     @RequiredFeatures({RENAME_SCHEMA})
     default void testRenameSchema()
+            throws Exception
     {
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         String initialSchemaName = "testRenameSchemaInitial";
         String renamedSchemaName = "testRenameSchemaRenamed";
 
-        run(ImmutableList.of(
-                metadata -> metadata.createSchema(session, initialSchemaName, ImmutableMap.of()),
-                metadata -> metadata.renameSchema(session, initialSchemaName, renamedSchemaName),
-                metadata -> assertEquals(getOnlyElement(metadata.listSchemaNames(session)), renamedSchemaName),
-                metadata -> assertEquals(metadata.listTables(session, renamedSchemaName).size(), 0),
-                metadata -> assertEquals(metadata.listTables(session, null).size(), 0),
-                metadata -> metadata.dropSchema(session, renamedSchemaName)));
+        withMetadata(
+                ImmutableList.of(
+                        metadata -> metadata.createSchema(session, initialSchemaName, ImmutableMap.of()),
+                        metadata -> metadata.renameSchema(session, initialSchemaName, renamedSchemaName),
+                        metadata -> assertEquals(getOnlyElement(metadata.listSchemaNames(session)), renamedSchemaName),
+                        metadata -> assertEquals(metadata.listTables(session, renamedSchemaName).size(), 0),
+                        metadata -> assertEquals(metadata.listTables(session, null).size(), 0),
+                        metadata -> metadata.dropSchema(session, renamedSchemaName)));
     }
 }

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/MetadataSchemaTest.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/MetadataSchemaTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.unittest;
+
+import com.facebook.presto.connector.meta.RequiredFeatures;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.RENAME_SCHEMA;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@RequiredFeatures({CREATE_SCHEMA, DROP_SCHEMA})
+public interface MetadataSchemaTest
+        extends BaseMetadataTest
+{
+    Map<String, Object> getTableProperties();
+
+    @Test
+    default void testCreateDropSchema()
+    {
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        String schemaName = "testCreateSchema";
+
+        run(ImmutableList.of(
+                metadata -> metadata.createSchema(session, schemaName, ImmutableMap.of()),
+                metadata -> assertEquals(getOnlyElement(metadata.listSchemaNames(session)), schemaName),
+                metadata -> assertEquals(metadata.listTables(session, schemaName).size(), 0),
+                metadata -> assertEquals(metadata.listTables(session, null).size(), 0),
+                metadata -> metadata.dropSchema(session, schemaName)));
+    }
+
+    @Test
+    @RequiredFeatures({RENAME_SCHEMA})
+    default void testRenameSchema()
+    {
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        String initialSchemaName = "testRenameSchemaInitial";
+        String renamedSchemaName = "testRenameSchemaRenamed";
+
+        run(ImmutableList.of(
+                metadata -> metadata.createSchema(session, initialSchemaName, ImmutableMap.of()),
+                metadata -> metadata.renameSchema(session, initialSchemaName, renamedSchemaName),
+                metadata -> assertEquals(getOnlyElement(metadata.listSchemaNames(session)), renamedSchemaName),
+                metadata -> assertEquals(metadata.listTables(session, renamedSchemaName).size(), 0),
+                metadata -> assertEquals(metadata.listTables(session, null).size(), 0),
+                metadata -> metadata.dropSchema(session, renamedSchemaName)));
+    }
+}

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/MetadataTableTest.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/MetadataTableTest.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.unittest;
+
+import com.facebook.presto.connector.meta.RequiredFeatures;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.ADD_COLUMN;
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_TABLE_AS;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_TABLE;
+import static com.facebook.presto.connector.meta.ConnectorFeature.RENAME_COLUMN;
+import static com.facebook.presto.connector.meta.ConnectorFeature.RENAME_TABLE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@RequiredFeatures({CREATE_TABLE_AS, DROP_TABLE})
+public interface MetadataTableTest
+        extends BaseMetadataTest
+{
+    default void testRenameTable(SchemaTableName initial, SchemaTableName renamed)
+            throws Exception
+    {
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(
+                initial,
+                ImmutableList.of(
+                        new ColumnMetadata("bigint_column", BIGINT),
+                        new ColumnMetadata("double_column", DOUBLE)),
+                getTableProperties());
+
+        try (AutoCloseable cleanup = new AllCloser(withSchemas(session, schemaNamesOf(initial, renamed)))) {
+            run(ImmutableList.of(
+                    metadata -> {
+                        ConnectorOutputTableHandle handle = metadata.beginCreateTable(session, tableMetadata, Optional.empty());
+                        metadata.finishCreateTable(session, handle, ImmutableList.of());
+                    },
+                    metadata -> metadata.renameTable(session, metadata.getTableHandle(session, initial), renamed),
+                    metadata -> assertEquals(getOnlyElement(metadata.listTables(session, renamed.getSchemaName())), renamed),
+                    metadata -> metadata.dropTable(session, metadata.getTableHandle(session, renamed))));
+        }
+    }
+
+    @Test
+    @RequiredFeatures(RENAME_TABLE)
+    default void testRenameTableWithinSchema()
+            throws Exception
+    {
+        testRenameTable(
+                schemaTableName("initial"),
+                schemaTableName("renamed"));
+    }
+
+    @Test
+    @RequiredFeatures({CREATE_SCHEMA, DROP_SCHEMA})
+    default void testRenameTableAcrossSchema()
+            throws Exception
+    {
+        testRenameTable(
+                schemaTableName("initialSchema", "initialTable"),
+                schemaTableName("renamedSchema", "renamedTable"));
+    }
+
+    @Test
+    default void testListColumnsOneSchema()
+            throws Exception
+    {
+        SchemaTableName schemaTableName1 = schemaTableName("table1");
+        SchemaTableName schemaTableName2 = schemaTableName("table2");
+
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+
+        List<ColumnMetadata> columns = ImmutableList.of(
+                new ColumnMetadata("bigint_column", BIGINT),
+                new ColumnMetadata("double_column", DOUBLE));
+
+        List<ColumnMetadata> expectedColumns = withSystemColumns(columns);
+
+        ConnectorTableMetadata tableMetadata11 = new ConnectorTableMetadata(schemaTableName1, columns, getTableProperties());
+        ConnectorTableMetadata tableMetadata12 = new ConnectorTableMetadata(schemaTableName2, columns, getTableProperties());
+
+        try (AutoCloseable cleanup = withTables(session, tableMetadata11, tableMetadata12)) {
+            run(ImmutableList.of(
+                    metadata -> assertEquals(metadata.listTableColumns(session, new SchemaTablePrefix()),
+                            ImmutableMap.of(
+                                    schemaTableName1, expectedColumns,
+                                    schemaTableName2, expectedColumns)),
+                    metadata -> assertEquals(metadata.listTableColumns(session, prefixOf(schemaTableName1)),
+                            ImmutableMap.of(
+                                    schemaTableName1, expectedColumns))));
+        }
+    }
+
+    @Test
+    @RequiredFeatures({CREATE_SCHEMA, DROP_SCHEMA})
+    default void testListColumnsMultiSchema()
+            throws Exception
+    {
+        String schemaName1 = "testListColumns1";
+        String schemaName2 = "testListColumns2";
+        SchemaTableName schemaTableName11 = schemaTableName(schemaName1, "table1");
+        SchemaTableName schemaTableName12 = schemaTableName(schemaName1, "table2");
+        SchemaTableName schemaTableName2 = schemaTableName(schemaName2, "table");
+
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+
+        List<ColumnMetadata> columns = ImmutableList.of(
+                new ColumnMetadata("bigint_column", BIGINT),
+                new ColumnMetadata("double_column", DOUBLE));
+
+        List<ColumnMetadata> expectedColumns = withSystemColumns(columns);
+
+        ConnectorTableMetadata tableMetadata11 = new ConnectorTableMetadata(schemaTableName11, columns, getTableProperties());
+        ConnectorTableMetadata tableMetadata12 = new ConnectorTableMetadata(schemaTableName12, columns, getTableProperties());
+        ConnectorTableMetadata tableMetadata2 = new ConnectorTableMetadata(schemaTableName2, columns, getTableProperties());
+
+        try (AutoCloseable cleanup = withTables(session, tableMetadata11, tableMetadata12, tableMetadata2)) {
+            run(ImmutableList.of(
+                    metadata -> assertEquals(metadata.listTableColumns(session, new SchemaTablePrefix()),
+                            ImmutableMap.of(
+                                    schemaTableName11, expectedColumns,
+                                    schemaTableName12, expectedColumns,
+                                    schemaTableName2, expectedColumns)),
+                    metadata -> assertEquals(metadata.listTableColumns(session, prefixOfSchemaName(schemaTableName2)),
+                            ImmutableMap.of(
+                                    schemaTableName2, expectedColumns))));
+        }
+    }
+
+    @Test
+    @RequiredFeatures(ADD_COLUMN)
+    default void testAddColumn()
+            throws Exception
+    {
+        SchemaTableName schemaTableName = schemaTableName("table");
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+
+        List<ColumnMetadata> initialColumns = ImmutableList.of(
+                new ColumnMetadata("bigint_column", BIGINT),
+                new ColumnMetadata("double_column", DOUBLE));
+
+        ColumnMetadata newColumn = new ColumnMetadata("varchar_column", VARCHAR);
+
+        List<ColumnMetadata> expectedInitialColumns = withSystemColumns(initialColumns);
+
+        List<ColumnMetadata> expectedFinalColumns = withSystemColumns(
+                ImmutableList.<ColumnMetadata>builder()
+                        .addAll(initialColumns)
+                        .add(newColumn)
+                        .build());
+
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(schemaTableName, initialColumns, getTableProperties());
+
+        try (AutoCloseable cleanup = withTables(session, tableMetadata)) {
+            run(ImmutableList.of(
+                    metadata -> assertEquals(metadata.listTableColumns(session, prefixOfSchemaName(schemaTableName)),
+                            ImmutableMap.of(schemaTableName, expectedInitialColumns)),
+                    metadata -> metadata.addColumn(session, metadata.getTableHandle(session, schemaTableName), newColumn),
+                    metadata -> assertEquals(metadata.listTableColumns(session, prefixOfSchemaName(schemaTableName)),
+                            ImmutableMap.of(schemaTableName, expectedFinalColumns))));
+        }
+    }
+
+    @Test
+    @RequiredFeatures(RENAME_COLUMN)
+    default void testRenameColumn()
+            throws Exception
+    {
+        SchemaTableName schemaTableName = schemaTableName("table");
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+
+        ColumnMetadata unchanging = new ColumnMetadata("bigint_column", BIGINT);
+        ColumnMetadata initial = new ColumnMetadata("initial_column", DOUBLE);
+        ColumnMetadata renamed = new ColumnMetadata("renamed_column", DOUBLE);
+
+        List<ColumnMetadata> initialColumns = ImmutableList.of(unchanging, initial);
+
+        List<ColumnMetadata> expectedInitialColumns = withSystemColumns(initialColumns);
+
+        List<ColumnMetadata> expectedFinalColumns = withSystemColumns(
+                ImmutableList.<ColumnMetadata>builder()
+                        .add(unchanging)
+                        .add(renamed)
+                        .build());
+
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(schemaTableName, initialColumns, getTableProperties());
+
+        try (AutoCloseable cleanup = withTables(session, tableMetadata)) {
+            run(ImmutableList.of(
+                    metadata -> assertEquals(metadata.listTableColumns(session, prefixOfSchemaName(schemaTableName)),
+                            ImmutableMap.of(schemaTableName, expectedInitialColumns)),
+                    metadata -> {
+                        ConnectorTableHandle table = metadata.getTableHandle(session, schemaTableName);
+                        Map<String, ColumnHandle> columns = metadata.getColumnHandles(session, table);
+                        metadata.renameColumn(
+                                session,
+                                table,
+                                columns.get("initial_column"),
+                                "renamed_column");
+                    },
+                    metadata -> assertEquals(metadata.listTableColumns(session, prefixOfSchemaName(schemaTableName)),
+                            ImmutableMap.of(schemaTableName, expectedFinalColumns))));
+        }
+    }
+}

--- a/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/SPITest.java
+++ b/presto-connector-tests/src/main/java/com/facebook/presto/connector/unittest/SPITest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.unittest;
+
+import com.facebook.presto.connector.meta.SupportedTestCondition;
+import com.facebook.presto.spi.connector.Connector;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(SupportedTestCondition.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public interface SPITest
+{
+    Connector getConnector();
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/AllFeaturesConnectorTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/AllFeaturesConnectorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import com.google.common.collect.ImmutableSet;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_TABLE;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_TABLE;
+
+@SupportedFeatures({CREATE_SCHEMA, DROP_SCHEMA, CREATE_TABLE, DROP_TABLE})
+public class AllFeaturesConnectorTest
+        extends VerifyRun
+        implements SubTest
+{
+    public AllFeaturesConnectorTest()
+    {
+        super(ImmutableSet.of("baseTest", "noMoreFeaturesRequiredTest", "moreFeaturesRequiredTest"));
+    }
+
+    @Override
+    public void createSchema()
+    {
+    }
+
+    @Override
+    public void dropSchema()
+    {
+    }
+
+    @Override
+    public void createTable()
+    {
+    }
+
+    @Override
+    public void dropTable()
+    {
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/BaseSPITest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/BaseSPITest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(SupportedTestCondition.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public interface BaseSPITest
+{
+    void ran(TestInfo testInfo);
+    void validate();
+
+    @AfterAll
+    default void postValidate()
+    {
+        validate();
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/BaseTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/BaseTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@RequiredFeatures({CREATE_SCHEMA})
+public interface BaseTest
+        extends BaseSPITest
+{
+    @Test
+    default void baseTest(TestInfo info)
+    {
+        ran(info);
+        createSchema();
+    }
+
+    default void createSchema()
+    {
+        fail("Unsupported createSchema");
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MissingBaseFeaturesConnectorTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MissingBaseFeaturesConnectorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_TABLE;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_TABLE;
+
+@SupportedFeatures({DROP_SCHEMA, CREATE_TABLE, DROP_TABLE})
+public class MissingBaseFeaturesConnectorTest
+        extends VerifyRun
+        implements SubTest
+{
+    @Override
+    public void dropSchema()
+    {
+    }
+
+    @Override
+    public void createTable()
+    {
+    }
+
+    @Override
+    public void dropTable()
+    {
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MissingChildFeaturesConnectorTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MissingChildFeaturesConnectorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import com.google.common.collect.ImmutableSet;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_TABLE;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_TABLE;
+
+@SupportedFeatures({CREATE_SCHEMA, CREATE_TABLE, DROP_TABLE})
+public class MissingChildFeaturesConnectorTest
+        extends VerifyRun
+        implements SubTest
+{
+    public MissingChildFeaturesConnectorTest()
+    {
+        super(ImmutableSet.of("baseTest"));
+    }
+
+    @Override
+    public void createSchema()
+    {
+    }
+
+    @Override
+    public void createTable()
+    {
+    }
+
+    @Override
+    public void dropTable()
+    {
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MissingMethodFeaturesConnectorTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MissingMethodFeaturesConnectorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import com.google.common.collect.ImmutableSet;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_SCHEMA;
+
+@SupportedFeatures({CREATE_SCHEMA, DROP_SCHEMA})
+public class MissingMethodFeaturesConnectorTest
+        extends VerifyRun
+        implements SubTest
+{
+    public MissingMethodFeaturesConnectorTest()
+    {
+        super(ImmutableSet.of("baseTest", "noMoreFeaturesRequiredTest"));
+    }
+
+    @Override
+    public void createSchema()
+    {
+    }
+
+    @Override
+    public void dropSchema()
+    {
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBase1Test.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBase1Test.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_SCHEMA;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@RequiredFeatures({CREATE_SCHEMA, DROP_SCHEMA})
+public interface MultiBase1Test
+        extends BaseSPITest
+{
+    default void dropSchema()
+    {
+        fail("Unsupported dropSchema");
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBase2Test.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBase2Test.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@RequiredFeatures({CREATE_SCHEMA})
+public interface MultiBase2Test
+        extends BaseSPITest
+{
+    default void createSchema()
+    {
+        fail("Unsupported createSchema");
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBaseCanRunConnectorTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBaseCanRunConnectorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import com.google.common.collect.ImmutableSet;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_SCHEMA;
+
+@SupportedFeatures({CREATE_SCHEMA, DROP_SCHEMA})
+public class MultiBaseCanRunConnectorTest
+        extends VerifyRun
+        implements MultiBaseSubTest
+{
+    public MultiBaseCanRunConnectorTest()
+    {
+        super(ImmutableSet.of("test"));
+    }
+
+    @Override
+    public void createSchema()
+    {
+    }
+
+    @Override
+    public void dropSchema()
+    {
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBaseCantRunConnectorTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBaseCantRunConnectorTest.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+public class MultiBaseCantRunConnectorTest
+        extends VerifyRun
+        implements MultiBaseSubTest
+{
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBaseSubTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/MultiBaseSubTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public interface MultiBaseSubTest
+        extends MultiBase1Test, MultiBase2Test
+{
+    @Test
+    default void test(TestInfo info)
+    {
+        ran(info);
+        createSchema();
+        dropSchema();
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/NoFeaturesConnectorTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/NoFeaturesConnectorTest.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+@SupportedFeatures({})
+public class NoFeaturesConnectorTest
+        extends VerifyRun
+        implements SubTest
+{
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/SubTest.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/SubTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_TABLE;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_TABLE;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@RequiredFeatures(DROP_SCHEMA)
+public interface SubTest
+        extends BaseTest
+{
+    @Test
+    default void noMoreFeaturesRequiredTest(TestInfo info)
+    {
+        ran(info);
+        createSchema();
+        dropSchema();
+    }
+
+    @Test
+    @RequiredFeatures({CREATE_TABLE, DROP_TABLE})
+    default void moreFeaturesRequiredTest(TestInfo info)
+    {
+        ran(info);
+        createSchema();
+        createTable();
+        dropTable();
+        dropSchema();
+    }
+
+    default void dropSchema()
+    {
+        fail("Unsupported dropSchema");
+    }
+
+    default void createTable()
+    {
+        fail("Unsupported createTable");
+    }
+
+    default void dropTable()
+    {
+        fail("Unsupported dropTable");
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/VerifyRun.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/connector/meta/VerifyRun.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.meta;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.TestInfo;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VerifyRun
+        implements BaseSPITest
+{
+    private final Set<String> shouldRunTestNames;
+    private Set<String> didRunTestNames;
+
+    protected VerifyRun()
+    {
+        this(ImmutableSet.of());
+    }
+
+    protected VerifyRun(Set<String> shouldRunTestNames)
+    {
+        this.shouldRunTestNames = shouldRunTestNames;
+        this.didRunTestNames = new HashSet<>();
+    }
+
+    @Override
+    public void ran(TestInfo testInfo)
+    {
+        didRunTestNames.add(testInfo.getTestMethod().get().getName());
+    }
+
+    @Override
+    public void validate()
+    {
+        assertEquals(shouldRunTestNames, didRunTestNames);
+    }
+}

--- a/presto-connector-tests/src/test/java/com/facebook/presto/tpch/TestTpchMetadata.java
+++ b/presto-connector-tests/src/test/java/com/facebook/presto/tpch/TestTpchMetadata.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpch;
+
+import com.facebook.presto.connector.meta.SupportedFeatures;
+import com.facebook.presto.connector.unittest.BaseMetadataTest;
+import com.facebook.presto.connector.unittest.MetadataSchemaTest;
+import com.facebook.presto.connector.unittest.MetadataTableTest;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.testing.TestingConnectorContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+/*
+ * Don't do this for other connectors. The TPCH connector is special because
+ * presto-main depends on presto-tpch for its own testing.
+ * presto-connector-tests depends on presto-main, and so we can't add
+ * presto-connector-tests as a dependency of presto-tpch without creating a
+ * circular dependency.
+ */
+@SupportedFeatures({})
+public class TestTpchMetadata
+        implements BaseMetadataTest, MetadataSchemaTest, MetadataTableTest
+{
+    @Override
+    public Connector getConnector()
+    {
+        TpchPlugin plugin = new TpchPlugin();
+        Iterable<ConnectorFactory> connectorFactories = plugin.getConnectorFactories();
+
+        ConnectorFactory factory = getOnlyElement(connectorFactories);
+        return factory.create("tpch", ImmutableMap.of(), new TestingConnectorContext());
+    }
+
+    @Override
+    public Map<String, Object> getTableProperties()
+    {
+        return ImmutableMap.of();
+    }
+
+    @Override
+    public List<String> systemSchemas()
+    {
+        return ImmutableList.of(
+                "tiny",
+                "sf1",
+                "sf100",
+                "sf300",
+                "sf1000",
+                "sf3000",
+                "sf10000",
+                "sf30000",
+                "sf100000");
+    }
+
+    private static final List<String> PER_SCHEMA_TABLES = ImmutableList.of(
+            "customer",
+            "orders",
+            "lineitem",
+            "part",
+            "partsupp",
+            "supplier",
+            "nation",
+            "region");
+
+    @Override
+    public List<SchemaTableName> systemTables()
+    {
+        return systemSchemas().stream()
+                .flatMap(schema -> PER_SCHEMA_TABLES.stream().map(table -> new SchemaTableName(schema, table)))
+                .collect(toImmutableList());
+    }
+}

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -207,6 +207,12 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-connector-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>
@@ -234,6 +240,12 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+		</dependency>
 
         <dependency>
             <groupId>io.airlift</groupId>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -54,7 +54,7 @@ public final class HiveQueryRunner
     public static final String HIVE_BUCKETED_CATALOG = "hive_bucketed";
     public static final String TPCH_SCHEMA = "tpch";
     private static final String TPCH_BUCKETED_SCHEMA = "tpch_bucketed";
-    private static final DateTimeZone TIME_ZONE = DateTimeZone.forID("Asia/Kathmandu");
+    public static final DateTimeZone TIME_ZONE = DateTimeZone.forID("Asia/Kathmandu");
 
     public static DistributedQueryRunner createQueryRunner(TpchTable<?>... tables)
             throws Exception

--- a/presto-hive/src/test/java/com/facebook/presto/hive/unittests/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/unittests/TestHiveMetadata.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.unittests;
+
+import com.facebook.presto.connector.meta.SupportedFeatures;
+import com.facebook.presto.connector.unittest.BaseMetadataTest;
+import com.facebook.presto.connector.unittest.MetadataSchemaTest;
+import com.facebook.presto.connector.unittest.MetadataTableTest;
+import com.facebook.presto.hive.HdfsConfiguration;
+import com.facebook.presto.hive.HdfsConfigurationUpdater;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.HivePlugin;
+import com.facebook.presto.hive.HiveS3Config;
+import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.testing.TestingConnectorContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.ADD_COLUMN;
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_TABLE;
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_TABLE_AS;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_TABLE;
+import static com.facebook.presto.connector.meta.ConnectorFeature.READ_DATA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.RENAME_COLUMN;
+import static com.facebook.presto.connector.meta.ConnectorFeature.RENAME_SCHEMA;
+import static com.facebook.presto.connector.meta.ConnectorFeature.RENAME_TABLE;
+import static com.facebook.presto.connector.meta.ConnectorFeature.WRITE_DATA;
+import static com.facebook.presto.hive.HiveQueryRunner.TIME_ZONE;
+import static com.facebook.presto.hive.HiveStorageFormat.TEXTFILE;
+import static com.facebook.presto.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
+import static com.facebook.presto.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY;
+import static com.facebook.presto.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
+import static com.facebook.presto.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+@SupportedFeatures({
+        READ_DATA,
+        WRITE_DATA,
+        CREATE_SCHEMA,
+        DROP_SCHEMA,
+        RENAME_SCHEMA,
+        CREATE_TABLE,
+        CREATE_TABLE_AS,
+        DROP_TABLE,
+        RENAME_TABLE,
+        ADD_COLUMN,
+        RENAME_COLUMN})
+public class TestHiveMetadata
+        implements BaseMetadataTest, MetadataSchemaTest, MetadataTableTest
+{
+    private Connector connector;
+
+    @BeforeAll
+    public void beforeAll()
+            throws Exception
+    {
+        this.connector = createHiveConnector();
+    }
+
+    @AfterAll
+    public void cleanUp()
+            throws Exception
+    {
+        connector.shutdown();
+    }
+
+    @Override
+    public Connector getConnector()
+    {
+        return connector;
+    }
+
+    @Override
+    public Map<String, Object> getTableProperties()
+    {
+        return ImmutableMap.of(
+                BUCKETED_BY_PROPERTY, ImmutableList.of(),
+                BUCKET_COUNT_PROPERTY, 0,
+                PARTITIONED_BY_PROPERTY, ImmutableList.of(),
+                STORAGE_FORMAT_PROPERTY, TEXTFILE);
+    }
+
+    @Override
+    public List<ColumnMetadata> withSystemColumns(List<ColumnMetadata> connectorColumns)
+    {
+        return ImmutableList.<ColumnMetadata>builder()
+                .addAll(connectorColumns)
+                .add(new ColumnMetadata("$path", VARCHAR, null, true))
+                .build();
+    }
+
+    private static Connector createHiveConnector()
+            throws IOException
+    {
+        File baseDir = Files.createTempDirectory("PrestoTest").resolve("hive_data").toFile();
+
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        HiveS3Config s3Config = new HiveS3Config();
+
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig, s3Config));
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
+        FileHiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
+
+        HivePlugin plugin = new HivePlugin("hive", metastore);
+        Iterable<ConnectorFactory> connectorFactories = plugin.getConnectorFactories();
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore.uri", "thrift://localhost:8080")
+                .put("hive.time-zone", TIME_ZONE.getID())
+                .build();
+
+        ConnectorFactory factory = getOnlyElement(connectorFactories);
+        return factory.create("hive", properties, new TestingConnectorContext());
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/unittests/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/unittests/TestHiveMetadata.java
@@ -109,7 +109,7 @@ public class TestHiveMetadata
     }
 
     @Override
-    public List<ColumnMetadata> withSystemColumns(List<ColumnMetadata> connectorColumns)
+    public List<ColumnMetadata> extendWithConnectorSpecificColumns(List<ColumnMetadata> connectorColumns)
     {
         return ImmutableList.<ColumnMetadata>builder()
                 .addAll(connectorColumns)

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -79,6 +79,12 @@
             <scope>test</scope>
         </dependency>
 
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+		</dependency>
+
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
@@ -106,6 +112,12 @@
         <dependency>
             <groupId>io.airlift.tpch</groupId>
             <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-connector-tests</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-postgresql/src/test/java/com/facebook/presto/unittests/TestPostgresqlMetadata.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/unittests/TestPostgresqlMetadata.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.unittests;
+
+import com.facebook.presto.connector.meta.SupportedFeatures;
+import com.facebook.presto.connector.unittest.BaseMetadataTest;
+import com.facebook.presto.connector.unittest.MetadataSchemaTest;
+import com.facebook.presto.connector.unittest.MetadataTableTest;
+import com.facebook.presto.plugin.postgresql.PostgreSqlPlugin;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.testing.TestingConnectorContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.testing.postgresql.TestingPostgreSqlServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.connector.meta.ConnectorFeature.CREATE_TABLE_AS;
+import static com.facebook.presto.connector.meta.ConnectorFeature.DROP_TABLE;
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+@SupportedFeatures({
+        CREATE_TABLE_AS,
+        DROP_TABLE})
+public class TestPostgresqlMetadata
+        implements BaseMetadataTest, MetadataTableTest, MetadataSchemaTest
+{
+    private TestingPostgreSqlServer server;
+    private Connector connector;
+
+    @BeforeAll
+    public void beforeAll()
+            throws Exception
+    {
+        this.server = new TestingPostgreSqlServer("testuser", "unittests");
+        this.connector = createPostgresqlConnector(server);
+    }
+
+    @AfterAll
+    public void cleanUp()
+            throws Exception
+    {
+        connector.shutdown();
+        server.close();
+    }
+
+    @Override
+    public Connector getConnector()
+    {
+        return connector;
+    }
+
+    private static Connector createPostgresqlConnector(TestingPostgreSqlServer server)
+            throws Exception
+    {
+        PostgreSqlPlugin plugin = new PostgreSqlPlugin();
+        Iterable<ConnectorFactory> connectorFactories = plugin.getConnectorFactories();
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("connection-url", server.getJdbcUrl())
+                .put("allow-drop-table", "true")
+                .build();
+
+        ConnectorFactory factory = getOnlyElement(connectorFactories);
+        return factory.create("postgresql", properties, new TestingConnectorContext());
+    }
+
+    @Override
+    public Map<String, Object> getTableProperties()
+    {
+        return ImmutableMap.of();
+    }
+
+    @Override
+    public SchemaTableName schemaTableName(String tableName)
+    {
+        return new SchemaTableName("public", tableName);
+    }
+
+    @Override
+    public List<String> systemSchemas()
+    {
+        return ImmutableList.of("pg_catalog", "public");
+    }
+
+    @Override
+    public List<AutoCloseable> withSchemas(ConnectorSession session, List<String> schemaNames)
+    {
+        return ImmutableList.of();
+    }
+}


### PR DESCRIPTION
Updated per discussion in https://github.com/prestodb/presto/issues/8150
Depends on https://github.com/airlift/airbase/pull/110

Notable updates from https://github.com/prestodb/presto/pull/8672:

- Tests are now enabled/disabled based on supported/required features using SupportedTestCondition
- Cleanup of schemas and tables created for tests is more robust; a failed test is less likely to cause subsequent failed tests
- Junit5 and TestNG tests coexist (pending the airbase change)