### PR TITLE
Use truncateToLengthAndTrimSpaces instead of trimSpacesAndTruncateToLength

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -58,7 +58,7 @@ import static com.facebook.presto.hive.util.SerDeUtils.getBlockObject;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
-import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.Decimals.rescale;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -388,7 +388,7 @@ class GenericHiveRecordCursor<K, V extends Writable>
                 value = truncateToLength(value, type);
             }
             if (isCharType(type)) {
-                value = trimSpacesAndTruncateToLength(value, type);
+                value = truncateToLengthAndTrimSpaces(value, type);
             }
 
             // store a copy of the bytes, since the hive reader can reuse the underlying buffer

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -77,7 +77,7 @@ import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.b
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.getParquetTupleDomain;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.predicateMatches;
 import static com.facebook.presto.spi.type.Chars.isCharType;
-import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
@@ -597,7 +597,7 @@ public class ParquetHiveRecordCursor
                 slices[fieldIndex] = truncateToLength(wrappedBuffer(value.getBytes()), type);
             }
             else if (isCharType(type)) {
-                slices[fieldIndex] = trimSpacesAndTruncateToLength(wrappedBuffer(value.getBytes()), type);
+                slices[fieldIndex] = truncateToLengthAndTrimSpaces(wrappedBuffer(value.getBytes()), type);
             }
             else {
                 slices[fieldIndex] = wrappedBuffer(value.getBytes());
@@ -1289,7 +1289,7 @@ public class ParquetHiveRecordCursor
                 type.writeSlice(builder, truncateToLength(wrappedBuffer(value.getBytes()), type));
             }
             else if (isCharType(type)) {
-                type.writeSlice(builder, trimSpacesAndTruncateToLength(wrappedBuffer(value.getBytes()), type));
+                type.writeSlice(builder, truncateToLengthAndTrimSpaces(wrappedBuffer(value.getBytes()), type));
             }
             else {
                 type.writeSlice(builder, wrappedBuffer(value.getBytes()));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
@@ -20,7 +20,7 @@ import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
 import static com.facebook.presto.spi.type.Chars.isCharType;
-import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.spi.type.Varchars.truncateToLength;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
@@ -50,7 +50,7 @@ public class ParquetBinaryColumnReader
                 value = truncateToLength(value, type);
             }
             if (isCharType(type)) {
-                value = trimSpacesAndTruncateToLength(value, type);
+                value = truncateToLengthAndTrimSpaces(value, type);
             }
             type.writeSlice(blockBuilder, value);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/SerDeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/SerDeUtils.java
@@ -62,7 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Float.floatToRawIntBits;
@@ -141,7 +141,7 @@ public final class SerDeUtils
             case CHAR:
                 CharType charType = (CharType) type;
                 HiveChar hiveChar = ((HiveCharObjectInspector) inspector).getPrimitiveJavaObject(object);
-                type.writeSlice(builder, trimSpacesAndTruncateToLength(Slices.utf8Slice(hiveChar.getValue()), charType.getLength()));
+                type.writeSlice(builder, truncateToLengthAndTrimSpaces(Slices.utf8Slice(hiveChar.getValue()), charType.getLength()));
                 return;
             case DATE:
                 DateType.DATE.writeLong(builder, formatDateAsLong(object, (DateObjectInspector) inspector));

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/CharacterStringCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/CharacterStringCasts.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.facebook.presto.spi.type.Chars.padSpaces;
-import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.Varchars.truncateToLength;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -72,7 +72,7 @@ public final class CharacterStringCasts
     @LiteralParameters({"x", "y"})
     public static Slice varcharToCharCast(@LiteralParameter("y") Long y, @SqlType("varchar(x)") Slice slice)
     {
-        return trimSpacesAndTruncateToLength(slice, y.intValue());
+        return truncateToLengthAndTrimSpaces(slice, y.intValue());
     }
 
     @ScalarOperator(OperatorType.CAST)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
@@ -40,7 +40,7 @@ import java.util.function.Function;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
-import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.Decimals.encodeUnscaledValue;
 import static com.facebook.presto.spi.type.Decimals.isLongDecimal;
 import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
