### PR TITLE
Fix bug in benchmark binary file spiller where pagebuilder is not reset between accumulating pages

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/spiller/BenchmarkBinaryFileSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/spiller/BenchmarkBinaryFileSpiller.java
@@ -142,6 +142,7 @@ public class BenchmarkBinaryFileSpiller
                     DOUBLE.writeDouble(pageBuilder.getBlockBuilder(4), lineItem.getExtendedPrice());
                 }
                 pages.add(pageBuilder.build());
+                pageBuilder.reset();
             }
 
             return pages.build();


### PR DESCRIPTION
The pagebuilder should be reset so it
doesn't accumulate pages during each loop.