### PR TITLE
Add yield signals to page projection

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
@@ -90,7 +90,6 @@ public class DictionaryAwarePageProjection
             lastDictionaryUsageCount += selectedPositions.size();
             // if dictionary was processed, produce a dictionary block; otherwise do normal processing
             if (projectedDictionary.isPresent()) {
-                lastDictionaryUsageCount += selectedPositions.size();
                 int[] outputIds = filterDictionaryIds(dictionaryBlock, selectedPositions);
                 return new DictionaryBlock(selectedPositions.size(), projectedDictionary.get(), outputIds, false, sourceIdFunction.apply(dictionaryBlock));
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.project;
 
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -21,6 +22,8 @@ import com.facebook.presto.spi.block.DictionaryId;
 import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
+
+import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -65,70 +68,137 @@ public class DictionaryAwarePageProjection
     }
 
     @Override
-    public Block project(ConnectorSession session, Page page, SelectedPositions selectedPositions)
+    public PageProjectionOutput project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        Block block = page.getBlock(0);
-        if (block instanceof LazyBlock) {
-            block = ((LazyBlock) block).getBlock();
-        }
-
-        if (block instanceof RunLengthEncodedBlock) {
-            Block value = ((RunLengthEncodedBlock) block).getValue();
-            Optional<Block> projectedValue = processDictionary(session, value);
-            // single value block is always considered effective, but the processing could have thrown
-            // in that case we fallback and process again so the correct error message sent
-            if (projectedValue.isPresent()) {
-                return new RunLengthEncodedBlock(projectedValue.get(), selectedPositions.size());
-            }
-        }
-
-        if (block instanceof DictionaryBlock) {
-            DictionaryBlock dictionaryBlock = (DictionaryBlock) block;
-            // Attempt to process the dictionary.  If dictionary is processing has not been considered effective, an empty response will be returned
-            Optional<Block> projectedDictionary = processDictionary(session, dictionaryBlock.getDictionary());
-            // record the usage count regardless of dictionary processing choice, so we have stats for next time
-            lastDictionaryUsageCount += selectedPositions.size();
-            // if dictionary was processed, produce a dictionary block; otherwise do normal processing
-            if (projectedDictionary.isPresent()) {
-                int[] outputIds = filterDictionaryIds(dictionaryBlock, selectedPositions);
-                return new DictionaryBlock(selectedPositions.size(), projectedDictionary.get(), outputIds, false, sourceIdFunction.apply(dictionaryBlock));
-            }
-        }
-
-        return projection.project(session, new Page(block), selectedPositions);
+        return new DictionaryAwarePageProjectionOutput(session, yieldSignal, page, selectedPositions);
     }
 
