### PR TITLE
Ban import of org.testng.JUnitAssert

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfoResource.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfoResource.java
@@ -36,8 +36,8 @@ import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.airlift.testing.Closeables.closeQuietly;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.AssertJUnit.assertNotNull;
 
 @Test(singleThreaded = true)
 public class TestQueryStateInfoResource

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSortExpressionExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSortExpressionExtractor.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 public class TestSortExpressionExtractor
 {
@@ -86,13 +86,13 @@ public class TestSortExpressionExtractor
     private static void assertGetSortExpression(Expression expression)
     {
         Optional<Expression> actual = SortExpressionExtractor.extractSortExpression(BUILD_SYMBOLS, expression);
-        assertEquals(Optional.empty(), actual);
+        assertEquals(actual, Optional.empty());
     }
 
     private static void assertGetSortExpression(Expression expression, String expectedSymbol)
     {
         Optional<Expression> expected = Optional.of(new SymbolReference(expectedSymbol));
         Optional<Expression> actual = SortExpressionExtractor.extractSortExpression(BUILD_SYMBOLS, expression);
-        assertEquals(expected, actual);
+        assertEquals(actual, expected);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TestExpressionVerifier.java
@@ -19,8 +19,8 @@ import com.facebook.presto.sql.tree.SymbolReference;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import static org.testng.AssertJUnit.assertFalse;
 
 public class TestExpressionVerifier
 {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestEliminateCrossJoins.java
@@ -47,8 +47,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.testng.Assert.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestEliminateCrossJoins

--- a/presto-spi/src/test/java/com/facebook/presto/spi/resourceGroups/TestResourceGroupId.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/resourceGroups/TestResourceGroupId.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.Assert.assertTrue;
 
 public class TestResourceGroupId
 {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataTypeTest.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/datatype/DataTypeTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
-import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 public class DataTypeTest
 {
@@ -50,9 +50,9 @@ public class DataTypeTest
         List<Object> expectedResults = inputs.stream().map(Input::toPrestoQueryResult).collect(toList());
         try (TestTable testTable = dataSetup.setupTestTable(unmodifiableList(inputs))) {
             MaterializedResult materializedRows = prestoExecutor.execute("SELECT * from " + testTable.getName());
-            assertEquals(expectedTypes, materializedRows.getTypes());
+            assertEquals(materializedRows.getTypes(), expectedTypes);
             MaterializedRow row = getOnlyElement(materializedRows);
-            assertEquals(expectedResults, row.getFields());
+            assertEquals(row.getFields(), expectedResults);
         }
     }
 

--- a/src/checkstyle/checks.xml
+++ b/src/checkstyle/checks.xml
@@ -75,6 +75,10 @@
         <property name="format" value="^[ \t]*import org.jetbrains.annotations.Nullable;$" />
         <property name="message" value="Use javax.annotation.Nullable instead of org.jetbrains.annotations.Nullable" />
     </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import static org.testng.AssertJUnit\." />
+        <property name="message" value="Use org.testng.Assert instead of org.testng.AssertJUnit" />
+    </module>
 
     <module name="SuppressWarningsFilter" />
     <module name="TreeWalker">
@@ -186,8 +190,7 @@
                 org.weakref.jmx.internal,
                 jersey.repackaged,
                 jdk.nashorn.internal,
-                jdk.internal,
-                org.testng.AssertJUnit" />
+                jdk.internal" />
         </module>
     </module>
 </module>

--- a/src/checkstyle/checks.xml
+++ b/src/checkstyle/checks.xml
@@ -186,7 +186,8 @@
                 org.weakref.jmx.internal,
                 jersey.repackaged,
                 jdk.nashorn.internal,
-                jdk.internal" />
+                jdk.internal,
+                org.testng.AssertJUnit" />
         </module>
     </module>
 </module>


### PR DESCRIPTION
Found these imports while looking into something else with `git grep`. We should be consistent in which style of assertions we use.

@electrum  