### PR TITLE
Add ArgumentProperty to describe scalar function argument

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/AbstractGreatestLeast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/AbstractGreatestLeast.java
@@ -37,7 +37,6 @@ import com.facebook.presto.sql.gen.CallSiteBinder;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -51,6 +50,8 @@ import static com.facebook.presto.bytecode.Parameter.arg;
 import static com.facebook.presto.bytecode.ParameterizedType.type;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -61,6 +62,7 @@ import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -110,9 +112,12 @@ public abstract class AbstractGreatestLeast
 
         Class<?> clazz = generate(javaTypes, type, compareMethod);
         MethodHandle methodHandle = methodHandle(clazz, getSignature().getName(), javaTypes.toArray(new Class<?>[javaTypes.size()]));
-        List<Boolean> nullableParameters = ImmutableList.copyOf(Collections.nCopies(javaTypes.size(), false));
 
-        return new ScalarFunctionImplementation(false, nullableParameters, methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                nCopies(javaTypes.size(), valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ApplyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ApplyFunction.java
@@ -25,9 +25,11 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.functionTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_BOXED_TYPE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.primitives.Primitives.wrap;
@@ -79,9 +81,9 @@ public final class ApplyFunction
         Type returnType = boundVariables.getTypeVariable("U");
         return new ScalarFunctionImplementation(
                 true,
-                ImmutableList.of(true, false),
-                ImmutableList.of(false, false),
-                ImmutableList.of(Optional.empty(), Optional.of(UnaryFunctionInterface.class)),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(USE_BOXED_TYPE),
+                        functionTypeArgumentProperty(UnaryFunctionInterface.class)),
                 METHOD_HANDLE.asType(
                         METHOD_HANDLE.type()
                                 .changeReturnType(wrap(returnType.getJavaType()))

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
@@ -32,6 +32,8 @@ import java.lang.invoke.MethodHandle;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.VarArgsToArrayAdapterGenerator.generateVarArgsToArrayAdapter;
@@ -96,9 +98,7 @@ public final class ArrayConcatFunction
 
         return new ScalarFunctionImplementation(
                 false,
-                nCopies(arity, false),
-                nCopies(arity, false),
-                nCopies(arity, Optional.empty()),
+                nCopies(arity, valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 methodHandleAndConstructor.getMethodHandle(),
                 Optional.of(methodHandleAndConstructor.getConstructor()),
                 isDeterministic());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
@@ -41,7 +41,6 @@ import com.google.common.primitives.Primitives;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -58,6 +57,8 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.equal;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_BOXED_TYPE;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
@@ -65,6 +66,7 @@ import static com.facebook.presto.util.Failures.checkCondition;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Collections.nCopies;
 
 public final class ArrayConstructor
         extends SqlScalarFunction
@@ -126,8 +128,11 @@ public final class ArrayConstructor
         catch (ReflectiveOperationException e) {
             throw Throwables.propagate(e);
         }
-        List<Boolean> nullableParameters = ImmutableList.copyOf(Collections.nCopies(stackTypes.size(), true));
-        return new ScalarFunctionImplementation(false, nullableParameters, methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                nCopies(stackTypes.size(), valueTypeArgumentProperty(USE_BOXED_TYPE)),
+                methodHandle,
+                isDeterministic());
     }
 
     private static Class<?> generateArrayConstructor(List<Class<?>> stackTypes, Type elementType)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
@@ -30,6 +30,8 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static java.lang.Math.toIntExact;
@@ -76,7 +78,11 @@ public class ArrayFlattenFunction
         Type elementType = boundVariables.getTypeVariable("E");
         Type arrayType = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(TypeSignatureParameter.of(elementType.getTypeSignature())));
         MethodHandle methodHandle = METHOD_HANDLE.bindTo(elementType).bindTo(arrayType);
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     public static Block flatten(Type type, Type arrayType, Block array)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReduceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReduceFunction.java
@@ -28,9 +28,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.functionTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_BOXED_TYPE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -81,9 +84,11 @@ public final class ArrayReduceFunction
         MethodHandle methodHandle = METHOD_HANDLE.bindTo(inputType);
         return new ScalarFunctionImplementation(
                 true,
-                ImmutableList.of(false, true, false, false),
-                ImmutableList.of(false, false, false, false),
-                ImmutableList.of(Optional.empty(), Optional.empty(), Optional.of(BinaryFunctionInterface.class), Optional.of(UnaryFunctionInterface.class)),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(USE_BOXED_TYPE),
+                        functionTypeArgumentProperty(BinaryFunctionInterface.class),
+                        functionTypeArgumentProperty(UnaryFunctionInterface.class)),
                 methodHandle.asType(
                         methodHandle.type()
                                 .changeParameterType(1, Primitives.wrap(intermediateType.getJavaType()))

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySubscriptOperator.java
@@ -27,6 +27,8 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -83,7 +85,13 @@ public class ArraySubscriptOperator
         }
         methodHandle = methodHandle.bindTo(elementType);
         requireNonNull(methodHandle, "methodHandle is null");
-        return new ScalarFunctionImplementation(true, ImmutableList.of(false, false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                true,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToArrayCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToArrayCast.java
@@ -47,6 +47,8 @@ import static com.facebook.presto.bytecode.ParameterizedType.type;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantBoolean;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.CAST;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -77,7 +79,13 @@ public class ArrayToArrayCast
         ScalarFunctionImplementation function = functionRegistry.getScalarFunctionImplementation(signature);
         Class<?> castOperatorClass = generateArrayCast(typeManager, signature, function);
         MethodHandle methodHandle = methodHandle(castOperatorClass, "castArray", ConnectorSession.class, Block.class);
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     private static Class<?> generateArrayCast(TypeManager typeManager, Signature elementCastSignature, ScalarFunctionImplementation elementCast)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToElementConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToElementConcatFunction.java
@@ -27,6 +27,8 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
@@ -93,6 +95,12 @@ public class ArrayToElementConcatFunction
         }
         methodHandle = methodHandle.bindTo(type);
 
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false, false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToJsonCast.java
@@ -41,6 +41,8 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.operator.scalar.JsonOperators.JSON_FACTORY;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Failures.checkCondition;
@@ -76,7 +78,13 @@ public class ArrayToJsonCast
 
         JsonGeneratorWriter writer = JsonGeneratorWriter.createJsonGeneratorWriter(type);
         MethodHandle methodHandle = METHOD_HANDLE.bindTo(writer);
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     public static Slice toJson(JsonGeneratorWriter writer, ConnectorSession session, Block block)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayTransformFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayTransformFunction.java
@@ -58,6 +58,9 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newIns
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.subtract;
 import static com.facebook.presto.bytecode.instruction.VariableInstruction.incrementVariable;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.functionTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
@@ -106,9 +109,9 @@ public final class ArrayTransformFunction
         Class<?> generatedClass = generateTransform(inputType, outputType);
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
-                ImmutableList.of(false, false),
-                ImmutableList.of(Optional.empty(), Optional.of(UnaryFunctionInterface.class)),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        functionTypeArgumentProperty(UnaryFunctionInterface.class)),
                 methodHandle(generatedClass, "transform", PageBuilder.class, Block.class, UnaryFunctionInterface.class),
                 Optional.of(methodHandle(generatedClass, "createPageBuilder")),
                 isDeterministic());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/CastFromUnknownOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/CastFromUnknownOperator.java
@@ -25,6 +25,8 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_BOXED_TYPE;
 import static com.facebook.presto.spi.function.OperatorType.CAST;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -70,7 +72,11 @@ public final class CastFromUnknownOperator
         else {
             methodHandle = METHOD_HANDLE_OBJECT.asType(METHOD_HANDLE_OBJECT.type().changeReturnType(toType.getJavaType()));
         }
-        return new ScalarFunctionImplementation(true, ImmutableList.of(true), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                true,
+                ImmutableList.of(valueTypeArgumentProperty(USE_BOXED_TYPE)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ElementToArrayConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ElementToArrayConcatFunction.java
@@ -27,6 +27,8 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
@@ -94,6 +96,12 @@ public class ElementToArrayConcatFunction
         }
         methodHandle = methodHandle.bindTo(type);
 
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false, false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/IdentityCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/IdentityCast.java
@@ -25,6 +25,8 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -48,6 +50,10 @@ public class IdentityCast
         checkArgument(boundVariables.getTypeVariables().size() == 1, "Expected only one type");
         Type type = boundVariables.getTypeVariable("T");
         MethodHandle identity = MethodHandles.identity(type.getJavaType());
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), identity, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                identity,
+                isDeterministic());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/InvokeFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/InvokeFunction.java
@@ -26,9 +26,9 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.functionTypeArgumentProperty;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.primitives.Primitives.wrap;
@@ -79,9 +79,7 @@ public final class InvokeFunction
         Type returnType = boundVariables.getTypeVariable("T");
         return new ScalarFunctionImplementation(
                 true,
-                ImmutableList.of(false),
-                ImmutableList.of(false),
-                ImmutableList.of(Optional.of(InvokeLambda.class)),
+                ImmutableList.of(functionTypeArgumentProperty(InvokeLambda.class)),
                 METHOD_HANDLE.asType(
                         METHOD_HANDLE.type()
                                 .changeReturnType(wrap(returnType.getJavaType()))),

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToArrayCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToArrayCast.java
@@ -38,6 +38,8 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Failures.checkCondition;
@@ -75,7 +77,11 @@ public class JsonToArrayCast
 
         BlockBuilderAppender elementAppender = BlockBuilderAppender.createBlockBuilderAppender(arrayType.getElementType());
         MethodHandle methodHandle = METHOD_HANDLE.bindTo(arrayType).bindTo(elementAppender);
-        return new ScalarFunctionImplementation(true, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                true,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToMapCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToMapCast.java
@@ -39,6 +39,8 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Failures.checkCondition;
@@ -80,7 +82,11 @@ public class JsonToMapCast
         BlockBuilderAppender keyAppender = createBlockBuilderAppender(mapType.getKeyType());
         BlockBuilderAppender valueAppender = createBlockBuilderAppender(mapType.getValueType());
         MethodHandle methodHandle = METHOD_HANDLE.bindTo(mapType).bindTo(keyAppender).bindTo(valueAppender);
-        return new ScalarFunctionImplementation(true, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                true,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToRowCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToRowCast.java
@@ -41,6 +41,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.withVariadicBound;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Failures.checkCondition;
@@ -84,7 +86,11 @@ public class JsonToRowCast
                 .map(rowField -> createBlockBuilderAppender(rowField.getType()))
                 .toArray(BlockBuilderAppender[]::new);
         MethodHandle methodHandle = METHOD_HANDLE.bindTo(rowType).bindTo(fieldAppenders).bindTo(getFieldNameToIndex(rowFields));
-        return new ScalarFunctionImplementation(true, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                true,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConcatFunction.java
@@ -36,6 +36,8 @@ import java.lang.invoke.MethodHandle;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.VarArgsToArrayAdapterGenerator.generateVarArgsToArrayAdapter;
@@ -105,9 +107,7 @@ public final class MapConcatFunction
 
         return new ScalarFunctionImplementation(
                 false,
-                nCopies(arity, false),
-                nCopies(arity, false),
-                nCopies(arity, Optional.empty()),
+                nCopies(arity, valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 methodHandleAndConstructor.getMethodHandle(),
                 Optional.of(methodHandleAndConstructor.getConstructor()),
                 isDeterministic());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
@@ -36,6 +36,8 @@ import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
 import static com.facebook.presto.util.Failures.checkCondition;
@@ -93,9 +95,9 @@ public final class MapConstructor
 
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
-                ImmutableList.of(false, false),
-                ImmutableList.of(Optional.empty(), Optional.empty()),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 METHOD_HANDLE.bindTo(mapType).bindTo(keyEqual).bindTo(keyHashCode),
                 Optional.of(instanceFactory),
                 isDeterministic());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapElementAtFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapElementAtFunction.java
@@ -33,6 +33,8 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -112,7 +114,13 @@ public class MapElementAtFunction
             methodHandle = methodHandle.asType(methodHandle.type().changeReturnType(Primitives.wrap(valueType.getJavaType())));
         }
 
-        return new ScalarFunctionImplementation(true, ImmutableList.of(false, false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                true,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapFilterFunction.java
@@ -63,6 +63,9 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.notEqu
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.subtract;
 import static com.facebook.presto.bytecode.instruction.VariableInstruction.incrementVariable;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.functionTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
@@ -114,9 +117,9 @@ public final class MapFilterFunction
                 TypeSignatureParameter.of(valueType.getTypeSignature())));
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
-                ImmutableList.of(false, false),
-                ImmutableList.of(Optional.empty(), Optional.of(BinaryFunctionInterface.class)),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        functionTypeArgumentProperty(BinaryFunctionInterface.class)),
                 generateFilter(mapType),
                 Optional.of(STATE_FACTORY.bindTo(mapType)),
                 isDeterministic());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapHashCodeOperator.java
@@ -27,6 +27,8 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.internalOperator;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -58,7 +60,11 @@ public class MapHashCodeOperator
         MethodHandle valueHashCodeFunction = functionRegistry.getScalarFunctionImplementation(internalOperator(HASH_CODE, BIGINT, ImmutableList.of(valueType))).getMethodHandle();
 
         MethodHandle method = METHOD_HANDLE.bindTo(keyHashCodeFunction).bindTo(valueHashCodeFunction).bindTo(keyType).bindTo(valueType);
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), method, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                method,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
@@ -36,6 +36,8 @@ import java.lang.invoke.MethodHandles;
 
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -101,7 +103,13 @@ public class MapSubscriptOperator
             methodHandle = methodHandle.asType(methodHandle.type().changeReturnType(Primitives.wrap(valueType.getJavaType())));
         }
 