-    private Optional<Block> processDictionary(ConnectorSession session, Block dictionary)
+    private class DictionaryAwarePageProjectionOutput
+            implements PageProjectionOutput
     {
-        if (lastInputDictionary == dictionary) {
-            return lastOutputDictionary;
+        private final ConnectorSession session;
+        private final DriverYieldSignal yieldSignal;
+        private final Block block;
+        private final SelectedPositions selectedPositions;
+
+        // if the block is RLE or dictionary block, we may use dictionary processing
+        private Optional<PageProjectionOutput> dictionaryProcessingProjectionOutput;
+        // always prepare to fall back to a general block in case the dictionary does not apply or fails
+        private Optional<PageProjectionOutput> fallbackProcessingProjectionOutput;
+
+        public DictionaryAwarePageProjectionOutput(@Nullable ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        {
+            this.session = session;
+            this.yieldSignal = requireNonNull(yieldSignal, "yieldSignal is null");
+
+            Block block = requireNonNull(page, "page is null").getBlock(0);
+            if (block instanceof LazyBlock) {
+                block = ((LazyBlock) block).getBlock();
+            }
+            this.block = block;
+            this.selectedPositions = requireNonNull(selectedPositions, "selectedPositions is null");
+
+            Optional<Block> dictionary = Optional.empty();
+            if (block instanceof RunLengthEncodedBlock) {
+                dictionary = Optional.of(((RunLengthEncodedBlock) block).getValue());
+            }
+            else if (block instanceof DictionaryBlock) {
+                dictionary = Optional.of(((DictionaryBlock) block).getDictionary());
+            }
+
+            // Try use dictionary processing first; if it fails, fall back to the generic case
+            dictionaryProcessingProjectionOutput = createDictionaryBlockProjection(dictionary);
+            fallbackProcessingProjectionOutput = Optional.empty();
         }
 
-        // Process dictionary if:
-        //   this is the first block
-        //   there is only entry in the dictionary
-        //   the last dictionary was used for more positions than were in the dictionary
-        boolean shouldProcessDictionary = lastInputDictionary == null || dictionary.getPositionCount() == 1 || lastDictionaryUsageCount >= lastInputDictionary.getPositionCount();
-
-        lastDictionaryUsageCount = 0;
-        lastInputDictionary = dictionary;
-
-        if (shouldProcessDictionary) {
-            try {
-                lastOutputDictionary = Optional.of(projection.project(session, new Page(dictionary), SelectedPositions.positionsRange(0, dictionary.getPositionCount())));
+        @Override
+        public Optional<Block> compute()
+        {
+            if (fallbackProcessingProjectionOutput.isPresent()) {
+                return fallbackProcessingProjectionOutput.get().compute();
             }
-            catch (Exception ignored) {
-                // Processing of dictionary failed, but we ignore the exception here
-                // and force reprocessing of the whole block using the normal code.
-                // The second pass may not fail due to filtering.
-                // todo dictionary processing should be able to tolerate failures of unused elements
+
+            Optional<Block> dictionaryOutput = Optional.empty();
+            if (dictionaryProcessingProjectionOutput.isPresent()) {
+                try {
+                    dictionaryOutput = dictionaryProcessingProjectionOutput.get().compute();
+                    if (!dictionaryOutput.isPresent()) {
+                        // dictionary processing yielded.
+                        return Optional.empty();
+                    }
+                    lastOutputDictionary = dictionaryOutput;
+                }
+                catch (Exception ignored) {
+                    // Processing of dictionary failed, but we ignore the exception here
+                    // and force reprocessing of the whole block using the normal code.
+                    // The second pass may not fail due to filtering.
+                    // todo dictionary processing should be able to tolerate failures of unused elements
+                    lastOutputDictionary = Optional.empty();
+                    dictionaryProcessingProjectionOutput = Optional.empty();
+                }
+            }
+
+            if (block instanceof DictionaryBlock) {
+                // Record the usage count regardless of dictionary processing choice, so we have stats for next time.
+                // This guarantees recording will happen once and only once regardless of whether dictionary processing was attempted and whether it succeeded.
+                lastDictionaryUsageCount += selectedPositions.size();
+            }
+
+            if (dictionaryOutput.isPresent()) {
+                if (block instanceof RunLengthEncodedBlock) {
+                    // single value block is always considered effective, but the processing could have thrown
+                    // in that case we fallback and process again so the correct error message sent
+                    return Optional.of(new RunLengthEncodedBlock(dictionaryOutput.get(), selectedPositions.size()));
+                }
+
+                if (block instanceof DictionaryBlock) {
+                    DictionaryBlock dictionaryBlock = (DictionaryBlock) block;
+                    // if dictionary was processed, produce a dictionary block; otherwise do normal processing
+                    int[] outputIds = filterDictionaryIds(dictionaryBlock, selectedPositions);
+                    return Optional.of(new DictionaryBlock(selectedPositions.size(), dictionaryOutput.get(), outputIds, false, sourceIdFunction.apply(dictionaryBlock)));
+                }
+
+                throw new UnsupportedOperationException("unexpected block type " + block.getClass());
+            }
+
+            // there is no dictionary handling or dictionary handling failed; fall back to general projection
+            verify(!dictionaryProcessingProjectionOutput.isPresent());
+            verify(!fallbackProcessingProjectionOutput.isPresent());
+            fallbackProcessingProjectionOutput = Optional.of(projection.project(session, yieldSignal, new Page(block), selectedPositions));
+            return fallbackProcessingProjectionOutput.get().compute();
+        }
+
+        private Optional<PageProjectionOutput> createDictionaryBlockProjection(Optional<Block> dictionary)
+        {
+            if (!dictionary.isPresent()) {
                 lastOutputDictionary = Optional.empty();
+                return Optional.empty();
             }
-        }
-        else {
+
+            if (lastInputDictionary == dictionary.get()) {
+                if (!lastOutputDictionary.isPresent()) {
+                    // we must have fallen back last time
+                    return Optional.empty();
+                }
+                return Optional.of(() -> lastOutputDictionary);
+            }
+
+            // Process dictionary if:
+            //   there is only one entry in the dictionary
+            //   this is the first block
+            //   the last dictionary was used for more positions than were in the dictionary
+            boolean shouldProcessDictionary = dictionary.get().getPositionCount() == 1 || lastInputDictionary == null || lastDictionaryUsageCount >= lastInputDictionary.getPositionCount();
+
+            // record the usage count regardless of dictionary processing choice, so we have stats for next time
+            lastDictionaryUsageCount = 0;
+            lastInputDictionary = dictionary.get();
             lastOutputDictionary = Optional.empty();
+
+            if (shouldProcessDictionary) {
+                return Optional.of(projection.project(session, yieldSignal, new Page(lastInputDictionary), SelectedPositions.positionsRange(0, lastInputDictionary.getPositionCount())));
+            }
+            return Optional.empty();
         }
-        return lastOutputDictionary;
     }
 
     private static int[] filterDictionaryIds(DictionaryBlock dictionaryBlock, SelectedPositions selectedPositions)

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.project;
+
+import com.facebook.presto.operator.DriverYieldSignal;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.relational.RowExpression;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class GeneratedPageProjection
+        implements PageProjection
+{
+    private final RowExpression projection;
+    private final boolean isDeterministic;
+    private final InputChannels inputChannels;
+    private final MethodHandle pageProjectionOutputFactory;
+
+    private BlockBuilder blockBuilder;
+
+    public GeneratedPageProjection(RowExpression projection, boolean isDeterministic, InputChannels inputChannels, MethodHandle pageProjectionOutputFactory)
+    {
+        this.projection = requireNonNull(projection, "projection is null");
+        this.isDeterministic = isDeterministic;
+        this.inputChannels = requireNonNull(inputChannels, "inputChannels is null");
+        this.pageProjectionOutputFactory = requireNonNull(pageProjectionOutputFactory, "pageProjectionOutputFactory is null");
+        this.blockBuilder = projection.getType().createBlockBuilder(new BlockBuilderStatus(), 1);
+    }
+
+    @Override
+    public Type getType()
+    {
+        return projection.getType();
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return isDeterministic;
+    }
+
+    @Override
+    public InputChannels getInputChannels()
+    {
+        return inputChannels;
+    }
+
+    @Override
+    public PageProjectionOutput project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+    {
+        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+        try {
+            return (PageProjectionOutput) pageProjectionOutputFactory.invoke(blockBuilder, session, yieldSignal, page, selectedPositions);
+        }
+        catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("projection", projection)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.project;
 
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -20,6 +21,9 @@ import com.facebook.presto.spi.type.Type;
 import com.google.common.primitives.Ints;
 
 import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
 
 public class InputPageProjection
         implements PageProjection
@@ -52,14 +56,32 @@ public class InputPageProjection
     }
 
     @Override
-    public Block project(ConnectorSession session, Page page, SelectedPositions selectedPositions)
+    public PageProjectionOutput project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        Block block = page.getBlock(0);
-        if (selectedPositions.isList()) {
-            List<Integer> positionList = Ints.asList(selectedPositions.getPositions())
-                    .subList(selectedPositions.getOffset(), selectedPositions.getOffset() + selectedPositions.size());
-            return block.copyPositions(positionList);
+        return new InputPageProjectionOutput(page, selectedPositions);
+    }
+
+    private class InputPageProjectionOutput
+            implements PageProjectionOutput
+    {
+        private final Block block;
+        private final SelectedPositions selectedPositions;
+
+        public InputPageProjectionOutput(Page page, SelectedPositions selectedPositions)
+        {
+            this.block = requireNonNull(page, "page is null").getBlock(0);
+            this.selectedPositions = requireNonNull(selectedPositions, "selectedPositions is null");
         }
-        return block.getRegion(selectedPositions.getOffset(), selectedPositions.size());
+
+        @Override
+        public Optional<Block> compute()
+        {
+            if (selectedPositions.isList()) {
+                List<Integer> positionList = Ints.asList(selectedPositions.getPositions())
+                        .subList(selectedPositions.getOffset(), selectedPositions.getOffset() + selectedPositions.size());
+                return Optional.of(block.copyPositions(positionList));
+            }
+            return Optional.of(block.getRegion(selectedPositions.getOffset(), selectedPositions.size()));
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InterpretedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InterpretedPageProjection.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.project;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -32,10 +33,12 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypesFromInput;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 public class InterpretedPageProjection
         implements PageProjection
@@ -90,36 +93,55 @@ public class InterpretedPageProjection
     }
 
     @Override
-    public Block project(ConnectorSession session, Page page, SelectedPositions selectedPositions)
+    public PageProjectionOutput project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        if (selectedPositions.isList()) {
-            project(page, selectedPositions.getPositions(), selectedPositions.getOffset(), selectedPositions.size());
-        }
-        else {
-            project(page, selectedPositions.getOffset(), selectedPositions.size());
-        }
-        Block block = blockBuilder.build();
-        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
-        return block;
+        return new InterpretedPageProjectionOutput(yieldSignal, page, selectedPositions);
     }
 
-    private void project(Page page, int[] selectedPositions, int offset, int length)
+    private class InterpretedPageProjectionOutput
+            implements PageProjectionOutput
     {
-        for (int index = offset; index < offset + length; index++) {
-            project(page, selectedPositions[index]);
-        }
-    }
+        private final DriverYieldSignal yieldSignal;
+        private final Block[] blocks;
+        private final SelectedPositions selectedPositions;
 
-    private void project(Page page, int offset, int length)
-    {
-        for (int position = offset; position < offset + length; position++) {
-            project(page, position);
-        }
-    }
+        private int nextIndexOrPosition;
 
-    private void project(Page page, int position)
-    {
-        Object value = evaluator.evaluate(position, page.getBlocks());
-        writeNativeValue(evaluator.getType(), blockBuilder, value);
+        public InterpretedPageProjectionOutput(DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        {
+            this.yieldSignal = requireNonNull(yieldSignal, "yieldSignal is null");
+            this.blocks = requireNonNull(page, "page is null").getBlocks();
+            this.selectedPositions = requireNonNull(selectedPositions, "selectedPositions is null");
+            this.nextIndexOrPosition = selectedPositions.getOffset();
+        }
+
+        @Override
+        public Optional<Block> compute()
+        {
+            int length = selectedPositions.getOffset() + selectedPositions.size();
+            if (selectedPositions.isList()) {
+                int[] positions = selectedPositions.getPositions();
+                while (nextIndexOrPosition < length) {
+                    writeNativeValue(evaluator.getType(), blockBuilder, evaluator.evaluate(positions[nextIndexOrPosition], blocks));
+                    nextIndexOrPosition++;
+                    if (yieldSignal.isSet()) {
+                        return Optional.empty();
+                    }
+                }
+            }
+            else {
+                while (nextIndexOrPosition < length) {
+                    writeNativeValue(evaluator.getType(), blockBuilder, evaluator.evaluate(nextIndexOrPosition, blocks));
+                    nextIndexOrPosition++;
+                    if (yieldSignal.isSet()) {
+                        return Optional.empty();
+                    }
+                }
+            }
+
+            Block block = blockBuilder.build();
+            blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+            return Optional.of(block);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
@@ -135,8 +135,11 @@ public class PageProcessor
         private long retainedSizeInBytes;
 
         // remember if we need to re-use the same batch size if we yield last time
+        // TODO: make this a local variable in computeNext
+        // processBatch() should return multiple values instead of using a field variable as part of its return
         private boolean forceYieldFinish;
         private int previousBatchSize;
+        private Optional<PageProjectionOutput> pageProjectOutput = Optional.empty();
 
         public PositionsPageProcessorIterator(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
@@ -266,7 +269,17 @@ public class PageProcessor
                     blocks[i] = previouslyComputedResults[i].getRegion(0, batchSize);
                 }
                 else {
-                    previouslyComputedResults[i] = projection.project(session, projection.getInputChannels().getInputChannels(page), positionsBatch);
+                    if (!pageProjectOutput.isPresent()) {
+                        pageProjectOutput = Optional.of(projection.project(session, yieldSignal, projection.getInputChannels().getInputChannels(page), positionsBatch));
+                    }
+                    Optional<Block> block = pageProjectOutput.get().compute();
+                    if (!block.isPresent()) {
+                        forceYieldFinish = true;
+                        previousBatchSize = batchSize;
+                        return Optional.empty();
+                    }
+                    pageProjectOutput = Optional.empty();
+                    previouslyComputedResults[i] = block.get();
                     blocks[i] = previouslyComputedResults[i];
                 }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjectionOutput.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjectionOutput.java
@@ -13,18 +13,11 @@
  */
 package com.facebook.presto.operator.project;
 
-import com.facebook.presto.operator.DriverYieldSignal;
-import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.block.Block;
 
-public interface PageProjection
+import java.util.Optional;
+
+public interface PageProjectionOutput
 {
-    Type getType();
-
-    boolean isDeterministic();
-
-    InputChannels getInputChannels();
-
-    PageProjectionOutput project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions);
+    Optional<Block> compute();
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -26,12 +26,14 @@ import com.facebook.presto.bytecode.control.ForLoop;
 import com.facebook.presto.bytecode.control.IfStatement;
 import com.facebook.presto.bytecode.expression.BytecodeExpression;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.ConstantPageProjection;
 import com.facebook.presto.operator.project.InputChannels;
 import com.facebook.presto.operator.project.InputPageProjection;
 import com.facebook.presto.operator.project.PageFieldsToInputParametersRewriter;
 import com.facebook.presto.operator.project.PageFilter;
 import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.operator.project.PageProjectionOutput;
 import com.facebook.presto.operator.project.SelectedPositions;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
@@ -187,11 +189,24 @@ public class PageFunctionCompiler
         PageFieldsToInputParametersRewriter.Result result = rewritePageFieldsToInputParameters(projection);
 
         CallSiteBinder callSiteBinder = new CallSiteBinder();
-        ClassDefinition classDefinition = defineProjectionClass(result.getRewrittenExpression(), result.getInputChannels(), callSiteBinder, classNameSuffix);
+
+        // generate PageProjectionOutput
+        ClassDefinition pageProjectionOutputDefinition = definePageProjectOutputClass(result.getRewrittenExpression(), callSiteBinder, classNameSuffix);
+
+        Class<? extends PageProjectionOutput> pageProjectionOutputClass;
+        try {
+            pageProjectionOutputClass = defineClass(pageProjectionOutputDefinition, PageProjectionOutput.class, callSiteBinder.getBindings(), getClass().getClassLoader());
+        }
+        catch (Exception e) {
+            throw new PrestoException(COMPILER_ERROR, e);
+        }
+
+        // TODO: it is no longer necessary to generate PageProjection
+        ClassDefinition classDefinition = defineProjectionClass(result.getRewrittenExpression(), result.getInputChannels(), pageProjectionOutputClass, callSiteBinder, classNameSuffix);
 
         Class<? extends PageProjection> projectionClass;
         try {
-            projectionClass = defineClass(classDefinition, PageProjection.class, callSiteBinder.getBindings(), getClass().getClassLoader());
+            projectionClass = defineClass(classDefinition, PageProjection.class, callSiteBinder.getBindings(), pageProjectionOutputClass.getClassLoader());
         }
         catch (Exception e) {
             throw new PrestoException(COMPILER_ERROR, e);
@@ -216,6 +231,7 @@ public class PageFunctionCompiler
 
     private ClassDefinition defineProjectionClass(RowExpression projection,
             InputChannels inputChannels,
+            Class<? extends PageProjectionOutput> pageProjectionOutputClass,
             CallSiteBinder callSiteBinder,
             Optional<String> classNameSuffix)
     {
@@ -227,12 +243,8 @@ public class PageFunctionCompiler
 
         FieldDefinition blockBuilderField = classDefinition.declareField(a(PRIVATE), "blockBuilder", BlockBuilder.class);
 
-        CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(classDefinition, callSiteBinder);
-
-        generatePageProjectMethod(classDefinition, blockBuilderField);
-
-        PreGeneratedExpressions preGeneratedExpressions = generateMethodsForLambdaAndTry(classDefinition, callSiteBinder, cachedInstanceBinder, projection);
-        generateProjectMethod(classDefinition, callSiteBinder, cachedInstanceBinder, preGeneratedExpressions, projection, blockBuilderField);
+        // project
+        generatePageProjectMethod(classDefinition, blockBuilderField, pageProjectionOutputClass);
 
         // getType
         BytecodeExpression type = invoke(callSiteBinder.bind(projection.getType(), Type.class), "type");
@@ -261,73 +273,181 @@ public class PageFunctionCompiler
                 .append(invoke(callSiteBinder.bind(toStringResult, String.class), "toString").ret());
 
         // constructor
-        generateConstructor(classDefinition, cachedInstanceBinder, preGeneratedExpressions, method -> {
-            Variable thisVariable = method.getThis();
-            BytecodeBlock body = method.getBody();
-            body.append(thisVariable.setField(
-                    blockBuilderField,
-                    type.invoke("createBlockBuilder", BlockBuilder.class, newInstance(BlockBuilderStatus.class), constantInt(1))));
-        });
+        MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC));
+
+        BytecodeBlock body = constructorDefinition.getBody();
+        Variable thisVariable = constructorDefinition.getThis();
+
+        body.comment("super();")
+                .append(thisVariable)
+                .invokeConstructor(Object.class)
+                .append(thisVariable.setField(
+                        blockBuilderField,
+                        type.invoke("createBlockBuilder", BlockBuilder.class, newInstance(BlockBuilderStatus.class), constantInt(1))));
+
+        body.ret();
 
         return classDefinition;
     }
 
-    private static MethodDefinition generatePageProjectMethod(ClassDefinition classDefinition, FieldDefinition blockBuilder)
+    private MethodDefinition generatePageProjectMethod(ClassDefinition classDefinition, FieldDefinition blockBuilder, Class<? extends PageProjectionOutput> pageProjectionOutputClass)
     {
         Parameter session = arg("session", ConnectorSession.class);
+        Parameter yieldSignal = arg("yieldSignal", DriverYieldSignal.class);
         Parameter page = arg("page", Page.class);
         Parameter selectedPositions = arg("selectedPositions", SelectedPositions.class);
 
         MethodDefinition method = classDefinition.declareMethod(
                 a(PUBLIC),
                 "project",
-                type(Block.class),
+                type(PageProjectionOutput.class),
                 ImmutableList.<Parameter>builder()
                         .add(session)
+                        .add(yieldSignal)
                         .add(page)
                         .add(selectedPositions)
                         .build());
+
+        Variable thisVariable = method.getThis();
+        BytecodeBlock body = method.getBody();
+
+        // reset block builder before using since a previous run may have thrown leaving data in the block builder
+        body.append(thisVariable.setField(
+                blockBuilder,
+                thisVariable.getField(blockBuilder).invoke("newBlockBuilderLike", BlockBuilder.class, newInstance(BlockBuilderStatus.class))))
+                .append(newInstance(pageProjectionOutputClass, thisVariable.getField(blockBuilder), session, yieldSignal, page, selectedPositions).ret());
+
+        return method;
+    }
+
+    private static ParameterizedType generateProjectionOutputClassName(Optional<String> classNameSuffix)
+    {
+        StringBuilder className = new StringBuilder(PageProjectionOutput.class.getSimpleName());
+        classNameSuffix.ifPresent(suffix -> className.append("_").append(suffix.replace('.', '_')));
+        return makeClassName(className.toString());
+    }
+
+    private ClassDefinition definePageProjectOutputClass(RowExpression projection, CallSiteBinder callSiteBinder, Optional<String> classNameSuffix)
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                generateProjectionOutputClassName(classNameSuffix),
+                type(Object.class),
+                type(PageProjectionOutput.class));
+
+        FieldDefinition blockBuilderField = classDefinition.declareField(a(PRIVATE), "blockBuilder", BlockBuilder.class);
+        FieldDefinition sessionField = classDefinition.declareField(a(PRIVATE), "session", ConnectorSession.class);
+        FieldDefinition yieldSignalField = classDefinition.declareField(a(PRIVATE), "yieldSignal", DriverYieldSignal.class);
+        FieldDefinition pageField = classDefinition.declareField(a(PRIVATE), "page", Page.class);
+        FieldDefinition selectedPositionsField = classDefinition.declareField(a(PRIVATE), "selectedPositions", SelectedPositions.class);
+        FieldDefinition nextIndexOrPositionField = classDefinition.declareField(a(PRIVATE), "nextIndexOrPosition", int.class);
+
+        CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(classDefinition, callSiteBinder);
+
+        // compute
+        generateComputeMethod(classDefinition, blockBuilderField, sessionField, yieldSignalField, pageField, selectedPositionsField, nextIndexOrPositionField);
+
+        // evaluate
+        PreGeneratedExpressions preGeneratedExpressions = generateMethodsForLambdaAndTry(classDefinition, callSiteBinder, cachedInstanceBinder, projection);
+        generateEvaluateMethod(classDefinition, callSiteBinder, cachedInstanceBinder, preGeneratedExpressions, projection, blockBuilderField);
+
+        // constructor
+        Parameter blockBuilder = arg("blockBuilder", BlockBuilder.class);
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter yieldSignal = arg("yieldSignal", DriverYieldSignal.class);
+        Parameter page = arg("page", Page.class);
+        Parameter selectedPositions = arg("selectedPositions", SelectedPositions.class);
+
+        MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC), blockBuilder, session, yieldSignal, page, selectedPositions);
+
+        BytecodeBlock body = constructorDefinition.getBody();
+        Variable thisVariable = constructorDefinition.getThis();
+
+        body.comment("super();")
+                .append(thisVariable)
+                .invokeConstructor(Object.class)
+                .append(thisVariable.setField(blockBuilderField, blockBuilder))
+                .append(thisVariable.setField(sessionField, session))
+                .append(thisVariable.setField(yieldSignalField, yieldSignal))
+                .append(thisVariable.setField(pageField, page))
+                .append(thisVariable.setField(selectedPositionsField, selectedPositions))
+                .append(thisVariable.setField(nextIndexOrPositionField, selectedPositions.invoke("getOffset", int.class)));
+
+        cachedInstanceBinder.generateInitializations(thisVariable, body);
+        for (CompiledLambda compiledLambda : preGeneratedExpressions.getCompiledLambdaMap().values()) {
+            compiledLambda.generateInitialization(thisVariable, body);
+        }
+        body.ret();
+
+        return classDefinition;
+    }
+
+    private static MethodDefinition generateComputeMethod(
+            ClassDefinition classDefinition,
+            FieldDefinition blockBuilder,
+            FieldDefinition session,
+            FieldDefinition yieldSignal,
+            FieldDefinition page,
+            FieldDefinition selectedPositions,
+            FieldDefinition nextIndexOrPosition)
+    {
+        MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "compute", type(Optional.class), ImmutableList.of());
 
         Scope scope = method.getScope();
         Variable thisVariable = method.getThis();
         BytecodeBlock body = method.getBody();
 
-        Variable from = scope.declareVariable("from", body, selectedPositions.invoke("getOffset", int.class));
-        Variable to = scope.declareVariable("to", body, add(from, selectedPositions.invoke("size", int.class)));
+        Variable from = scope.declareVariable("from", body, thisVariable.getField(nextIndexOrPosition));
+        Variable to = scope.declareVariable("to", body, add(thisVariable.getField(selectedPositions).invoke("getOffset", int.class), thisVariable.getField(selectedPositions).invoke("size", int.class)));
         Variable positions = scope.declareVariable(int[].class, "positions");
         Variable index = scope.declareVariable(int.class, "index");
 
-        // reset block builder before using since a previous run may have thrown leaving data in the block builder
-        body.append(thisVariable.setField(
-                blockBuilder,
-                thisVariable.getField(blockBuilder).invoke("newBlockBuilderLike", BlockBuilder.class, newInstance(BlockBuilderStatus.class))));
-
         IfStatement ifStatement = new IfStatement()
-                .condition(selectedPositions.invoke("isList", boolean.class));
+                .condition(thisVariable.getField(selectedPositions).invoke("isList", boolean.class));
         body.append(ifStatement);
 
         ifStatement.ifTrue(new BytecodeBlock()
-                .append(positions.set(selectedPositions.invoke("getPositions", int[].class)))
+                .append(positions.set(thisVariable.getField(selectedPositions).invoke("getPositions", int[].class)))
                 .append(new ForLoop("positions loop")
                         .initialize(index.set(from))
                         .condition(lessThan(index, to))
                         .update(index.increment())
-                        .body(thisVariable.invoke("project", void.class, session, page, positions.getElement(index)))));
+                        .body(new BytecodeBlock()
+                                .append(thisVariable.invoke("evaluate", void.class, thisVariable.getField(session), thisVariable.getField(page), positions.getElement(index)))
+                                .append(generateCheckYieldBlock(thisVariable, index, yieldSignal, nextIndexOrPosition)))));
 
         ifStatement.ifFalse(new ForLoop("range based loop")
                 .initialize(index.set(from))
                 .condition(lessThan(index, to))
                 .update(index.increment())
-                .body(thisVariable.invoke("project", void.class, session, page, index)));
+                .body(new BytecodeBlock()
+                        .append(thisVariable.invoke("evaluate", void.class, thisVariable.getField(session), thisVariable.getField(page), index))
+                        .append(generateCheckYieldBlock(thisVariable, index, yieldSignal, nextIndexOrPosition))));
 
-        Variable block = scope.declareVariable(Block.class, "block");
-        body.append(block.set(thisVariable.getField(blockBuilder).invoke("build", Block.class)))
-                .append(block.ret());
+        body.comment("return Optional.of(this.blockBuilder.build());")
+                .append(invokeStatic(
+                        Optional.class,
+                        "of",
+                        Optional.class,
+                        thisVariable.getField(blockBuilder).invoke("build", Block.class).cast(Object.class)).ret());
 
         return method;
     }
 
