### PR TITLE
Fix AllColumn formatting for SqlFormatter

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.sql;
 
-import com.facebook.presto.sql.tree.AllColumns;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
 import com.facebook.presto.sql.tree.ArrayConstructor;
@@ -488,16 +487,6 @@ public final class ExpressionFormatter
             builder.append(')');
 
             return builder.toString();
-        }
-
-        @Override
-        protected String visitAllColumns(AllColumns node, Void context)
-        {
-            if (node.getPrefix().isPresent()) {
-                return node.getPrefix().get() + ".*";
-            }
-
-            return "*";
         }
 
         @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -346,7 +346,10 @@ public final class SqlFormatter
         @Override
         protected Void visitAllColumns(AllColumns node, Integer context)
         {
-            builder.append(node.toString());
+            if (node.getPrefix().isPresent()) {
+                builder.append("\"" + node.getPrefix().get().toString() + "\".");
+            }
+            builder.append("*");
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AllColumns.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AllColumns.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class AllColumns
@@ -95,10 +96,8 @@ public class AllColumns
     @Override
     public String toString()
     {
-        if (prefix.isPresent()) {
-            return prefix.get() + ".*";
-        }
-
-        return "*";
+        return toStringHelper(this)
+                .add("prefix", prefix)
+                .toString();
     }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -2121,6 +2121,14 @@ public class TestSqlParser
                         new SubqueryExpression(simpleQuery(selectList(new LongLiteral("10"))))));
     }
 
+    @Test
+    public void testAllColumns()
+    {
+        assertStatement(
+                "select *, t.*, \"table\".*",
+                simpleQuery(selectList(new AllColumns(), new AllColumns(QualifiedName.of("t")), new AllColumns(QualifiedName.of("table")))));
+    }
+
     private static void assertCast(String type)
     {
         assertCast(type, type);


### PR DESCRIPTION
When formatting all columns, t.* will be formatted as t.* but should be "t".*, in case the prefix is a reserved word.