### PR TITLE
Introduce plan node dependency extraction

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.presto.sql.planner.SymbolsExtractor.extractDependencies;
 import static com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer.IndexKeyTracer;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -232,10 +233,8 @@ public final class ValidateDependenciesChecker
             source.accept(this, boundSymbols); // visit child
 
             Set<Symbol> inputs = createInputs(source, boundSymbols);
-            for (Expression expression : node.getAssignments().getExpressions()) {
-                Set<Symbol> dependencies = SymbolsExtractor.extractUnique(expression);
-                checkDependencies(inputs, dependencies, "Invalid node. Expression dependencies (%s) not in source plan output (%s)", dependencies, inputs);
-            }
+            Set<Symbol> dependencies = SymbolsExtractor.extractDependencies(node);
+            checkDependencies(inputs, extractDependencies(node), "Invalid node. Expression dependencies (%s) not in source plan output (%s)", dependencies, inputs);
 
             return null;
         }


### PR DESCRIPTION
Introduce plan node dependency extraction

Introduce plan node dependency extraction and use it for ProjectNode.
Initial plan was to check symbol dependencies in ProjectNode
constructor, but it is not possible due: #8459. Eventually, it would be
nice to port ValidateDependenciesChecker to plan node constructors.
