### PR TITLE
Add Block#copyPositions that uses primitive int array

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.block.BlockEncoding;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -197,9 +196,9 @@ public class GroupByIdBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        return block.copyPositions(positions);
+        return block.copyPositions(positions, offset, length);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositionsArray;
+
 public abstract class AbstractArrayBlock
         implements Block
 {
@@ -40,14 +42,17 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        int[] newOffsets = new int[positions.size() + 1];
-        boolean[] newValueIsNull = new boolean[positions.size()];
+        checkValidPositionsArray(positions, offset, length);
+
+        int[] newOffsets = new int[length + 1];
+        boolean[] newValueIsNull = new boolean[length];
 
         List<Integer> valuesPositions = new ArrayList<>();
         int newPosition = 0;
-        for (int position : positions) {
+        for (int i = 0; i < length; ++i) {
+            int position = positions[offset + i];
             if (isNull(position)) {
                 newValueIsNull[newPosition] = true;
                 newOffsets[newPosition + 1] = newOffsets[newPosition];
@@ -66,7 +71,7 @@ public abstract class AbstractArrayBlock
             newPosition++;
         }
         Block newValues = getValues().copyPositions(valuesPositions);
-        return new ArrayBlock(positions.size(), newValueIsNull, newOffsets, newValues);
+        return new ArrayBlock(length, newValueIsNull, newOffsets, newValues);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -15,8 +15,6 @@ package com.facebook.presto.spi.block;
 
 import io.airlift.slice.Slice;
 
-import java.util.List;
-
 public abstract class AbstractSingleArrayBlock
         implements Block
 {
@@ -156,7 +154,7 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
@@ -16,8 +16,6 @@ package com.facebook.presto.spi.block;
 
 import io.airlift.slice.Slice;
 
-import java.util.List;
-
 public abstract class AbstractSingleMapBlock
         implements Block
 {
@@ -242,7 +240,7 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -197,7 +197,20 @@ public interface Block
      * <p>
      * The returned block must be a compact representation of the original block.
      */
-    Block copyPositions(List<Integer> positions);
+    Block copyPositions(int[] positions, int offset, int length);
+
+    /**
+     * Returns a block containing the specified positions.
+     * All specified positions must be valid for this block.
+     * Use primitive version of this method if possible
+     * since it allows to avoid integer boxing.
+     * <p>
+     * The returned block must be a compact representation of the original block.
+     */
+    default Block copyPositions(List<Integer> positions)
+    {
+        return copyPositions(positions.stream().mapToInt(i -> i).toArray(), 0, positions.size());
+    }
 
     /**
      * Returns a block starting at the specified position and extends for the

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
@@ -13,10 +13,7 @@
  */
 package com.facebook.presto.spi.block;
 
-import java.util.List;
-import java.util.Set;
-
-import static java.util.stream.Collectors.toSet;
+import static java.util.Objects.requireNonNull;
 
 final class BlockUtil
 {
@@ -30,11 +27,27 @@ final class BlockUtil
     {
     }
 
-    static void checkValidPositions(List<Integer> positions, int positionCount)
+    static void checkValidPositions(int[] positions, int offset, int length, int positionCount)
     {
-        Set<Integer> invalidPositions = positions.stream().filter(position -> position >= positionCount).collect(toSet());
-        if (!invalidPositions.isEmpty()) {
-            throw new IllegalArgumentException("Invalid positions " + invalidPositions + " in block with " + positionCount + " positions");
+        checkValidPositionsArray(positions, offset, length);
+
+        for (int i = 0; i < length; ++i) {
+            int position = positions[offset + i];
+            if (position > positionCount) {
+                throw new IllegalArgumentException("Invalid position " + position + " in block with " + positionCount + " positions");
+            }
+        }
+    }
+
+    static void checkValidPositionsArray(int[] positions, int offset, int length)
+    {
+        requireNonNull(positions, "positions array is null");
+        if (offset < 0 || offset > positions.length) {
+            throw new IndexOutOfBoundsException("Invalid offset " + offset + " for positions array with " + positions.length + " elements");
+        }
+
+        if (length < 0 || offset + length > positions.length) {
+            throw new IndexOutOfBoundsException("Invalid length " + length + " for positions array with " + positions.length + " elements and offset " + offset);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -16,9 +16,9 @@ package com.facebook.presto.spi.block;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.BiConsumer;
 
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositionsArray;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
 
@@ -132,17 +132,19 @@ public class ByteArrayBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        boolean[] newValueIsNull = new boolean[positions.size()];
-        byte[] newValues = new byte[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            int position = positions.get(i);
+        checkValidPositionsArray(positions, offset, length);
+
+        boolean[] newValueIsNull = new boolean[length];
+        byte[] newValues = new byte[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
             checkReadablePosition(position);
             newValueIsNull[i] = valueIsNull[position + arrayOffset];
             newValues[i] = values[position + arrayOffset];
         }
-        return new ByteArrayBlock(positions.size(), newValueIsNull, newValues);
+        return new ByteArrayBlock(length, newValueIsNull, newValues);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -18,9 +18,9 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.BiConsumer;
 
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositionsArray;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
@@ -192,17 +192,19 @@ public class ByteArrayBlockBuilder
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        boolean[] newValueIsNull = new boolean[positions.size()];
-        byte[] newValues = new byte[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            int position = positions.get(i);
+        checkValidPositionsArray(positions, offset, length);
+
+        boolean[] newValueIsNull = new boolean[length];
+        byte[] newValues = new byte[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
             checkReadablePosition(position);
             newValueIsNull[i] = valueIsNull[position];
             newValues[i] = values[position];
         }
-        return new ByteArrayBlock(positions.size(), newValueIsNull, newValues);
+        return new ByteArrayBlock(length, newValueIsNull, newValues);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -265,16 +265,17 @@ public class DictionaryBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        checkValidPositions(positions, positionCount);
+        checkValidPositions(positions, offset, length, positionCount);
 
         List<Integer> positionsToCopy = new ArrayList<>();
         Map<Integer, Integer> oldIndexToNewIndex = new HashMap<>();
-        int[] newIds = new int[positions.size()];
+        int[] newIds = new int[length];
 
-        for (int i = 0; i < positions.size(); i++) {
-            int oldIndex = getId(positions.get(i));
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            int oldIndex = getId(position);
             if (!oldIndexToNewIndex.containsKey(oldIndex)) {
                 oldIndexToNewIndex.put(oldIndex, positionsToCopy.size());
                 positionsToCopy.add(oldIndex);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
@@ -18,7 +18,6 @@ import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
@@ -92,18 +91,19 @@ public class FixedWidthBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        checkValidPositions(positions, positionCount);
+        checkValidPositions(positions, offset, length, positionCount);
 
-        SliceOutput newSlice = Slices.allocate(positions.size() * fixedSize).getOutput();
-        SliceOutput newValueIsNull = Slices.allocate(positions.size()).getOutput();
+        SliceOutput newSlice = Slices.allocate(length * fixedSize).getOutput();
+        SliceOutput newValueIsNull = Slices.allocate(length).getOutput();
 
-        for (int position : positions) {
+        for (int i = 0; i < length; ++i) {
+            int position = positions[offset + i];
             newSlice.writeBytes(slice, position * fixedSize, fixedSize);
             newValueIsNull.writeByte(valueIsNull.getByte(position));
         }
-        return new FixedWidthBlock(fixedSize, positions.size(), newSlice.slice(), newValueIsNull.slice());
+        return new FixedWidthBlock(fixedSize, length, newSlice.slice(), newValueIsNull.slice());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -21,7 +21,6 @@ import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.MAX_ARRAY_SIZE;
@@ -109,18 +108,19 @@ public class FixedWidthBlockBuilder
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        checkValidPositions(positions, positionCount);
+        checkValidPositions(positions, offset, length, positionCount);
 
-        SliceOutput newSlice = Slices.allocate(positions.size() * fixedSize).getOutput();
-        SliceOutput newValueIsNull = Slices.allocate(positions.size()).getOutput();
+        SliceOutput newSlice = Slices.allocate(length * fixedSize).getOutput();
+        SliceOutput newValueIsNull = Slices.allocate(length).getOutput();
 
-        for (int position : positions) {
+        for (int i = 0; i < length; ++i) {
+            int position = positions[offset + i];
             newValueIsNull.appendByte(valueIsNull.getUnderlyingSlice().getByte(position));
             newSlice.appendBytes(getRawSlice().getBytes(position * fixedSize, fixedSize));
         }
-        return new FixedWidthBlock(fixedSize, positions.size(), newSlice.slice(), newValueIsNull.slice());
+        return new FixedWidthBlock(fixedSize, length, newSlice.slice(), newValueIsNull.slice());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -16,9 +16,9 @@ package com.facebook.presto.spi.block;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.BiConsumer;
 
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositionsArray;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
 
@@ -132,17 +132,19 @@ public class IntArrayBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        boolean[] newValueIsNull = new boolean[positions.size()];
-        int[] newValues = new int[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            int position = positions.get(i);
+        checkValidPositionsArray(positions, offset, length);
+
+        boolean[] newValueIsNull = new boolean[length];
+        int[] newValues = new int[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
             checkReadablePosition(position);
             newValueIsNull[i] = valueIsNull[position + arrayOffset];
             newValues[i] = values[position + arrayOffset];
         }
-        return new IntArrayBlock(positions.size(), newValueIsNull, newValues);
+        return new IntArrayBlock(length, newValueIsNull, newValues);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -18,10 +18,10 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositionsArray;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
@@ -193,17 +193,19 @@ public class IntArrayBlockBuilder
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        boolean[] newValueIsNull = new boolean[positions.size()];
-        int[] newValues = new int[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            int position = positions.get(i);
+        checkValidPositionsArray(positions, offset, length);
+
+        boolean[] newValueIsNull = new boolean[length];
+        int[] newValues = new int[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
             checkReadablePosition(position);
             newValueIsNull[i] = valueIsNull[position];
             newValues[i] = values[position];
         }
-        return new IntArrayBlock(positions.size(), newValueIsNull, newValues);
+        return new IntArrayBlock(length, newValueIsNull, newValues);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -16,7 +16,6 @@ package com.facebook.presto.spi.block;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import static java.util.Objects.requireNonNull;
@@ -201,10 +200,10 @@ public class LazyBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
         assureLoaded();
-        return block.copyPositions(positions);
+        return block.copyPositions(positions, offset, length);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -16,9 +16,9 @@ package com.facebook.presto.spi.block;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.BiConsumer;
 
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositionsArray;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.toIntExact;
@@ -179,17 +179,19 @@ public class LongArrayBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        boolean[] newValueIsNull = new boolean[positions.size()];
-        long[] newValues = new long[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            int position = positions.get(i);
+        checkValidPositionsArray(positions, offset, length);
+
+        boolean[] newValueIsNull = new boolean[length];
+        long[] newValues = new long[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
             checkReadablePosition(position);
             newValueIsNull[i] = valueIsNull[position + arrayOffset];
             newValues[i] = values[position + arrayOffset];
         }
-        return new LongArrayBlock(positions.size(), newValueIsNull, newValues);
+        return new LongArrayBlock(length, newValueIsNull, newValues);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -18,10 +18,10 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositionsArray;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
@@ -240,17 +240,19 @@ public class LongArrayBlockBuilder
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        boolean[] newValueIsNull = new boolean[positions.size()];
-        long[] newValues = new long[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            int position = positions.get(i);
+        checkValidPositionsArray(positions, offset, length);
+
+        boolean[] newValueIsNull = new boolean[length];
+        long[] newValues = new long[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
             checkReadablePosition(position);
             newValueIsNull[i] = valueIsNull[position];
             newValues[i] = values[position];
         }
-        return new LongArrayBlock(positions.size(), newValueIsNull, newValues);
+        return new LongArrayBlock(length, newValueIsNull, newValues);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
@@ -96,10 +95,10 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        checkValidPositions(positions, positionCount);
-        return new RunLengthEncodedBlock(value.copyRegion(0, 1), positions.size());
+        checkValidPositions(positions, offset, length, positionCount);
+        return new RunLengthEncodedBlock(value.copyRegion(0, 1), length);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -16,9 +16,9 @@ package com.facebook.presto.spi.block;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.BiConsumer;
 
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositionsArray;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
 
@@ -132,17 +132,19 @@ public class ShortArrayBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        boolean[] newValueIsNull = new boolean[positions.size()];
-        short[] newValues = new short[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            int position = positions.get(i);
+        checkValidPositionsArray(positions, offset, length);
+
+        boolean[] newValueIsNull = new boolean[length];
+        short[] newValues = new short[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
             checkReadablePosition(position);
             newValueIsNull[i] = valueIsNull[position + arrayOffset];
             newValues[i] = values[position + arrayOffset];
         }
-        return new ShortArrayBlock(positions.size(), newValueIsNull, newValues);
+        return new ShortArrayBlock(length, newValueIsNull, newValues);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -18,10 +18,10 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositionsArray;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
@@ -193,17 +193,19 @@ public class ShortArrayBlockBuilder
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        boolean[] newValueIsNull = new boolean[positions.size()];
-        short[] newValues = new short[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            int position = positions.get(i);
+        checkValidPositionsArray(positions, offset, length);
+
+        boolean[] newValueIsNull = new boolean[length];
+        short[] newValues = new short[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
             checkReadablePosition(position);
             newValueIsNull[i] = valueIsNull[position];
             newValues[i] = values[position];
         }
-        return new ShortArrayBlock(positions.size(), newValueIsNull, newValues);
+        return new ShortArrayBlock(length, newValueIsNull, newValues);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SliceArrayBlock.java
@@ -19,7 +19,6 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
@@ -91,17 +90,18 @@ public class SliceArrayBlock
     }
 
     @Override
-    public Block copyPositions(List<Integer> positions)
+    public Block copyPositions(int[] positions, int offset, int length)
     {
-        checkValidPositions(positions, positionCount);
+        checkValidPositions(positions, offset, length, positionCount);
 
-        Slice[] newValues = new Slice[positions.size()];
-        for (int i = 0; i < positions.size(); i++) {
-            if (!isEntryNull(positions.get(i))) {
-                newValues[i] = Slices.copyOf(values[positions.get(i)]);
+        Slice[] newValues = new Slice[length];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            if (!isEntryNull(position)) {
+                newValues[i] = Slices.copyOf(values[position]);
             }
         }
-        return new SliceArrayBlock(positions.size(), newValues);
+        return new SliceArrayBlock(length, newValues);
     }
 
     @Override


### PR DESCRIPTION
Block#copyPositions with primitive int array argument
allows to avoid boxing of position indexes therefore
it is more performant than the list version.

FYI: @losipiuk @arhimondr 