### PR TITLE
Reading Postgresql arrays

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -206,7 +206,10 @@ public class BaseJdbcClient
                 boolean found = false;
                 while (resultSet.next()) {
                     found = true;
-                    Type columnType = toPrestoType(resultSet.getInt("DATA_TYPE"), resultSet.getInt("COLUMN_SIZE"));
+                    Type columnType = toPrestoType(
+                            resultSet.getInt("DATA_TYPE"),
+                            resultSet.getInt("COLUMN_SIZE"),
+                            resultSet.getString("TYPE_NAME"));
                     // skip unsupported column types
                     if (columnType != null) {
                         String columnName = resultSet.getString("COLUMN_NAME");
@@ -469,7 +472,7 @@ public class BaseJdbcClient
         }
     }
 
-    protected Type toPrestoType(int jdbcType, int columnSize)
+    protected Type toPrestoType(int jdbcType, int columnSize, String typeName)
     {
         switch (jdbcType) {
             case Types.BIT:

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -434,6 +434,12 @@ public class BaseJdbcClient
         return connection.prepareStatement(sql);
     }
 
+    @Override
+    public JdbcResultSetReader getJdbcResultSetReader()
+    {
+        return new BaseJdbcResultSetReader();
+    }
+
     protected ResultSet getTables(Connection connection, String schemaName, String tableName)
             throws SQLException
     {

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcResultSetReader.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcResultSetReader.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.CharType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.SmallintType;
+import com.facebook.presto.spi.type.TimeType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TinyintType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.base.CharMatcher;
+import io.airlift.slice.Slice;
+import org.joda.time.chrono.ISOChronology;
+
+import java.sql.ResultSet;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.Float.floatToRawIntBits;
+import static org.joda.time.DateTimeZone.UTC;
+
+public class BaseJdbcResultSetReader
+        implements JdbcResultSetReader
+{
+    private static final ISOChronology UTC_CHRONOLOGY = ISOChronology.getInstance(UTC);
+
+    @Override
+    public boolean getBoolean(ResultSet resultSet, int column, Type type) throws Exception
+    {
+        return resultSet.getBoolean(column);
+    }
+
+    @Override
+    public long getLong(ResultSet resultSet, int column, Type type) throws Exception
+    {
+        if (type.equals(TinyintType.TINYINT)) {
+            return (long) resultSet.getByte(column);
+        }
+        if (type.equals(SmallintType.SMALLINT)) {
+            return (long) resultSet.getShort(column);
+        }
+        if (type.equals(IntegerType.INTEGER)) {
+            return (long) resultSet.getInt(column);
+        }
+        if (type.equals(RealType.REAL)) {
+            return (long) floatToRawIntBits(resultSet.getFloat(column));
+        }
+        if (type.equals(BigintType.BIGINT)) {
+            return resultSet.getLong(column);
+        }
+        if (type.equals(DateType.DATE)) {
+            // JDBC returns a date using a timestamp at midnight in the JVM timezone
+            long localMillis = resultSet.getDate(column).getTime();
+            // Convert it to a midnight in UTC
+            long utcMillis = ISOChronology.getInstance().getZone().getMillisKeepLocal(UTC, localMillis);
+            // convert to days
+            return TimeUnit.MILLISECONDS.toDays(utcMillis);
+        }
+        if (type.equals(TimeType.TIME)) {
+            Time time = resultSet.getTime(column);
+            return UTC_CHRONOLOGY.millisOfDay().get(time.getTime());
+        }
+        if (type.equals(TimestampType.TIMESTAMP)) {
+            Timestamp timestamp = resultSet.getTimestamp(column);
+            return timestamp.getTime();
+        }
+        throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unhandled type for long: " + type.getTypeSignature());
+    }
+
+    @Override
+    public double getDouble(ResultSet resultSet, int column, Type type) throws Exception
+    {
+        return resultSet.getDouble(column);
+    }
+
+    @Override
+    public Slice getSlice(ResultSet resultSet, int column, Type type) throws Exception
+    {
+        if (type instanceof VarcharType) {
+            return utf8Slice(resultSet.getString(column));
+        }
+        if (type instanceof CharType) {
+            return utf8Slice(CharMatcher.is(' ').trimTrailingFrom(resultSet.getString(column)));
+        }
+        if (type.equals(VarbinaryType.VARBINARY)) {
+            return wrappedBuffer(resultSet.getBytes(column));
+        }
+        throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unhandled type for slice: " + type.getTypeSignature());
+    }
+
+    private static final int VALUE_COLUMN = 2;
+    private static final int DEFAULT_EXPECTED_ENTRIES = 4;
+
+    @Override
+    public Object getObject(ResultSet resultSet, int column, Type type) throws Exception
+    {
+        if (!(type instanceof ArrayType)) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unhandled type for object: " + type.getTypeSignature());
+        }
+
+        Type elementType = ((ArrayType) type).getElementType();
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), DEFAULT_EXPECTED_ENTRIES);
+        ResultSet arrayResultSet = resultSet.getArray(column).getResultSet();
+
+        if (elementType.getJavaType() == boolean.class) {
+            while (arrayResultSet.next()) {
+                if (this.isNull(arrayResultSet, VALUE_COLUMN, elementType)) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    elementType.writeBoolean(
+                            blockBuilder,
+                            this.getBoolean(arrayResultSet, VALUE_COLUMN, elementType));
+                }
+            }
+        }
+        else if (elementType.getJavaType() == long.class) {
+            while (arrayResultSet.next()) {
+                if (this.isNull(arrayResultSet, VALUE_COLUMN, elementType)) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    elementType.writeLong(
+                            blockBuilder,
+                            this.getLong(arrayResultSet, VALUE_COLUMN, elementType));
+                }
+            }
+        }
+        else if (elementType.getJavaType() == double.class) {
+            while (arrayResultSet.next()) {
+                if (this.isNull(arrayResultSet, VALUE_COLUMN, elementType)) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    elementType.writeDouble(
+                            blockBuilder,
+                            this.getDouble(arrayResultSet, VALUE_COLUMN, elementType));
+                }
+            }
+        }
+        else if (elementType.getJavaType() == Slice.class) {
+            while (arrayResultSet.next()) {
+                if (this.isNull(arrayResultSet, VALUE_COLUMN, elementType)) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    elementType.writeSlice(
+                            blockBuilder,
+                            this.getSlice(arrayResultSet, VALUE_COLUMN, elementType));
+                }
+            }
+        }
+        else if (elementType.getJavaType() == Block.class) {
+            while (arrayResultSet.next()) {
+                if (this.isNull(arrayResultSet, VALUE_COLUMN, elementType)) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    elementType.writeObject(
+                            blockBuilder,
+                            this.getObject(arrayResultSet, VALUE_COLUMN, elementType));
+                }
+            }
+        }
+        else {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR,
+                    "Unknown java class " + elementType.getJavaType() +
+                    " from type: " + type.getTypeSignature());
+        }
+        return blockBuilder.build();
+    }
+
+    @Override
+    public boolean isNull(ResultSet resultSet, int column, Type type) throws Exception
+    {
+        // JDBC is kind of dumb: we need to read the field and then ask
+        // if it was null, which means we are wasting effort here.
+        // We could save the result of the field access if it matters.
+        resultSet.getObject(column);
+
+        return resultSet.wasNull();
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -63,4 +63,6 @@ public interface JdbcClient
 
     PreparedStatement getPreparedStatement(Connection connection, String sql)
             throws SQLException;
+
+    JdbcResultSetReader getJdbcResultSetReader();
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcResultSetReader.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcResultSetReader.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slice;
+
+import java.sql.ResultSet;
+
+public interface JdbcResultSetReader
+{
+    boolean getBoolean(ResultSet resultSet, int column, Type type) throws Exception;
+
+    long getLong(ResultSet resultSet, int column, Type type) throws Exception;
+
+    double getDouble(ResultSet resultSet, int column, Type type) throws Exception;
+
+    Slice getSlice(ResultSet resultSet, int column, Type type) throws Exception;
+
+    Object getObject(ResultSet resultSet, int column, Type type) throws Exception;
+
+    boolean isNull(ResultSet resultSet, int column, Type type) throws Exception;
+}

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -13,17 +13,42 @@
  */
 package com.facebook.presto.plugin.postgresql;
 
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.SmallintType;
+import com.facebook.presto.spi.type.TimeType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.google.common.collect.ImmutableList;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
 
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static io.airlift.tpch.TpchTable.ORDERS;
 import static org.testng.Assert.assertTrue;
 
@@ -84,6 +109,150 @@ public class TestPostgreSqlIntegrationSmokeTest
         computeActual("SELECT * FROM test_ft");
         execute("DROP FOREIGN TABLE tpch.test_ft");
         execute("DROP SERVER devnull");
+    }
+
+    private class ArrayTest
+    {
+        final String rowDefinition;
+        final String insertionValue;
+        final Type expectedType;
+        final Object expectedValue;
+
+        ArrayTest(String rowDefinition,
+                  String insertionValue,
+                  Type expectedTypes,
+                  Object expectedValues)
+        {
+            this.rowDefinition = rowDefinition;
+            this.insertionValue = insertionValue;
+            this.expectedType = expectedTypes;
+            this.expectedValue = expectedValues;
+        }
+
+        MaterializedResult getExpectedResult()
+        {
+            return MaterializedResult
+                    .resultBuilder(getSession(), expectedType)
+                    .row(expectedValue)
+                    .build();
+        }
+
+        String createTableStatement(String name)
+        {
+            return String.format("CREATE TABLE %s (%s)", name, rowDefinition);
+        }
+
+        String insertStatement(String name)
+        {
+            return String.format("INSERT INTO %s VALUES %s", name, insertionValue);
+        }
+    }
+
+    @Test
+    public void testPostgreSqlArrays() throws SQLException, ParseException
+    {
+        List<ArrayTest> tests = ImmutableList.of(
+                new ArrayTest(
+                        "text_array text[]",
+                        "('{a, b, c}')",
+                        new ArrayType(VarcharType.createUnboundedVarcharType()),
+                        Arrays.asList("a", "b", "c")),
+                new ArrayTest(
+                        "varchar_array varchar(128)[]",
+                        "('{a, bcdefg}')",
+                        new ArrayType(VarcharType.createVarcharType(128)),
+                        Arrays.asList("a", "bcdefg")),
+                new ArrayTest(
+                        "bit_array bit[]",
+                        "('{1, 0}')",
+                        new ArrayType(BooleanType.BOOLEAN),
+                        Arrays.asList(true, false)),
+                new ArrayTest(
+                        "bool_array bool[]",
+                        "('{true, false, true}')",
+                        new ArrayType(BooleanType.BOOLEAN),
+                        Arrays.asList(true, false, true)),
+                new ArrayTest(
+                        "int2_array int2[]",
+                        "('{2, -10, 40}')",
+                        new ArrayType(SmallintType.SMALLINT),
+                        Arrays.asList((short) 2, (short) -10, (short) 40)),
+                new ArrayTest(
+                        "int4_array int4[]",
+                        "('{2, -10, 40, 1000000}')",
+                        new ArrayType(IntegerType.INTEGER),
+                        Arrays.asList(2, -10, 40, 1000000)),
+                new ArrayTest(
+                        "int8_array int8[]",
+                        "('{2, -123456789, 40, 123456789012}')",
+                        new ArrayType(BigintType.BIGINT),
+                        Arrays.asList(2L, -123456789L, 40L, 123456789012L)),
+                new ArrayTest(
+                        "float4_array float4[]",
+                        "('{0.25,100.25}')",
+                        new ArrayType(DoubleType.DOUBLE),
+                        Arrays.asList(0.25d, 100.25d)),
+                new ArrayTest(
+                        "float8_array float8[]",
+                        "('{0.25,234556790.5}')",
+                        new ArrayType(DoubleType.DOUBLE),
+                        Arrays.asList(0.25d, 234556790.5d)),
+                new ArrayTest(
+                        "numeric_array numeric[]",
+                        "('{-100.25, 0, 923.25}')",
+                        new ArrayType(DoubleType.DOUBLE),
+                        Arrays.asList(-100.25d, 0d, 923.25d)),
+                new ArrayTest(
+                        "byte_array bytea[]",
+                        "('{a,b,c,d}')",
+                        new ArrayType(VarbinaryType.VARBINARY),
+                        Arrays.asList(
+                                ByteBuffer.wrap("a".getBytes(StandardCharsets.UTF_8)),
+                                ByteBuffer.wrap("b".getBytes(StandardCharsets.UTF_8)),
+                                ByteBuffer.wrap("c".getBytes(StandardCharsets.UTF_8)),
+                                ByteBuffer.wrap("d".getBytes(StandardCharsets.UTF_8)))),
+                new ArrayTest(
+                        "date_array date[]",
+                        "('{2008-08-08, 2002-02-02}')",
+                        new ArrayType(DateType.DATE),
+                        Arrays.asList(
+                                new Date(LocalDate.parse("2008-08-08")
+                                        .atStartOfDay(ZoneOffset.UTC)
+                                        .toEpochSecond() * 1000),
+                                new Date(LocalDate.parse("2002-02-02")
+                                        .atStartOfDay(ZoneOffset.UTC)
+                                        .toEpochSecond() * 1000))),
+                new ArrayTest(
+                        "time_array time[]",
+                        "('{12:00:00, 16:59:01}')",
+                        new ArrayType(TimeType.TIME),
+                        Arrays.asList(
+                                Time.valueOf("12:00:00"),
+                                Time.valueOf("16:59:01"))),
+                new ArrayTest(
+                        "timestamp_array timestamp[]",
+                        "('{2004-12-31T00:23:12, 2001-12-24T11:32:22}')",
+                        new ArrayType(TimestampType.TIMESTAMP),
+                        Arrays.asList(
+                                Timestamp.valueOf("2004-12-31 00:23:12"),
+                                Timestamp.valueOf("2001-12-24 11:32:22"))),
+                new ArrayTest(
+                        "int_array int4[]",
+                        "('{1,null}')",
+                        new ArrayType(IntegerType.INTEGER),
+                        Arrays.asList(1, null)),
+                new ArrayTest(
+                        "int_array int4[]",
+                        "('{}')",
+                        new ArrayType(IntegerType.INTEGER),
+                        Arrays.asList()));
+        for (ArrayTest test : tests) {
+            execute(test.createTableStatement("tpch.test_arrays"));
+            execute(test.insertStatement("tpch.test_arrays"));
+            MaterializedResult actual = computeActual("select * from test_arrays");
+            assertEquals(actual, test.getExpectedResult());
+            execute("drop table tpch.test_arrays");
+        }
     }
 
     private void execute(String sql)


### PR DESCRIPTION
Hi,

And thanks for the great software!

This pull request implements reading of postgresql arrays:
It does it by the following changes in presto-base-jdbc:

1. Move interpretation of JDBC ResultSet to a separate JdbcResultSetReader class from JdbcRecordCursor,
this new JdbcResultReader is overrideable in client for database-specific resultset-interpretations.
2. Convert JDBC Arrays to Presto Arrays.
3. Add the database specific TYPE_NAME from the column metadata to the method toPrestoType

And the following changes in presto-postgresql:
1. Using the TYPE_NAME from above convert postgresql arrays to proper presto types.
2. Tests for the conversion of postgresql arrays to presto (which are mostly in the base-jdbc driver and should for compliant JDBC drivers be database-independent)

Fixes https://github.com/prestodb/presto/issues/11422