### PR TITLE
Handle GROUPING when aggregation expressions require implicit coercions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -595,7 +595,7 @@ class QueryPlanner
         // Add back the implicit casts that we removed in 2.a
         // TODO: this is a hack, we should change type coercions to coerce the inputs to functions/operators instead of coercing the output
         if (needPostProjectionCoercion) {
-            return explicitCoercionFields(subPlan, distinctGroupingColumns, analysis.getAggregates(node));
+            subPlan = explicitCoercionFields(subPlan, distinctGroupingColumns, analysis.getAggregates(node));
         }
 
         // 4. Project and re-write all grouping functions

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1931,6 +1931,11 @@ public abstract class AbstractTestQueries
                 groupingSet2);
 
         assertQuery(query, "VALUES (0), (822283861886), (995358664191)");
+
+        // GROUPING + implicit coercions (issue #8738)
+        assertQuery(
+                "SELECT GROUPING(k), SUM(v) + 1.0 FROM (VALUES (1, 1)) AS t(k,v) GROUP BY k",
+                "VALUES (0, 2.0)");
     }
 
     @Test


### PR DESCRIPTION
During planning of aggregation operations, the code was returning early
if the aggregation expressions required implicit coercions.

As a result, GROUPING was not being rewritten, causing downstream
failures during planning.

Fixes #8738