### PR TITLE
Provide final stats in JDBC progress callback

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -1783,6 +1783,9 @@ public class PrestoResultSet
                 }
             }
 
+            QueryResults results = client.finalResults();
+            progressCallback.accept(QueryStats.create(results.getId(), results.getStats()));
+
             if (client.isFailed()) {
                 throw propagate(resultsException(client.finalResults()));
             }


### PR DESCRIPTION
Always invoke the callback with the final stats at query completion.