### PR TITLE
Make sure RcFileWriter closer registers all streams

### DIFF
--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileWriter.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileWriter.java
@@ -192,12 +192,12 @@ public class RcFileWriter
             throws IOException
     {
         try (Closer closer = Closer.create()) {
-            writeRowGroup();
             closer.register(output);
             closer.register(keySectionOutput::destroy);
             for (ColumnEncoder columnEncoder : columnEncoders) {
                 closer.register(columnEncoder::destroy);
             }
+            writeRowGroup();
         }
     }
 


### PR DESCRIPTION
We have seen in production where writeRowGroup() throws an exception
that causes output streams fail to close.

e.g.:
```
Caused by: java.io.UncheckedIOException: org.apache.hadoop.ipc.RemoteException: org.apache.hadoop.hdfs.server.namenode.LeaseExpiredException: 
        ...
        at io.airlift.slice.OutputStreamSliceOutput.writeToOutputStream(OutputStreamSliceOutput.java:355)
        at io.airlift.slice.OutputStreamSliceOutput.writeBytes(OutputStreamSliceOutput.java:178)
        at io.airlift.slice.OutputStreamSliceOutput.writeBytes(OutputStreamSliceOutput.java:169)
        at com.facebook.presto.rcfile.RcFileWriter.writeRowGroup(RcFileWriter.java:319)
        at com.facebook.presto.rcfile.RcFileWriter.close(RcFileWriter.java:195)
        at com.facebook.presto.hive.RcFileFileWriter.rollback(RcFileFileWriter.java:150)
        ... 23 more
```