### PR TITLE
Add Property node to treat property keys as identifiers 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateSchemaTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateSchemaTask.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.metadata.MetadataUtil.createCatalogSchemaName;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.SCHEMA_ALREADY_EXISTS;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 
@@ -72,7 +73,7 @@ public class CreateSchemaTask
         Map<String, Object> properties = metadata.getSchemaPropertyManager().getProperties(
                 connectorId,
                 schema.getCatalogName(),
-                statement.getProperties(),
+                mapFromProperties(statement.getProperties()),
                 session,
                 metadata,
                 parameters);

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -49,6 +49,7 @@ import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.DUPLICATE_COLUMN_NAME;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
@@ -152,15 +153,16 @@ public class CreateTableTask
         ConnectorId connectorId = metadata.getCatalogHandle(session, tableName.getCatalogName())
                 .orElseThrow(() -> new PrestoException(NOT_FOUND, "Catalog does not exist: " + tableName.getCatalogName()));
 
+        Map<String, Expression> sqlProperties = mapFromProperties(statement.getProperties());
         Map<String, Object> properties = metadata.getTablePropertyManager().getProperties(
                 connectorId,
                 tableName.getCatalogName(),
-                statement.getProperties(),
+                sqlProperties,
                 session,
                 metadata,
                 parameters);
 
-        Map<String, Object> finalProperties = combineProperties(statement.getProperties().keySet(), properties, inheritedProperties);
+        Map<String, Object> finalProperties = combineProperties(sqlProperties.keySet(), properties, inheritedProperties);
 
         ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName.asSchemaTableName(), ImmutableList.copyOf(columns.values()), finalProperties, statement.getComment());
         try {

--- a/presto-main/src/main/java/com/facebook/presto/sql/NodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/NodeUtils.java
@@ -13,12 +13,17 @@
  */
 package com.facebook.presto.sql;
 
+import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.OrderBy;
+import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.sql.tree.SortItem;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 public class NodeUtils
 {
@@ -27,5 +32,12 @@ public class NodeUtils
     public static List<SortItem> getSortItemsFromOrderBy(Optional<OrderBy> orderBy)
     {
         return orderBy.map(OrderBy::getSortItems).orElse(ImmutableList.of());
+    }
+
+    public static Map<String, Expression> mapFromProperties(List<Property> properties)
+    {
+        return properties.stream().collect(toImmutableMap(
+                property -> property.getName().getValue(),
+                Property::getValue));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/SemanticErrorCode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/SemanticErrorCode.java
@@ -90,4 +90,6 @@ public enum SemanticErrorCode
     INVALID_PARAMETER_USAGE,
 
     STANDALONE_LAMBDA,
+
+    DUPLICATE_PROPERTY,
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -54,6 +54,7 @@ import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.OrderBy;
+import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Relation;
@@ -487,11 +488,15 @@ final class ShowQueriesRewrite
                     sqlProperties.put(propertyName, sqlExpression);
                 }
 
+                List<Property> propertyNodes = sqlProperties.build().entrySet().stream()
+                        .map(entry -> new Property(new Identifier(entry.getKey()), entry.getValue()))
+                        .collect(toImmutableList());
+
                 CreateTable createTable = new CreateTable(
                         QualifiedName.of(objectName.getCatalogName(), objectName.getSchemaName(), objectName.getObjectName()),
                         columns,
                         false,
-                        sqlProperties.build(),
+                        propertyNodes,
                         connectorTableMetadata.getComment());
                 return singleValueQuery("Create Table", formatSql(createTable, Optional.of(parameters)).trim());
             }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCreateTableTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCreateTableTask.java
@@ -35,7 +35,6 @@ import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -94,7 +93,7 @@ public class TestCreateTableTask
         CreateTable statement = new CreateTable(QualifiedName.of("test_table"),
                 ImmutableList.of(new ColumnDefinition(identifier("a"), "BIGINT", Optional.empty())),
                 true,
-                ImmutableMap.of(),
+                ImmutableList.of(),
                 Optional.empty());
 
         getFutureValue(new CreateTableTask().internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, emptyList()));
