### PR TITLE
Introduce Rule.Result

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -154,7 +154,9 @@ public class IterativeOptimizer
         long duration;
         try {
             long start = System.nanoTime();
-            transformed = rule.apply(match.value(), match.captures(), context);
+            Result result = new Result();
+            rule.apply(match.value(), match.captures(), context, result);
+            transformed = result.getTransformed();
             duration = System.nanoTime() - start;
         }
         catch (RuntimeException e) {
@@ -255,6 +257,23 @@ public class IterativeOptimizer
         public Session getSession()
         {
             return session;
+        }
+    }
+
+    private static class Result
+            implements Rule.Result
+    {
+        private Optional<PlanNode> transformed = Optional.empty();
+
+        @Override
+        public Rule.Result transformTo(PlanNode planNode)
+        {
+            return this;
+        }
+
+        private Optional<PlanNode> getTransformed()
+        {
+            return transformed;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
@@ -34,7 +34,18 @@ public interface Rule<T>
         return true;
     }
 
-    Optional<PlanNode> apply(T node, Captures captures, Context context);
+    @Deprecated
+    default Optional<PlanNode> apply(T node, Captures captures, Context context)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    // TODO remove default implementaiton once deprecated apply method got removed
+    default void apply(T node, Captures captures, Context context, Result result)
+    {
+        apply(node, captures, context)
+                .ifPresent(transformed -> result.transformTo(transformed));
+    }
 
     interface Context
     {
@@ -45,5 +56,10 @@ public interface Rule<T>
         SymbolAllocator getSymbolAllocator();
 
         Session getSession();
+    }
+
+    interface Result
+    {
+        Result transformTo(PlanNode planNode);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -30,12 +30,10 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.Closeable;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static java.util.Optional.empty;
 import static java.util.stream.Collectors.toSet;
 
 public class RuleTester
@@ -113,17 +111,14 @@ public class RuleTester
         }
 
         @Override
-        public Optional<PlanNode> apply(PlanNode node, Captures captures, Context context)
+        public void apply(PlanNode node, Captures captures, Context context, Result result)
         {
             PlanNodeMatcher planNodeMatcher = new PlanNodeMatcher(context.getLookup());
             Set<Rule> matching = ruleSet.rules().stream()
                     .filter(rule -> matches(rule.getPattern(), node, planNodeMatcher))
                     .collect(toSet());
-            if (matching.size() == 0) {
-                return empty();
-            }
 
-            return getOnlyElement(matching).apply(node, captures, context);
+            getOnlyElement(matching).apply(node, captures, context, result);
         }
 
         private boolean matches(Pattern pattern, PlanNode node, PlanNodeMatcher planNodeMatcher)


### PR DESCRIPTION
Introduce Rule.Result

This is going to make Rule interface to be more flexible:
 - rule could be easy extended to be able to produce mulitple equivalent
 transformation
 - rule could be easy extended to be able to produce node traits
 - optimizer will be able to provide its own Rule.Result implementation
 - rule can produce results on the fly
