### PR TITLE
Run PruneCountAggregationOverScalar only for single output default aggregation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
@@ -50,10 +50,10 @@ public class PruneCountAggregationOverScalar
     @Override
     public Optional<PlanNode> apply(AggregationNode parent, Captures captures, Context context)
     {
-        Map<Symbol, AggregationNode.Aggregation> assignments = parent.getAggregations();
-        if (parent.hasDefaultOutput() && assignments.size() != 1) {
+        if (!parent.hasDefaultOutput() || parent.getOutputSymbols().size() != 1) {
             return Optional.empty();
         }
+        Map<Symbol, AggregationNode.Aggregation> assignments = parent.getAggregations();
         for (Map.Entry<Symbol, AggregationNode.Aggregation> entry : assignments.entrySet()) {
             AggregationNode.Aggregation aggregation = entry.getValue();
             requireNonNull(aggregation, "aggregation is null");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8973,5 +8973,8 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT COUNT(*) FROM (SELECT SUM(orderkey) FROM orders group by custkey)",
                 "VALUES 1000");
+        assertQuery("SELECT count(*) FROM (VALUES 2) t(a) GROUP BY a", "VALUES 1");
+        assertQuery("SELECT a, count(*) FROM (VALUES 2) t(a) GROUP BY a", "VALUES (2, 1)");
+        assertQuery("SELECT count(*) FROM (VALUES 2) t(a) GROUP BY a+1", "VALUES 1");
     }
 }


### PR DESCRIPTION
Run PruneCountAggregationOverScalar only for single output default aggregation
