### PR TITLE
Prepare base-jdbc to handle connection-specific types

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -15,6 +15,8 @@ package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.RecordSet;
+import com.facebook.presto.spi.RecordSink;
 import com.facebook.presto.spi.SchemaTableName;
 
 import javax.annotation.Nullable;
@@ -63,4 +65,8 @@ public interface JdbcClient
 
     PreparedStatement getPreparedStatement(Connection connection, String sql)
             throws SQLException;
+
+    RecordSet getJdbcRecordSet(JdbcSplit jdbcSplit, List<JdbcColumnHandle> handles);
+
+    RecordSink getJdbcRecordSink(JdbcOutputTableHandle tableHandle);
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSetProvider.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSetProvider.java
@@ -48,6 +48,6 @@ public class JdbcRecordSetProvider
             handles.add((JdbcColumnHandle) handle);
         }
 
-        return new JdbcRecordSet(jdbcClient, jdbcSplit, handles.build());
+        return jdbcClient.getJdbcRecordSet(jdbcSplit, handles.build());
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSink.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSink.java
@@ -47,7 +47,7 @@ public class JdbcRecordSink
     private int field = -1;
     private int batchSize;
 
-    public JdbcRecordSink(JdbcOutputTableHandle handle, JdbcClient jdbcClient)
+    public JdbcRecordSink(JdbcClient jdbcClient, JdbcOutputTableHandle handle)
     {
         try {
             connection = jdbcClient.getConnection(handle);

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSinkProvider.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSinkProvider.java
@@ -38,12 +38,12 @@ public class JdbcRecordSinkProvider
     @Override
     public RecordSink getRecordSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle tableHandle)
     {
-        return new JdbcRecordSink((JdbcOutputTableHandle) tableHandle, jdbcClient);
+        return jdbcClient.getJdbcRecordSink((JdbcOutputTableHandle) tableHandle);
     }
 
     @Override
     public RecordSink getRecordSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle)
     {
-        return new JdbcRecordSink((JdbcOutputTableHandle) tableHandle, jdbcClient);
+        return jdbcClient.getJdbcRecordSink((JdbcOutputTableHandle) tableHandle);
     }
 }


### PR DESCRIPTION
Hello and Thanks for the great piece of software! 

I'm in the middle of implementing reading and writing of PostgreSQL's array and json/jsonb-types in presto.

This pull-request is mainly to discuss approach, and maybe get these simple changes merged so I can make the proper adaptions in the PostgreSQL-driver.

To do that I'd like to make the recordsets and recordsinks overridable by connection-specific code, and so
I've taken to let the JdbcRecordSetProvider and JdbcRecordSinkProvider ask the jdbcClient for a recordset-object. Per default all will be as it was, as the default BaseJdbcClient just returns the same JdbcRecordSet and JdbcRecordSink as before, but it's now possible to override what to send in classes inheriting form BaseJdbcClient or implement the JdbcClient interface.

In addition the toPrestoType call has been extended to also take the DB-specific typename from the columns-records which contains sufficient information in all databases and cases I know of to do proper type-conversion to presto.