-    private MethodDefinition generateProjectMethod(
+    private static BytecodeBlock generateCheckYieldBlock(Variable thisVariable, Variable index, FieldDefinition yieldSignal, FieldDefinition nextIndexOrPosition)
+    {
+        return new BytecodeBlock()
+                .comment("if (yieldSignal.isSet()) return Optional.empty();")
+                .append(new IfStatement()
+                        .condition(thisVariable.getField(yieldSignal).invoke("isSet", boolean.class))
+                        .ifTrue(new BytecodeBlock()
+                                .comment("nextIndexOrPosition = index + 1;")
+                                .append(thisVariable.setField(nextIndexOrPosition, add(index, constantInt(1))))
+                                .comment("return Optional.empty();")
+                                .append(invokeStatic(Optional.class, "empty", Optional.class).ret())));
+    }
+
+    private MethodDefinition generateEvaluateMethod(
             ClassDefinition classDefinition,
             CallSiteBinder callSiteBinder,
             CachedInstanceBinder cachedInstanceBinder,
@@ -341,7 +461,7 @@ public class PageFunctionCompiler
 
         MethodDefinition method = classDefinition.declareMethod(
                 a(PUBLIC),
-                "project",
+                "evaluate",
                 type(void.class),
                 ImmutableList.<Parameter>builder()
                         .add(session)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -225,8 +225,9 @@ public class TestScanFilterAndProjectOperator
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
         operator.noMoreSplits();
 
-        // we only check yield signal once a column has been completely processed; thus the first 19 outputs will get nothing
-        for (int i = 0; i < totalColumns - 1; i++) {
+        // yield for every cell: 20 X 1000 times
+        // currently we enforce a yield check for every position; free feel to adjust the number if the behavior changes
+        for (int i = 0; i < totalRows * totalColumns; i++) {
             driverContext.getYieldSignal().setWithDelay(SECONDS.toNanos(1000), driverContext.getYieldExecutor());
             assertNull(operator.getOutput());
             driverContext.getYieldSignal().reset();

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
@@ -332,25 +332,31 @@ public class TestPageProcessor
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
         PageProcessor pageProcessor = new PageProcessor(
                 Optional.empty(),
-                Collections.nCopies(columns, new YieldPageProjection(new InputPageProjection(0, VARCHAR), yieldSignal)));
+                Collections.nCopies(columns, new YieldPageProjection(new InputPageProjection(0, VARCHAR))));
 
         Slice[] slices = new Slice[rows];
         Arrays.fill(slices, Slices.allocate(rows));
         Page inputPage = new Page(new SliceArrayBlock(slices.length, slices));
 
         PageProcessorOutput output = pageProcessor.process(SESSION, yieldSignal, inputPage);
+
+        // Test yield signal works for page processor.
+        // The purpose of this test is NOT to test the yield signal in page projection; we have other tests to cover that.
+        // In page processor, we check yield signal after a column has been completely processed.
+        // So we would like to set yield signal when the column has just finished processing in order to let page processor capture the yield signal when the block is returned.
+        // Also, we would like to reset the yield signal before starting to process the next column in order NOT to yield per position inside the column.
         for (int i = 0; i < columns - 1; i++) {
             assertTrue(output.hasNext());
             assertNull(output.next().orElse(null));
-
-            // we do not need a yield for the next projection
-            if (yieldSignal.isSet()) {
-                yieldSignal.reset();
-            }
+            assertTrue(yieldSignal.isSet());
+            yieldSignal.reset();
         }
         assertTrue(output.hasNext());
         Page actualPage = output.next().orElse(null);
         assertNotNull(actualPage);
+        assertTrue(yieldSignal.isSet());
+        yieldSignal.reset();
+
         Block[] blocks = new Block[columns];
         Arrays.fill(blocks, new SliceArrayBlock(rows, slices));
         Page expectedPage = new Page(blocks);
@@ -388,10 +394,10 @@ public class TestPageProcessor
         }
 
         @Override
-        public Block project(ConnectorSession session, Page page, SelectedPositions selectedPositions)
+        public PageProjectionOutput project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
             setInvocationCount(getInvocationCount() + 1);
-            return delegate.project(session, page, selectedPositions);
+            return delegate.project(session, yieldSignal, page, selectedPositions);
         }
 
         public int getInvocationCount()
@@ -408,28 +414,38 @@ public class TestPageProcessor
     private class YieldPageProjection
             extends InvocationCountPageProjection
     {
-        private final DriverYieldSignal yieldSignal;
-
-        public YieldPageProjection(PageProjection delegate, DriverYieldSignal yieldSignal)
+        public YieldPageProjection(PageProjection delegate)
         {
             super(delegate);
-            this.yieldSignal = yieldSignal;
         }
 
         @Override
-        public Block project(ConnectorSession session, Page page, SelectedPositions selectedPositions)
+        public PageProjectionOutput project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
-            // do not yield while projecting
-            if (yieldSignal.isSet()) {
-                yieldSignal.reset();
-            }
-            Block result = delegate.project(session, page, selectedPositions);
+            return new YieldPageProjectionOutput(session, yieldSignal, page, selectedPositions);
+        }
 
-            // force yield right after projection
-            // call setWithDelay() only to pair with reset()
-            yieldSignal.setWithDelay(1, executor);
-            yieldSignal.forceYieldForTesting();
-            return result;
+        private class YieldPageProjectionOutput
+                implements PageProjectionOutput
+        {
+            private final DriverYieldSignal yieldSignal;
+            private final PageProjectionOutput result;
+
+            public YieldPageProjectionOutput(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+            {
+                this.yieldSignal = yieldSignal;
+                this.result = delegate.project(session, yieldSignal, page, selectedPositions);
+            }
+
+            @Override
+            public Optional<Block> compute()
+            {
+                Optional<Block> block = result.compute();
+                assertNotNull(block.get());
+                yieldSignal.setWithDelay(1, executor);
+                yieldSignal.forceYieldForTesting();
+                return block;
+            }
         }
     }
 
@@ -455,11 +471,11 @@ public class TestPageProcessor
         }
 
         @Override
-        public Block project(ConnectorSession session, Page page, SelectedPositions selectedPositions)
+        public PageProjectionOutput project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
             Block block = page.getBlock(0);
             block.assureLoaded();
-            return block;
+            return () -> Optional.of(block);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.sql.gen;
 
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.operator.project.PageProjectionOutput;
 import com.facebook.presto.operator.project.SelectedPositions;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
@@ -22,9 +24,11 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.sql.relational.CallExpression;
 import com.google.common.collect.ImmutableList;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
@@ -35,6 +39,8 @@ import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.field;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
@@ -49,8 +55,16 @@ public class TestPageFunctionCompiler
             field(0, BIGINT),
             constant(10L, BIGINT));
 
