### PR TITLE
Fix the way max query runtime is enforced

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -549,8 +549,8 @@ public class SqlQueryManager
                 continue;
             }
             Duration queryMaxRunTime = SystemSessionProperties.getQueryMaxRunTime(query.getSession());
-            DateTime executionStartTime = query.getQueryInfo().getQueryStats().getCreateTime();
-            if (executionStartTime.plus(queryMaxRunTime.toMillis()).isBeforeNow()) {
+            DateTime executionStartTime = query.getQueryInfo().getQueryStats().getExecutionStartTime();
+            if (executionStartTime != null && executionStartTime.plus(queryMaxRunTime.toMillis()).isBeforeNow()) {
                 query.fail(new PrestoException(EXCEEDED_TIME_LIMIT, "Query exceeded maximum time limit of " + queryMaxRunTime));
             }
         }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution.resourceGroups.db;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
 import com.facebook.presto.resourceGroups.db.DbResourceGroupConfigurationManager;
@@ -27,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_RUN_TIME;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
@@ -42,7 +44,10 @@ import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getSele
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.rejectingSession;
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.waitForCompleteQueryCount;
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.waitForRunningQueryCount;
+import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.testing.Assertions.assertContains;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 
@@ -205,6 +210,34 @@ public class TestQueues
         dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, null, null, null, null, null, null, "3s", 3L);
         QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
+    }
+
+    @Test(timeOut = 60_000)
+    public void testQueryRuntimeLimit()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("sf100000")
+                .setSource("dashboard")
+                .setSystemProperty(QUERY_MAX_RUN_TIME, "1ms")
+                .build();
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+        QueryId query = createQuery(queryRunner, session, LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, query, FAILED);
+        assertEquals(queryManager.getQueryInfo(query).getErrorCode(), EXCEEDED_TIME_LIMIT.toErrorCode());
+        assertContains(queryManager.getQueryInfo(query).getFailureInfo().getMessage(), "Query exceeded maximum time limit of 1.00ms");
+        // set max running queries to 0 for the dashboard resource group so that new queries get queued immediately
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 0, null, null, null, null, null, null, null, 3L);
+        dbConfigurationManager.load();
+        QueryId secondQuery = createQuery(queryRunner, session, LONG_LASTING_QUERY);
+        //this query should immediately get queued
+        waitForQueryState(queryRunner, secondQuery, QUEUED);
+        // after a 5s wait this query should still be QUEUED, not FAILED as the max runtime should be enforced after the query starts running
+        Thread.sleep(5_000);
+        assertEquals(queryManager.getQueryInfo(secondQuery).getState(), QUEUED);
     }
 
     @Test(timeOut = 60_000)


### PR DESCRIPTION
Previously this limit was enforced starting from the query creation time,
which would cause the queueing time to be included in the query runtime
calculation. With this change the limit is enforced starting from the
query execution time.

Fixes #8780.