### PR TITLE
Add support for zero-argument lambda expression

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestLambdaExpression.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestLambdaExpression.java
@@ -84,6 +84,12 @@ public class TestLambdaExpression
     }
 
     @Test
+    public void testLambdaWithoutArgument()
+    {
+        assertFunction("invoke(() -> 42)", INTEGER, 42);
+    }
+
+    @Test
     public void testSessionDependent()
             throws Exception
     {

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -293,7 +293,7 @@ primaryExpression
     | qualifiedName '(' ASTERISK ')' filter? over?                                        #functionCall
     | qualifiedName '(' (setQuantifier? expression (',' expression)*)? ')' filter? over?  #functionCall
     | identifier '->' expression                                                          #lambda
-    | '(' identifier (',' identifier)* ')' '->' expression                                #lambda
+    | '(' (identifier (',' identifier)*)? ')' '->' expression                             #lambda
     | '(' query ')'                                                                       #subqueryExpression
     // This is an extension to ANSI SQL, which considers EXISTS to be a <boolean expression>
     | EXISTS '(' query ')'                                                                #exists

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1884,6 +1884,10 @@ public class TestSqlParser
     public void testLambda()
             throws Exception
     {
+        assertExpression("() -> x",
+                new LambdaExpression(
+                        ImmutableList.of(),
+                        new Identifier("x")));
         assertExpression("x -> sin(x)",
                 new LambdaExpression(
                         ImmutableList.of(new LambdaArgumentDeclaration(identifier("x"))),


### PR DESCRIPTION
This is pre-requisite for re-implementing try as a syntactic sugar.