-        return new ScalarFunctionImplementation(true, ImmutableList.of(false, false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                true,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToJsonCast.java
@@ -37,6 +37,8 @@ import java.util.TreeMap;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.operator.scalar.JsonOperators.JSON_FACTORY;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Failures.checkCondition;
@@ -78,7 +80,11 @@ public class MapToJsonCast
         JsonGeneratorWriter writer = JsonGeneratorWriter.createJsonGeneratorWriter(valueType);
         MethodHandle methodHandle = METHOD_HANDLE.bindTo(provider).bindTo(writer);
 
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
@@ -72,6 +72,9 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newIns
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.subtract;
 import static com.facebook.presto.bytecode.instruction.VariableInstruction.incrementVariable;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.functionTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
@@ -125,9 +128,9 @@ public final class MapTransformKeyFunction
                 TypeSignatureParameter.of(valueType.getTypeSignature())));
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
-                ImmutableList.of(false, false),
-                ImmutableList.of(Optional.empty(), Optional.of(BinaryFunctionInterface.class)),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        functionTypeArgumentProperty(BinaryFunctionInterface.class)),
                 generateTransformKey(keyType, transformedKeyType, valueType, resultMapType),
                 Optional.of(STATE_FACTORY.bindTo(resultMapType)),
                 isDeterministic());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
