### PR TITLE
Allow max-memory-per-node to be exactly (xmx - reservedMemory)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/LocalMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/LocalMemoryManager.java
@@ -49,7 +49,7 @@ public final class LocalMemoryManager
         maxMemory = new DataSize(maxHeap - systemMemoryConfig.getReservedSystemMemory().toBytes(), BYTE);
 
         ImmutableMap.Builder<MemoryPoolId, MemoryPool> builder = ImmutableMap.builder();
-        checkArgument(config.getMaxQueryMemoryPerNode().toBytes() < maxMemory.toBytes(), format("%s set to %s, but only %s of useable heap available", QUERY_MAX_MEMORY_PER_NODE_CONFIG, config.getMaxQueryMemoryPerNode(), maxMemory));
+        checkArgument(config.getMaxQueryMemoryPerNode().toBytes() <= maxMemory.toBytes(), format("%s set to %s, but only %s of useable heap available", QUERY_MAX_MEMORY_PER_NODE_CONFIG, config.getMaxQueryMemoryPerNode(), maxMemory));
         builder.put(RESERVED_POOL, new MemoryPool(RESERVED_POOL, config.getMaxQueryMemoryPerNode()));
         DataSize generalPoolSize = new DataSize(Math.max(0, maxMemory.toBytes() - config.getMaxQueryMemoryPerNode().toBytes()), BYTE);
         builder.put(GENERAL_POOL, new MemoryPool(GENERAL_POOL, generalPoolSize));


### PR DESCRIPTION
Now it is possible to get a very weird error message:

```
query.max-memory-per-node set to 9GB, but only 9663676416B of useable heap available
```