### PR TITLE
Add additional connectors to config.properties

### DIFF
--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -35,7 +35,9 @@ plugin.bundles=\
   ../../../presto-cassandra/pom.xml,\
   ../../../presto-mysql/pom.xml,\
   ../../../presto-postgresql/pom.xml,\
-  ../../../presto-sqlserver/pom.xml
+  ../../../presto-sqlserver/pom.xml,\
+  ../../../presto-ml/pom.xml,\
+  ../../../presto-tpcds/pom.xml
 
 presto.version=testversion
 distributed-joins-enabled=true


### PR DESCRIPTION
In order to unify the test environment in Docker and IntelliJ dev env,
missing plugins are added to enable product tests run in IntelliJ the
same way as it's run in Docker.