### PR TITLE
Use TupleDomain.all() in the blackhole TableLayout

### DIFF
--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
@@ -245,13 +245,6 @@ public class BlackHoleMetadata
     @Override
     public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
     {
-        return new ConnectorTableLayout(
-                handle,
-                Optional.empty(),
-                TupleDomain.none(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                ImmutableList.of());
+        return new ConnectorTableLayout(handle);
     }
 }


### PR DESCRIPTION
The TupleDomain for the table layouts in the blackhole connector should
be TupleDomain.all() instead of none() since the blackhole connector
produces zeroed data for the tables it creates.