### PR TITLE
Add retry interval when adding column in raptor

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -287,6 +287,14 @@ public class DatabaseShardManager
                 if (attempts >= MAX_ADD_COLUMN_ATTEMPTS) {
                     throw metadataError(e);
                 }
+                log.warn(e, "Failed to alter table on attempt %s, will retry. SQL: %s", attempts, sql);
+                try {
+                    SECONDS.sleep(3);
+                }
+                catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw metadataError(ie);
+                }
             }
         }
     }


### PR DESCRIPTION
The wait interval is hardcoded to be 3 seconds and will retry for up to 100 times which add up to 5 min. ALTER TABLE failure should be rare and we would like to ensure that we make enough retries.

#8874 