### PR TITLE
Fix blackhole handling of unenforced constraints

### DIFF
--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
@@ -30,7 +30,6 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -239,7 +238,7 @@ public class BlackHoleMetadata
                 blackHoleHandle.getRowsPerPage(),
                 blackHoleHandle.getFieldsLength(),
                 blackHoleHandle.getPageProcessingDelay());
-        return ImmutableList.of(new ConnectorTableLayoutResult(getTableLayout(session, layoutHandle), TupleDomain.all()));
+        return ImmutableList.of(new ConnectorTableLayoutResult(getTableLayout(session, layoutHandle), constraint.getSummary()));
     }
 
     @Override

--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
@@ -243,6 +243,16 @@ public class TestBlackHoleSmoke
         dropBlackholeAllTypesTable();
     }
 
+    @Test
+    public void testSelectWithUnenforcedConstraint()
+            throws Exception
+    {
+        createBlackholeAllTypesTable();
+        MaterializedResult rows = queryRunner.execute("SELECT * FROM blackhole_all_types where _bigint > 10");
+        assertEquals(rows.getRowCount(), 0);
+        dropBlackholeAllTypesTable();
+    }
+
     private void createBlackholeAllTypesTable()
     {
         assertThatQueryReturnsValue(


### PR DESCRIPTION
Return the constraint in the ConnectorTableLayoutResult so a filter node
gets added.