-    @Test
-    public void testFailureDoesNotCorruptFutureResults()
+    private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("test-%s"));
+
+    @DataProvider(name = "forceYield")
+    public static Object[][] forceYield()
+    {
+        return new Object[][] {{true}, {false}};
+    }
+
+    @Test(dataProvider = "forceYield")
+    public void testFailureDoesNotCorruptFutureResults(boolean forceYield)
             throws Exception
     {
         PageFunctionCompiler functionCompiler = new PageFunctionCompiler(createTestMetadataManager(), 0);
@@ -60,13 +74,26 @@ public class TestPageFunctionCompiler
 
         // process good page and verify we got the expected number of result rows
         Page goodPage = createLongBlockPage(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-        Block goodResult = projection.project(SESSION, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()));
+        // yield 10 times
+        Block goodResult;
+        if (forceYield) {
+            goodResult = projectWithYield(projection, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()), 10);
+        }
+        else {
+            goodResult = projectWithoutYield(projection, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()));
+        }
         assertEquals(goodPage.getPositionCount(), goodResult.getPositionCount());
 
         // addition will throw due to integer overflow
         Page badPage = createLongBlockPage(0, 1, 2, 3, 4, Long.MAX_VALUE);
         try {
-            projection.project(SESSION, badPage, SelectedPositions.positionsRange(0, 100));
+            // yield 6 times then fail
+            if (forceYield) {
+                projectWithYield(projection, badPage, SelectedPositions.positionsRange(0, 100), 6);
+            }
+            else {
+                projectWithoutYield(projection, badPage, SelectedPositions.positionsRange(0, 100));
+            }
             fail("expected exception");
         }
         catch (PrestoException e) {
@@ -75,7 +102,12 @@ public class TestPageFunctionCompiler
 
         // running the good page should still work
         // if block builder in generated code was not reset properly, we could get junk results after the failure
-        goodResult = projection.project(SESSION, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()));
+        if (forceYield) {
+            goodResult = projectWithYield(projection, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()), 10);
+        }
+        else {
+            goodResult = projectWithoutYield(projection, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()));
+        }
         assertEquals(goodPage.getPositionCount(), goodResult.getPositionCount());
     }
 
