### PR TITLE
Remove loadedBlockBytes stats

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/FileFormatDataSourceStats.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/FileFormatDataSourceStats.java
@@ -24,7 +24,6 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class FileFormatDataSourceStats
 {
     private final DistributionStat readBytes = new DistributionStat();
-    private final DistributionStat loadedBlockBytes = new DistributionStat();
     private final DistributionStat maxCombinedBytesPerRow = new DistributionStat();
     private final TimeStat time0Bto100KB = new TimeStat(MILLISECONDS);
     private final TimeStat time100KBto1MB = new TimeStat(MILLISECONDS);
@@ -36,13 +35,6 @@ public class FileFormatDataSourceStats
     public DistributionStat getReadBytes()
     {
         return readBytes;
-    }
-
-    @Managed
-    @Nested
-    public DistributionStat getLoadedBlockBytes()
-    {
-        return loadedBlockBytes;
     }
 
     @Managed
@@ -95,11 +87,6 @@ public class FileFormatDataSourceStats
         else {
             time10MBPlus.add(nanos, NANOSECONDS);
         }
-    }
-
-    public void addLoadedBlockSize(long bytes)
-    {
-        loadedBlockBytes.add(bytes);
     }
 
     public void addMaxCombinedBytesPerRow(long bytes)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
@@ -151,7 +151,7 @@ public class OrcPageSource
                     blocks[fieldId] = constantBlocks[fieldId].getRegion(0, batchSize);
                 }
                 else {
-                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId], type, stats));
+                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId], type));
                 }
             }
             return new Page(batchSize, blocks);
@@ -219,14 +219,12 @@ public class OrcPageSource
         private final int expectedBatchId = batchId;
         private final int columnIndex;
         private final Type type;
-        private final FileFormatDataSourceStats stats;
         private boolean loaded;
 
-        public OrcBlockLoader(int columnIndex, Type type, FileFormatDataSourceStats stats)
+        public OrcBlockLoader(int columnIndex, Type type)
         {
             this.columnIndex = columnIndex;
             this.type = requireNonNull(type, "type is null");
-            this.stats = requireNonNull(stats, "stats is null");
         }
 
         @Override
@@ -248,8 +246,6 @@ public class OrcPageSource
                 }
                 throw new PrestoException(HIVE_CURSOR_ERROR, e);
             }
-
-            stats.addLoadedBlockSize(lazyBlock.getSizeInBytes());
 
             loaded = true;
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -241,7 +241,6 @@ public class TestOrcPageSourceMemoryTracking
         assertTrue(pageSource.isFinished());
         assertEquals(pageSource.getSystemMemoryUsage(), 0);
         pageSource.close();
-        assertEquals((int) stats.getLoadedBlockBytes().getAllTime().getCount(), 50);
     }
 
     @Test(dataProvider = "rowCount")


### PR DESCRIPTION
Adding stats for every block loaded is burning CPU. Given the problem of
bounding the size of blocks has been resolved, the stats is no longer
needed.

Resolves #8885 