@@ -108,7 +107,7 @@ public class TestCreateTableTask
         CreateTable statement = new CreateTable(QualifiedName.of("test_table"),
                 ImmutableList.of(new ColumnDefinition(identifier("a"), "BIGINT", Optional.empty())),
                 false,
-                ImmutableMap.of(),
+                ImmutableList.of(),
                 Optional.empty());
 
         try {

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -70,6 +70,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.CATALOG_NOT_SPE
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.COLUMN_NAME_NOT_SPECIFIED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.COLUMN_TYPE_UNKNOWN;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.DUPLICATE_COLUMN_NAME;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.DUPLICATE_PROPERTY;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.DUPLICATE_RELATION;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_LITERAL;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_ORDINAL;
@@ -1074,20 +1075,32 @@ public class TestAnalyzer
         assertFails(DUPLICATE_COLUMN_NAME, 1, 24, "CREATE TABLE test(abc, AbC) AS SELECT 1, 2");
         assertFails(COLUMN_TYPE_UNKNOWN, 1, 1, "CREATE TABLE test(x) AS SELECT null");
         assertFails(MISSING_ATTRIBUTE, ".*Column 'y' cannot be resolved", "CREATE TABLE test(x) WITH (p1 = y) AS SELECT null");
+        assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE TABLE test(x) WITH (p1 = 'p1', p2 = 'p2', p1 = 'p3') AS SELECT null");
+        assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE TABLE test(x) WITH (p1 = 'p1', \"p1\" = 'p2') AS SELECT null");
     }
 
     @Test
     public void testCreateTable()
             throws Exception
     {
+        analyze("CREATE TABLE test (id bigint)");
+        analyze("CREATE TABLE test (id bigint) WITH (p1 = 'p1')");
+
         assertFails(MISSING_ATTRIBUTE, ".*Column 'y' cannot be resolved", "CREATE TABLE test (x bigint) WITH (p1 = y)");
+        assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE TABLE test (id bigint) WITH (p1 = 'p1', p2 = 'p2', p1 = 'p3')");
+        assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE TABLE test (id bigint) WITH (p1 = 'p1', \"p1\" = 'p2')");
     }
 
     @Test
     public void testCreateSchema()
             throws Exception
     {
+        analyze("CREATE SCHEMA test");
+        analyze("CREATE SCHEMA test WITH (p1 = 'p1')");
+
         assertFails(MISSING_ATTRIBUTE, ".*Column 'y' cannot be resolved", "CREATE SCHEMA test WITH (p1 = y)");
+        assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE SCHEMA test WITH (p1 = 'p1', p2 = 'p2', p1 = 'p3')");
+        assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE SCHEMA test WITH (p1 = 'p1', \"p1\" = 'p2')");
     }
 
     @Test

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.sql.parser;
 
-import com.facebook.presto.sql.parser.SqlBaseParser.PropertiesContext;
-import com.facebook.presto.sql.parser.SqlBaseParser.PropertyContext;
 import com.facebook.presto.sql.tree.AddColumn;
 import com.facebook.presto.sql.tree.AliasedRelation;
 import com.facebook.presto.sql.tree.AllColumns;
@@ -99,6 +97,7 @@ import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Prepare;
+import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.facebook.presto.sql.tree.Query;
@@ -155,7 +154,6 @@ import com.facebook.presto.sql.tree.WindowFrame;
 import com.facebook.presto.sql.tree.With;
 import com.facebook.presto.sql.tree.WithQuery;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -164,7 +162,6 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -205,11 +202,16 @@ class AstBuilder
     @Override
     public Node visitCreateSchema(SqlBaseParser.CreateSchemaContext context)
     {
+        List<Property> properties = ImmutableList.of();
+        if (context.properties() != null) {
+            properties = visit(context.properties().property(), Property.class);
+        }
+
         return new CreateSchema(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 context.EXISTS() != null,
-                processProperties(context.properties()));
+                properties);
     }
 
     @Override
