### PR TITLE
Add additional context information to HdfsEnvironment

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
@@ -62,7 +62,7 @@ public class GenericHiveRecordCursorProvider
     {
         // make sure the FileSystem is created with the proper Configuration object
         try {
-            this.hdfsEnvironment.getFileSystem(session.getUser(), path);
+            this.hdfsEnvironment.getFileSystem(session.getUser(), path, configuration);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed getting FileSystem: " + path, e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
@@ -13,11 +13,12 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import org.apache.hadoop.conf.Configuration;
 
 import java.net.URI;
 
 public interface HdfsConfiguration
 {
-    Configuration getConfiguration(URI uri);
+    Configuration getConfiguration(HdfsContext context, URI uri);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import org.apache.hadoop.conf.Configuration;
 
 import javax.inject.Inject;
@@ -60,7 +61,7 @@ public class HiveHdfsConfiguration
     }
 
     @Override
-    public Configuration getConfiguration(URI uri)
+    public Configuration getConfiguration(HdfsContext context, URI uri)
     {
         // use the same configuration for everything
         return hadoopConfiguration.get();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
 import com.facebook.presto.hive.metastore.Table;
@@ -45,16 +46,17 @@ public class HiveLocationService
     @Override
     public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, String user, String queryId, String schemaName, String tableName)
     {
-        Path targetPath = getTableDefaultLocation(user, metastore, hdfsEnvironment, schemaName, tableName);
+        HdfsContext context = new HdfsContext(user, queryId, schemaName, tableName);
+        Path targetPath = getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName);
 
         // verify the target directory for the table
-        if (pathExists(user, hdfsEnvironment, targetPath)) {
+        if (pathExists(context, hdfsEnvironment, targetPath)) {
             throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format("Target directory for table '%s.%s' already exists: %s", schemaName, tableName, targetPath));
         }
 
         Path writePath;
-        if (shouldUseTemporaryDirectory(user, targetPath)) {
-            writePath = createTemporaryPath(user, hdfsEnvironment, targetPath);
+        if (shouldUseTemporaryDirectory(context, targetPath)) {
+            writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
         }
         else {
             writePath = targetPath;
@@ -66,11 +68,12 @@ public class HiveLocationService
     @Override
     public LocationHandle forExistingTable(SemiTransactionalHiveMetastore metastore, String user, String queryId, Table table)
     {
+        HdfsContext context = new HdfsContext(user, queryId, table.getDatabaseName(), table.getTableName());
         Path targetPath = new Path(table.getStorage().getLocation());
 
         Optional<Path> writePath;
-        if (shouldUseTemporaryDirectory(user, targetPath)) {
-            writePath = Optional.of(createTemporaryPath(user, hdfsEnvironment, targetPath));
+        if (shouldUseTemporaryDirectory(context, targetPath)) {
+            writePath = Optional.of(createTemporaryPath(context, hdfsEnvironment, targetPath));
         }
         else {
             writePath = Optional.empty();
@@ -79,10 +82,10 @@ public class HiveLocationService
         return new LocationHandle(targetPath, writePath, true);
     }
 
-    private boolean shouldUseTemporaryDirectory(String user, Path path)
+    private boolean shouldUseTemporaryDirectory(HdfsContext context, Path path)
     {
         // skip using temporary directory for S3
-        return !isS3FileSystem(user, hdfsEnvironment, path);
+        return !isS3FileSystem(context, hdfsEnvironment, path);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
@@ -88,7 +89,7 @@ public class HivePageSourceProvider
                 cursorProviders,
                 pageSourceFactories,
                 hiveSplit.getClientId(),
-                hdfsEnvironment.getConfiguration(path),
+                hdfsEnvironment.getConfiguration(new HdfsContext(session, hiveSplit.getDatabase(), hiveSplit.getTable()), path),
                 session,
                 path,
                 hiveSplit.getBucketNumber(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.HivePageSinkMetadataProvider;
 import com.facebook.presto.hive.metastore.Partition;
@@ -201,7 +202,7 @@ public class HiveWriterFactory
                 .collect(toImmutableMap(PropertyMetadata::getName,
                         entry -> session.getProperty(entry.getName(), entry.getJavaType()).toString()));
 
-        Configuration conf = hdfsEnvironment.getConfiguration(writePath);
+        Configuration conf = hdfsEnvironment.getConfiguration(new HdfsContext(session, schemaName, tableName), writePath);
         this.conf = toJobConf(conf);
 
         // make sure the FileSystem is created with the correct Configuration object
@@ -271,7 +272,7 @@ public class HiveWriterFactory
                 if (partitionName.isPresent() && !target.equals(write)) {
                     // When target path is different from write path,
                     // verify that the target directory for the partition does not already exist
-                    if (HiveWriteUtils.pathExists(session.getUser(), hdfsEnvironment, target)) {
+                    if (HiveWriteUtils.pathExists(new HdfsContext(session, schemaName, tableName), hdfsEnvironment, target)) {
                         throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format(
                                 "Target directory for new partition '%s' of table '%s.%s' already exists: %s",
                                 partitionName,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore;
 
 import com.facebook.presto.hadoop.HadoopFileStatus;
 import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.PartitionNotFoundException;
 import com.facebook.presto.hive.TableAlreadyExistsException;
@@ -291,7 +292,8 @@ public class SemiTransactionalHiveMetastore
         Action<TableAndMore> oldTableAction = tableActions.get(schemaTableName);
         TableAndMore tableAndMore = new TableAndMore(table, Optional.of(principalPrivileges), currentPath, Optional.empty());
         if (oldTableAction == null) {
-            tableActions.put(schemaTableName, new Action<>(ActionType.ADD, tableAndMore, session.getUser(), session.getQueryId()));
+            HdfsContext context = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
+            tableActions.put(schemaTableName, new Action<>(ActionType.ADD, tableAndMore, context));
             return;
         }
         switch (oldTableAction.getType()) {
@@ -314,7 +316,8 @@ public class SemiTransactionalHiveMetastore
         SchemaTableName schemaTableName = new SchemaTableName(databaseName, tableName);
         Action<TableAndMore> oldTableAction = tableActions.get(schemaTableName);
         if (oldTableAction == null || oldTableAction.getType() == ActionType.ALTER) {
-            tableActions.put(schemaTableName, new Action<>(ActionType.DROP, null, session.getUser(), session.getQueryId()));
+            HdfsContext context = new HdfsContext(session, databaseName, tableName);
+            tableActions.put(schemaTableName, new Action<>(ActionType.DROP, null, context));
             return;
         }
         switch (oldTableAction.getType()) {
@@ -366,11 +369,12 @@ public class SemiTransactionalHiveMetastore
             if (!table.isPresent()) {
                 throw new TableNotFoundException(schemaTableName);
             }
+            HdfsContext context = new HdfsContext(session, databaseName, tableName);
             tableActions.put(
                     schemaTableName,
                     new Action<>(
                             ActionType.INSERT_EXISTING,
-                            new TableAndMore(table.get(), Optional.empty(), Optional.of(currentLocation), Optional.of(fileNames)), session.getUser(), session.getQueryId()));
+                            new TableAndMore(table.get(), Optional.empty(), Optional.of(currentLocation), Optional.of(fileNames)), context));
             return;
         }
 
@@ -402,9 +406,9 @@ public class SemiTransactionalHiveMetastore
         }
 
         Path path = new Path(table.get().getStorage().getLocation());
-        String user = session.getUser();
+        HdfsContext context = new HdfsContext(session, databaseName, tableName);
         setExclusive((delegate, hdfsEnvironment) -> {
-            RecursiveDeleteResult recursiveDeleteResult = recursiveDeleteFiles(hdfsEnvironment, user, path, ImmutableList.of(""), false);
+            RecursiveDeleteResult recursiveDeleteResult = recursiveDeleteFiles(hdfsEnvironment, context, path, ImmutableList.of(""), false);
             if (!recursiveDeleteResult.getNotDeletedEligibleItems().isEmpty()) {
                 throw new PrestoException(HIVE_FILESYSTEM_ERROR, format(
                         "Error deleting from unpartitioned table %s. These items can not be deleted: %s",
@@ -581,20 +585,21 @@ public class SemiTransactionalHiveMetastore
         checkArgument(getPrestoQueryId(partition).isPresent());
         Map<List<String>, Action<PartitionAndMore>> partitionActionsOfTable = partitionActions.computeIfAbsent(new SchemaTableName(databaseName, tableName), k -> new HashMap<>());
         Action<PartitionAndMore> oldPartitionAction = partitionActionsOfTable.get(partition.getValues());
+        HdfsContext context = new HdfsContext(session, databaseName, tableName);
         if (oldPartitionAction == null) {
             partitionActionsOfTable.put(
                     partition.getValues(),
-                    new Action<>(ActionType.ADD, new PartitionAndMore(partition, currentLocation, Optional.empty()), session.getUser(), session.getQueryId()));
+                    new Action<>(ActionType.ADD, new PartitionAndMore(partition, currentLocation, Optional.empty()), context));
             return;
         }
         switch (oldPartitionAction.getType()) {
             case DROP: {
-                if (!oldPartitionAction.getUser().equals(session.getUser())) {
+                if (!oldPartitionAction.getContext().getUser().equals(session.getUser())) {
                     throw new PrestoException(TRANSACTION_CONFLICT, "Operation on the same partition with different user in the same transaction is not supported");
                 }
                 partitionActionsOfTable.put(
                         partition.getValues(),
-                        new Action<>(ActionType.ALTER, new PartitionAndMore(partition, currentLocation, Optional.empty()), session.getUser(), session.getQueryId()));
+                        new Action<>(ActionType.ALTER, new PartitionAndMore(partition, currentLocation, Optional.empty()), context));
                 break;
             }
             case ADD:
@@ -612,7 +617,8 @@ public class SemiTransactionalHiveMetastore
         Map<List<String>, Action<PartitionAndMore>> partitionActionsOfTable = partitionActions.computeIfAbsent(new SchemaTableName(databaseName, tableName), k -> new HashMap<>());
         Action<PartitionAndMore> oldPartitionAction = partitionActionsOfTable.get(partitionValues);
         if (oldPartitionAction == null) {
-            partitionActionsOfTable.put(partitionValues, new Action<>(ActionType.DROP, null, session.getUser(), session.getQueryId()));
+            HdfsContext context = new HdfsContext(session, databaseName, tableName);
+            partitionActionsOfTable.put(partitionValues, new Action<>(ActionType.DROP, null, context));
             return;
         }
         switch (oldPartitionAction.getType()) {
@@ -640,9 +646,10 @@ public class SemiTransactionalHiveMetastore
             if (!partition.isPresent()) {
                 throw new PartitionNotFoundException(schemaTableName, partitionValues);
             }
+            HdfsContext context = new HdfsContext(session, databaseName, tableName);
             partitionActionsOfTable.put(
                     partitionValues,
-                    new Action<>(ActionType.INSERT_EXISTING, new PartitionAndMore(partition.get(), currentLocation, Optional.of(fileNames)), session.getUser(), session.getQueryId()));
+                    new Action<>(ActionType.INSERT_EXISTING, new PartitionAndMore(partition.get(), currentLocation, Optional.of(fileNames)), context));
             return;
         }
 
@@ -718,7 +725,8 @@ public class SemiTransactionalHiveMetastore
                 throw new PrestoException(NOT_SUPPORTED, "Can not insert into a table with a partition that has been modified in the same transaction when Presto is configured to skip temporary directories.");
             }
         }
-        declaredIntentionsToWrite.add(new DeclaredIntentionToWrite(writeMode, session.getUser(), stagingPathRoot, filePrefix, schemaTableName));
+        HdfsContext context = new HdfsContext(session, schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        declaredIntentionsToWrite.add(new DeclaredIntentionToWrite(writeMode, context, stagingPathRoot, filePrefix, schemaTableName));
     }
 
     public synchronized void commit()
@@ -784,10 +792,10 @@ public class SemiTransactionalHiveMetastore
                         committer.prepareAlterTable();
                         break;
                     case ADD:
-                        committer.prepareAddTable(action.getUser(), action.getData());
+                        committer.prepareAddTable(action.getContext(), action.getData());
                         break;
                     case INSERT_EXISTING:
-                        committer.prepareInsertExistingTable(action.getUser(), action.getData());
+                        committer.prepareInsertExistingTable(action.getContext(), action.getData());
                         break;
                     default:
                         throw new IllegalStateException("Unknown action type");
@@ -803,13 +811,13 @@ public class SemiTransactionalHiveMetastore
                             committer.prepareDropPartition(schemaTableName, partitionValues);
                             break;
                         case ALTER:
-                            committer.prepareAlterPartition(action.getQueryId(), action.getUser(), action.getData());
+                            committer.prepareAlterPartition(action.getContext(), action.getData());
                             break;
                         case ADD:
-                            committer.prepareAddPartition(action.getUser(), action.getData());
+                            committer.prepareAddPartition(action.getContext(), action.getData());
                             break;
                         case INSERT_EXISTING:
-                            committer.prepareInsertExistingPartition(action.getUser(), action.getData());
+                            committer.prepareInsertExistingPartition(action.getContext(), action.getData());
                             break;
                         default:
                             throw new IllegalStateException("Unknown action type");
@@ -909,7 +917,7 @@ public class SemiTransactionalHiveMetastore
             throw new UnsupportedOperationException("Dropping and then creating a table with the same name is not supported");
         }
 
-        private void prepareAddTable(String user, TableAndMore tableAndMore)
+        private void prepareAddTable(HdfsContext context, TableAndMore tableAndMore)
         {
             Table table = tableAndMore.getTable();
             if (table.getTableType().equals(MANAGED_TABLE.name())) {
@@ -924,17 +932,17 @@ public class SemiTransactionalHiveMetastore
                     }
                     else {
                         renameDirectory(
-                                user,
+                                context,
                                 hdfsEnvironment,
                                 currentPath.get(),
                                 targetPath,
-                                () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, true)));
+                                () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
                     }
                 }
                 else {
                     // CREATE TABLE AS SELECT partitioned table, or
                     // CREATE TABLE partitioned/unpartitioned table (without data)
-                    if (pathExists(user, hdfsEnvironment, targetPath)) {
+                    if (pathExists(context, hdfsEnvironment, targetPath)) {
                         if (currentPath.isPresent() && currentPath.get().equals(targetPath)) {
                             // It is okay to skip directory creation when currentPath is equal to targetPath
                             // because the directory may have been created when creating partition directories.
@@ -948,8 +956,8 @@ public class SemiTransactionalHiveMetastore
                         }
                     }
                     else {
-                        cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, true));
-                        createDirectory(user, hdfsEnvironment, targetPath);
+                        cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true));
+                        createDirectory(context, hdfsEnvironment, targetPath);
                     }
                 }
             }
@@ -957,14 +965,14 @@ public class SemiTransactionalHiveMetastore
             addTableOperations.add(new CreateTableOperation(table, tableAndMore.getPrincipalPrivileges()));
         }
 
-        private void prepareInsertExistingTable(String user, TableAndMore tableAndMore)
+        private void prepareInsertExistingTable(HdfsContext context, TableAndMore tableAndMore)
         {
             Table table = tableAndMore.getTable();
             Path targetPath = new Path(table.getStorage().getLocation());
             Path currentPath = tableAndMore.getCurrentLocation().get();
-            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, false));
+            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, false));
             if (!targetPath.equals(currentPath)) {
-                asyncRename(hdfsEnvironment, renameExecutor, fileRenameCancelled, fileRenameFutures, user, currentPath, targetPath, tableAndMore.getFileNames().get());
+                asyncRename(hdfsEnvironment, renameExecutor, fileRenameCancelled, fileRenameFutures, context, currentPath, targetPath, tableAndMore.getFileNames().get());
             }
         }
 