@@ -123,6 +155,33 @@ public class TestPageFunctionCompiler
         assertNotSame(
                 noCacheCompiler.compileProjection(ADD_10_EXPRESSION, Optional.empty()),
                 noCacheCompiler.compileProjection(ADD_10_EXPRESSION, Optional.of("hint2")));
+    }
+
+    private Block projectWithYield(PageProjection projection, Page page, SelectedPositions selectedPositions, int expectedYields)
+    {
+        DriverYieldSignal yieldSignal = new DriverYieldSignal();
+        PageProjectionOutput output = projection.project(SESSION, yieldSignal, page, selectedPositions);
+
+        Optional<Block> result = Optional.empty();
+        for (int i = 0; i < 1000; i++) {
+            yieldSignal.setWithDelay(1, executor);
+            yieldSignal.forceYieldForTesting();
+            result = output.compute();
+            if (result.isPresent()) {
+                assertEquals(i, expectedYields);
+                break;
+            }
+            yieldSignal.reset();
+        }
+        if (!result.isPresent()) {
+            fail("result is not present");
+        }
+        return result.get();
+    }
+
+    private Block projectWithoutYield(PageProjection projection, Page page, SelectedPositions selectedPositions)
+    {
+        return projection.project(SESSION, new DriverYieldSignal(), page, selectedPositions).compute().orElseThrow(IllegalStateException::new);
     }
 
     private static Page createLongBlockPage(long... values)

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
@@ -121,8 +121,9 @@ public class TestPageFunctionCompiler
         String classSuffix = stageId + "_" + planNodeId;
         Supplier<PageProjection> projectionSupplier = functionCompiler.compileProjection(ADD_10_EXPRESSION, Optional.of(classSuffix));
         PageProjection projection = projectionSupplier.get();