@@ -217,7 +217,7 @@ public class TupleDomainOrcPredicate<C>
             return createDomain(type, hasNullValue, columnStatistics.getDecimalStatistics(), value -> encodeUnscaledValue(rescale(value, (DecimalType) type).unscaledValue()));
         }
         else if (isCharType(type) && columnStatistics.getStringStatistics() != null) {
-            return createDomain(type, hasNullValue, columnStatistics.getStringStatistics(), value -> trimSpacesAndTruncateToLength(value, type));
+            return createDomain(type, hasNullValue, columnStatistics.getStringStatistics(), value -> truncateToLengthAndTrimSpaces(value, type));
         }
         else if (isVarcharType(type) && columnStatistics.getStringStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getStringStatistics());

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
@@ -45,7 +45,7 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_GROUP_DICTI
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_GROUP_DICTIONARY_LENGTH;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.type.Chars.isCharType;
-import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.spi.type.Varchars.truncateToLength;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -280,7 +280,7 @@ public class SliceDictionaryStreamReader
                     value = truncateToLength(value, type);
                 }
                 if (isCharType(type)) {
-                    value = trimSpacesAndTruncateToLength(value, type);
+                    value = truncateToLengthAndTrimSpaces(value, type);
                 }
                 dictionary[dictionaryOutputOffset + i] = value;
             }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -125,7 +125,7 @@ import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.Decimals.rescale;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -706,7 +706,7 @@ public class OrcTester
                 type.writeSlice(blockBuilder, slice);
             }
             else if (type instanceof CharType) {
-                Slice slice = trimSpacesAndTruncateToLength(utf8Slice((String) value), type);
+                Slice slice = truncateToLengthAndTrimSpaces(utf8Slice((String) value), type);
                 type.writeSlice(blockBuilder, slice);
             }
             else if (VARBINARY.equals(type)) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Chars.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Chars.java
@@ -74,28 +74,28 @@ public final class Chars
         return buffer;
     }
 
-    public static Slice trimSpacesAndTruncateToLength(Slice slice, Type type)
+    public static Slice truncateToLengthAndTrimSpaces(Slice slice, Type type)
     {
         requireNonNull(type, "type is null");
         if (!isCharType(type)) {
             throw new IllegalArgumentException("type must be the instance of CharType");
         }
-        return trimSpacesAndTruncateToLength(slice, CharType.class.cast(type));
+        return truncateToLengthAndTrimSpaces(slice, CharType.class.cast(type));
     }
 
-    public static Slice trimSpacesAndTruncateToLength(Slice slice, CharType charType)
+    public static Slice truncateToLengthAndTrimSpaces(Slice slice, CharType charType)
     {
         requireNonNull(charType, "charType is null");
-        return trimSpacesAndTruncateToLength(slice, charType.getLength());
+        return truncateToLengthAndTrimSpaces(slice, charType.getLength());
     }
 
-    public static Slice trimSpacesAndTruncateToLength(Slice slice, int maxLength)
+    public static Slice truncateToLengthAndTrimSpaces(Slice slice, int maxLength)
     {
         requireNonNull(slice, "slice is null");
         if (maxLength < 0) {
             throw new IllegalArgumentException("Max length must be greater or equal than zero");
         }
-        return truncateToLength(trimTrailingSpaces(slice), maxLength);
+        return trimTrailingSpaces(truncateToLength(slice, maxLength));
     }
 
     public static Slice trimTrailingSpaces(Slice slice)

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestChars.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestChars.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.Chars.byteCountWithoutTrailingSpace;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static org.testng.Assert.assertEquals;
@@ -24,6 +25,20 @@ import static org.testng.Assert.fail;
 
 public class TestChars
 {
+    @Test
+    public void testTruncateToLengthAndTrimSpaces()
+    {
+        assertEquals(utf8Slice("a"), truncateToLengthAndTrimSpaces(utf8Slice("a c"), 1));
+        assertEquals(utf8Slice("a"), truncateToLengthAndTrimSpaces(utf8Slice("a  "), 1));
+        assertEquals(utf8Slice("a"), truncateToLengthAndTrimSpaces(utf8Slice("abc"), 1));
+        assertEquals(utf8Slice(""), truncateToLengthAndTrimSpaces(utf8Slice("a c"), 0));
+        assertEquals(utf8Slice("a c"), truncateToLengthAndTrimSpaces(utf8Slice("a c "), 3));
+        assertEquals(utf8Slice("a c"), truncateToLengthAndTrimSpaces(utf8Slice("a c "), 4));
+        assertEquals(utf8Slice("a c"), truncateToLengthAndTrimSpaces(utf8Slice("a c "), 5));
+        assertEquals(utf8Slice(""), truncateToLengthAndTrimSpaces(utf8Slice("  "), 1));
+        assertEquals(utf8Slice(""), truncateToLengthAndTrimSpaces(utf8Slice(""), 1));
+    }
+
     @Test
     public void testByteCountWithoutTrailingSpaces()
             throws Exception

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.Chars.trimSpacesAndTruncateToLength;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -90,7 +90,7 @@ public class TpcdsTableStatisticsFactory
             return Slices.utf8Slice((String) tpcdsValue);
         }
         else if (type instanceof CharType) {
-            return trimSpacesAndTruncateToLength(Slices.utf8Slice((String) tpcdsValue), type);
+            return truncateToLengthAndTrimSpaces(Slices.utf8Slice((String) tpcdsValue), type);
         }
         else if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(DATE) || (type instanceof DecimalType && isShortDecimal(type))) {
             return ((Number) tpcdsValue).longValue();


### PR DESCRIPTION

The latter can produce trailing spaces which is incorrect char representation.

Fixes: https://github.com/prestodb/presto/issues/8843