@@ -244,12 +246,17 @@ class AstBuilder
             columnAliases = Optional.of(visit(context.columnAliases().identifier(), Identifier.class));
         }
 
+        List<Property> properties = ImmutableList.of();
+        if (context.properties() != null) {
+            properties = visit(context.properties().property(), Property.class);
+        }
+
         return new CreateTableAsSelect(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 (Query) visit(context.query()),
                 context.EXISTS() != null,
-                processProperties(context.properties()),
+                properties,
                 context.NO() == null,
                 columnAliases,
                 comment);
@@ -262,24 +269,17 @@ class AstBuilder
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
         }
+        List<Property> properties = ImmutableList.of();
+        if (context.properties() != null) {
+            properties = visit(context.properties().property(), Property.class);
+        }
         return new CreateTable(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 visit(context.tableElement(), TableElement.class),
                 context.EXISTS() != null,
-                processProperties(context.properties()),
+                properties,
                 comment);
-    }
-
-    private Map<String, Expression> processProperties(PropertiesContext propertiesContext)
-    {
-        ImmutableMap.Builder<String, Expression> properties = ImmutableMap.builder();
-        if (propertiesContext != null) {
-            for (PropertyContext propertyContext : propertiesContext.property()) {
-                properties.put(propertyContext.identifier().getText(), (Expression) visit(propertyContext.expression()));
-            }
-        }
-        return properties.build();
     }
 
     @Override
@@ -464,6 +464,12 @@ class AstBuilder
         return new DescribeInput(
                 getLocation(context),
                 (Identifier) visit(context.identifier()));