@@ -67,6 +67,9 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newIns
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.subtract;
 import static com.facebook.presto.bytecode.instruction.VariableInstruction.incrementVariable;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.functionTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
@@ -120,9 +123,9 @@ public final class MapTransformValueFunction
                 TypeSignatureParameter.of(transformedValueType.getTypeSignature())));
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
-                ImmutableList.of(false, false),
-                ImmutableList.of(Optional.empty(), Optional.of(BinaryFunctionInterface.class)),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        functionTypeArgumentProperty(BinaryFunctionInterface.class)),
                 generateTransform(keyType, valueType, transformedValueType, resultMapType),
                 Optional.of(STATE_FACTORY.bindTo(resultMapType)),
                 isDeterministic());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ParametricScalar.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ParametricScalar.java
@@ -84,9 +84,7 @@ public class ParametricScalar
             checkCondition(methodHandleAndConstructor.isPresent(), FUNCTION_IMPLEMENTATION_ERROR, String.format("Exact implementation of %s do not match expected java types.", boundSignature.getName()));
             return new ScalarFunctionImplementation(
                     implementation.isNullable(),
-                    implementation.getNullableArguments(),
-                    implementation.getNullFlags(),
-                    implementation.getLambdaInterface(),
+                    implementation.getArgumentProperties(),
                     methodHandleAndConstructor.get().getMethodHandle(),
                     methodHandleAndConstructor.get().getConstructor(),
                     isDeterministic());
@@ -99,9 +97,7 @@ public class ParametricScalar
                 checkCondition(selectedImplementation == null, AMBIGUOUS_FUNCTION_IMPLEMENTATION, "Ambiguous implementation for %s with bindings %s", getSignature(), boundVariables.getTypeVariables());
                 selectedImplementation = new ScalarFunctionImplementation(
                         implementation.isNullable(),
-                        implementation.getNullableArguments(),
-                        implementation.getNullFlags(),
-                        implementation.getLambdaInterface(),
+                        implementation.getArgumentProperties(),
                         methodHandle.get().getMethodHandle(),
                         methodHandle.get().getConstructor(),
                         isDeterministic());
