### PR TITLE
Add encryption to spilling to disk for aggregation

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -335,6 +335,12 @@
             <artifactId>jaxrs-testing</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk16</artifactId>
+            <version>1.46</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/AES256Encryptor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/AES256Encryptor.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import com.facebook.presto.spi.PrestoException;
+
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.modes.CBCBlockCipher;
+import org.bouncycastle.crypto.paddings.PKCS7Padding;
+import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+
+public class AES256Encryptor
+        implements Encryptor
+{
+    private static final String ENCRYPTION_ALGORITHM = "AES";
+    private static final int KEY_SIZE = 256;
+
+    private final PaddedBufferedBlockCipher pbbc;
+    private final KeyParameter key;
+    private final int blockSize;
+
+    public AES256Encryptor()
+    {
+        this.pbbc = new PaddedBufferedBlockCipher(new CBCBlockCipher(new AESEngine()), new PKCS7Padding());
+        this.key = new KeyParameter(getKey());
+        this.blockSize = pbbc.getBlockSize();
+    }
+
+    public byte[] encrypt(byte[] data)
+    {
+        try {
+            return cipherData(data, true);
+        }
+        catch (Exception e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Exception thrown while encrypting a spill page", e);
+        }
+    }
+
+    public byte[] decrypt(byte[] data)
+    {
+        try {
+            return cipherData(data, false);
+        }
+        catch (Exception e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Exception thrown while decrypting a spill page", e);
+        }
+    }
+
+    private byte[] cipherData(byte[] data, boolean encrypt) throws Exception
+    {
+        int inputOffset = 0;
+        int inputLength = data.length;
+        int outputOffset = 0;
+
+        byte[] iv = new byte[blockSize];
+        if (encrypt) {
+            SecureRandom random = new SecureRandom();
+            random.nextBytes(iv);
+            outputOffset += blockSize;
+        }
+        else {
+            System.arraycopy(data, 0, iv, 0, blockSize);
+            inputOffset += blockSize;
+            inputLength -= blockSize;
+        }
+
+        pbbc.init(encrypt, new ParametersWithIV(key, iv));
+        byte[] output = new byte[pbbc.getOutputSize(inputLength) + outputOffset];
+
+        if (encrypt) {
+            System.arraycopy(iv, 0, output, 0, blockSize);
+        }
+
+        int outputLength = outputOffset + pbbc.processBytes(data, inputOffset, inputLength, output, outputOffset);
+        outputLength += pbbc.doFinal(output, outputLength);
+
+        return Arrays.copyOf(output, outputLength);
+    }
+
+    private byte[] getKey()
+    {
+        try {
+            KeyGenerator kg = KeyGenerator.getInstance(ENCRYPTION_ALGORITHM);
+            kg.init(KEY_SIZE);
+            SecretKey sk = kg.generateKey();
+
+            return sk.getEncoded();
+        }
+        catch (Exception e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Exception thrown while creating spill encryptor", e);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/Encryptor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/Encryptor.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+public interface Encryptor
+{
+  /**
+   * Encrypts the source data
+   */
+  byte[] encrypt(byte[] data);
+
+  /**
+   * Decrypts encrypted data
+   */
+  byte[] decrypt(byte[] encryptedData);
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/PageEncryption.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/PageEncryption.java
@@ -17,14 +17,14 @@ import com.facebook.presto.spi.PrestoException;
 
 import static com.facebook.presto.spi.StandardErrorCode.CORRUPT_PAGE;
 
-public enum PageCompression
+public enum PageEncryption
 {
-    UNCOMPRESSED((byte) 0),
-    COMPRESSED((byte) 1);
+    UNENCRYPTED((byte) 0),
+    ENCRYPTED((byte) 1);
 
     private final byte marker;
 
-    PageCompression(byte marker)
+    PageEncryption(byte marker)
     {
         this.marker = marker;
     }
@@ -34,11 +34,11 @@ public enum PageCompression
         return marker;
     }
 
-    public static PageCompression lookupCompressionCodecFromMarker(byte marker)
+    public static PageEncryption lookupEncryptionCodecFromMarker(byte marker)
     {
-        if (marker != UNCOMPRESSED.getMarker() && marker != COMPRESSED.getMarker()) {
+        if (marker != UNENCRYPTED.getMarker() && marker != ENCRYPTED.getMarker()) {
             throw new PrestoException(CORRUPT_PAGE, "Page marker did not contain expected value");
         }
-        return UNCOMPRESSED.getMarker() == marker ? UNCOMPRESSED : COMPRESSED;
+        return UNENCRYPTED.getMarker() == marker ? UNENCRYPTED : ENCRYPTED;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/PagesSerdeFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/PagesSerdeFactory.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.execution.buffer;
 
 import com.facebook.presto.spi.block.BlockEncodingSerde;
+import io.airlift.compress.Compressor;
+import io.airlift.compress.Decompressor;
 import io.airlift.compress.lz4.Lz4Compressor;
 import io.airlift.compress.lz4.Lz4Decompressor;
 
@@ -25,19 +27,35 @@ public class PagesSerdeFactory
 {
     private final BlockEncodingSerde blockEncodingSerde;
     private final boolean compressionEnabled;
+    private final boolean encryptionEnabled;
 
     public PagesSerdeFactory(BlockEncodingSerde blockEncodingSerde, boolean compressionEnabled)
     {
+        this(blockEncodingSerde, compressionEnabled, false);
+    }
+
+    public PagesSerdeFactory(BlockEncodingSerde blockEncodingSerde, boolean compressionEnabled, boolean encryptionEnabled)
+    {
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.compressionEnabled = compressionEnabled;
+        this.encryptionEnabled = encryptionEnabled;
     }
 
     public PagesSerde createPagesSerde()
     {
+        Optional<Compressor> compressor = Optional.empty();
+        Optional<Decompressor> decompressor = Optional.empty();
+        Optional<Encryptor> encryptor = Optional.empty();
+
         if (compressionEnabled) {
-            return new PagesSerde(blockEncodingSerde, Optional.of(new Lz4Compressor()), Optional.of(new Lz4Decompressor()));
+            compressor = Optional.of(new Lz4Compressor());
+            decompressor = Optional.of(new Lz4Decompressor());
         }
 
-        return new PagesSerde(blockEncodingSerde, Optional.empty(), Optional.empty());
+        if (encryptionEnabled) {
+            encryptor = Optional.of(new AES256Encryptor());
+        }
+
+        return new PagesSerde(blockEncodingSerde, compressor, decompressor, encryptor);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/SerializedPage.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/SerializedPage.java
@@ -29,13 +29,15 @@ public class SerializedPage
 
     private final Slice slice;
     private final PageCompression compression;
+    private final PageEncryption encryption;
     private final int positionCount;
     private final int uncompressedSizeInBytes;
 
-    public SerializedPage(Slice slice, PageCompression compression, int positionCount, int uncompressedSizeInBytes)
+    public SerializedPage(Slice slice, PageCompression compression, PageEncryption encryption, int positionCount, int uncompressedSizeInBytes)
     {
         this.slice = requireNonNull(slice, "slice is null");
         this.compression = requireNonNull(compression, "compression is null");
+        this.encryption = requireNonNull(encryption, "encryption is null");
         this.positionCount = positionCount;
         checkArgument(uncompressedSizeInBytes >= 0, "uncompressedSizeInBytes is negative");
         checkArgument(compression == UNCOMPRESSED || uncompressedSizeInBytes > slice.length(), "compressed size must be smaller than uncompressed size when compressed");
@@ -73,14 +75,20 @@ public class SerializedPage
         return compression;
     }
 
+    public PageEncryption getEncryption()
+    {
+        return encryption;
+    }
+
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("positionCount", positionCount)
-                .add("compression", compression)
-                .add("sizeInBytes", slice.length())
-                .add("uncompressedSizeInBytes", uncompressedSizeInBytes)
-                .toString();
+                       .add("positionCount", positionCount)
+                       .add("compression", compression)
+                       .add("encryption", encryption)
+                       .add("sizeInBytes", slice.length())
+                       .add("uncompressedSizeInBytes", uncompressedSizeInBytes)
+                       .toString();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.execution.buffer.PageCompression.UNCOMPRESSED;
+import static com.facebook.presto.execution.buffer.PageEncryption.UNENCRYPTED;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
@@ -54,7 +55,7 @@ import static java.util.Objects.requireNonNull;
 public class ExchangeClient
         implements Closeable
 {
-    private static final SerializedPage NO_MORE_PAGES = new SerializedPage(EMPTY_SLICE, UNCOMPRESSED, 0, 0);
+    private static final SerializedPage NO_MORE_PAGES = new SerializedPage(EMPTY_SLICE, UNCOMPRESSED, UNENCRYPTED, 0, 0);
 
     private final long bufferCapacity;
     private final DataSize maxResponseSize;

--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpillerFactory.java
@@ -85,7 +85,7 @@ public class FileSingleStreamSpillerFactory
             List<Path> spillPaths,
             double maxUsedSpaceThreshold)
     {
-        this.serdeFactory = new PagesSerdeFactory(requireNonNull(blockEncodingSerde, "blockEncodingSerde is null"), false);
+        this.serdeFactory = new PagesSerdeFactory(requireNonNull(blockEncodingSerde, "blockEncodingSerde is null"), false, false);
         this.executor = requireNonNull(executor, "executor is null");
         this.spillerStats = requireNonNull(spillerStats, "spillerStats can not be null");
         requireNonNull(spillPaths, "spillPaths is null");

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestEncryption.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestEncryption.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+
+public class TestEncryption
+{
+    @Test
+    public void testAES256Encryptor() throws Exception
+    {
+        Encryptor encryptor = new AES256Encryptor();
+        String input1 = "Test input \n1234567890;:'\" `~!@#$%^&*()_+-={}[],.<>/?\\";
+        String input2 = "asdfAasdf;LJasdfj;908q209812-09348710293847-09ajsdf98hB";
+
+        byte[] inputData1 = input1.getBytes();
+        byte[] encrypted1 = encryptor.encrypt(inputData1);
+        assertNotSame(inputData1, encrypted1);
+
+        byte[] inputData2 = input2.getBytes();
+        byte[] encrypted2 = encryptor.encrypt(inputData2);
+        assertNotSame(inputData2, encrypted2);
+
+        byte[] decryptedData1 = encryptor.decrypt(encrypted1);
+        assertEquals(inputData1, decryptedData1);
+
+        byte[] decryptedData2 = encryptor.decrypt(encrypted2);
+        assertEquals(inputData2, decryptedData2);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
@@ -68,7 +68,7 @@ public class TestPagesSerde
         // empty page
         Page page = new Page(builder.build());
         int pageSize = serializedSize(ImmutableList.of(BIGINT), page);
-        assertEquals(pageSize, 35); // page overhead
+        assertEquals(pageSize, 36); // page overhead
 
         // page with one value
         BIGINT.writeLong(builder, 123);
@@ -91,7 +91,7 @@ public class TestPagesSerde
         // empty page
         Page page = new Page(builder.build());
         int pageSize = serializedSize(ImmutableList.of(VARCHAR), page);
-        assertEquals(pageSize, 43); // page overhead
+        assertEquals(pageSize, 44); // page overhead
 
         // page with one value
         VARCHAR.writeString(builder, "alice");


### PR DESCRIPTION
Currently spilled pages are compressed by not encrypted and this poses
a security risk in some cases. The purpose of this change is to encrypt
pages with an in-memory symmetric key before they are written to the
disk (after compression), then decrypt them after they are read.