+    }
+
+    @Override
+    public Node visitProperty(SqlBaseParser.PropertyContext context)
+    {
+        return new Property(getLocation(context), (Identifier) visit(context.identifier()), (Expression) visit(context.expression()));
     }
 
     // ********************** query expressions ********************

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -542,6 +542,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitProperty(Property node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitDropTable(DropTable node, C context)
     {
         return visitStatement(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateSchema.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateSchema.java
@@ -14,10 +14,8 @@
 package com.facebook.presto.sql.tree;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -29,24 +27,24 @@ public class CreateSchema
 {
     private final QualifiedName schemaName;
     private final boolean notExists;
-    private final Map<String, Expression> properties;
+    private final List<Property> properties;
 
-    public CreateSchema(QualifiedName schemaName, boolean notExists, Map<String, Expression> properties)
+    public CreateSchema(QualifiedName schemaName, boolean notExists, List<Property> properties)
     {
         this(Optional.empty(), schemaName, notExists, properties);
     }
 
-    public CreateSchema(NodeLocation location, QualifiedName schemaName, boolean notExists, Map<String, Expression> properties)
+    public CreateSchema(NodeLocation location, QualifiedName schemaName, boolean notExists, List<Property> properties)
     {
         this(Optional.of(location), schemaName, notExists, properties);
     }
 
-    private CreateSchema(Optional<NodeLocation> location, QualifiedName schemaName, boolean notExists, Map<String, Expression> properties)
+    private CreateSchema(Optional<NodeLocation> location, QualifiedName schemaName, boolean notExists, List<Property> properties)
     {
         super(location);
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.notExists = notExists;
-        this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
+        this.properties = ImmutableList.copyOf(requireNonNull(properties, "properties is null"));
     }
 
     public QualifiedName getSchemaName()
@@ -59,7 +57,7 @@ public class CreateSchema
         return notExists;
     }
 
-    public Map<String, Expression> getProperties()
+    public List<Property> getProperties()
     {
         return properties;
     }
@@ -71,11 +69,9 @@ public class CreateSchema
     }
 
     @Override
-    public List<Node> getChildren()
+    public List<Property> getChildren()
     {
-        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
-        nodes.addAll(properties.values());
-        return nodes.build();
+        return properties;
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
@@ -14,10 +14,8 @@
 package com.facebook.presto.sql.tree;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -30,26 +28,26 @@ public class CreateTable
     private final QualifiedName name;
     private final List<TableElement> elements;
     private final boolean notExists;
-    private final Map<String, Expression> properties;
+    private final List<Property> properties;
     private final Optional<String> comment;
 
-    public CreateTable(QualifiedName name, List<TableElement> elements, boolean notExists, Map<String, Expression> properties, Optional<String> comment)
+    public CreateTable(QualifiedName name, List<TableElement> elements, boolean notExists, List<Property> properties, Optional<String> comment)
     {
         this(Optional.empty(), name, elements, notExists, properties, comment);
     }
 
-    public CreateTable(NodeLocation location, QualifiedName name, List<TableElement> elements, boolean notExists, Map<String, Expression> properties, Optional<String> comment)
+    public CreateTable(NodeLocation location, QualifiedName name, List<TableElement> elements, boolean notExists, List<Property> properties, Optional<String> comment)
     {
         this(Optional.of(location), name, elements, notExists, properties, comment);
     }
 
-    private CreateTable(Optional<NodeLocation> location, QualifiedName name, List<TableElement> elements, boolean notExists, Map<String, Expression> properties, Optional<String> comment)
+    private CreateTable(Optional<NodeLocation> location, QualifiedName name, List<TableElement> elements, boolean notExists, List<Property> properties, Optional<String> comment)
     {
         super(location);
         this.name = requireNonNull(name, "table is null");
         this.elements = ImmutableList.copyOf(requireNonNull(elements, "elements is null"));
         this.notExists = notExists;
-        this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
+        this.properties = requireNonNull(properties, "properties is null");
         this.comment = requireNonNull(comment, "comment is null");
     }
 
@@ -68,7 +66,7 @@ public class CreateTable
         return notExists;
     }
 
-    public Map<String, Expression> getProperties()
+    public List<Property> getProperties()
     {
         return properties;
     }
@@ -89,7 +87,7 @@ public class CreateTable
     {
         return ImmutableList.<Node>builder()
                 .addAll(elements)
-                .addAll(properties.values())
+                .addAll(properties)
                 .build();
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
@@ -14,10 +14,8 @@
 package com.facebook.presto.sql.tree;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -30,28 +28,28 @@ public class CreateTableAsSelect
     private final QualifiedName name;
     private final Query query;
     private final boolean notExists;
-    private final Map<String, Expression> properties;
+    private final List<Property> properties;
     private final boolean withData;
     private final Optional<List<Identifier>> columnAliases;
     private final Optional<String> comment;
 
-    public CreateTableAsSelect(QualifiedName name, Query query, boolean notExists, Map<String, Expression> properties, boolean withData, Optional<List<Identifier>> columnAliases, Optional<String> comment)
+    public CreateTableAsSelect(QualifiedName name, Query query, boolean notExists, List<Property> properties, boolean withData, Optional<List<Identifier>> columnAliases, Optional<String> comment)
     {
         this(Optional.empty(), name, query, notExists, properties, withData, columnAliases, comment);
     }
 
-    public CreateTableAsSelect(NodeLocation location, QualifiedName name, Query query, boolean notExists, Map<String, Expression> properties, boolean withData, Optional<List<Identifier>> columnAliases, Optional<String> comment)
+    public CreateTableAsSelect(NodeLocation location, QualifiedName name, Query query, boolean notExists, List<Property> properties, boolean withData, Optional<List<Identifier>> columnAliases, Optional<String> comment)
     {
         this(Optional.of(location), name, query, notExists, properties, withData, columnAliases, comment);
     }
 
-    private CreateTableAsSelect(Optional<NodeLocation> location, QualifiedName name, Query query, boolean notExists, Map<String, Expression> properties, boolean withData, Optional<List<Identifier>> columnAliases, Optional<String> comment)
+    private CreateTableAsSelect(Optional<NodeLocation> location, QualifiedName name, Query query, boolean notExists, List<Property> properties, boolean withData, Optional<List<Identifier>> columnAliases, Optional<String> comment)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
         this.query = requireNonNull(query, "query is null");
         this.notExists = notExists;
-        this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
+        this.properties = ImmutableList.copyOf(requireNonNull(properties, "properties is null"));
         this.withData = withData;
         this.columnAliases = columnAliases;
         this.comment = requireNonNull(comment, "comment is null");
@@ -72,7 +70,7 @@ public class CreateTableAsSelect
         return notExists;
     }
 
-    public Map<String, Expression> getProperties()
+    public List<Property> getProperties()
     {
         return properties;
     }
@@ -101,10 +99,10 @@ public class CreateTableAsSelect
     @Override
     public List<Node> getChildren()
     {
-        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
-        nodes.add(query);
-        nodes.addAll(properties.values());
-        return nodes.build();
+        return ImmutableList.<Node>builder()
+                .add(query)
+                .addAll(properties)
+                .build();
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.sql.tree;
 
-import java.util.Map.Entry;
 import java.util.Set;
 
 public abstract class DefaultTraversalVisitor<R, C>
@@ -512,7 +511,18 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitCreateTableAsSelect(CreateTableAsSelect node, C context)
     {
         process(node.getQuery(), context);
-        node.getProperties().values().forEach(expression -> process(expression, context));
+        for (Property property : node.getProperties()) {
+            process(property, context);
+        }
+
+        return null;
+    }
+
+    @Override
+    protected R visitProperty(Property node, C context)
+    {
+        process(node.getName(), context);
+        process(node.getValue(), context);
 
         return null;
     }
@@ -547,8 +557,8 @@ public abstract class DefaultTraversalVisitor<R, C>
         for (TableElement tableElement : node.getElements()) {
             process(tableElement, context);
         }
-        for (Entry<String, Expression> entry : node.getProperties().entrySet()) {
-            process(entry.getValue(), context);
+        for (Property property : node.getProperties()) {
+            process(property, context);
         }
 
         return null;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Property.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Property.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class Property
+        extends Node
+{
+    private final Identifier name;
+    private final Expression value;
+
+    public Property(Identifier name, Expression value)
+    {
+        this(Optional.empty(), name, value);
+    }
+
+    public Property(NodeLocation location, Identifier name, Expression value)
+    {
+        this(Optional.of(location), name, value);
+    }
+
+    private Property(Optional<NodeLocation> location, Identifier name, Expression value)
+    {
+        super(location);
+        this.name = requireNonNull(name, "name is null");
+        this.value = requireNonNull(value, "value is null");
+    }
+
+    public Identifier getName()
+    {
+        return name;
+    }
+
+    public Expression getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitProperty(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of(name, value);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Property other = (Property) obj;
+        return Objects.equals(name, other.name) &&
+                Objects.equals(value, other.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, value);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("value", value)
+                .toString();
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryRewriter.java
@@ -32,7 +32,6 @@ import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.Table;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.TimeLimiter;
@@ -128,7 +127,7 @@ public class QueryRewriter
             throws SQLException, QueryRewriteException
     {
         QualifiedName temporaryTableName = generateTemporaryTableName(statement.getTarget());
-        Statement createTemporaryTable = new CreateTable(temporaryTableName, ImmutableList.of(new LikeClause(statement.getTarget(), Optional.of(INCLUDING))), true, ImmutableMap.of(), Optional.empty());
+        Statement createTemporaryTable = new CreateTable(temporaryTableName, ImmutableList.of(new LikeClause(statement.getTarget(), Optional.of(INCLUDING))), true, ImmutableList.of(), Optional.empty());
         String createTemporaryTableSql = formatSql(createTemporaryTable, Optional.empty());
         String insertSql = formatSql(new Insert(temporaryTableName, statement.getColumns(), statement.getQuery()), Optional.empty());
         String checksumSql = checksumSql(getColumnsForTable(connection, query.getCatalog(), query.getSchema(), statement.getTarget().toString()), temporaryTableName);


### PR DESCRIPTION
Table/Schema properties were represented as String-to-Expression map,
which cannot handle delimited identifiers correctly as quotes are
treated as part of the property name.
Create SQL tree node Property to replace the maps used in CreateSchema,
 CreateTable, and CreateTableAsSelect.