@@ -117,9 +113,7 @@ public class ParametricScalar
                 checkCondition(selectedImplementation == null, AMBIGUOUS_FUNCTION_IMPLEMENTATION, "Ambiguous implementation for %s with bindings %s", getSignature(), boundVariables.getTypeVariables());
                 selectedImplementation = new ScalarFunctionImplementation(
                         implementation.isNullable(),
-                        implementation.getNullableArguments(),
-                        implementation.getNullFlags(),
-                        implementation.getLambdaInterface(),
+                        implementation.getArgumentProperties(),
                         methodHandle.get().getMethodHandle(),
                         methodHandle.get().getConstructor(),
                         isDeterministic());

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/Re2JCastToRegexpFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/Re2JCastToRegexpFunction.java
@@ -26,6 +26,8 @@ import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
 
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.function.OperatorType.CAST;
 import static com.facebook.presto.spi.type.Chars.padSpaces;
@@ -65,8 +67,10 @@ public class Re2JCastToRegexpFunction
     public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         return new ScalarFunctionImplementation(
-                false, ImmutableList.of(false),
-                insertArguments(METHOD_HANDLE, 0, dfaStatesLimit, dfaRetries, padSpaces, boundVariables.getLongVariable("x")), true);
+                false,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                insertArguments(METHOD_HANDLE, 0, dfaStatesLimit, dfaRetries, padSpaces, boundVariables.getLongVariable("x")),
+                true);
     }
 
     public static Re2JRegexp castToRegexp(int dfaStatesLimit, int dfaRetries, boolean padSpaces, long typeLength, Slice pattern)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowDistinctFromOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowDistinctFromOperator.java
@@ -27,6 +27,8 @@ import java.lang.invoke.MethodHandle;
 import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_BOXED_TYPE;
 import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
@@ -60,7 +62,9 @@ public class RowDistinctFromOperator
         }
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(true, true),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(USE_BOXED_TYPE),
+                        valueTypeArgumentProperty(USE_BOXED_TYPE)),
                 METHOD_HANDLE.bindTo(type).bindTo(argumentMethods.build()),
                 isDeterministic());
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
@@ -27,6 +27,8 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -50,7 +52,13 @@ public class RowEqualOperator
     public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = boundVariables.getTypeVariable("T");
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false, false), METHOD_HANDLE.bindTo(type), isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                METHOD_HANDLE.bindTo(type),
+                isDeterministic());
     }
 
     public static boolean equals(Type rowType, Block leftRow, Block rightRow)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowGreaterThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowGreaterThanOperator.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
@@ -44,7 +46,9 @@ public final class RowGreaterThanOperator
         Type type = boundVariables.getTypeVariable("T");
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 METHOD_HANDLE.bindTo(type).bindTo(getMethodHandles((RowType) type, functionRegistry, GREATER_THAN)),
                 isDeterministic());
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowGreaterThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowGreaterThanOrEqualOperator.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -45,7 +47,9 @@ public final class RowGreaterThanOrEqualOperator
         Type type = boundVariables.getTypeVariable("T");
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 METHOD_HANDLE.bindTo(type).bindTo(getMethodHandles((RowType) type, functionRegistry, GREATER_THAN)),
                 isDeterministic());
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -51,7 +53,11 @@ public class RowHashCodeOperator
     public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = boundVariables.getTypeVariable("T");
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), METHOD_HANDLE.bindTo(type), isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                METHOD_HANDLE.bindTo(type),
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowLessThanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowLessThanOperator.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
@@ -44,7 +46,9 @@ public final class RowLessThanOperator
         Type type = boundVariables.getTypeVariable("T");
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 METHOD_HANDLE.bindTo(type).bindTo(getMethodHandles((RowType) type, functionRegistry, LESS_THAN)),
                 isDeterministic());
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowLessThanOrEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowLessThanOrEqualOperator.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -45,7 +47,9 @@ public final class RowLessThanOrEqualOperator
         Type type = boundVariables.getTypeVariable("T");
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 METHOD_HANDLE.bindTo(type).bindTo(getMethodHandles((RowType) type, functionRegistry, LESS_THAN)),
                 isDeterministic());
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowNotEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowNotEqualOperator.java
@@ -26,6 +26,8 @@ import com.google.common.collect.ImmutableList;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.Signature.comparableWithVariadicBound;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -49,7 +51,13 @@ public class RowNotEqualOperator
     public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         Type type = boundVariables.getTypeVariable("T");
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false, false), METHOD_HANDLE.bindTo(type), isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                METHOD_HANDLE.bindTo(type),
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToJsonCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToJsonCast.java
@@ -43,6 +43,8 @@ import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.withVariadicBound;
 import static com.facebook.presto.operator.scalar.JsonOperators.JSON_FACTORY;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Failures.checkCondition;
@@ -83,7 +85,11 @@ public class RowToJsonCast
         }
         MethodHandle methodHandle = METHOD_HANDLE.bindTo(fieldWriters);
 
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
@@ -56,6 +56,8 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.withVariadicBound;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.CAST;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.gen.InvokeFunctionBytecodeExpression.invokeFunction;
@@ -85,7 +87,11 @@ public class RowToRowCast
         }
         Class<?> castOperatorClass = generateRowCast(fromType, toType, functionRegistry);
         MethodHandle methodHandle = methodHandle(castOperatorClass, "castRow", ConnectorSession.class, Block.class);
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                methodHandle,
+                isDeterministic());
     }
 
     private static Class<?> generateRowCast(Type fromType, Type toType, FunctionRegistry functionRegistry)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ScalarFunctionImplementation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ScalarFunctionImplementation.java
