### PR TITLE
Add additional context information to HdfsEnvironment

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
@@ -62,7 +62,7 @@ public class GenericHiveRecordCursorProvider
     {
         // make sure the FileSystem is created with the proper Configuration object
         try {
-            this.hdfsEnvironment.getFileSystem(session.getUser(), path);
+            this.hdfsEnvironment.getFileSystem(session.getUser(), path, configuration);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed getting FileSystem: " + path, e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
@@ -13,11 +13,12 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import org.apache.hadoop.conf.Configuration;
 
 import java.net.URI;
 
 public interface HdfsConfiguration
 {
-    Configuration getConfiguration(URI uri);
+    Configuration getConfiguration(HdfsContext context, URI uri);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import org.apache.hadoop.conf.Configuration;
 
 import javax.inject.Inject;
@@ -60,7 +61,7 @@ public class HiveHdfsConfiguration
     }
 
     @Override
-    public Configuration getConfiguration(URI uri)
+    public Configuration getConfiguration(HdfsContext context, URI uri)
     {
         // use the same configuration for everything
         return hadoopConfiguration.get();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
@@ -426,7 +427,7 @@ public class HiveMetadata
     {
         Optional<String> location = HiveSchemaProperties.getLocation(properties).map(locationUri -> {
             try {
-                hdfsEnvironment.getFileSystem(session.getUser(), new Path(locationUri));
+                hdfsEnvironment.getFileSystem(new HdfsContext(session, schemaName), new Path(locationUri));
             }
             catch (IOException e) {
                 throw new PrestoException(INVALID_SCHEMA_PROPERTY, "Invalid location URI: " + locationUri, e);
@@ -483,11 +484,11 @@ public class HiveMetadata
         String externalLocation = getExternalLocation(tableMetadata.getProperties());
         if (externalLocation != null) {
             external = true;
-            targetPath = getExternalPath(session.getUser(), externalLocation);
+            targetPath = getExternalPath(new HdfsContext(session, schemaName, tableName), externalLocation);
         }
         else {
             external = false;
-            LocationHandle locationHandle = locationService.forNewTable(metastore, session.getUser(), session.getQueryId(), schemaName, tableName);
+            LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName);
             targetPath = locationService.targetPathRoot(locationHandle);
         }
 
@@ -528,11 +529,11 @@ public class HiveMetadata
         return tableProperties.build();
     }
 
-    private Path getExternalPath(String user, String location)
+    private Path getExternalPath(HdfsContext context, String location)
     {
         try {
             Path path = new Path(location);
-            if (!hdfsEnvironment.getFileSystem(user, path).isDirectory(path)) {
+            if (!hdfsEnvironment.getFileSystem(context, path).isDirectory(path)) {
                 throw new PrestoException(INVALID_TABLE_PROPERTY, "External location must be a directory");
             }
             return path;
@@ -688,7 +689,7 @@ public class HiveMetadata
         HiveStorageFormat actualStorageFormat = partitionedBy.isEmpty() ? tableStorageFormat : partitionStorageFormat;
         actualStorageFormat.validateColumns(columnHandles);
 
-        LocationHandle locationHandle = locationService.forNewTable(metastore, session.getUser(), session.getQueryId(), schemaName, tableName);
+        LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName);
         HiveOutputTableHandle result = new HiveOutputTableHandle(
                 connectorId,
                 schemaName,
@@ -743,12 +744,12 @@ public class HiveMetadata
         partitionUpdates = PartitionUpdate.mergePartitionUpdates(partitionUpdates);
 
         if (handle.getBucketProperty().isPresent()) {
-            ImmutableList<PartitionUpdate> partitionUpdatesForMissingBuckets = computePartitionUpdatesForMissingBuckets(handle, table, partitionUpdates);
+            ImmutableList<PartitionUpdate> partitionUpdatesForMissingBuckets = computePartitionUpdatesForMissingBuckets(session, handle, table, partitionUpdates);
             // replace partitionUpdates before creating the empty files so that those files will be cleaned up if we end up rollback
             partitionUpdates = PartitionUpdate.mergePartitionUpdates(Iterables.concat(partitionUpdates, partitionUpdatesForMissingBuckets));
             for (PartitionUpdate partitionUpdate : partitionUpdatesForMissingBuckets) {
                 Optional<Partition> partition = table.getPartitionColumns().isEmpty() ? Optional.empty() : Optional.of(buildPartitionObject(session.getQueryId(), table, partitionUpdate));
-                createEmptyFile(partitionUpdate.getWritePath(), table, partition, partitionUpdate.getFileNames());
+                createEmptyFile(session, partitionUpdate.getWritePath(), table, partition, partitionUpdate.getFileNames());
             }
         }
 
@@ -768,7 +769,11 @@ public class HiveMetadata
                         .collect(Collectors.toList())));
     }
 
-    private ImmutableList<PartitionUpdate> computePartitionUpdatesForMissingBuckets(HiveWritableTableHandle handle, Table table, List<PartitionUpdate> partitionUpdates)
+    private ImmutableList<PartitionUpdate> computePartitionUpdatesForMissingBuckets(
+            ConnectorSession session,
+            HiveWritableTableHandle handle,
+            Table table,
+            List<PartitionUpdate> partitionUpdates)
     {
         ImmutableList.Builder<PartitionUpdate> partitionUpdatesForMissingBucketsBuilder = ImmutableList.builder();
         HiveStorageFormat storageFormat = table.getPartitionColumns().isEmpty() ? handle.getTableStorageFormat() : handle.getPartitionStorageFormat();
@@ -776,6 +781,8 @@ public class HiveMetadata
             int bucketCount = handle.getBucketProperty().get().getBucketCount();
 
             List<String> fileNamesForMissingBuckets = computeFileNamesForMissingBuckets(
+                    session,
+                    table,
                     storageFormat,
                     partitionUpdate.getTargetPath(),
                     handle.getFilePrefix(),
@@ -791,13 +798,21 @@ public class HiveMetadata
         return partitionUpdatesForMissingBucketsBuilder.build();
     }
 
-    private List<String> computeFileNamesForMissingBuckets(HiveStorageFormat storageFormat, Path targetPath, String filePrefix, int bucketCount, PartitionUpdate partitionUpdate)
+    private List<String> computeFileNamesForMissingBuckets(
+            ConnectorSession session,
+            Table table,
+            HiveStorageFormat storageFormat,
+            Path targetPath,
+            String filePrefix,
+            int bucketCount,
+            PartitionUpdate partitionUpdate)
     {
         if (partitionUpdate.getFileNames().size() == bucketCount) {
             // fast path for common case
             return ImmutableList.of();
         }
-        JobConf conf = toJobConf(hdfsEnvironment.getConfiguration(targetPath));
+        HdfsContext hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
+        JobConf conf = toJobConf(hdfsEnvironment.getConfiguration(hdfsContext, targetPath));
         String fileExtension = HiveWriterFactory.getFileExtension(conf, fromHiveStorageFormat(storageFormat));
         Set<String> fileNames = ImmutableSet.copyOf(partitionUpdate.getFileNames());
         ImmutableList.Builder<String> missingFileNamesBuilder = ImmutableList.builder();
@@ -812,9 +827,9 @@ public class HiveMetadata
         return missingFileNames;
     }
 
-    private void createEmptyFile(Path path, Table table, Optional<Partition> partition, List<String> fileNames)
+    private void createEmptyFile(ConnectorSession session, Path path, Table table, Optional<Partition> partition, List<String> fileNames)
     {
-        JobConf conf = toJobConf(hdfsEnvironment.getConfiguration(path));
+        JobConf conf = toJobConf(hdfsEnvironment.getConfiguration(new HdfsContext(session, table.getDatabaseName(), table.getTableName()), path));
 
         Properties schema;
         StorageFormat format;
@@ -873,7 +888,7 @@ public class HiveMetadata
                 .collect(toList());
 
         HiveStorageFormat tableStorageFormat = extractHiveStorageFormat(table.get());
-        LocationHandle locationHandle = locationService.forExistingTable(metastore, session.getUser(), session.getQueryId(), table.get());
+        LocationHandle locationHandle = locationService.forExistingTable(metastore, session, table.get());
         HiveInsertTableHandle result = new HiveInsertTableHandle(
                 connectorId,
                 tableName.getSchemaName(),
@@ -921,12 +936,12 @@ public class HiveMetadata
         }
 
         if (handle.getBucketProperty().isPresent()) {
-            ImmutableList<PartitionUpdate> partitionUpdatesForMissingBuckets = computePartitionUpdatesForMissingBuckets(handle, table.get(), partitionUpdates);
+            ImmutableList<PartitionUpdate> partitionUpdatesForMissingBuckets = computePartitionUpdatesForMissingBuckets(session, handle, table.get(), partitionUpdates);
             // replace partitionUpdates before creating the empty files so that those files will be cleaned up if we end up rollback
             partitionUpdates = PartitionUpdate.mergePartitionUpdates(Iterables.concat(partitionUpdates, partitionUpdatesForMissingBuckets));
             for (PartitionUpdate partitionUpdate : partitionUpdatesForMissingBuckets) {
                 Optional<Partition> partition = table.get().getPartitionColumns().isEmpty() ? Optional.empty() : Optional.of(buildPartitionObject(session.getQueryId(), table.get(), partitionUpdate));
-                createEmptyFile(partitionUpdate.getWritePath(), table.get(), partition, partitionUpdate.getFileNames());
+                createEmptyFile(session, partitionUpdate.getWritePath(), table.get(), partition, partitionUpdate.getFileNames());
             }
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
@@ -88,7 +89,7 @@ public class HivePageSourceProvider
                 cursorProviders,
                 pageSourceFactories,
                 hiveSplit.getClientId(),
-                hdfsEnvironment.getConfiguration(path),
+                hdfsEnvironment.getConfiguration(new HdfsContext(session, hiveSplit.getDatabase(), hiveSplit.getTable()), path),
                 session,
                 path,
                 hiveSplit.getBucketNumber(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
@@ -384,7 +385,7 @@ public final class HiveWriteUtils
         }
     }
 
-    public static Path getTableDefaultLocation(String user, SemiTransactionalHiveMetastore metastore, HdfsEnvironment hdfsEnvironment, String schemaName, String tableName)
+    public static Path getTableDefaultLocation(HdfsContext context, SemiTransactionalHiveMetastore metastore, HdfsEnvironment hdfsEnvironment, String schemaName, String tableName)
     {
         Optional<String> location = getDatabase(metastore, schemaName).getLocation();
         if (!location.isPresent() || location.get().isEmpty()) {
@@ -392,11 +393,11 @@ public final class HiveWriteUtils
         }
 
         Path databasePath = new Path(location.get());
-        if (!isS3FileSystem(user, hdfsEnvironment, databasePath)) {
-            if (!pathExists(user, hdfsEnvironment, databasePath)) {
+        if (!isS3FileSystem(context, hdfsEnvironment, databasePath)) {
+            if (!pathExists(context, hdfsEnvironment, databasePath)) {
                 throw new PrestoException(HIVE_DATABASE_LOCATION_ERROR, format("Database '%s' location does not exist: %s", schemaName, databasePath));
             }
-            if (!isDirectory(user, hdfsEnvironment, databasePath)) {
+            if (!isDirectory(context, hdfsEnvironment, databasePath)) {
                 throw new PrestoException(HIVE_DATABASE_LOCATION_ERROR, format("Database '%s' location is not a directory: %s", schemaName, databasePath));
             }
         }
@@ -409,31 +410,31 @@ public final class HiveWriteUtils
         return metastore.getDatabase(database).orElseThrow(() -> new SchemaNotFoundException(database));
     }
 
-    public static boolean pathExists(String user, HdfsEnvironment hdfsEnvironment, Path path)
+    public static boolean pathExists(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         try {
-            return hdfsEnvironment.getFileSystem(user, path).exists(path);
+            return hdfsEnvironment.getFileSystem(context, path).exists(path);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed checking path: " + path, e);
         }
     }
 
-    public static boolean isS3FileSystem(String user, HdfsEnvironment hdfsEnvironment, Path path)
+    public static boolean isS3FileSystem(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         try {
-            return hdfsEnvironment.getFileSystem(user, path) instanceof PrestoS3FileSystem;
+            return hdfsEnvironment.getFileSystem(context, path) instanceof PrestoS3FileSystem;
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed checking path: " + path, e);
         }
     }
 
-    public static boolean isViewFileSystem(String user, HdfsEnvironment hdfsEnvironment, Path path)
+    public static boolean isViewFileSystem(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         try {
             // Hadoop 1.x does not have the ViewFileSystem class
-            return hdfsEnvironment.getFileSystem(user, path)
+            return hdfsEnvironment.getFileSystem(context, path)
                     .getClass().getName().equals("org.apache.hadoop.fs.viewfs.ViewFileSystem");
         }
         catch (IOException e) {
@@ -441,23 +442,23 @@ public final class HiveWriteUtils
         }
     }
 
-    private static boolean isDirectory(String user, HdfsEnvironment hdfsEnvironment, Path path)
+    private static boolean isDirectory(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         try {
-            return hdfsEnvironment.getFileSystem(user, path).isDirectory(path);
+            return hdfsEnvironment.getFileSystem(context, path).isDirectory(path);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed checking path: " + path, e);
         }
     }
 
-    public static Path createTemporaryPath(String user, HdfsEnvironment hdfsEnvironment, Path targetPath)
+    public static Path createTemporaryPath(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path targetPath)
     {
         // use a per-user temporary directory to avoid permission problems
-        String temporaryPrefix = "/tmp/presto-" + user;
+        String temporaryPrefix = "/tmp/presto-" + context.getIdentity().getUser();
 
         // use relative temporary directory on ViewFS
-        if (isViewFileSystem(user, hdfsEnvironment, targetPath)) {
+        if (isViewFileSystem(context, hdfsEnvironment, targetPath)) {
             temporaryPrefix = ".hive-staging";
         }
 
@@ -465,15 +466,15 @@ public final class HiveWriteUtils
         Path temporaryRoot = new Path(targetPath, temporaryPrefix);
         Path temporaryPath = new Path(temporaryRoot, randomUUID().toString());
 
-        createDirectory(user, hdfsEnvironment, temporaryPath);
+        createDirectory(context, hdfsEnvironment, temporaryPath);
 
         return temporaryPath;
     }
 
-    public static void createDirectory(String user, HdfsEnvironment hdfsEnvironment, Path path)
+    public static void createDirectory(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         try {
-            if (!hdfsEnvironment.getFileSystem(user, path).mkdirs(path, ALL_PERMISSIONS)) {
+            if (!hdfsEnvironment.getFileSystem(context, path).mkdirs(path, ALL_PERMISSIONS)) {
                 throw new IOException("mkdirs returned false");
             }
         }
@@ -483,7 +484,7 @@ public final class HiveWriteUtils
 
         // explicitly set permission since the default umask overrides it on creation
         try {
-            hdfsEnvironment.getFileSystem(user, path).setPermission(path, ALL_PERMISSIONS);
+            hdfsEnvironment.getFileSystem(context, path).setPermission(path, ALL_PERMISSIONS);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed to set permission on directory: " + path, e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.HivePageSinkMetadataProvider;
 import com.facebook.presto.hive.metastore.Partition;
@@ -201,7 +202,7 @@ public class HiveWriterFactory
                 .collect(toImmutableMap(PropertyMetadata::getName,
                         entry -> session.getProperty(entry.getName(), entry.getJavaType()).toString()));
 
-        Configuration conf = hdfsEnvironment.getConfiguration(writePath);
+        Configuration conf = hdfsEnvironment.getConfiguration(new HdfsContext(session, schemaName, tableName), writePath);
         this.conf = toJobConf(conf);
 
         // make sure the FileSystem is created with the correct Configuration object
@@ -271,7 +272,7 @@ public class HiveWriterFactory
                 if (partitionName.isPresent() && !target.equals(write)) {
                     // When target path is different from write path,
                     // verify that the target directory for the partition does not already exist
-                    if (HiveWriteUtils.pathExists(session.getUser(), hdfsEnvironment, target)) {
+                    if (HiveWriteUtils.pathExists(new HdfsContext(session, schemaName, tableName), hdfsEnvironment, target)) {
                         throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format(
                                 "Target directory for new partition '%s' of table '%s.%s' already exists: %s",
                                 partitionName,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/LocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/LocationService.java
@@ -16,15 +16,16 @@ package com.facebook.presto.hive;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
 import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
 import org.apache.hadoop.fs.Path;
 
 import java.util.Optional;
 
 public interface LocationService
 {
-    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, String user, String queryId, String schemaName, String tableName);
+    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName);
 
-    LocationHandle forExistingTable(SemiTransactionalHiveMetastore metastore, String user, String queryId, Table table);
+    LocationHandle forExistingTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table);
 
     /**
      * Target path for the specified existing partition.

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore;
 
 import com.facebook.presto.hadoop.HadoopFileStatus;
 import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.PartitionNotFoundException;
 import com.facebook.presto.hive.TableAlreadyExistsException;
@@ -291,7 +292,8 @@ public class SemiTransactionalHiveMetastore
         Action<TableAndMore> oldTableAction = tableActions.get(schemaTableName);
         TableAndMore tableAndMore = new TableAndMore(table, Optional.of(principalPrivileges), currentPath, Optional.empty());
         if (oldTableAction == null) {
-            tableActions.put(schemaTableName, new Action<>(ActionType.ADD, tableAndMore, session.getUser(), session.getQueryId()));
+            HdfsContext context = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
+            tableActions.put(schemaTableName, new Action<>(ActionType.ADD, tableAndMore, context));
             return;
         }
         switch (oldTableAction.getType()) {
@@ -314,7 +316,8 @@ public class SemiTransactionalHiveMetastore
         SchemaTableName schemaTableName = new SchemaTableName(databaseName, tableName);
         Action<TableAndMore> oldTableAction = tableActions.get(schemaTableName);
         if (oldTableAction == null || oldTableAction.getType() == ActionType.ALTER) {
-            tableActions.put(schemaTableName, new Action<>(ActionType.DROP, null, session.getUser(), session.getQueryId()));
+            HdfsContext context = new HdfsContext(session, databaseName, tableName);
+            tableActions.put(schemaTableName, new Action<>(ActionType.DROP, null, context));
             return;
         }
         switch (oldTableAction.getType()) {
@@ -366,11 +369,12 @@ public class SemiTransactionalHiveMetastore
             if (!table.isPresent()) {
                 throw new TableNotFoundException(schemaTableName);
             }
+            HdfsContext context = new HdfsContext(session, databaseName, tableName);
             tableActions.put(
                     schemaTableName,
                     new Action<>(
                             ActionType.INSERT_EXISTING,
-                            new TableAndMore(table.get(), Optional.empty(), Optional.of(currentLocation), Optional.of(fileNames)), session.getUser(), session.getQueryId()));
+                            new TableAndMore(table.get(), Optional.empty(), Optional.of(currentLocation), Optional.of(fileNames)), context));
             return;
         }
 
@@ -402,9 +406,9 @@ public class SemiTransactionalHiveMetastore
         }
 
         Path path = new Path(table.get().getStorage().getLocation());
-        String user = session.getUser();
+        HdfsContext context = new HdfsContext(session, databaseName, tableName);
         setExclusive((delegate, hdfsEnvironment) -> {
-            RecursiveDeleteResult recursiveDeleteResult = recursiveDeleteFiles(hdfsEnvironment, user, path, ImmutableList.of(""), false);
+            RecursiveDeleteResult recursiveDeleteResult = recursiveDeleteFiles(hdfsEnvironment, context, path, ImmutableList.of(""), false);
             if (!recursiveDeleteResult.getNotDeletedEligibleItems().isEmpty()) {
                 throw new PrestoException(HIVE_FILESYSTEM_ERROR, format(
                         "Error deleting from unpartitioned table %s. These items can not be deleted: %s",
@@ -581,20 +585,21 @@ public class SemiTransactionalHiveMetastore
         checkArgument(getPrestoQueryId(partition).isPresent());
         Map<List<String>, Action<PartitionAndMore>> partitionActionsOfTable = partitionActions.computeIfAbsent(new SchemaTableName(databaseName, tableName), k -> new HashMap<>());
         Action<PartitionAndMore> oldPartitionAction = partitionActionsOfTable.get(partition.getValues());
+        HdfsContext context = new HdfsContext(session, databaseName, tableName);
         if (oldPartitionAction == null) {
             partitionActionsOfTable.put(
                     partition.getValues(),
-                    new Action<>(ActionType.ADD, new PartitionAndMore(partition, currentLocation, Optional.empty()), session.getUser(), session.getQueryId()));
+                    new Action<>(ActionType.ADD, new PartitionAndMore(partition, currentLocation, Optional.empty()), context));
             return;
         }
         switch (oldPartitionAction.getType()) {
             case DROP: {
-                if (!oldPartitionAction.getUser().equals(session.getUser())) {
+                if (!oldPartitionAction.getContext().getIdentity().getUser().equals(session.getUser())) {
                     throw new PrestoException(TRANSACTION_CONFLICT, "Operation on the same partition with different user in the same transaction is not supported");
                 }
                 partitionActionsOfTable.put(
                         partition.getValues(),
-                        new Action<>(ActionType.ALTER, new PartitionAndMore(partition, currentLocation, Optional.empty()), session.getUser(), session.getQueryId()));
+                        new Action<>(ActionType.ALTER, new PartitionAndMore(partition, currentLocation, Optional.empty()), context));
                 break;
             }
             case ADD:
@@ -612,7 +617,8 @@ public class SemiTransactionalHiveMetastore
         Map<List<String>, Action<PartitionAndMore>> partitionActionsOfTable = partitionActions.computeIfAbsent(new SchemaTableName(databaseName, tableName), k -> new HashMap<>());
         Action<PartitionAndMore> oldPartitionAction = partitionActionsOfTable.get(partitionValues);
         if (oldPartitionAction == null) {
-            partitionActionsOfTable.put(partitionValues, new Action<>(ActionType.DROP, null, session.getUser(), session.getQueryId()));
+            HdfsContext context = new HdfsContext(session, databaseName, tableName);
+            partitionActionsOfTable.put(partitionValues, new Action<>(ActionType.DROP, null, context));
             return;
         }
         switch (oldPartitionAction.getType()) {
@@ -640,9 +646,10 @@ public class SemiTransactionalHiveMetastore
             if (!partition.isPresent()) {
                 throw new PartitionNotFoundException(schemaTableName, partitionValues);
             }
+            HdfsContext context = new HdfsContext(session, databaseName, tableName);
             partitionActionsOfTable.put(
                     partitionValues,
-                    new Action<>(ActionType.INSERT_EXISTING, new PartitionAndMore(partition.get(), currentLocation, Optional.of(fileNames)), session.getUser(), session.getQueryId()));
+                    new Action<>(ActionType.INSERT_EXISTING, new PartitionAndMore(partition.get(), currentLocation, Optional.of(fileNames)), context));
             return;
         }
 
@@ -718,7 +725,8 @@ public class SemiTransactionalHiveMetastore
                 throw new PrestoException(NOT_SUPPORTED, "Can not insert into a table with a partition that has been modified in the same transaction when Presto is configured to skip temporary directories.");
             }
         }
-        declaredIntentionsToWrite.add(new DeclaredIntentionToWrite(writeMode, session.getUser(), stagingPathRoot, filePrefix, schemaTableName));
+        HdfsContext context = new HdfsContext(session, schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        declaredIntentionsToWrite.add(new DeclaredIntentionToWrite(writeMode, context, stagingPathRoot, filePrefix, schemaTableName));
     }
 
     public synchronized void commit()
@@ -784,10 +792,10 @@ public class SemiTransactionalHiveMetastore
                         committer.prepareAlterTable();
                         break;
                     case ADD:
-                        committer.prepareAddTable(action.getUser(), action.getData());
+                        committer.prepareAddTable(action.getContext(), action.getData());
                         break;
                     case INSERT_EXISTING:
-                        committer.prepareInsertExistingTable(action.getUser(), action.getData());
+                        committer.prepareInsertExistingTable(action.getContext(), action.getData());
                         break;
                     default:
                         throw new IllegalStateException("Unknown action type");
@@ -803,13 +811,13 @@ public class SemiTransactionalHiveMetastore
                             committer.prepareDropPartition(schemaTableName, partitionValues);
                             break;
                         case ALTER:
-                            committer.prepareAlterPartition(action.getQueryId(), action.getUser(), action.getData());
+                            committer.prepareAlterPartition(action.getContext(), action.getData());
                             break;
                         case ADD:
-                            committer.prepareAddPartition(action.getUser(), action.getData());
+                            committer.prepareAddPartition(action.getContext(), action.getData());
                             break;
                         case INSERT_EXISTING:
-                            committer.prepareInsertExistingPartition(action.getUser(), action.getData());
+                            committer.prepareInsertExistingPartition(action.getContext(), action.getData());
                             break;
                         default:
                             throw new IllegalStateException("Unknown action type");
@@ -909,7 +917,7 @@ public class SemiTransactionalHiveMetastore
             throw new UnsupportedOperationException("Dropping and then creating a table with the same name is not supported");
         }
 
-        private void prepareAddTable(String user, TableAndMore tableAndMore)
+        private void prepareAddTable(HdfsContext context, TableAndMore tableAndMore)
         {
             Table table = tableAndMore.getTable();
             if (table.getTableType().equals(MANAGED_TABLE.name())) {
@@ -924,17 +932,17 @@ public class SemiTransactionalHiveMetastore
                     }
                     else {
                         renameDirectory(
-                                user,
+                                context,
                                 hdfsEnvironment,
                                 currentPath.get(),
                                 targetPath,
-                                () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, true)));
+                                () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
                     }
                 }
                 else {
                     // CREATE TABLE AS SELECT partitioned table, or
                     // CREATE TABLE partitioned/unpartitioned table (without data)
-                    if (pathExists(user, hdfsEnvironment, targetPath)) {
+                    if (pathExists(context, hdfsEnvironment, targetPath)) {
                         if (currentPath.isPresent() && currentPath.get().equals(targetPath)) {
                             // It is okay to skip directory creation when currentPath is equal to targetPath
                             // because the directory may have been created when creating partition directories.
@@ -948,8 +956,8 @@ public class SemiTransactionalHiveMetastore
                         }
                     }
                     else {
-                        cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, true));
-                        createDirectory(user, hdfsEnvironment, targetPath);
+                        cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true));
+                        createDirectory(context, hdfsEnvironment, targetPath);
                     }
                 }
             }
@@ -957,14 +965,14 @@ public class SemiTransactionalHiveMetastore
             addTableOperations.add(new CreateTableOperation(table, tableAndMore.getPrincipalPrivileges()));
         }
 
-        private void prepareInsertExistingTable(String user, TableAndMore tableAndMore)
+        private void prepareInsertExistingTable(HdfsContext context, TableAndMore tableAndMore)
         {
             Table table = tableAndMore.getTable();
             Path targetPath = new Path(table.getStorage().getLocation());
             Path currentPath = tableAndMore.getCurrentLocation().get();
-            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, false));
+            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, false));
             if (!targetPath.equals(currentPath)) {
-                asyncRename(hdfsEnvironment, renameExecutor, fileRenameCancelled, fileRenameFutures, user, currentPath, targetPath, tableAndMore.getFileNames().get());
+                asyncRename(hdfsEnvironment, renameExecutor, fileRenameCancelled, fileRenameFutures, context, currentPath, targetPath, tableAndMore.getFileNames().get());
             }
         }
 
@@ -975,7 +983,7 @@ public class SemiTransactionalHiveMetastore
                     () -> delegate.dropPartition(schemaTableName.getSchemaName(), schemaTableName.getTableName(), partitionValues, true)));
         }
 
-        private void prepareAlterPartition(String queryId, String user, PartitionAndMore partitionAndMore)
+        private void prepareAlterPartition(HdfsContext context, PartitionAndMore partitionAndMore)
         {
             Partition partition = partitionAndMore.getPartition();
             String targetLocation = partition.getStorage().getLocation();
@@ -996,20 +1004,20 @@ public class SemiTransactionalHiveMetastore
             // Otherwise,
             // * Remember we will need to delete the location of the old partition at the end if transaction successfully commits
             if (targetLocation.equals(oldPartitionLocation)) {
-                Path oldPartitionStagingPath = new Path(oldPartitionPath.getParent(), "_temp_" + oldPartitionPath.getName() + "_" + queryId);
+                Path oldPartitionStagingPath = new Path(oldPartitionPath.getParent(), "_temp_" + oldPartitionPath.getName() + "_" + context.getQueryId());
                 renameDirectory(
-                        user,
+                        context,
                         hdfsEnvironment,
                         oldPartitionPath,
                         oldPartitionStagingPath,
-                        () -> renameTasksForAbort.add(new DirectoryRenameTask(user, oldPartitionStagingPath, oldPartitionPath)));
+                        () -> renameTasksForAbort.add(new DirectoryRenameTask(context, oldPartitionStagingPath, oldPartitionPath)));
                 if (!skipDeletionForAlter) {
-                    deletionTasksForFinish.add(new DirectoryDeletionTask(user, oldPartitionStagingPath));
+                    deletionTasksForFinish.add(new DirectoryDeletionTask(context, oldPartitionStagingPath));
                 }
             }
             else {
                 if (!skipDeletionForAlter) {
-                    deletionTasksForFinish.add(new DirectoryDeletionTask(user, oldPartitionPath));
+                    deletionTasksForFinish.add(new DirectoryDeletionTask(context, oldPartitionPath));
                 }
             }
 
@@ -1017,18 +1025,18 @@ public class SemiTransactionalHiveMetastore
             Path targetPath = new Path(targetLocation);
             if (!targetPath.equals(currentPath)) {
                 renameDirectory(
-                        user,
+                        context,
                         hdfsEnvironment,
                         currentPath,
                         targetPath,
-                        () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, true)));
+                        () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
             }
             // Partition alter must happen regardless of whether original and current location is the same
             // because metadata might change: e.g. storage format, column types, etc
             alterPartitionOperations.add(new AlterPartitionOperation(partition, oldPartition.get()));
         }
 
-        private void prepareAddPartition(String user, PartitionAndMore partitionAndMore)
+        private void prepareAddPartition(HdfsContext context, PartitionAndMore partitionAndMore)
         {
             Partition partition = partitionAndMore.getPartition();
             String targetLocation = partition.getStorage().getLocation();
@@ -1042,37 +1050,37 @@ public class SemiTransactionalHiveMetastore
 
             if (!targetPath.equals(currentPath)) {
                 renameDirectory(
-                        user,
+                        context,
                         hdfsEnvironment,
                         currentPath,
                         targetPath,
-                        () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, true)));
+                        () -> cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, true)));
             }
             partitionAdder.addPartition(partition);
         }
 
-        private void prepareInsertExistingPartition(String user, PartitionAndMore partitionAndMore)
+        private void prepareInsertExistingPartition(HdfsContext context, PartitionAndMore partitionAndMore)
         {
             Partition partition = partitionAndMore.getPartition();
             Path targetPath = new Path(partition.getStorage().getLocation());
             Path currentPath = partitionAndMore.getCurrentLocation();
-            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(user, targetPath, false));
+            cleanUpTasksForAbort.add(new DirectoryCleanUpTask(context, targetPath, false));
             if (!targetPath.equals(currentPath)) {
-                asyncRename(hdfsEnvironment, renameExecutor, fileRenameCancelled, fileRenameFutures, user, currentPath, targetPath, partitionAndMore.getFileNames());
+                asyncRename(hdfsEnvironment, renameExecutor, fileRenameCancelled, fileRenameFutures, context, currentPath, targetPath, partitionAndMore.getFileNames());
             }
         }
 
         private void executeCleanupTasksForAbort(List<String> filePrefixes)
         {
             for (DirectoryCleanUpTask cleanUpTask : cleanUpTasksForAbort) {
-                recursiveDeleteFilesAndLog(cleanUpTask.getUser(), cleanUpTask.getPath(), filePrefixes, cleanUpTask.isDeleteEmptyDirectory(), "temporary directory commit abort");
+                recursiveDeleteFilesAndLog(cleanUpTask.getContext(), cleanUpTask.getPath(), filePrefixes, cleanUpTask.isDeleteEmptyDirectory(), "temporary directory commit abort");
             }
         }
 
         private void executeDeletionTasksForFinish()
         {
             for (DirectoryDeletionTask deletionTask : deletionTasksForFinish) {
-                if (!deleteRecursivelyIfExists(deletionTask.getUser(), hdfsEnvironment, deletionTask.getPath())) {
+                if (!deleteRecursivelyIfExists(deletionTask.getContext(), hdfsEnvironment, deletionTask.getPath())) {
                     logCleanupFailure("Error deleting directory %s", deletionTask.getPath().toString());
                 }
             }
@@ -1084,8 +1092,8 @@ public class SemiTransactionalHiveMetastore
                 try {
                     // Ignore the task if the source directory doesn't exist.
                     // This is probably because the original rename that we are trying to undo here never succeeded.
-                    if (pathExists(directoryRenameTask.getUser(), hdfsEnvironment, directoryRenameTask.getRenameFrom())) {
-                        renameDirectory(directoryRenameTask.getUser(), hdfsEnvironment, directoryRenameTask.getRenameFrom(), directoryRenameTask.getRenameTo(), () -> { });
+                    if (pathExists(directoryRenameTask.getContext(), hdfsEnvironment, directoryRenameTask.getRenameFrom())) {
+                        renameDirectory(directoryRenameTask.getContext(), hdfsEnvironment, directoryRenameTask.getRenameFrom(), directoryRenameTask.getRenameTo(), () -> { });
                     }
                 }
                 catch (Throwable throwable) {
@@ -1101,7 +1109,7 @@ public class SemiTransactionalHiveMetastore
                     continue;
                 }
                 Path path = declaredIntentionToWrite.getRootPath();
-                recursiveDeleteFilesAndLog(declaredIntentionToWrite.getUser(), path, ImmutableList.of(), true, "staging directory cleanup");
+                recursiveDeleteFilesAndLog(declaredIntentionToWrite.getContext(), path, ImmutableList.of(), true, "staging directory cleanup");
             }
         }
 
@@ -1248,7 +1256,7 @@ public class SemiTransactionalHiveMetastore
                     // the unique prefix for queries in this transaction.
 
                     recursiveDeleteFilesAndLog(
-                            declaredIntentionToWrite.getUser(),
+                            declaredIntentionToWrite.getContext(),
                             rootPath,
                             ImmutableList.of(declaredIntentionToWrite.getFilePrefix()),
                             true,
@@ -1295,7 +1303,7 @@ public class SemiTransactionalHiveMetastore
                         // TODO: It is a known deficiency that some empty directory does not get cleaned up in S3.
                         // We can not delete any of the directories here since we do not know who created them.
                         recursiveDeleteFilesAndLog(
-                                declaredIntentionToWrite.getUser(),
+                                declaredIntentionToWrite.getContext(),
                                 path,
                                 ImmutableList.of(declaredIntentionToWrite.getFilePrefix()),
                                 false,
@@ -1406,14 +1414,14 @@ public class SemiTransactionalHiveMetastore
             Executor executor,
             AtomicBoolean cancelled,
             List<CompletableFuture<?>> fileRenameFutures,
-            String user,
+            HdfsContext context,
             Path currentPath,
             Path targetPath,
             List<String> fileNames)
     {
         FileSystem fileSystem;
         try {
-            fileSystem = hdfsEnvironment.getFileSystem(user, currentPath);
+            fileSystem = hdfsEnvironment.getFileSystem(context, currentPath);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, format("Error moving data files to final location. Error listing directory %s", currentPath), e);
@@ -1438,11 +1446,11 @@ public class SemiTransactionalHiveMetastore
         }
     }
 
-    private void recursiveDeleteFilesAndLog(String user, Path directory, List<String> filePrefixes, boolean deleteEmptyDirectories, String reason)
+    private void recursiveDeleteFilesAndLog(HdfsContext context, Path directory, List<String> filePrefixes, boolean deleteEmptyDirectories, String reason)
     {
         RecursiveDeleteResult recursiveDeleteResult = recursiveDeleteFiles(
                 hdfsEnvironment,
-                user,
+                context,
                 directory,
                 filePrefixes,
                 deleteEmptyDirectories);
@@ -1476,11 +1484,11 @@ public class SemiTransactionalHiveMetastore
      * @param filePrefixes prefix of files that should be deleted
      * @param deleteEmptyDirectories whether empty directories should be deleted
      */
-    private static RecursiveDeleteResult recursiveDeleteFiles(HdfsEnvironment hdfsEnvironment, String user, Path directory, List<String> filePrefixes, boolean deleteEmptyDirectories)
+    private static RecursiveDeleteResult recursiveDeleteFiles(HdfsEnvironment hdfsEnvironment, HdfsContext context, Path directory, List<String> filePrefixes, boolean deleteEmptyDirectories)
     {
         FileSystem fileSystem;
         try {
-            fileSystem = hdfsEnvironment.getFileSystem(user, directory);
+            fileSystem = hdfsEnvironment.getFileSystem(context, directory);
 
             if (!fileSystem.exists(directory)) {
                 return new RecursiveDeleteResult(true, ImmutableList.of());
@@ -1588,11 +1596,11 @@ public class SemiTransactionalHiveMetastore
      *
      * @return true if the location no longer exists
      */
-    private static boolean deleteRecursivelyIfExists(String user, HdfsEnvironment hdfsEnvironment, Path path)
+    private static boolean deleteRecursivelyIfExists(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         FileSystem fileSystem;
         try {
-            fileSystem = hdfsEnvironment.getFileSystem(user, path);
+            fileSystem = hdfsEnvironment.getFileSystem(context, path);
         }
         catch (IOException ignored) {
             return false;
@@ -1601,15 +1609,15 @@ public class SemiTransactionalHiveMetastore
         return deleteIfExists(fileSystem, path, true);
     }
 
-    private static void renameDirectory(String user, HdfsEnvironment hdfsEnvironment, Path source, Path target, Runnable runWhenPathDoesntExist)
+    private static void renameDirectory(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path source, Path target, Runnable runWhenPathDoesntExist)
     {
-        if (pathExists(user, hdfsEnvironment, target)) {
+        if (pathExists(context, hdfsEnvironment, target)) {
             throw new PrestoException(HIVE_PATH_ALREADY_EXISTS,
                     format("Unable to rename from %s to %s: target directory already exists", source, target));
         }
 
-        if (!pathExists(user, hdfsEnvironment, target.getParent())) {
-            createDirectory(user, hdfsEnvironment, target.getParent());
+        if (!pathExists(context, hdfsEnvironment, target.getParent())) {
+            createDirectory(context, hdfsEnvironment, target.getParent());
         }
 
         // The runnable will assume that if rename fails, it will be okay to delete the directory (if the directory is empty).
@@ -1617,7 +1625,7 @@ public class SemiTransactionalHiveMetastore
         runWhenPathDoesntExist.run();
 
         try {
-            if (!hdfsEnvironment.getFileSystem(user, source).rename(source, target)) {
+            if (!hdfsEnvironment.getFileSystem(context, source).rename(source, target)) {
                 throw new PrestoException(HIVE_FILESYSTEM_ERROR, format("Failed to rename %s to %s: rename returned false", source, target));
             }
         }
@@ -1691,10 +1699,9 @@ public class SemiTransactionalHiveMetastore
     {
         private final ActionType type;
         private final T data;
-        private final String user;
-        private final String queryId;
+        private final HdfsContext context;
 
-        public Action(ActionType type, T data, String user, String queryId)
+        public Action(ActionType type, T data, HdfsContext context)
         {
             this.type = requireNonNull(type, "type is null");
             if (type == ActionType.DROP) {
@@ -1704,8 +1711,7 @@ public class SemiTransactionalHiveMetastore
                 requireNonNull(data, "data is null");
             }
             this.data = data;
-            this.user = requireNonNull(user, "user is null");
-            this.queryId = requireNonNull(queryId, "queryId is null");
+            this.context = requireNonNull(context, "context is null");
         }
 
         public ActionType getType()
@@ -1719,14 +1725,9 @@ public class SemiTransactionalHiveMetastore
             return data;
         }
 
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
-        }
-
-        public String getQueryId()
-        {
-            return queryId;
+            return context;
         }
 
         @Override
@@ -1845,15 +1846,15 @@ public class SemiTransactionalHiveMetastore
     private static class DeclaredIntentionToWrite
     {
         private final WriteMode mode;
-        private final String user;
+        private final HdfsContext context;
         private final String filePrefix;
         private final Path rootPath;
         private final SchemaTableName schemaTableName;
 
-        public DeclaredIntentionToWrite(WriteMode mode, String user, Path stagingPathRoot, String filePrefix, SchemaTableName schemaTableName)
+        public DeclaredIntentionToWrite(WriteMode mode, HdfsContext context, Path stagingPathRoot, String filePrefix, SchemaTableName schemaTableName)
         {
             this.mode = requireNonNull(mode, "mode is null");
-            this.user = requireNonNull(user, "user is null");
+            this.context = requireNonNull(context, "context is null");
             this.rootPath = requireNonNull(stagingPathRoot, "stagingPathRoot is null");
             this.filePrefix = requireNonNull(filePrefix, "filePrefix is null");
             this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
@@ -1864,9 +1865,9 @@ public class SemiTransactionalHiveMetastore
             return mode;
         }
 
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
+            return context;
         }
 
         public String getFilePrefix()
@@ -1889,7 +1890,7 @@ public class SemiTransactionalHiveMetastore
         {
             return toStringHelper(this)
                     .add("mode", mode)
-                    .add("user", user)
+                    .add("context", context)
                     .add("filePrefix", filePrefix)
                     .add("rootPath", rootPath)
                     .add("schemaTableName", schemaTableName)
@@ -1899,20 +1900,20 @@ public class SemiTransactionalHiveMetastore
 
     private static class DirectoryCleanUpTask
     {
-        private final String user;
+        private final HdfsContext context;
         private final Path path;
         private final boolean deleteEmptyDirectory;
 
-        public DirectoryCleanUpTask(String user, Path path, boolean deleteEmptyDirectory)
+        public DirectoryCleanUpTask(HdfsContext context, Path path, boolean deleteEmptyDirectory)
         {
-            this.user = user;
+            this.context = context;
             this.path = path;
             this.deleteEmptyDirectory = deleteEmptyDirectory;
         }
 
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
+            return context;
         }
 
         public Path getPath()
@@ -1929,7 +1930,7 @@ public class SemiTransactionalHiveMetastore
         public String toString()
         {
             return toStringHelper(this)
-                    .add("user", user)
+                    .add("context", context)
                     .add("path", path)
                     .add("deleteEmptyDirectory", deleteEmptyDirectory)
                     .toString();
@@ -1938,18 +1939,18 @@ public class SemiTransactionalHiveMetastore
 
     private static class DirectoryDeletionTask
     {
-        private final String user;
+        private final HdfsContext context;
         private final Path path;
 
-        public DirectoryDeletionTask(String user, Path path)
+        public DirectoryDeletionTask(HdfsContext context, Path path)
         {
-            this.user = user;
+            this.context = context;
             this.path = path;
         }
 
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
+            return context;
         }
 
         public Path getPath()
@@ -1961,7 +1962,7 @@ public class SemiTransactionalHiveMetastore
         public String toString()
         {
             return toStringHelper(this)
-                    .add("user", user)
+                    .add("context", context)
                     .add("path", path)
                     .toString();
         }
@@ -1969,20 +1970,20 @@ public class SemiTransactionalHiveMetastore
 
     private static class DirectoryRenameTask
     {
-        private final String user;
+        private final HdfsContext context;
         private final Path renameFrom;
         private final Path renameTo;
 
-        public DirectoryRenameTask(String user, Path renameFrom, Path renameTo)
+        public DirectoryRenameTask(HdfsContext context, Path renameFrom, Path renameTo)
         {
-            this.user = requireNonNull(user, "user is null");
+            this.context = requireNonNull(context, "context is null");
             this.renameFrom = requireNonNull(renameFrom, "renameFrom is null");
             this.renameTo = requireNonNull(renameTo, "renameTo is null");
         }
 
-        public String getUser()
+        public HdfsContext getContext()
         {
-            return user;
+            return context;
         }
 
         public Path getRenameFrom()
@@ -1999,7 +2000,7 @@ public class SemiTransactionalHiveMetastore
         public String toString()
         {
             return toStringHelper(this)
-                    .add("user", user)
+                    .add("context", context)
                     .add("renameFrom", renameFrom)
                     .add("renameTo", renameTo)
                     .toString();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.metastore.file;
 
 import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.SchemaAlreadyExistsException;
 import com.facebook.presto.hive.TableAlreadyExistsException;
@@ -31,6 +32,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.security.Identity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -89,7 +91,7 @@ public class FileHiveMetastore
 
     private final HdfsEnvironment hdfsEnvironment;
     private final Path catalogDirectory;
-    private final String metastoreUser;
+    private final HdfsContext hdfsContext;
     private final FileSystem metadataFileSystem;
 
     private final JsonCodec<DatabaseMetadata> databaseCodec = JsonCodec.jsonCodec(DatabaseMetadata.class);
@@ -107,9 +109,9 @@ public class FileHiveMetastore
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.catalogDirectory = new Path(requireNonNull(catalogDirectory, "baseDirectory is null"));
-        this.metastoreUser = requireNonNull(metastoreUser, "metastoreUser is null");
+        this.hdfsContext = new HdfsContext(new Identity(metastoreUser, Optional.empty()));
         try {
-            metadataFileSystem = hdfsEnvironment.getFileSystem(metastoreUser, this.catalogDirectory);
+            metadataFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, this.catalogDirectory);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
@@ -214,7 +216,7 @@ public class FileHiveMetastore
         else if (table.getTableType().equals(EXTERNAL_TABLE.name())) {
             try {
                 Path externalLocation = new Path(table.getStorage().getLocation());
-                FileSystem externalFileSystem = hdfsEnvironment.getFileSystem(metastoreUser, externalLocation);
+                FileSystem externalFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, externalLocation);
                 if (!externalFileSystem.isDirectory(externalLocation)) {
                     throw new PrestoException(HIVE_METASTORE_ERROR, "External table location does not exist");
                 }
@@ -531,7 +533,7 @@ public class FileHiveMetastore
         else if (table.getTableType().equals(EXTERNAL_TABLE.name())) {
             try {
                 Path externalLocation = new Path(partition.getStorage().getLocation());
-                FileSystem externalFileSystem = hdfsEnvironment.getFileSystem(metastoreUser, externalLocation);
+                FileSystem externalFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, externalLocation);
                 if (!externalFileSystem.isDirectory(externalLocation)) {
                     throw new PrestoException(HIVE_METASTORE_ERROR, "External partition location does not exist");
                 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.GroupByHashPageIndexerFactory;
 import com.facebook.presto.hive.AbstractTestHiveClient.HiveTransaction;
 import com.facebook.presto.hive.AbstractTestHiveClient.Transaction;
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.BridgingHiveMetastore;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
@@ -43,6 +44,7 @@ import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
@@ -97,6 +99,8 @@ import static org.testng.Assert.assertTrue;
 @Test(groups = "hive-s3")
 public abstract class AbstractTestHiveClientS3
 {
+    private static final HdfsContext TESTING_CONTEXT = new HdfsContext(new Identity("test", Optional.empty()));
+
     protected String writableBucket;
 
     protected String database;
@@ -262,7 +266,7 @@ public abstract class AbstractTestHiveClientS3
         Path basePath = new Path("s3://presto-test-hive/");
         Path tablePath = new Path(basePath, "presto_test_s3");
         Path filePath = new Path(tablePath, "test1.csv");
-        FileSystem fs = hdfsEnvironment.getFileSystem("user", basePath);
+        FileSystem fs = hdfsEnvironment.getFileSystem(TESTING_CONTEXT, basePath);
 
         assertTrue(isDirectory(fs.getFileStatus(basePath)));
         assertTrue(isDirectory(fs.getFileStatus(tablePath)));
@@ -275,7 +279,7 @@ public abstract class AbstractTestHiveClientS3
             throws Exception
     {
         Path basePath = new Path(format("s3://%s/rename/%s/", writableBucket, UUID.randomUUID()));
-        FileSystem fs = hdfsEnvironment.getFileSystem("user", basePath);
+        FileSystem fs = hdfsEnvironment.getFileSystem(TESTING_CONTEXT, basePath);
         assertFalse(fs.exists(basePath));
 
         // create file foo.txt
@@ -500,7 +504,7 @@ public abstract class AbstractTestHiveClientS3
                 if (deleteData) {
                     for (String location : locations) {
                         Path path = new Path(location);
-                        hdfsEnvironment.getFileSystem("user", path).delete(path, true);
+                        hdfsEnvironment.getFileSystem(TESTING_CONTEXT, path).delete(path, true);
                     }
                 }
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveWriteUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveWriteUtils.java
@@ -13,23 +13,27 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.hive.HiveTestUtils.createTestHdfsEnvironment;
 import static com.facebook.presto.hive.HiveWriteUtils.isS3FileSystem;
 import static com.facebook.presto.hive.HiveWriteUtils.isViewFileSystem;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestHiveWriteUtils
 {
+    private static final HdfsContext CONTEXT = new HdfsContext(SESSION, "test_schema");
+
     @Test
     public void testIsS3FileSystem()
     {
         HdfsEnvironment hdfsEnvironment = createTestHdfsEnvironment(new HiveClientConfig());
-        assertTrue(isS3FileSystem("user", hdfsEnvironment, new Path("s3://test-bucket/test-folder")));
-        assertFalse(isS3FileSystem("user", hdfsEnvironment, new Path("/test-dir/test-folder")));
+        assertTrue(isS3FileSystem(CONTEXT, hdfsEnvironment, new Path("s3://test-bucket/test-folder")));
+        assertFalse(isS3FileSystem(CONTEXT, hdfsEnvironment, new Path("/test-dir/test-folder")));
     }
 
     @Test
@@ -40,9 +44,9 @@ public class TestHiveWriteUtils
         Path nonViewfsPath = new Path("hdfs://localhost/test-dir/test-folder");
 
         // ViewFS check requires the mount point config
-        hdfsEnvironment.getConfiguration(viewfsPath).set("fs.viewfs.mounttable.ns-default.link./test-folder", "hdfs://localhost/app");
+        hdfsEnvironment.getConfiguration(CONTEXT, viewfsPath).set("fs.viewfs.mounttable.ns-default.link./test-folder", "hdfs://localhost/app");
 
-        assertTrue(isViewFileSystem("user", hdfsEnvironment, viewfsPath));
-        assertFalse(isViewFileSystem("user", hdfsEnvironment, nonViewfsPath));
+        assertTrue(isViewFileSystem(CONTEXT, hdfsEnvironment, viewfsPath));
+        assertFalse(isViewFileSystem(CONTEXT, hdfsEnvironment, nonViewfsPath));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -34,6 +35,7 @@ public class FullConnectorSession
 {
     private final String queryId;
     private final Identity identity;
+    private final Optional<String> source;
     private final TimeZoneKey timeZoneKey;
     private final Locale locale;
     private final long startTime;
@@ -45,12 +47,14 @@ public class FullConnectorSession
     public FullConnectorSession(
             String queryId,
             Identity identity,
+            Optional<String> source,
             TimeZoneKey timeZoneKey,
             Locale locale,
             long startTime)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.identity = requireNonNull(identity, "identity is null");
+        this.source = requireNonNull(source, "source is null");
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
         this.locale = requireNonNull(locale, "locale is null");
         this.startTime = startTime;
@@ -64,6 +68,7 @@ public class FullConnectorSession
     public FullConnectorSession(
             String queryId,
             Identity identity,
+            Optional<String> source,
             TimeZoneKey timeZoneKey,
             Locale locale,
             long startTime,
@@ -74,6 +79,7 @@ public class FullConnectorSession
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.identity = requireNonNull(identity, "identity is null");
+        this.source = requireNonNull(source, "source is null");
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
         this.locale = requireNonNull(locale, "locale is null");
         this.startTime = startTime;
@@ -88,6 +94,12 @@ public class FullConnectorSession
     public String getQueryId()
     {
         return queryId;
+    }
+
+    @Override
+    public Optional<String> getSource()
+    {
+        return source;
     }
 
     @Override
@@ -131,10 +143,12 @@ public class FullConnectorSession
                 .omitNullValues()
                 .add("queryId", queryId)
                 .add("user", getUser())
+                .add("source", source.orElse(null))
                 .add("timeZoneKey", timeZoneKey)
                 .add("locale", locale)
                 .add("startTime", startTime)
                 .add("properties", properties)
+                .omitNullValues()
                 .toString();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -295,7 +295,7 @@ public final class Session
 
     public ConnectorSession toConnectorSession()
     {
-        return new FullConnectorSession(queryId.toString(), identity, timeZoneKey, locale, startTime);
+        return new FullConnectorSession(queryId.toString(), identity, source, timeZoneKey, locale, startTime);
     }
 
     public ConnectorSession toConnectorSession(ConnectorId connectorId)
@@ -304,6 +304,7 @@ public final class Session
         return new FullConnectorSession(
                 queryId.toString(),
                 identity,
+                source,
                 timeZoneKey,
                 locale,
                 startTime,

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -42,6 +42,7 @@ public class TestingConnectorSession
 
     private final String queryId;
     private final Identity identity;
+    private final Optional<String> source;
     private final TimeZoneKey timeZoneKey;
     private final Locale locale;
     private final long startTime;
@@ -50,11 +51,12 @@ public class TestingConnectorSession
 
     public TestingConnectorSession(List<PropertyMetadata<?>> properties)
     {
-        this("user", UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of());
+        this("user", Optional.of("test"), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of());
     }
 
     public TestingConnectorSession(
             String user,
+            Optional<String> source,
             TimeZoneKey timeZoneKey,
             Locale locale,
             long startTime,
@@ -63,6 +65,7 @@ public class TestingConnectorSession
     {
         this.queryId = queryIdGenerator.createNextQueryId().toString();
         this.identity = new Identity(requireNonNull(user, "user is null"), Optional.empty());
+        this.source = requireNonNull(source, "source is null");
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
         this.locale = requireNonNull(locale, "locale is null");
         this.startTime = startTime;
@@ -74,6 +77,12 @@ public class TestingConnectorSession
     public String getQueryId()
     {
         return queryId;
+    }
+
+    @Override
+    public Optional<String> getSource()
+    {
+        return source;
     }
 
     @Override
@@ -119,10 +128,12 @@ public class TestingConnectorSession
     {
         return toStringHelper(this)
                 .add("user", getUser())
+                .add("source", source.orElse(null))
                 .add("timeZoneKey", timeZoneKey)
                 .add("locale", locale)
                 .add("startTime", startTime)
                 .add("properties", propertyValues)
+                .omitNullValues()
                 .toString();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -39,6 +39,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.operator.scalar.DateTimeFunctions.currentDate;
@@ -134,7 +135,7 @@ public class TestDateTimeFunctions
     private static void assertCurrentDateAtInstant(TimeZoneKey timeZoneKey, long instant)
     {
         long expectedDays = epochDaysInZone(timeZoneKey, instant);
-        long dateTimeCalculation = currentDate(new TestingConnectorSession("test", timeZoneKey, US, instant, ImmutableList.of(), ImmutableMap.of()));
+        long dateTimeCalculation = currentDate(new TestingConnectorSession("test", Optional.empty(), timeZoneKey, US, instant, ImmutableList.of(), ImmutableMap.of()));
         assertEquals(dateTimeCalculation, expectedDays);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -17,10 +17,13 @@ import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.type.TimeZoneKey;
 
 import java.util.Locale;
+import java.util.Optional;
 
 public interface ConnectorSession
 {
     String getQueryId();
+
+    Optional<String> getSource();
 
     default String getUser()
     {

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
@@ -13,65 +13,17 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.DynamicSliceOutput;
 import org.testng.annotations.Test;
 
-import java.util.Locale;
-import java.util.Optional;
-
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
-import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.spi.block.TestingSession.SESSION;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestDictionaryBlockEncoding
 {
-    private static final ConnectorSession SESSION = new ConnectorSession()
-    {
-        @Override
-        public String getQueryId()
-        {
-            return "test_query_id";
-        }
-
-        @Override
-        public Identity getIdentity()
-        {
-            return new Identity("user", Optional.empty());
-        }
-
-        @Override
-        public TimeZoneKey getTimeZoneKey()
-        {
-            return UTC_KEY;
-        }
-
-        @Override
-        public Locale getLocale()
-        {
-            return ENGLISH;
-        }
-
-        @Override
-        public long getStartTime()
-        {
-            return 0;
-        }
-
-        @Override
-        public <T> T getProperty(String name, Class<T> type)
-        {
-            throw new PrestoException(INVALID_SESSION_PROPERTY, "Unknown session property " + name);
-        }
-    };
-
     @Test
     public void testRoundTrip()
     {

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockEncoding.java
@@ -13,64 +13,16 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.DynamicSliceOutput;
 import org.testng.annotations.Test;
 
-import java.util.Locale;
-import java.util.Optional;
-
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
-import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.spi.block.TestingSession.SESSION;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 
 public class TestVariableWidthBlockEncoding
 {
-    private static final ConnectorSession SESSION = new ConnectorSession()
-    {
-        @Override
-        public String getQueryId()
-        {
-            return "test_query_id";
-        }
-
-        @Override
-        public Identity getIdentity()
-        {
-            return new Identity("user", Optional.empty());
-        }
-
-        @Override
-        public TimeZoneKey getTimeZoneKey()
-        {
-            return UTC_KEY;
-        }
-
-        @Override
-        public Locale getLocale()
-        {
-            return ENGLISH;
-        }
-
-        @Override
-        public long getStartTime()
-        {
-            return 0;
-        }
-
-        @Override
-        public <T> T getProperty(String name, Class<T> type)
-        {
-            throw new PrestoException(INVALID_SESSION_PROPERTY, "Unknown session property " + name);
-        }
-    };
-
     @Test
     public void testRoundTrip()
     {

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingSession.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.type.TimeZoneKey;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static java.util.Locale.ENGLISH;
+
+public final class TestingSession
+{
+    public static final ConnectorSession SESSION = new ConnectorSession()
+    {
+        @Override
+        public String getQueryId()
+        {
+            return "test_query_id";
+        }
+
+        @Override
+        public Identity getIdentity()
+        {
+            return new Identity("user", Optional.empty());
+        }
+
+        @Override
+        public TimeZoneKey getTimeZoneKey()
+        {
+            return UTC_KEY;
+        }
+
+        @Override
+        public Locale getLocale()
+        {
+            return ENGLISH;
+        }
+
+        @Override
+        public long getStartTime()
+        {
+            return 0;
+        }
+
+        @Override
+        public <T> T getProperty(String name, Class<T> type)
+        {
+            throw new PrestoException(INVALID_SESSION_PROPERTY, "Unknown session property " + name);
+        }
+    };
+
+    private TestingSession() {}
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingSession.java
@@ -36,6 +36,12 @@ public final class TestingSession
         }
 
         @Override
+        public Optional<String> getSource()
+        {
+            return Optional.of("TestSource");
+        }
+
+        @Override
         public Identity getIdentity()
         {
             return new Identity("user", Optional.empty());


### PR DESCRIPTION
Expose user, queryId, schema and table to HdfsEnvironment so file system
implementations can attribute usage to a query.