### PR TITLE
Make TestMinWorkerRequirement single threaded

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMinWorkerRequirement.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMinWorkerRequirement.java
@@ -20,6 +20,8 @@ import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+// run single threaded to avoid creating multiple query runners at once
+@Test(singleThreaded = true)
 public class TestMinWorkerRequirement
 {
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Cluster is still initializing, there are insufficient active worker nodes \\(4\\) to run query")


### PR DESCRIPTION
This avoids creating multiple query runners at once.