@@ -18,61 +18,33 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
-import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
-import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentType.FUNCTION_TYPE;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentType.VALUE_TYPE;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Collections.nCopies;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class ScalarFunctionImplementation
 {
     private final boolean nullable;
-    private final List<Boolean> nullableArguments;
-    private final List<Boolean> nullFlags;
-    private final List<Optional<Class>> lambdaInterface;
+    private final List<ArgumentProperty> argumentProperties;
     private final MethodHandle methodHandle;
     private final Optional<MethodHandle> instanceFactory;
     private final boolean deterministic;
 
-    public ScalarFunctionImplementation(boolean nullable, List<Boolean> nullableArguments, MethodHandle methodHandle, boolean deterministic)
-    {
-        this(
-                nullable,
-                nullableArguments,
-                nCopies(nullableArguments.size(), false),
-                nCopies(nullableArguments.size(), Optional.empty()),
-                methodHandle,
-                Optional.empty(),
-                deterministic);
-    }
-
-    public ScalarFunctionImplementation(boolean nullable, List<Boolean> nullableArguments, List<Boolean> nullFlags, MethodHandle methodHandle, boolean deterministic)
-    {
-        this(
-                nullable,
-                nullableArguments,
-                nullFlags,
-                nCopies(nullableArguments.size(), Optional.empty()),
-                methodHandle,
-                Optional.empty(),
-                deterministic);
-    }
-
     public ScalarFunctionImplementation(
             boolean nullable,
-            List<Boolean> nullableArguments,
-            List<Boolean> nullFlags,
-            List<Optional<Class>> lambdaInterface,
+            List<ArgumentProperty> argumentProperties,
             MethodHandle methodHandle,
             boolean deterministic)
     {
         this(
                 nullable,
-                nullableArguments,
-                nullFlags,
-                lambdaInterface,
+                argumentProperties,
                 methodHandle,
                 Optional.empty(),
                 deterministic);
@@ -80,17 +52,13 @@ public final class ScalarFunctionImplementation
 
     public ScalarFunctionImplementation(
             boolean nullable,
-            List<Boolean> nullableArguments,
-            List<Boolean> nullFlags,
-            List<Optional<Class>> lambdaInterface,
+            List<ArgumentProperty> argumentProperties,
             MethodHandle methodHandle,
             Optional<MethodHandle> instanceFactory,
             boolean deterministic)
     {
         this.nullable = nullable;
-        this.nullableArguments = ImmutableList.copyOf(requireNonNull(nullableArguments, "nullableArguments is null"));
-        this.nullFlags = ImmutableList.copyOf(requireNonNull(nullFlags, "nullFlags is null"));
-        this.lambdaInterface = ImmutableList.copyOf(requireNonNull(lambdaInterface, "lambdaInterface is null"));
+        this.argumentProperties = ImmutableList.copyOf(requireNonNull(argumentProperties, "argumentProperties is null"));
         this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
         this.instanceFactory = requireNonNull(instanceFactory, "instanceFactory is null");
         this.deterministic = deterministic;
@@ -110,22 +78,6 @@ public final class ScalarFunctionImplementation
                 checkArgument(parameterList.get(1) == ConnectorSession.class, "ConnectorSession must be the second argument when instanceFactory is present");
             }
         }
-
-        checkCondition(nullFlags.size() == nullableArguments.size(), FUNCTION_IMPLEMENTATION_ERROR, "size of nullFlags is not equal to size of nullableArguments: %s", methodHandle);
-        checkCondition(nullFlags.size() == lambdaInterface.size(), FUNCTION_IMPLEMENTATION_ERROR, "size of nullFlags is not equal to size of lambdaInterface: %s", methodHandle);
-        // check if
-        // - nullableArguments and nullFlags match
-        // - lambda interface is not nullable
-        // - lambda interface is annotated with FunctionalInterface
-        for (int i = 0; i < nullFlags.size(); i++) {
-            if (nullFlags.get(i)) {
-                checkCondition(nullableArguments.get(i), FUNCTION_IMPLEMENTATION_ERROR, "argument %s marked as @IsNull is not nullable in method: %s", i, methodHandle);
-            }
-            if (lambdaInterface.get(i).isPresent()) {
-                checkCondition(!nullableArguments.get(i), FUNCTION_IMPLEMENTATION_ERROR, "argument %s marked as lambda is nullable in method: %s", i, methodHandle);
-                checkCondition(lambdaInterface.get(i).get().isAnnotationPresent(FunctionalInterface.class), FUNCTION_IMPLEMENTATION_ERROR, "argument %s is marked as lambda but the function interface class is not annotated: %s", i, methodHandle);
-            }
-        }
     }
 
     public boolean isNullable()
@@ -133,19 +85,9 @@ public final class ScalarFunctionImplementation
         return nullable;
     }
 
-    public List<Boolean> getNullableArguments()
+    public ArgumentProperty getArgumentProperty(int argumentIndex)
     {
-        return nullableArguments;
-    }
-
-    public List<Boolean> getNullFlags()
-    {
-        return nullFlags;
-    }
-
-    public List<Optional<Class>> getLambdaInterface()
-    {
-        return lambdaInterface;
+        return argumentProperties.get(argumentIndex);
     }
 
     public MethodHandle getMethodHandle()
