### PR TITLE
Upgrade Accumulo to 1.7.3

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.accumulo.version>1.6.2</dep.accumulo.version>
+        <dep.accumulo.version>1.7.3</dep.accumulo.version>
         <dep.curator.version>2.12.0</dep.curator.version>
         <dep.log4j.version>1.2.17</dep.log4j.version>
     </properties>
@@ -28,6 +28,10 @@
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.beust</groupId>
@@ -80,6 +84,7 @@
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-minicluster</artifactId>
             <version>${dep.accumulo.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
@@ -88,6 +93,10 @@
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-minicluster</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.beust</groupId>
@@ -108,10 +117,6 @@
                 <exclusion>
                     <groupId>org.apache.accumulo</groupId>
                     <artifactId>accumulo-monitor</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -226,7 +231,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.1</version>
+            <version>2.4</version>
         </dependency>
 
         <dependency>

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/AccumuloQueryRunner.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/AccumuloQueryRunner.java
@@ -49,6 +49,7 @@ import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.airlift.units.Duration.nanosSince;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.accumulo.minicluster.MemoryUnit.MEGABYTE;
 
 public final class AccumuloQueryRunner
 {
@@ -192,6 +193,7 @@ public final class AccumuloQueryRunner
 
         // Start MAC and connect to it
         MiniAccumuloCluster accumulo = new MiniAccumuloCluster(macDir, MAC_PASSWORD);
+        accumulo.getConfig().setDefaultMemory(512, MEGABYTE);
         accumulo.start();
 
         // Add shutdown hook to stop MAC and cleanup temporary files


### PR DESCRIPTION
Includes MiniAccumuloCluster memory bump to 512M
Includes organization and updates to dependencies

Fixes #8789