@@ -975,7 +983,7 @@ public class SemiTransactionalHiveMetastore
                     () -> delegate.dropPartition(schemaTableName.getSchemaName(), schemaTableName.getTableName(), partitionValues, true)));
         }
 
-        private void prepareAlterPartition(String queryId, String user, PartitionAndMore partitionAndMore)
+        private void prepareAlterPartition(HdfsContext context, PartitionAndMore partitionAndMore)
         {
             Partition partition = partitionAndMore.getPartition();
             String targetLocation = partition.getStorage().getLocation();
@@ -996,20 +1004,20 @@ public class SemiTransactionalHiveMetastore
             // Otherwise,
             // * Remember we will need to delete the location of the old partition at the end if transaction successfully commits
             if (targetLocation.equals(oldPartitionLocation)) {
-                Path oldPartitionStagingPath = new Path(oldPartitionPath.getParent(), "_temp_" + oldPartitionPath.getName() + "_" + queryId);
+                Path oldPartitionStagingPath = new Path(oldPartitionPath.getParent(), "_temp_" + oldPartitionPath.getName() + "_" + context.getQueryId());
                 renameDirectory(
-                        user,
+                        context,
                         hdfsEnvironment,
                         oldPartitionPath,
                         oldPartitionStagingPath,
-                        () -> renameTasksForAbort.add(new DirectoryRenameTask(user, oldPartitionStagingPath, oldPartitionPath)));
+                        () -> renameTasksForAbort.add(new DirectoryRenameTask(context, oldPartitionStagingPath, oldPartitionPath)));
                 if (!skipDeletionForAlter) {
-                    deletionTasksForFinish.add(new DirectoryDeletionTask(user, oldPartitionStagingPath));
+                    deletionTasksForFinish.add(new DirectoryDeletionTask(context, oldPartitionStagingPath));
                 }
             }
             else {
                 if (!skipDeletionForAlter) {
-                    deletionTasksForFinish.add(new DirectoryDeletionTask(user, oldPartitionPath));
+                    deletionTasksForFinish.add(new DirectoryDeletionTask(context, oldPartitionPath));
                 }
             }
 