@@ -161,5 +103,97 @@ public final class ScalarFunctionImplementation
     public boolean isDeterministic()
     {
         return deterministic;
+    }
+
+    public static class ArgumentProperty
+    {
+        // TODO: Alternatively, we can store com.facebook.presto.spi.type.Type
+        private final ArgumentType argumentType;
+        private final Optional<NullConvention> nullConvention;
+        private final Optional<Class> lambdaInterface;
+
+        public static ArgumentProperty valueTypeArgumentProperty(NullConvention nullConvention)
+        {
+            return new ArgumentProperty(VALUE_TYPE, Optional.of(nullConvention), Optional.empty());
+        }
+
+        public static ArgumentProperty functionTypeArgumentProperty(Class lambdaInterface)
+        {
+            return new ArgumentProperty(FUNCTION_TYPE, Optional.empty(), Optional.of(lambdaInterface));
+        }
+
+        private ArgumentProperty(ArgumentType argumentType, Optional<NullConvention> nullConvention, Optional<Class> lambdaInterface)
+        {
+            switch (argumentType) {
+                case VALUE_TYPE:
+                    checkArgument(nullConvention.isPresent(), "nullConvention must present for value type");
+                    checkArgument(!lambdaInterface.isPresent(), "lambdaInterface must not present for value type");
+                    break;
+                case FUNCTION_TYPE:
+                    checkArgument(!nullConvention.isPresent(), "nullConvention must not present for function type");
+                    checkArgument(lambdaInterface.isPresent(), "lambdaInterface must present for function type");
+                    checkArgument(lambdaInterface.get().isAnnotationPresent(FunctionalInterface.class), "lambdaInterface must be annotated with FunctionalInterface");
+                    break;
+                default:
+                    throw new UnsupportedOperationException(format("Unsupported argument type: %s", argumentType));
+            }
+
+            this.argumentType = argumentType;
+            this.nullConvention = nullConvention;
+            this.lambdaInterface = lambdaInterface;
+        }
+
+        public ArgumentType getArgumentType()
+        {
+            return argumentType;
+        }
+
+        public NullConvention getNullConvention()
+        {
+            checkState(getArgumentType() == VALUE_TYPE, "nullConvention only applies to value type argument");
+            return nullConvention.get();
+        }
+
+        public Class getLambdaInterface()
+        {
+            checkState(getArgumentType() == FUNCTION_TYPE, "lambdaInterface only applies to function type argument");
+            return lambdaInterface.get();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+
+            ArgumentProperty other = (ArgumentProperty) obj;
+            return this.argumentType == other.argumentType &&
+                    this.nullConvention.equals(other.nullConvention) &&
+                    this.lambdaInterface.equals(other.lambdaInterface);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(nullConvention, lambdaInterface);
+        }
+    }
+
+    public enum NullConvention
+    {
+        RETURN_NULL_ON_NULL,
+        USE_BOXED_TYPE,
+        USE_NULL_FLAG,
+    }
+
+    public enum ArgumentType
+    {
+        VALUE_TYPE,
+        FUNCTION_TYPE
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipWithFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipWithFunction.java
@@ -28,9 +28,11 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.functionTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
@@ -83,9 +85,10 @@ public final class ZipWithFunction
         Type outputElementType = boundVariables.getTypeVariable("R");
         return new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false, false),
-                ImmutableList.of(false, false, false),
-                ImmutableList.of(Optional.empty(), Optional.empty(), Optional.of(BinaryFunctionInterface.class)),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        functionTypeArgumentProperty(BinaryFunctionInterface.class)),
                 METHOD_HANDLE.bindTo(leftElementType).bindTo(rightElementType).bindTo(outputElementType),
                 isDeterministic());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/FunctionCallCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/FunctionCallCodeGenerator.java
@@ -22,6 +22,9 @@ import com.facebook.presto.sql.relational.RowExpression;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentType.VALUE_TYPE;
 
 public class FunctionCallCodeGenerator
         implements BytecodeGenerator
@@ -36,7 +39,13 @@ public class FunctionCallCodeGenerator
         List<BytecodeNode> argumentsBytecode = new ArrayList<>();
         for (int i = 0; i < arguments.size(); i++) {
             RowExpression argument = arguments.get(i);
-            argumentsBytecode.add(context.generate(argument, function.getLambdaInterface().get(i)));
+            ScalarFunctionImplementation.ArgumentProperty argumentProperty = function.getArgumentProperty(i);
+            if (argumentProperty.getArgumentType() == VALUE_TYPE) {
+                argumentsBytecode.add(context.generate(argument));
+            }
+            else {
+                argumentsBytecode.add(context.generate(argument, Optional.of(argumentProperty.getLambdaInterface())));
+            }
         }
 
         return context.generateCall(signature.getName(), function, argumentsBytecode);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -110,6 +110,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
