### PR TITLE
Add yield signals to page processors

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/FilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FilterAndProjectOperator.java
@@ -89,7 +89,7 @@ public class FilterAndProjectOperator
         requireNonNull(page, "page is null");
         checkState(!currentOutput.hasNext(), "Page buffer is full");
 
-        currentOutput = processor.process(operatorContext.getSession().toConnectorSession(), page);
+        currentOutput = processor.process(operatorContext.getSession().toConnectorSession(), operatorContext.getDriverContext().getYieldSignal(), page);
         outputMemoryContext.setBytes(currentOutput.getRetainedSizeInBytes());
     }
 
@@ -99,7 +99,7 @@ public class FilterAndProjectOperator
         if (!currentOutput.hasNext()) {
             return null;
         }
-        return currentOutput.next();
+        return currentOutput.next().orElse(null);
     }
 
     public static class FilterAndProjectOperatorFactory

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
@@ -232,7 +232,7 @@ public class PageProcessor
 
                 // if possible, use previouslyComputedResults produced in prior optimistic failure attempt
                 PageProjection projection = projections.get(i);
-                if (previouslyComputedResults[i] != null && previouslyComputedResults[i].getPositionCount() > batchSize) {
+                if (previouslyComputedResults[i] != null && previouslyComputedResults[i].getPositionCount() >= batchSize) {
                     blocks[i] = previouslyComputedResults[i].getRegion(0, batchSize);
                 }
                 else {

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessorOutput.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessorOutput.java
@@ -16,21 +16,22 @@ package com.facebook.presto.operator.project;
 import com.facebook.presto.spi.Page;
 
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.function.LongSupplier;
 
 import static java.util.Collections.emptyIterator;
 import static java.util.Objects.requireNonNull;
 
 public class PageProcessorOutput
-        implements Iterator<Page>
+        implements Iterator<Optional<Page>>
 {
     public static final PageProcessorOutput EMPTY_PAGE_PROCESSOR_OUTPUT = new PageProcessorOutput(() -> 0, emptyIterator());
 
     private final LongSupplier retainedSizeInBytesSupplier;
-    private final Iterator<Page> pages;
+    private final Iterator<Optional<Page>> pages;
     private long retainedSizeInBytes;
 
-    public PageProcessorOutput(LongSupplier retainedSizeInBytesSupplier, Iterator<Page> pages)
+    public PageProcessorOutput(LongSupplier retainedSizeInBytesSupplier, Iterator<Optional<Page>> pages)
     {
         this.retainedSizeInBytesSupplier = requireNonNull(retainedSizeInBytesSupplier, "retainedSizeInBytesSupplier is null");
         this.pages = requireNonNull(pages, "pages is null");
@@ -51,7 +52,7 @@ public class PageProcessorOutput
     }
 
     @Override
-    public Page next()
+    public Optional<Page> next()
     {
         return pages.next();
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestColumnarPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestColumnarPageProcessor.java
@@ -48,7 +48,7 @@ public class TestColumnarPageProcessor
             throws Exception
     {
         Page page = createPage(types, false);
-        Page outputPage = getOnlyElement(processor.process(SESSION, page));
+        Page outputPage = getOnlyElement(processor.process(SESSION, new DriverYieldSignal(), page)).orElseThrow(() -> new AssertionError("page is not present"));
         assertPageEquals(types, outputPage, page);
     }
 
@@ -57,7 +57,7 @@ public class TestColumnarPageProcessor
             throws Exception
     {
         Page page = createPage(types, true);
-        Page outputPage = getOnlyElement(processor.process(SESSION, page));
+        Page outputPage = getOnlyElement(processor.process(SESSION, new DriverYieldSignal(), page)).orElseThrow(() -> new AssertionError("page is not present"));
         assertPageEquals(types, outputPage, page);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/index/TestTupleFilterProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/index/TestTupleFilterProcessor.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.index;
 
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.Type;
@@ -61,7 +62,7 @@ public class TestTupleFilterProcessor
                 outputTypes,
                 new PageFunctionCompiler(createTestMetadataManager(), 0));
         PageProcessor tupleFilterProcessor = filterFactory.createPageProcessor(tuplePage).get();
-        Page actualPage = getOnlyElement(tupleFilterProcessor.process(SESSION, inputPage));
+        Page actualPage = getOnlyElement(tupleFilterProcessor.process(SESSION, new DriverYieldSignal(), inputPage)).orElseThrow(() -> new AssertionError("page is not present"));
 
         Page expectedPage = Iterables.getOnlyElement(rowPagesBuilder(outputTypes)
                 .row("a", 1L, true, 0.1, 0.0)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayDistinct.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayDistinct.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.aggregation.TypedSet;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
@@ -80,10 +81,10 @@ public class BenchmarkArrayDistinct
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS * ARRAY_SIZE * NUM_TYPES)
-    public List<Page> arrayDistinct(BenchmarkData data)
+    public List<Optional<Page>> arrayDistinct(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
@@ -20,6 +20,7 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -93,10 +94,10 @@ public class BenchmarkArrayFilter
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS * ARRAY_SIZE * NUM_TYPES)
-    public List<Page> benchmark(BenchmarkData data)
+    public List<Optional<Page>> benchmark(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayHashCodeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayHashCodeOperator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -88,10 +89,10 @@ public class BenchmarkArrayHashCodeOperator
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS * ARRAY_SIZE * NUM_TYPES)
-    public List<Page> arrayHashCode(BenchmarkData data)
+    public List<Optional<Page>> arrayHashCode(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayJoin.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -67,10 +68,10 @@ public class BenchmarkArrayJoin
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS * ARRAY_SIZE)
-    public List<Page> benchmark(BenchmarkData data)
+    public List<Optional<Page>> benchmark(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySort.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySort.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -80,10 +81,10 @@ public class BenchmarkArraySort
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS * ARRAY_SIZE * NUM_TYPES)
-    public List<Page> arraySort(BenchmarkData data)
+    public List<Optional<Page>> arraySort(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySubscript.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySubscript.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.ArrayBlock;
@@ -78,10 +79,10 @@ public class BenchmarkArraySubscript
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS)
-    public List<Page> arraySubscript(BenchmarkData data)
+    public List<Optional<Page>> arraySubscript(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayTransform.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayTransform.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
@@ -84,7 +85,7 @@ public class BenchmarkArrayTransform
     @OperationsPerInvocation(POSITIONS * ARRAY_SIZE * NUM_TYPES)
     public Object benchmark(BenchmarkData data)
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToArrayCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToArrayCast.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -71,10 +72,10 @@ public class BenchmarkJsonToArrayCast
 
     @Benchmark
     @OperationsPerInvocation(POSITION_COUNT)
-    public List<Page> benchmark(BenchmarkData data)
+    public List<Optional<Page>> benchmark(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToMapCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToMapCast.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -71,10 +72,10 @@ public class BenchmarkJsonToMapCast
 
     @Benchmark
     @OperationsPerInvocation(POSITION_COUNT)
-    public List<Page> benchmark(BenchmarkData data)
+    public List<Optional<Page>> benchmark(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.ArrayBlock;
@@ -75,10 +76,10 @@ public class BenchmarkMapConcat
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS)
-    public List<Page> mapConcat(BenchmarkData data)
+    public List<Optional<Page>> mapConcat(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapSubscript.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapSubscript.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.ArrayBlock;
@@ -80,10 +81,10 @@ public class BenchmarkMapSubscript
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS)
-    public List<Page> mapSubscript(BenchmarkData data)
+    public List<Optional<Page>> mapSubscript(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformKey.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformKey.java
@@ -17,6 +17,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -80,10 +81,10 @@ public class BenchmarkTransformKey
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS * NUM_TYPES)
-    public List<Page> benchmark(BenchmarkData data)
+    public List<Optional<Page>> benchmark(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformValue.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformValue.java
@@ -17,6 +17,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -83,10 +84,10 @@ public class BenchmarkTransformValue
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS * NUM_TYPES)
-    public List<Page> benchmark(BenchmarkData data)
+    public List<Optional<Page>> benchmark(BenchmarkData data)
             throws Throwable
     {
-        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
 
     @SuppressWarnings("FieldMayBeFinal")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -20,6 +20,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.SqlFunction;
 import com.facebook.presto.operator.DriverContext;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.FilterAndProjectOperator.FilterAndProjectOperatorFactory;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.operator.OperatorFactory;
@@ -309,7 +310,7 @@ public final class FunctionAssertions
         long maxRetainedSize = 0;
         int maxIterationCount = 0;
         for (int iterationCount = 0; iterationCount < Math.max(1000, maxIterationCount * 4); iterationCount++) {
-            PageProcessorOutput output = processor.process(session.toConnectorSession(), SOURCE_PAGE);
+            PageProcessorOutput output = processor.process(session.toConnectorSession(), new DriverYieldSignal(), SOURCE_PAGE);
             // consume the iterator
             Iterators.getOnlyElement(output);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.DictionaryBlock;
@@ -98,7 +99,7 @@ public class TestPageProcessorCompiler
 
         Slice varcharValue = Slices.utf8Slice("hello");
         Page page = new Page(RunLengthEncodedBlock.create(BIGINT, 123L, 100), RunLengthEncodedBlock.create(VARCHAR, varcharValue, 100));
-        Page outputPage = getOnlyElement(processor.process(null, page));
+        Page outputPage = getOnlyElement(processor.process(null, new DriverYieldSignal(), page)).orElseThrow(() -> new AssertionError("page is not present"));
 
         assertEquals(outputPage.getPositionCount(), 100);
         assertTrue(outputPage.getBlock(0) instanceof RunLengthEncodedBlock);
@@ -123,7 +124,7 @@ public class TestPageProcessorCompiler
         PageProcessor processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field(0, VARCHAR))).get();
 
         Page page = new Page(createDictionaryBlock(createExpectedValues(10), 100));
-        Page outputPage = getOnlyElement(processor.process(null, page));
+        Page outputPage = getOnlyElement(processor.process(null, new DriverYieldSignal(), page)).orElseThrow(() -> new AssertionError("page is not present"));
 
         assertEquals(outputPage.getPositionCount(), 100);
         assertTrue(outputPage.getBlock(0) instanceof DictionaryBlock);
@@ -132,7 +133,7 @@ public class TestPageProcessorCompiler
         assertEquals(dictionaryBlock.getDictionary().getPositionCount(), 10);
 
         // test filter caching
-        Page outputPage2 = getOnlyElement(processor.process(null, page));
+        Page outputPage2 = getOnlyElement(processor.process(null, new DriverYieldSignal(), page)).orElseThrow(() -> new AssertionError("page is not present"));
         assertEquals(outputPage2.getPositionCount(), 100);
         assertTrue(outputPage2.getBlock(0) instanceof DictionaryBlock);
 
@@ -151,7 +152,7 @@ public class TestPageProcessorCompiler
         PageProcessor processor = compiler.compilePageProcessor(Optional.of(filter), ImmutableList.of(field(0, BIGINT))).get();
 
         Page page = new Page(createRLEBlock(5L, 100));
-        Page outputPage = getOnlyElement(processor.process(null, page));
+        Page outputPage = getOnlyElement(processor.process(null, new DriverYieldSignal(), page)).orElseThrow(() -> new AssertionError("page is not present"));
 
         assertEquals(outputPage.getPositionCount(), 100);
         assertTrue(outputPage.getBlock(0) instanceof RunLengthEncodedBlock);
@@ -167,7 +168,7 @@ public class TestPageProcessorCompiler
         PageProcessor processor = compiler.compilePageProcessor(Optional.empty(), ImmutableList.of(field(0, VARCHAR))).get();
 
         Page page = new Page(createDictionaryBlock(createExpectedValues(10), 100));
-        Page outputPage = getOnlyElement(processor.process(null, page));
+        Page outputPage = getOnlyElement(processor.process(null, new DriverYieldSignal(), page)).orElseThrow(() -> new AssertionError("page is not present"));
 
         assertEquals(outputPage.getPositionCount(), 100);
         assertTrue(outputPage.getBlock(0) instanceof DictionaryBlock);
@@ -191,7 +192,7 @@ public class TestPageProcessorCompiler
         assertFalse(new DeterminismEvaluator(metadataManager.getFunctionRegistry()).isDeterministic(lessThanRandomExpression));
 
         Page page = new Page(createLongDictionaryBlock(1, 100));
-        Page outputPage = getOnlyElement(processor.process(null, page));
+        Page outputPage = getOnlyElement(processor.process(null, new DriverYieldSignal(), page)).orElseThrow(() -> new AssertionError("page is not present"));
         assertFalse(outputPage.getBlock(0) instanceof DictionaryBlock);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.gen;
 
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
@@ -95,9 +96,9 @@ public class BenchmarkPageProcessor
     }
 
     @Benchmark
-    public List<Page> compiled()
+    public List<Optional<Page>> compiled()
     {
-        return ImmutableList.copyOf(compiledProcessor.process(null, inputPage));
+        return ImmutableList.copyOf(compiledProcessor.process(null, new DriverYieldSignal(), inputPage));
     }
 
     public static void main(String[] args)

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/InCodeGeneratorBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/InCodeGeneratorBenchmark.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.gen;
 
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
@@ -135,9 +136,9 @@ public class InCodeGeneratorBenchmark
     }
 
     @Benchmark
-    public List<Page> benchmark()
+    public List<Optional<Page>> benchmark()
     {
-        return ImmutableList.copyOf(processor.process(SESSION, inputPage));
+        return ImmutableList.copyOf(processor.process(SESSION, new DriverYieldSignal(), inputPage));
     }
 
     public static void main(String[] args)

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
@@ -135,9 +135,9 @@ public class PageProcessorBenchmark
     }
 
     @Benchmark
-    public List<Page> columnOriented()
+    public List<Optional<Page>> columnOriented()
     {
-        return ImmutableList.copyOf(pageProcessor.process(null, inputPage));
+        return ImmutableList.copyOf(pageProcessor.process(null, new DriverYieldSignal(), inputPage));
     }
 
     private RowExpression getFilter(Type type)

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
@@ -16,6 +16,7 @@ package com.facebook.presto.type;
 import com.facebook.presto.RowPagesBuilder;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.BigintType;
@@ -533,7 +534,7 @@ public class BenchmarkDecimalOperators
 
     private Object execute(BaseState state)
     {
-        return ImmutableList.copyOf(state.getProcessor().process(SESSION, state.getInputPage()));
+        return ImmutableList.copyOf(state.getProcessor().process(SESSION, new DriverYieldSignal(), state.getInputPage()));
     }
 
     private static class BaseState


### PR DESCRIPTION
Wire yield signals into the iterator created by page processors. During
the computation of the next page, it may pause and return null pages.
The computation will continue when the iterator is called again. The
yield is at column processing granularity.


**Further splitting the PR into two (together with https://github.com/prestodb/presto/pull/8726) given that one would be rather complicated; let's move one step a time.**