@@ -1017,18 +1025,18 @@ public class SemiTransactionalHiveMetastore
             Path targetPath = new Path(targetLocation);
             if (!targetPath.equals(currentPath)) {
                 renameDirectory(
-                        user,
+                        context,
                         hdfsEnvironment,
                         currentPath,
                         targetPath,
-                        () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, true)));
+                        () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
             }
             // Partition alter must happen regardless of whether original and current location is the same
             // because metadata might change: e.g. storage format, column types, etc
             alterPartitionOperations.add(new AlterPartitionOperation(partition, oldPartition.get()));
         }
 
-        private void prepareAddPartition(String user, PartitionAndMore partitionAndMore)
+        private void prepareAddPartition(HdfsContext context, PartitionAndMore partitionAndMore)
         {
             Partition partition = partitionAndMore.getPartition();
             String targetLocation = partition.getStorage().getLocation();
@@ -1042,37 +1050,37 @@ public class SemiTransactionalHiveMetastore
 
             if (!targetPath.equals(currentPath)) {
                 renameDirectory(
-                        user,
+                        context,
                         hdfsEnvironment,
                         currentPath,
                         targetPath,
-                        () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, true)));
+                        () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
             }
             partitionAdder.addPartition(partition);
         }
 
-        private void prepareInsertExistingPartition(String user, PartitionAndMore partitionAndMore)
+        private void prepareInsertExistingPartition(HdfsContext context, PartitionAndMore partitionAndMore)
         {
             Partition partition = partitionAndMore.getPartition();
             Path targetPath = new Path(partition.getStorage().getLocation());
             Path currentPath = partitionAndMore.getCurrentLocation();
-            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, false));
+            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, false));
             if (!targetPath.equals(currentPath)) {
-                asyncRename(hdfsEnvironment, renameExecutor, fileRenameCancelled, fileRenameFutures, user, currentPath, targetPath, partitionAndMore.getFileNames());
+                asyncRename(hdfsEnvironment, renameExecutor, fileRenameCancelled, fileRenameFutures, context, currentPath, targetPath, partitionAndMore.getFileNames());
             }
         }
 
         private void executeCleanupTasksForAbort(List<String> filePrefixes)
         {
             for (DirectoryCleanUpTask cleanUpTask : cleanUpTasksForAbort) {
-                recursiveDeleteFilesAndLog(cleanUpTask.getUser(), cleanUpTask.getPath(), filePrefixes, cleanUpTask.isDeleteEmptyDirectory(), "temporary directory commit abort");
+                recursiveDeleteFilesAndLog(cleanUpTask.getContext(), cleanUpTask.getPath(), filePrefixes, cleanUpTask.isDeleteEmptyDirectory(), "temporary directory commit abort");
             }
         }
 
         private void executeDeletionTasksForFinish()
         {
             for (DirectoryDeletionTask deletionTask : deletionTasksForFinish) {
-                if (!deleteRecursivelyIfExists(deletionTask.getUser(), hdfsEnvironment, deletionTask.getPath())) {
+                if (!deleteRecursivelyIfExists(deletionTask.getContext(), hdfsEnvironment, deletionTask.getPath())) {
                     logCleanupFailure("Error deleting directory %s", deletionTask.getPath().toString());
                 }
             }
@@ -1084,8 +1092,8 @@ public class SemiTransactionalHiveMetastore
                 try {
                     // Ignore the task if the source directory doesn't exist.
                     // This is probably because the original rename that we are trying to undo here never succeeded.
-                    if (pathExists(directoryRenameTask.getUser(), hdfsEnvironment, directoryRenameTask.getRenameFrom())) {
-                        renameDirectory(directoryRenameTask.getUser(), hdfsEnvironment, directoryRenameTask.getRenameFrom(), directoryRenameTask.getRenameTo(), () -> { });
+                    if (pathExists(directoryRenameTask.getContext(), hdfsEnvironment, directoryRenameTask.getRenameFrom())) {
+                        renameDirectory(directoryRenameTask.getContext(), hdfsEnvironment, directoryRenameTask.getRenameFrom(), directoryRenameTask.getRenameTo(), () -> { });
                     }
                 }
                 catch (Throwable throwable) {
@@ -1101,7 +1109,7 @@ public class SemiTransactionalHiveMetastore
                     continue;
                 }
                 Path path = declaredIntentionToWrite.getRootPath();
-                recursiveDeleteFilesAndLog(declaredIntentionToWrite.getUser(), path, ImmutableList.of(), true, "staging directory cleanup");
+                recursiveDeleteFilesAndLog(declaredIntentionToWrite.getContext(), path, ImmutableList.of(), true, "staging directory cleanup");
             }
         }
 
@@ -1248,7 +1256,7 @@ public class SemiTransactionalHiveMetastore
                     // the unique prefix for queries in this transaction.
 
                     recursiveDeleteFilesAndLog(
-                            declaredIntentionToWrite.getUser(),
+                            declaredIntentionToWrite.getContext(),
                             rootPath,
                             ImmutableList.of(declaredIntentionToWrite.getFilePrefix()),
                             true,
@@ -1295,7 +1303,7 @@ public class SemiTransactionalHiveMetastore
                         // TODO: It is a known deficiency that some empty directory does not get cleaned up in S3.
                         // We can not delete any of the directories here since we do not know who created them.
                         recursiveDeleteFilesAndLog(
-                                declaredIntentionToWrite.getUser(),
+                                declaredIntentionToWrite.getContext(),
                                 path,
                                 ImmutableList.of(declaredIntentionToWrite.getFilePrefix()),
                                 false,
@@ -1406,14 +1414,14 @@ public class SemiTransactionalHiveMetastore
             Executor executor,
             AtomicBoolean cancelled,
             List<CompletableFuture<?>> fileRenameFutures,
-            String user,
+            HdfsContext context,
             Path currentPath,
             Path targetPath,
             List<String> fileNames)
     {
         FileSystem fileSystem;
         try {
-            fileSystem = hdfsEnvironment.getFileSystem(user, currentPath);
+            fileSystem = hdfsEnvironment.getFileSystem(context, currentPath);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, format("Error moving data files to final location. Error listing directory %s", currentPath), e);
@@ -1438,11 +1446,11 @@ public class SemiTransactionalHiveMetastore
         }
     }
 
-    private void recursiveDeleteFilesAndLog(String user, Path directory, List<String> filePrefixes, boolean deleteEmptyDirectories, String reason)
+    private void recursiveDeleteFilesAndLog(HdfsContext context, Path directory, List<String> filePrefixes, boolean deleteEmptyDirectories, String reason)
     {
         RecursiveDeleteResult recursiveDeleteResult = recursiveDeleteFiles(
                 hdfsEnvironment,
-                user,
+                context,
                 directory,
                 filePrefixes,
                 deleteEmptyDirectories);
@@ -1476,11 +1484,11 @@ public class SemiTransactionalHiveMetastore
      * @param filePrefixes prefix of files that should be deleted
      * @param deleteEmptyDirectories whether empty directories should be deleted
      */
-    private static RecursiveDeleteResult recursiveDeleteFiles(HdfsEnvironment hdfsEnvironment, String user, Path directory, List<String> filePrefixes, boolean deleteEmptyDirectories)
+    private static RecursiveDeleteResult recursiveDeleteFiles(HdfsEnvironment hdfsEnvironment, HdfsContext context, Path directory, List<String> filePrefixes, boolean deleteEmptyDirectories)
     {
         FileSystem fileSystem;
         try {
-            fileSystem = hdfsEnvironment.getFileSystem(user, directory);
+            fileSystem = hdfsEnvironment.getFileSystem(context, directory);
 
             if (!fileSystem.exists(directory)) {
                 return new RecursiveDeleteResult(true, ImmutableList.of());
@@ -1588,11 +1596,11 @@ public class SemiTransactionalHiveMetastore
      *
      * @return true if the location no longer exists
      */
-    private static boolean deleteRecursivelyIfExists(String user, HdfsEnvironment hdfsEnvironment, Path path)
+    private static boolean deleteRecursivelyIfExists(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         FileSystem fileSystem;
         try {
-            fileSystem = hdfsEnvironment.getFileSystem(user, path);
+            fileSystem = hdfsEnvironment.getFileSystem(context, path);
         }
         catch (IOException ignored) {
             return false;
@@ -1601,15 +1609,15 @@ public class SemiTransactionalHiveMetastore
         return deleteIfExists(fileSystem, path, true);
     }
 
-    private static void renameDirectory(String user, HdfsEnvironment hdfsEnvironment, Path source, Path target, Runnable runWhenPathDoesntExist)
+    private static void renameDirectory(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path source, Path target, Runnable runWhenPathDoesntExist)
     {
-        if (pathExists(user, hdfsEnvironment, target)) {
+        if (pathExists(context, hdfsEnvironment, target)) {
             throw new PrestoException(HIVE_PATH_ALREADY_EXISTS,
                     format("Unable to rename from %s to %s: target directory already exists", source, target));
         }
 
-        if (!pathExists(user, hdfsEnvironment, target.getParent())) {
-            createDirectory(user, hdfsEnvironment, target.getParent());
+        if (!pathExists(context, hdfsEnvironment, target.getParent())) {
+            createDirectory(context, hdfsEnvironment, target.getParent());
         }
 
         // The runnable will assume that if rename fails, it will be okay to delete the directory (if the directory is empty).
@@ -1617,7 +1625,7 @@ public class SemiTransactionalHiveMetastore
         runWhenPathDoesntExist.run();
 
         try {
-            if (!hdfsEnvironment.getFileSystem(user, source).rename(source, target)) {
+            if (!hdfsEnvironment.getFileSystem(context, source).rename(source, target)) {
                 throw new PrestoException(HIVE_FILESYSTEM_ERROR, format("Failed to rename %s to %s: rename returned false", source, target));
             }
         }
@@ -1691,11 +1699,10 @@ public class SemiTransactionalHiveMetastore
     {
         private final ActionType type;
         private final T data;
-        private final String user;
-        private final String queryId;
+        private final HdfsContext context;
 
         @JsonCreator
-        public Action(@JsonProperty("type") ActionType type, @JsonProperty("data") T data, @JsonProperty("user") String user, @JsonProperty("queryId") String queryId)
+        public Action(@JsonProperty("type") ActionType type, @JsonProperty("data") T data, @JsonProperty("context") HdfsContext context)
         {
             this.type = requireNonNull(type, "type is null");
             if (type == ActionType.DROP) {
@@ -1705,8 +1712,7 @@ public class SemiTransactionalHiveMetastore
                 requireNonNull(data, "data is null");
             }
             this.data = data;
-            this.user = requireNonNull(user, "user is null");
-            this.queryId = requireNonNull(queryId, "queryId is null");
+            this.context = requireNonNull(context, "context is null");
         }
 
         @JsonProperty
@@ -1728,15 +1734,9 @@ public class SemiTransactionalHiveMetastore
         }
 
         @JsonProperty
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
-        }
-
-        @JsonProperty
-        public String getQueryId()
-        {
-            return queryId;
+            return context;
         }
 
         @Override
@@ -1855,15 +1855,15 @@ public class SemiTransactionalHiveMetastore
     private static class DeclaredIntentionToWrite
     {
         private final WriteMode mode;
-        private final String user;
+        private final HdfsContext context;
         private final String filePrefix;
         private final Path rootPath;
         private final SchemaTableName schemaTableName;
 
-        public DeclaredIntentionToWrite(WriteMode mode, String user, Path stagingPathRoot, String filePrefix, SchemaTableName schemaTableName)
+        public DeclaredIntentionToWrite(WriteMode mode, HdfsContext context, Path stagingPathRoot, String filePrefix, SchemaTableName schemaTableName)
         {
             this.mode = requireNonNull(mode, "mode is null");
-            this.user = requireNonNull(user, "user is null");
+            this.context = requireNonNull(context, "context is null");
             this.rootPath = requireNonNull(stagingPathRoot, "stagingPathRoot is null");
             this.filePrefix = requireNonNull(filePrefix, "filePrefix is null");
             this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
@@ -1874,9 +1874,9 @@ public class SemiTransactionalHiveMetastore
             return mode;
         }
 
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
+            return context;
         }
 
         public String getFilePrefix()
@@ -1899,7 +1899,7 @@ public class SemiTransactionalHiveMetastore
         {
             return toStringHelper(this)
                     .add("mode", mode)
-                    .add("user", user)
+                    .add("context", context)
                     .add("filePrefix", filePrefix)
                     .add("rootPath", rootPath)
                     .add("schemaTableName", schemaTableName)
@@ -1909,20 +1909,20 @@ public class SemiTransactionalHiveMetastore
 
     private static class DirectoryCleanUpTask
     {
-        private final String user;
+        private final HdfsContext context;
         private final Path path;
         private final boolean deleteEmptyDirectory;
 
-        public DirectoryCleanUpTask(String user, Path path, boolean deleteEmptyDirectory)
+        public DirectoryCleanUpTask(HdfsContext context, Path path, boolean deleteEmptyDirectory)
         {
-            this.user = user;
+            this.context = context;
             this.path = path;
             this.deleteEmptyDirectory = deleteEmptyDirectory;
         }
 
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
+            return context;
         }
 
         public Path getPath()
@@ -1939,7 +1939,7 @@ public class SemiTransactionalHiveMetastore
         public String toString()
         {
             return toStringHelper(this)
-                    .add("user", user)
+                    .add("context", context)
                     .add("path", path)
                     .add("deleteEmptyDirectory", deleteEmptyDirectory)
                     .toString();
@@ -1948,18 +1948,18 @@ public class SemiTransactionalHiveMetastore
 
     private static class DirectoryDeletionTask
     {
-        private final String user;
+        private final HdfsContext context;
         private final Path path;
 
-        public DirectoryDeletionTask(String user, Path path)
+        public DirectoryDeletionTask(HdfsContext context, Path path)
         {
-            this.user = user;
+            this.context = context;
             this.path = path;
         }
 
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
+            return context;
         }
 
         public Path getPath()
@@ -1971,7 +1971,7 @@ public class SemiTransactionalHiveMetastore
         public String toString()
         {
             return toStringHelper(this)
-                    .add("user", user)
+                    .add("context", context)
                     .add("path", path)
                     .toString();
         }
@@ -1979,20 +1979,20 @@ public class SemiTransactionalHiveMetastore
 
     private static class DirectoryRenameTask
     {
-        private final String user;
+        private final HdfsContext context;
         private final Path renameFrom;
         private final Path renameTo;
 
-        public DirectoryRenameTask(String user, Path renameFrom, Path renameTo)
+        public DirectoryRenameTask(HdfsContext context, Path renameFrom, Path renameTo)
         {
-            this.user = requireNonNull(user, "user is null");
+            this.context = requireNonNull(context, "context is null");
             this.renameFrom = requireNonNull(renameFrom, "renameFrom is null");
             this.renameTo = requireNonNull(renameTo, "renameTo is null");
         }
 
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
+            return context;
         }
 
         public Path getRenameFrom()
@@ -2009,7 +2009,7 @@ public class SemiTransactionalHiveMetastore
         public String toString()
         {
             return toStringHelper(this)
-                    .add("user", user)
+                    .add("context", context)
                     .add("renameFrom", renameFrom)
                     .add("renameTo", renameTo)
                     .toString();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.metastore.file;
 
 import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.SchemaAlreadyExistsException;
 import com.facebook.presto.hive.TableAlreadyExistsException;
@@ -89,7 +90,7 @@ public class FileHiveMetastore
 
     private final HdfsEnvironment hdfsEnvironment;
     private final Path catalogDirectory;
-    private final String metastoreUser;
+    private final HdfsContext hdfsContext;
     private final FileSystem metadataFileSystem;
 
     private final JsonCodec<DatabaseMetadata> databaseCodec = JsonCodec.jsonCodec(DatabaseMetadata.class);
@@ -107,9 +108,9 @@ public class FileHiveMetastore
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.catalogDirectory = new Path(requireNonNull(catalogDirectory, "baseDirectory is null"));
-        this.metastoreUser = requireNonNull(metastoreUser, "metastoreUser is null");
+        this.hdfsContext = new HdfsContext(requireNonNull(metastoreUser, "metastoreUser is null"));
         try {
-            metadataFileSystem = hdfsEnvironment.getFileSystem(metastoreUser, this.catalogDirectory);
+            metadataFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, this.catalogDirectory);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
@@ -214,7 +215,7 @@ public class FileHiveMetastore
         else if (table.getTableType().equals(EXTERNAL_TABLE.name())) {
             try {
                 Path externalLocation = new Path(table.getStorage().getLocation());
-                FileSystem externalFileSystem = hdfsEnvironment.getFileSystem(metastoreUser, externalLocation);
+                FileSystem externalFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, externalLocation);
                 if (!externalFileSystem.isDirectory(externalLocation)) {
                     throw new PrestoException(HIVE_METASTORE_ERROR, "External table location does not exist");
                 }
@@ -531,7 +532,7 @@ public class FileHiveMetastore
         else if (table.getTableType().equals(EXTERNAL_TABLE.name())) {
             try {
                 Path externalLocation = new Path(partition.getStorage().getLocation());
-                FileSystem externalFileSystem = hdfsEnvironment.getFileSystem(metastoreUser, externalLocation);
+                FileSystem externalFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, externalLocation);
                 if (!externalFileSystem.isDirectory(externalLocation)) {
                     throw new PrestoException(HIVE_METASTORE_ERROR, "External partition location does not exist");
                 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.GroupByHashPageIndexerFactory;
 import com.facebook.presto.hadoop.HadoopFileStatus;
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.BridgingHiveMetastore;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
@@ -132,7 +133,6 @@ import static com.facebook.presto.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
 import static com.facebook.presto.hive.HiveMetadata.PRESTO_VERSION_NAME;
 import static com.facebook.presto.hive.HiveMetadata.convertToPredicate;
 import static com.facebook.presto.hive.HiveStorageFormat.AVRO;
-import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
 import static com.facebook.presto.hive.HiveStorageFormat.JSON;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
 import static com.facebook.presto.hive.HiveStorageFormat.PARQUET;
@@ -1706,14 +1706,16 @@ public abstract class AbstractTestHiveClient
 
                 // verify we have data files
                 stagingPathRoot = getStagingPathRoot(outputHandle);
-                assertFalse(listAllDataFiles(stagingPathRoot).isEmpty());
+                HdfsContext context = new HdfsContext(session, temporaryCreateRollbackTable.getSchemaName(), temporaryCreateRollbackTable.getTableName());
+                assertFalse(listAllDataFiles(context, stagingPathRoot).isEmpty());
 
                 // rollback the table
                 transaction.rollback();
             }
 
             // verify all files have been deleted
-            assertTrue(listAllDataFiles(stagingPathRoot).isEmpty());
+            HdfsContext context = new HdfsContext(newSession(), temporaryCreateRollbackTable.getSchemaName(), temporaryCreateRollbackTable.getTableName());
+            assertTrue(listAllDataFiles(context, stagingPathRoot).isEmpty());
 
             // verify table is not in the metastore
             try (Transaction transaction = newTransaction()) {
@@ -1949,7 +1951,8 @@ public abstract class AbstractTestHiveClient
             Collection<Slice> fragments = getFutureValue(sink.finish());
 
             // verify all new files start with the unique prefix
-            for (String filePath : listAllDataFiles(getStagingPathRoot(outputHandle))) {
+            HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
+            for (String filePath : listAllDataFiles(context, getStagingPathRoot(outputHandle))) {
                 assertTrue(new Path(filePath).getName().startsWith(getFilePrefix(outputHandle)));
             }
 
@@ -2090,7 +2093,8 @@ public abstract class AbstractTestHiveClient
 
             // verify all temp files start with the unique prefix
             stagingPathRoot = getStagingPathRoot(insertTableHandle);
-            Set<String> tempFiles = listAllDataFiles(stagingPathRoot);
+            HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
+            Set<String> tempFiles = listAllDataFiles(context, stagingPathRoot);
             assertTrue(!tempFiles.isEmpty());
             for (String filePath : tempFiles) {
                 assertTrue(new Path(filePath).getName().startsWith(getFilePrefix(insertTableHandle)));
@@ -2101,7 +2105,8 @@ public abstract class AbstractTestHiveClient
         }
 
         // verify temp directory is empty
-        assertTrue(listAllDataFiles(stagingPathRoot).isEmpty());
+        HdfsContext context = new HdfsContext(newSession(), tableName.getSchemaName(), tableName.getTableName());
+        assertTrue(listAllDataFiles(context, stagingPathRoot).isEmpty());
 
         // verify the data is unchanged
         try (Transaction transaction = newTransaction()) {
@@ -2150,9 +2155,10 @@ public abstract class AbstractTestHiveClient
     protected Set<String> listAllDataFiles(Transaction transaction, String schemaName, String tableName)
             throws IOException
     {
+        HdfsContext context = new HdfsContext(newSession(), schemaName, tableName);
         Set<String> existingFiles = new HashSet<>();
         for (String location : listAllDataPaths(transaction.getMetastore(schemaName), schemaName, tableName)) {
-            existingFiles.addAll(listAllDataFiles(new Path(location)));
+            existingFiles.addAll(listAllDataFiles(context, new Path(location)));
         }
         return existingFiles;
     }
@@ -2180,11 +2186,11 @@ public abstract class AbstractTestHiveClient
         return locations.build();
     }
 
-    protected Set<String> listAllDataFiles(Path path)
+    protected Set<String> listAllDataFiles(HdfsContext context, Path path)
             throws IOException
     {
         Set<String> result = new HashSet<>();
-        FileSystem fileSystem = hdfsEnvironment.getFileSystem("user", path);
+        FileSystem fileSystem = hdfsEnvironment.getFileSystem(context, path);
         if (fileSystem.exists(path)) {
             for (FileStatus fileStatus : fileSystem.listStatus(path)) {
                 if (fileStatus.getPath().getName().startsWith(".presto")) {
@@ -2194,7 +2200,7 @@ public abstract class AbstractTestHiveClient
                     result.add(fileStatus.getPath().toString());
                 }
                 else if (HadoopFileStatus.isDirectory(fileStatus)) {
-                    result.addAll(listAllDataFiles(fileStatus.getPath()));
+                    result.addAll(listAllDataFiles(context, fileStatus.getPath()));
                 }
             }
         }
@@ -2260,7 +2266,8 @@ public abstract class AbstractTestHiveClient
             assertEquals(listAllDataFiles(transaction, tableName.getSchemaName(), tableName.getTableName()), existingFiles);
 
             // verify all temp files start with the unique prefix
-            Set<String> tempFiles = listAllDataFiles(getStagingPathRoot(insertTableHandle));
+            HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
+            Set<String> tempFiles = listAllDataFiles(context, getStagingPathRoot(insertTableHandle));
             assertTrue(!tempFiles.isEmpty());
             for (String filePath : tempFiles) {
                 assertTrue(new Path(filePath).getName().startsWith(getFilePrefix(insertTableHandle)));
@@ -2284,7 +2291,8 @@ public abstract class AbstractTestHiveClient
             assertEquals(listAllDataFiles(transaction, tableName.getSchemaName(), tableName.getTableName()), existingFiles);
 
             // verify temp directory is empty
-            assertTrue(listAllDataFiles(stagingPathRoot).isEmpty());
+            HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
+            assertTrue(listAllDataFiles(context, stagingPathRoot).isEmpty());
         }
     }
 
@@ -2371,7 +2379,8 @@ public abstract class AbstractTestHiveClient
             assertEquals(listAllDataFiles(transaction, tableName.getSchemaName(), tableName.getTableName()), existingFiles);
 
             // verify all temp files start with the unique prefix
-            Set<String> tempFiles = listAllDataFiles(getStagingPathRoot(insertTableHandle));
+            HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
+            Set<String> tempFiles = listAllDataFiles(context, getStagingPathRoot(insertTableHandle));
             assertTrue(!tempFiles.isEmpty());
             for (String filePath : tempFiles) {
                 assertTrue(new Path(filePath).getName().startsWith(getFilePrefix(insertTableHandle)));
@@ -2395,7 +2404,8 @@ public abstract class AbstractTestHiveClient
             assertEquals(listAllDataFiles(transaction, tableName.getSchemaName(), tableName.getTableName()), existingFiles);
 
             // verify temp directory is empty
-            assertTrue(listAllDataFiles(stagingPathRoot).isEmpty());
+            HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
+            assertTrue(listAllDataFiles(context, stagingPathRoot).isEmpty());
         }
     }
 
@@ -2430,7 +2440,8 @@ public abstract class AbstractTestHiveClient
 
         // check that temporary files are removed
         if (!writePath.equals(targetPath)) {
-            FileSystem fileSystem = hdfsEnvironment.getFileSystem("user", writePath);
+            HdfsContext context = new HdfsContext(newSession(), tableName.getSchemaName(), tableName.getTableName());
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(context, writePath);
             assertFalse(fileSystem.exists(writePath));
         }
 
@@ -3112,15 +3123,15 @@ public abstract class AbstractTestHiveClient
             transaction.commit();
         }
 
-        ConnectorSession session = newSession();
-        List<String> targetDirectoryList = listDirectory(session.getUser(), targetPath);
+        HdfsContext context = new HdfsContext(newSession(), schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        List<String> targetDirectoryList = listDirectory(context, targetPath);
         assertEquals(targetDirectoryList, ImmutableList.of());
     }
 
-    private List<String> listDirectory(String user, Path path)
+    private List<String> listDirectory(HdfsContext context, Path path)
             throws IOException
     {
-        FileSystem fileSystem = hdfsEnvironment.getFileSystem(user, path);
+        FileSystem fileSystem = hdfsEnvironment.getFileSystem(context, path);
         return Arrays.stream(fileSystem.listStatus(path))
                 .map(FileStatus::getPath)
                 .map(Path::getName)
@@ -3304,7 +3315,8 @@ public abstract class AbstractTestHiveClient
 
         // check that temporary files are removed
         if (writePath != null && !writePath.equals(targetPath)) {
-            FileSystem fileSystem = hdfsEnvironment.getFileSystem("user", writePath);
+            HdfsContext context = new HdfsContext(newSession(), tableName.getSchemaName(), tableName.getTableName());
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(context, writePath);
             assertFalse(fileSystem.exists(writePath));
         }
 
@@ -3469,7 +3481,7 @@ public abstract class AbstractTestHiveClient
     protected class DirectoryRenameFailure
             implements ConflictTrigger
     {
-        private String user;
+        private HdfsContext context;
         private Path path;
 
         @Override
@@ -3482,23 +3494,23 @@ public abstract class AbstractTestHiveClient
                 throw new TestingRollbackException();
             }
             path = new Path(targetPath + "/pk1=b/pk2=add2");
-            user = session.getUser();
-            createDirectory(user, hdfsEnvironment, path);
+            context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
+            createDirectory(context, hdfsEnvironment, path);
         }
 
         @Override
         public void verifyAndCleanup(SchemaTableName tableName)
                 throws IOException
         {
-            assertEquals(listDirectory(user, path), ImmutableList.of());
-            hdfsEnvironment.getFileSystem(user, path).delete(path, false);
+            assertEquals(listDirectory(context, path), ImmutableList.of());
+            hdfsEnvironment.getFileSystem(context, path).delete(path, false);
         }
     }
 
     protected class FileRenameFailure
             implements ConflictTrigger
     {
-        private String user;
+        private HdfsContext context;
         private Path path;
 
         @Override
@@ -3513,8 +3525,8 @@ public abstract class AbstractTestHiveClient
             }
             assertNotNull(path);
 
-            user = session.getUser();
-            FileSystem fileSystem = hdfsEnvironment.getFileSystem(user, path);
+            context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(context, path);
             fileSystem.createNewFile(path);
         }
 
@@ -3524,7 +3536,7 @@ public abstract class AbstractTestHiveClient
         {
             // The file we added to trigger a conflict was cleaned up because it matches the query prefix.
             // Consider this the same as a network failure that caused the successful creation of file not reported to the caller.
-            assertEquals(hdfsEnvironment.getFileSystem(user, path).exists(path), false);
+            assertEquals(hdfsEnvironment.getFileSystem(context, path).exists(path), false);
         }
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.GroupByHashPageIndexerFactory;
 import com.facebook.presto.hive.AbstractTestHiveClient.HiveTransaction;
 import com.facebook.presto.hive.AbstractTestHiveClient.Transaction;
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.BridgingHiveMetastore;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
@@ -262,7 +263,7 @@ public abstract class AbstractTestHiveClientS3
         Path basePath = new Path("s3://presto-test-hive/");
         Path tablePath = new Path(basePath, "presto_test_s3");
         Path filePath = new Path(tablePath, "test1.csv");
-        FileSystem fs = hdfsEnvironment.getFileSystem("user", basePath);
+        FileSystem fs = hdfsEnvironment.getFileSystem(new HdfsContext("user"), basePath);
 
         assertTrue(isDirectory(fs.getFileStatus(basePath)));
         assertTrue(isDirectory(fs.getFileStatus(tablePath)));
@@ -275,7 +276,7 @@ public abstract class AbstractTestHiveClientS3
             throws Exception
     {
         Path basePath = new Path(format("s3://%s/rename/%s/", writableBucket, UUID.randomUUID()));
-        FileSystem fs = hdfsEnvironment.getFileSystem("user", basePath);
+        FileSystem fs = hdfsEnvironment.getFileSystem(new HdfsContext("user"), basePath);
         assertFalse(fs.exists(basePath));
 
         // create file foo.txt
@@ -500,7 +501,7 @@ public abstract class AbstractTestHiveClientS3
                 if (deleteData) {
                     for (String location : locations) {
                         Path path = new Path(location);
-                        hdfsEnvironment.getFileSystem("user", path).delete(path, true);
+                        hdfsEnvironment.getFileSystem(new HdfsContext("user"), path).delete(path, true);
                     }
                 }
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveWriteUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveWriteUtils.java
@@ -13,23 +13,27 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.hive.HiveTestUtils.createTestHdfsEnvironment;
 import static com.facebook.presto.hive.HiveWriteUtils.isS3FileSystem;
 import static com.facebook.presto.hive.HiveWriteUtils.isViewFileSystem;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestHiveWriteUtils
 {
+    private static final HdfsContext CONTEXT = new HdfsContext(SESSION, "test_schema");
+
     @Test
     public void testIsS3FileSystem()
     {
         HdfsEnvironment hdfsEnvironment = createTestHdfsEnvironment(new HiveClientConfig());
-        assertTrue(isS3FileSystem("user", hdfsEnvironment, new Path("s3://test-bucket/test-folder")));
-        assertFalse(isS3FileSystem("user", hdfsEnvironment, new Path("/test-dir/test-folder")));
+        assertTrue(isS3FileSystem(CONTEXT, hdfsEnvironment, new Path("s3://test-bucket/test-folder")));
+        assertFalse(isS3FileSystem(CONTEXT, hdfsEnvironment, new Path("/test-dir/test-folder")));
     }
 
     @Test
@@ -40,9 +44,9 @@ public class TestHiveWriteUtils
         Path nonViewfsPath = new Path("hdfs://localhost/test-dir/test-folder");
 
         // ViewFS check requires the mount point config
-        hdfsEnvironment.getConfiguration(viewfsPath).set("fs.viewfs.mounttable.ns-default.link./test-folder", "hdfs://localhost/app");
+        hdfsEnvironment.getConfiguration(CONTEXT, viewfsPath).set("fs.viewfs.mounttable.ns-default.link./test-folder", "hdfs://localhost/app");
 
-        assertTrue(isViewFileSystem("user", hdfsEnvironment, viewfsPath));
-        assertFalse(isViewFileSystem("user", hdfsEnvironment, nonViewfsPath));
+        assertTrue(isViewFileSystem(CONTEXT, hdfsEnvironment, viewfsPath));
+        assertFalse(isViewFileSystem(CONTEXT, hdfsEnvironment, nonViewfsPath));
     }
 }


### PR DESCRIPTION
Expose user, queryId, schema and table to HdfsEnvironment so file system
implementations can attribute usage to a query.