@@ -958,7 +959,7 @@ public class ExpressionInterpreter
             ScalarFunctionImplementation function = metadata.getFunctionRegistry().getScalarFunctionImplementation(functionSignature);
             for (int i = 0; i < argumentValues.size(); i++) {
                 Object value = argumentValues.get(i);
-                if (value == null && !function.getNullableArguments().get(i)) {
+                if (value == null && function.getArgumentProperty(i).getNullConvention() == RETURN_NULL_ON_NULL) {
                     return null;
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.metadata.Signature.internalScalarFunction;
 import static com.facebook.presto.operator.scalar.JsonStringToArrayCast.JSON_STRING_TO_ARRAY_NAME;
 import static com.facebook.presto.operator.scalar.JsonStringToMapCast.JSON_STRING_TO_MAP_NAME;
 import static com.facebook.presto.operator.scalar.JsonStringToRowCast.JSON_STRING_TO_ROW_NAME;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
@@ -181,7 +182,7 @@ public class ExpressionOptimizer
                 for (RowExpression argument : arguments) {
                     Object value = ((ConstantExpression) argument).getValue();
                     // if any argument is null, return null
-                    if (value == null && !function.getNullableArguments().get(index)) {
+                    if (value == null && function.getArgumentProperty(index).getNullConvention() == RETURN_NULL_ON_NULL) {
                         return constantNull(call.getType());
                     }
                     constantArguments.add(value);

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
@@ -27,6 +27,8 @@ import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.metadata.SqlScalarFunctionBuilder.constant;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_NULL_FLAG;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.function.OperatorType.BETWEEN;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
@@ -136,8 +138,9 @@ public class DecimalInequalityOperators
     private static SqlScalarFunction distinctOperator()
     {
         return makeBinaryOperatorFunctionBuilder(IS_DISTINCT_FROM)
-                .nullableArguments(true, true)
-                .nullFlags(true, true)
+                .argumentProperties(
+                        valueTypeArgumentProperty(USE_NULL_FLAG),
+                        valueTypeArgumentProperty(USE_NULL_FLAG))
                 .implementation(b -> b
                         .methods("distinctShortShort", "distinctLongLong"))
                 .build();

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionRegistry.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Collections;
 import java.util.List;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
@@ -40,6 +39,8 @@ import static com.facebook.presto.metadata.FunctionRegistry.getMagicLiteralFunct
 import static com.facebook.presto.metadata.FunctionRegistry.mangleOperatorName;
 import static com.facebook.presto.metadata.FunctionRegistry.unmangleOperator;
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -48,6 +49,7 @@ import static com.facebook.presto.type.TypeUtils.resolveTypes;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.transform;
 import static java.lang.String.format;
+import static java.util.Collections.nCopies;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -396,7 +398,11 @@ public class TestFunctionRegistry
                             TypeManager typeManager,
                             FunctionRegistry functionRegistry)
                     {
-                        return new ScalarFunctionImplementation(false, Collections.nCopies(arity, Boolean.FALSE), MethodHandles.identity(Void.class), true);
+                        return new ScalarFunctionImplementation(
+                                false,
+                                nCopies(arity, valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                                MethodHandles.identity(Void.class),
+                                true);
                     }
 
                     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/GenericLongFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/GenericLongFunction.java
@@ -24,6 +24,8 @@ import java.lang.invoke.MethodHandle;
 import java.util.function.LongUnaryOperator;
 
 import static com.facebook.presto.metadata.Signature.internalScalarFunction;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.StandardTypes.BIGINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -64,7 +66,7 @@ public final class GenericLongFunction
     public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
         MethodHandle methodHandle = METHOD_HANDLE.bindTo(longUnaryOperator);
-        return new ScalarFunctionImplementation(false, ImmutableList.of(false), methodHandle, isDeterministic());
+        return new ScalarFunctionImplementation(false, ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL)), methodHandle, isDeterministic());
     }
 
     public static long apply(LongUnaryOperator longUnaryOperator, long value)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForScalars.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForScalars.java
@@ -64,7 +64,7 @@ public class TestAnnotationEngineForScalars
         extends TestAnnotationEngine
 {
     @ScalarFunction("single_implementation_parametric_scalar")
-    @Description("Simple scalar with single implemenatation based on class")
+    @Description("Simple scalar with single implementation based on class")
     public static class SingleImplementationScalarFunction
     {
         @SqlType(DOUBLE)
@@ -91,7 +91,7 @@ public class TestAnnotationEngineForScalars
         assertEquals(scalar.getSignature(), expectedSignature);
         assertTrue(scalar.isDeterministic());
         assertFalse(scalar.isHidden());
-        assertEquals(scalar.getDescription(), "Simple scalar with single implemenatation based on class");
+        assertEquals(scalar.getDescription(), "Simple scalar with single implementation based on class");
 
         assertImplementationCount(scalar, 1, 0, 0);
 
@@ -229,7 +229,7 @@ public class TestAnnotationEngineForScalars
     public static class StaticMethodScalarFunction
     {
         @ScalarFunction("static_method_scalar")
-        @Description("Simple scalar with single implemenatation based on method")
+        @Description("Simple scalar with single implementation based on method")
         @SqlType(DOUBLE)
         public static double fun(@SqlType(DOUBLE) double v)
         {
@@ -254,7 +254,7 @@ public class TestAnnotationEngineForScalars
         assertEquals(scalar.getSignature(), expectedSignature);
         assertTrue(scalar.isDeterministic());
         assertFalse(scalar.isHidden());
-        assertEquals(scalar.getDescription(), "Simple scalar with single implemenatation based on method");
+        assertEquals(scalar.getDescription(), "Simple scalar with single implementation based on method");
     }
 
     public static class MultiScalarFunction

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForScalars.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForScalars.java
@@ -46,6 +46,10 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_BOXED_TYPE;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_NULL_FLAG;
 import static com.facebook.presto.spi.type.StandardTypes.BIGINT;
 import static com.facebook.presto.spi.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.spi.type.StandardTypes.DOUBLE;
@@ -93,8 +97,8 @@ public class TestAnnotationEngineForScalars
 
         ScalarFunctionImplementation specialized = scalar.specialize(BoundVariables.builder().build(), 1, new TypeRegistry(), null);
         assertFalse(specialized.getInstanceFactory().isPresent());
-        assertTrue(specialized.getNullableArguments().stream().allMatch(v -> !v));
-        assertTrue(specialized.getNullFlags().stream().allMatch(v -> !v));
+
+        assertEquals(specialized.getArgumentProperty(0).getNullConvention(), RETURN_NULL_ON_NULL);
     }
 
     @ScalarFunction(value = "hidden_scalar_function", hidden = true)
@@ -178,8 +182,9 @@ public class TestAnnotationEngineForScalars
 
         ScalarFunctionImplementation specialized = scalar.specialize(BoundVariables.builder().build(), 2, new TypeRegistry(), null);
         assertFalse(specialized.getInstanceFactory().isPresent());
-        assertEquals(specialized.getNullableArguments(), ImmutableList.of(false, true));
-        assertEquals(specialized.getNullFlags(), ImmutableList.of(false, true));
+
+        assertEquals(specialized.getArgumentProperty(0), valueTypeArgumentProperty(RETURN_NULL_ON_NULL));
+        assertEquals(specialized.getArgumentProperty(1), valueTypeArgumentProperty(USE_NULL_FLAG));
     }
 
     @ScalarFunction("scalar_with_nullable_complex")
@@ -216,8 +221,9 @@ public class TestAnnotationEngineForScalars
 
         ScalarFunctionImplementation specialized = scalar.specialize(BoundVariables.builder().build(), 2, new TypeRegistry(), null);
         assertFalse(specialized.getInstanceFactory().isPresent());
-        assertEquals(specialized.getNullableArguments(), ImmutableList.of(false, true));
-        assertEquals(specialized.getNullFlags(), ImmutableList.of(false, false));
+
+        assertEquals(specialized.getArgumentProperty(0), valueTypeArgumentProperty(RETURN_NULL_ON_NULL));
+        assertEquals(specialized.getArgumentProperty(1), valueTypeArgumentProperty(USE_BOXED_TYPE));
     }
 
     public static class StaticMethodScalarFunction

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
@@ -63,6 +63,8 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.operator.scalar.BenchmarkArrayFilter.ExactArrayFilterFunction.EXACT_ARRAY_FILTER_FUNCTION;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -224,7 +226,9 @@ public class BenchmarkArrayFilter
             Type type = boundVariables.getTypeVariable("T");
             return new ScalarFunctionImplementation(
                     false,
-                    ImmutableList.of(false, false),
+                    ImmutableList.of(
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                     METHOD_HANDLE.bindTo(type),
                     isDeterministic());
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarImplementationValidation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarImplementationValidation.java
@@ -20,6 +20,8 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodHandle;
 import java.util.Optional;
 
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -35,7 +37,9 @@ public class TestScalarImplementationValidation
         MethodHandle validFunctionMethodHandle = methodHandle(TestScalarImplementationValidation.class, "validConnectorSessionParameterPosition", ConnectorSession.class, long.class, long.class);
         ScalarFunctionImplementation validFunction = new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 validFunctionMethodHandle,
                 false);
         assertEquals(validFunction.getMethodHandle(), validFunctionMethodHandle);
@@ -43,7 +47,9 @@ public class TestScalarImplementationValidation
         try {
             ScalarFunctionImplementation invalidFunction = new ScalarFunctionImplementation(
                     false,
-                    ImmutableList.of(false, false),
+                    ImmutableList.of(
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                     methodHandle(TestScalarImplementationValidation.class, "invalidConnectorSessionParameterPosition", long.class, long.class, ConnectorSession.class),
                     false);
             fail("expected exception");
@@ -56,9 +62,9 @@ public class TestScalarImplementationValidation
         MethodHandle validFunctionWithInstanceFactoryMethodHandle = methodHandle(TestScalarImplementationValidation.class, "validConnectorSessionParameterPosition", Object.class, ConnectorSession.class, long.class, long.class);
         ScalarFunctionImplementation validFunctionWithInstanceFactory = new ScalarFunctionImplementation(
                 false,
-                ImmutableList.of(false, false),
-                ImmutableList.of(false, false),
-                ImmutableList.of(Optional.empty(), Optional.empty()),
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 validFunctionWithInstanceFactoryMethodHandle,
                 Optional.of(STATE_FACTORY),
                 false);
@@ -67,9 +73,9 @@ public class TestScalarImplementationValidation
         try {
             ScalarFunctionImplementation invalidFunctionWithInstanceFactory = new ScalarFunctionImplementation(
                     false,
-                    ImmutableList.of(false, false),
-                    ImmutableList.of(false, false),
-                    ImmutableList.of(Optional.empty(), Optional.empty()),
+                    ImmutableList.of(
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                     methodHandle(TestScalarImplementationValidation.class, "invalidConnectorSessionParameterPosition", Object.class, long.class, long.class, ConnectorSession.class),
                     Optional.of(STATE_FACTORY),
                     false);

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
@@ -31,6 +31,8 @@ import java.lang.invoke.MethodHandle;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.sql.gen.TestVarArgsToArrayAdapterGenerator.TestVarArgsSum.VAR_ARGS_SUM;
 import static com.facebook.presto.sql.gen.VarArgsToArrayAdapterGenerator.generateVarArgsToArrayAdapter;
@@ -114,9 +116,7 @@ public class TestVarArgsToArrayAdapterGenerator
                     USER_STATE_FACTORY);
             return new ScalarFunctionImplementation(
                     false,
-                    nCopies(arity, false),
-                    nCopies(arity, false),
-                    nCopies(arity, Optional.empty()),
+                    nCopies(arity, valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                     methodHandleAndConstructor.getMethodHandle(),
                     Optional.of(methodHandleAndConstructor.getConstructor()),
                     isDeterministic());

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StatefulSleepingSum.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StatefulSleepingSum.java
@@ -27,6 +27,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.util.Reflection.constructorMethodHandle;
 import static com.facebook.presto.util.Reflection.methodHandle;
@@ -74,9 +76,7 @@ public class StatefulSleepingSum
         int args = 4;
         return new ScalarFunctionImplementation(
                 false,
-                nCopies(args, false),
-                nCopies(args, false),
-                nCopies(args, Optional.empty()),
+                nCopies(args, valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
                 methodHandle(StatefulSleepingSum.class, "statefulSleepingSum", State.class, double.class, long.class, long.class, long.class),
                 Optional.of(constructorMethodHandle(State.class)),
                 true);


### PR DESCRIPTION


Scalar function already has the following three properties:
- nullable
- hasNullFlag
- lambdaInterface

This makes code difficult to understand, and difficult to maintain
in the feature if more properties need to be added.

This commit refactors existing three properties into ArgumentOption.