### PR TITLE
Update java doc after introducing yield signal

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -209,7 +209,7 @@ public class LookupJoinOperator
      * for the current probe position, calling this again will produce rows that wasn't been produced in previous
      * invocations.
      *
-     * @return true if all eligible rows have been produced; false otherwise (because pageBuilder became full)
+     * @return true if all eligible rows have been produced; false otherwise
      */
     private boolean joinCurrentPosition(DriverYieldSignal yieldSignal)
     {


### PR DESCRIPTION
After introducing yield signal, false is returned by `LookupJoinOperator::joinCurrentPosition`
either because pageBuilder became full or because yield signal was set.