-        // class name should look like PageProjection_20170707_223500_67496_zguwn_2_7_XX
-        assertTrue(projection.getClass().getSimpleName().startsWith("PageProjection_" + stageId.replace('.', '_') + "_" + planNodeId));
+        PageProjectionOutput pageProjectionOutput = projection.project(SESSION, new DriverYieldSignal(), createLongBlockPage(0), SelectedPositions.positionsRange(0, 1));
+        // class name should look like PageProjectionOutput_20170707_223500_67496_zguwn_2_7_XX
+        assertTrue(pageProjectionOutput.getClass().getSimpleName().startsWith("PageProjectionOutput_" + stageId.replace('.', '_') + "_" + planNodeId));
     }
 
     @Test


### PR DESCRIPTION
Trunk (with `PageProjection` generated and without checking yield signal):
```
Benchmark                          Mode  Cnt     Score     Error  Units
BenchmarkPageProcessor.compiled   thrpt   50  5266.166 ± 170.086  ops/s
BenchmarkPageProcessor.handCoded  thrpt   50  6046.107 ±  25.990  ops/s
```

With both `PageProjectionOutput` and `PageProjection` generated:
```
Benchmark                          Mode  Cnt     Score    Error  Units
BenchmarkPageProcessor.compiled   thrpt   50  5399.072 ± 71.479  ops/s
BenchmarkPageProcessor.handCoded  thrpt   50  6041.955 ± 32.595  ops/s
```

With `PageProjectionOutput` generated and `PageProjection` hand-coded:
```
Benchmark                          Mode  Cnt     Score    Error  Units
BenchmarkPageProcessor.compiled   thrpt   50  5362.882 ± 45.355  ops/s
BenchmarkPageProcessor.handCoded  thrpt   50  5967.048 ± 81.459  ops/s
```