### PR TITLE
Fix split_to_map function to produce map block

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -109,6 +109,7 @@ import com.facebook.presto.operator.scalar.Re2JRegexpFunctions;
 import com.facebook.presto.operator.scalar.RepeatFunction;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.operator.scalar.SequenceFunction;
+import com.facebook.presto.operator.scalar.SplitToMapFunction;
 import com.facebook.presto.operator.scalar.StringFunctions;
 import com.facebook.presto.operator.scalar.TypeOfFunction;
 import com.facebook.presto.operator.scalar.UrlFunctions;
@@ -453,6 +454,7 @@ public class FunctionRegistry
                 .scalar(RepeatFunction.class)
                 .scalars(SequenceFunction.class)
                 .scalars(StringFunctions.class)
+                .scalars(SplitToMapFunction.class)
                 .scalars(VarbinaryFunctions.class)
                 .scalars(UrlFunctions.class)
                 .scalars(MathFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/SplitToMapFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/SplitToMapFunction.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static java.lang.String.format;
+
+public class SplitToMapFunction
+{
+    private final PageBuilder pageBuilder;
+
+    public SplitToMapFunction(@TypeParameter("map<varchar,varchar>") Type mapType)
+    {
+        pageBuilder = new PageBuilder(ImmutableList.of(mapType));
+    }
+
+    @Description("creates a map using entryDelimiter and keyValueDelimiter")
+    @ScalarFunction
+    @SqlType("map<varchar,varchar>")
+    public Block splitToMap(@TypeParameter("map<varchar,varchar>") Type mapType, @SqlType(StandardTypes.VARCHAR) Slice string, @SqlType(StandardTypes.VARCHAR) Slice entryDelimiter, @SqlType(StandardTypes.VARCHAR) Slice keyValueDelimiter)
+    {
+        checkCondition(entryDelimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "entryDelimiter is empty");
+        checkCondition(keyValueDelimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "keyValueDelimiter is empty");
+        checkCondition(!entryDelimiter.equals(keyValueDelimiter), INVALID_FUNCTION_ARGUMENT, "entryDelimiter and keyValueDelimiter must not be the same");
+
+        Map<Slice, Slice> map = new HashMap<>();
+        int entryStart = 0;
+        while (entryStart < string.length()) {
+            // Extract key-value pair based on current index
+            // then add the pair if it can be split by keyValueDelimiter
+            Slice keyValuePair;
+            int entryEnd = string.indexOf(entryDelimiter, entryStart);
+            if (entryEnd >= 0) {
+                keyValuePair = string.slice(entryStart, entryEnd - entryStart);
+            }
+            else {
+                // The rest of the string is the last possible pair.
+                keyValuePair = string.slice(entryStart, string.length() - entryStart);
+            }
+
+            int keyEnd = keyValuePair.indexOf(keyValueDelimiter);
+            if (keyEnd >= 0) {
+                int valueStart = keyEnd + keyValueDelimiter.length();
+                Slice key = keyValuePair.slice(0, keyEnd);
+                Slice value = keyValuePair.slice(valueStart, keyValuePair.length() - valueStart);
+
+                if (value.indexOf(keyValueDelimiter) >= 0) {
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Key-value delimiter must appear exactly once in each entry. Bad input: '" + keyValuePair.toStringUtf8() + "'");
+                }
+                if (map.containsKey(key)) {
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Duplicate keys (%s) are not allowed", key.toStringUtf8()));
+                }
+
+                map.put(key, value);
+            }
+            else {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Key-value delimiter must appear exactly once in each entry. Bad input: '" + keyValuePair.toStringUtf8() + "'");
+            }
+
+            if (entryEnd < 0) {
+                // No more pairs to add
+                break;
+            }
+            // Next possible pair is placed next to the current entryDelimiter
+            entryStart = entryEnd + entryDelimiter.length();
+        }
+
+        if (pageBuilder.isFull()) {
+            pageBuilder.reset();
+        }
+        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder singleMapBlockBuilder = blockBuilder.beginBlockEntry();
+        for (Map.Entry<Slice, Slice> entry : map.entrySet()) {
+            VARCHAR.writeSlice(singleMapBlockBuilder, entry.getKey());
+            VARCHAR.writeSlice(singleMapBlockBuilder, entry.getValue());
+        }
+        blockBuilder.closeEntry();
+        pageBuilder.declarePosition();
+
+        return (Block) mapType.getObject(blockBuilder, blockBuilder.getPositionCount() - 1);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -36,8 +36,6 @@ import io.airlift.slice.SliceUtf8;
 import io.airlift.slice.Slices;
 
 import java.text.Normalizer;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -57,7 +55,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Character.MAX_CODE_POINT;
 import static java.lang.Character.SURROGATE;
 import static java.lang.Math.toIntExact;
-import static java.lang.String.format;
 
 /**
  * Current implementation is based on code points from Unicode and does ignore grapheme cluster boundaries.
@@ -408,66 +405,6 @@ public final class StringFunctions
 
         // index is too big, null is returned
         return null;
-    }
-
-    @Description("creates a map using entryDelimiter and keyValueDelimiter")
-    @ScalarFunction
-    @SqlType("map<varchar,varchar>")
-    public static Block splitToMap(@SqlType(StandardTypes.VARCHAR) Slice string, @SqlType(StandardTypes.VARCHAR) Slice entryDelimiter, @SqlType(StandardTypes.VARCHAR) Slice keyValueDelimiter)
-    {
-        checkCondition(entryDelimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "entryDelimiter is empty");
-        checkCondition(keyValueDelimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "keyValueDelimiter is empty");
-        checkCondition(!entryDelimiter.equals(keyValueDelimiter), INVALID_FUNCTION_ARGUMENT, "entryDelimiter and keyValueDelimiter must not be the same");
-
-        Map<Slice, Slice> map = new HashMap<>();
-        int entryStart = 0;
-        while (entryStart < string.length()) {
-            // Extract key-value pair based on current index
-            // then add the pair if it can be split by keyValueDelimiter
-            Slice keyValuePair;
-            int entryEnd = string.indexOf(entryDelimiter, entryStart);
-            if (entryEnd >= 0) {
-                keyValuePair = string.slice(entryStart, entryEnd - entryStart);
-            }
-            else {
-                // The rest of the string is the last possible pair.
-                keyValuePair = string.slice(entryStart, string.length() - entryStart);
-            }
-
-            int keyEnd = keyValuePair.indexOf(keyValueDelimiter);
-            if (keyEnd >= 0) {
-                int valueStart = keyEnd + keyValueDelimiter.length();
-                Slice key = keyValuePair.slice(0, keyEnd);
-                Slice value = keyValuePair.slice(valueStart, keyValuePair.length() - valueStart);
-
-                if (value.indexOf(keyValueDelimiter) >= 0) {
-                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Key-value delimiter must appear exactly once in each entry. Bad input: '" + keyValuePair.toStringUtf8() + "'");
-                }
-                if (map.containsKey(key)) {
-                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Duplicate keys (%s) are not allowed", key.toStringUtf8()));
-                }
-
-                map.put(key, value);
-            }
-            else {
-                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Key-value delimiter must appear exactly once in each entry. Bad input: '" + keyValuePair.toStringUtf8() + "'");
-            }
-
-            if (entryEnd < 0) {
-                // No more pairs to add
-                break;
-            }
-            // Next possible pair is placed next to the current entryDelimiter
-            entryStart = entryEnd + entryDelimiter.length();
-        }
-
-        BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), map.size());
-        for (Map.Entry<Slice, Slice> entry : map.entrySet()) {
-            VARCHAR.writeSlice(builder, entry.getKey());
-            VARCHAR.writeSlice(builder, entry.getValue());
-        }
-
-        return builder.build();
     }
 
     @Description("removes whitespace from the beginning of a string")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -410,6 +410,8 @@ public class TestStringFunctions
         assertInvalidFunction("SPLIT_TO_MAP('key', ',', '=')", "Key-value delimiter must appear exactly once in each entry. Bad input: 'key'");
         assertInvalidFunction("SPLIT_TO_MAP('key==value', ',', '=')", "Key-value delimiter must appear exactly once in each entry. Bad input: 'key==value'");
         assertInvalidFunction("SPLIT_TO_MAP('key=va=lue', ',', '=')", "Key-value delimiter must appear exactly once in each entry. Bad input: 'key=va=lue'");
+
+        assertCachedInstanceHasBoundedRetainedSize("SPLIT_TO_MAP('a=123,b=.4,c=,=d', ',', '=')");
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -217,6 +217,9 @@ public class MapType
     @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
+        if (!(value instanceof SingleMapBlock)) {
+            throw new IllegalArgumentException("Maps must be represented with SingleMapBlock");
+        }
         blockBuilder.writeObject(value).closeEntry();
     }
 


### PR DESCRIPTION
This fixes query involving `split_to_map(...)[...]` where f can be any function
or operator.

Previously, split_to_map produces a VariableWidthBlock where keys and values
take even and odd positions in the same Block. This clever trick no longer
works now that maps are required to use map block.