### PR TITLE
[prototype only] Reuse existing arrays in GroupByHash

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -41,14 +41,24 @@ import static com.facebook.presto.util.HashCollisionsEstimator.estimateNumberOfH
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
+import static io.airlift.slice.SizeOf.sizeOfByteArray;
+import static io.airlift.slice.SizeOf.sizeOfIntArray;
+import static io.airlift.slice.SizeOf.sizeOfLongArray;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
 import static it.unimi.dsi.fastutil.HashCommon.murmurHash3;
+import static it.unimi.dsi.fastutil.HashCommon.nextPowerOfTwo;
+import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 
 // This implementation assumes arrays used in the hash are always a power of 2
 public class MultiChannelGroupByHash
         implements GroupByHash
 {
+    private static final int SEGMENT_SHIFT = 20;
+    private static final int SEGMENT_SIZE = 1 << SEGMENT_SHIFT;
+    private static final int SEGMENT_MASK = SEGMENT_SIZE - 1;
+    private static final long SIZE_OF_SEGMENT = sizeOfIntArray(SEGMENT_SIZE) + sizeOfByteArray(SEGMENT_SIZE) + sizeOfLongArray(SEGMENT_SIZE);
+
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MultiChannelGroupByHash.class).instanceSize();
     private static final float FILL_RATIO = 0.75f;
     private final List<Type> types;
@@ -65,12 +75,13 @@ public class MultiChannelGroupByHash
 
     private long completedPagesMemorySize;
 
+    private int segments;
     private int hashCapacity;
     private int maxFill;
     private int mask;
-    private long[] groupAddressByHash;
-    private int[] groupIdsByHash;
-    private byte[] rawHashByHashPosition;
+    private long[][] groupAddressByHash;
+    private int[][] groupIdsByHash;
+    private byte[][] rawHashByHashPosition;
 
     private final LongBigArray groupAddressByGroupId;
 
@@ -124,16 +135,24 @@ public class MultiChannelGroupByHash
         startNewPage();
 
         // reserve memory for the arrays
-        hashCapacity = arraySize(expectedSize, FILL_RATIO);
+        hashCapacity = max(arraySize(expectedSize, FILL_RATIO), SEGMENT_SIZE);
+        // must be power of 2
+        segments = hashCapacity / SEGMENT_SIZE;
+        verify(hashCapacity % SEGMENT_SIZE == 0);
+        verify(segments == nextPowerOfTwo(segments));
 
         maxFill = calculateMaxFill(hashCapacity);
         mask = hashCapacity - 1;
-        groupAddressByHash = new long[hashCapacity];
-        Arrays.fill(groupAddressByHash, -1);
 
-        rawHashByHashPosition = new byte[hashCapacity];
-
-        groupIdsByHash = new int[hashCapacity];
+        groupAddressByHash = new long[segments][];
+        groupIdsByHash = new int[segments][];
+        rawHashByHashPosition = new byte[segments][];
+        for (int i = 0; i < segments; i++) {
+            groupAddressByHash[i] = new long[SEGMENT_SIZE];
+            Arrays.fill(groupAddressByHash[i], -1);
+            groupIdsByHash[i] = new int[SEGMENT_SIZE];
+            rawHashByHashPosition[i] = new byte[SEGMENT_SIZE];
+        }
 
         groupAddressByGroupId = new LongBigArray();
         groupAddressByGroupId.ensureCapacity(maxFill);
@@ -155,6 +174,7 @@ public class MultiChannelGroupByHash
                 (sizeOf(channelBuilders.get(0).elements()) * channelBuilders.size()) +
                 completedPagesMemorySize +
                 currentPageBuilder.getRetainedSizeInBytes() +
+                (segments * SIZE_OF_SEGMENT) +
                 sizeOf(groupAddressByHash) +
                 sizeOf(groupIdsByHash) +
                 groupAddressByGroupId.sizeOf() +
@@ -241,8 +261,8 @@ public class MultiChannelGroupByHash
         int hashPosition = (int) getHashPosition(rawHash, mask);
 
         // look for a slot containing this key
-        while (groupAddressByHash[hashPosition] != -1) {
-            if (positionEqualsCurrentRow(groupAddressByHash[hashPosition], hashPosition, position, page, (byte) rawHash, hashChannels)) {
+        while (groupAddressByHash[segment(hashPosition)][offset(hashPosition)] != -1) {
+            if (positionEqualsCurrentRow(groupAddressByHash[segment(hashPosition)][offset(hashPosition)], hashPosition, position, page, (byte) rawHash, hashChannels)) {
                 // found an existing slot for this key
                 return true;
             }
@@ -266,10 +286,10 @@ public class MultiChannelGroupByHash
 
         // look for an empty slot or a slot containing this key
         int groupId = -1;
-        while (groupAddressByHash[hashPosition] != -1) {
-            if (positionEqualsCurrentRow(groupAddressByHash[hashPosition], hashPosition, position, page, (byte) rawHash, channels)) {
+        while (groupAddressByHash[segment(hashPosition)][offset(hashPosition)] != -1) {
+            if (positionEqualsCurrentRow(groupAddressByHash[segment(hashPosition)][offset(hashPosition)], hashPosition, position, page, (byte) rawHash, channels)) {
                 // found an existing slot for this key
-                groupId = groupIdsByHash[hashPosition];
+                groupId = groupIdsByHash[segment(hashPosition)][offset(hashPosition)];
 
                 break;
             }
@@ -304,9 +324,9 @@ public class MultiChannelGroupByHash
         // record group id in hash
         int groupId = nextGroupId++;
 
-        groupAddressByHash[hashPosition] = address;
-        rawHashByHashPosition[hashPosition] = (byte) rawHash;
-        groupIdsByHash[hashPosition] = groupId;
+        groupAddressByHash[segment(hashPosition)][offset(hashPosition)] = address;
+        rawHashByHashPosition[segment(hashPosition)][offset(hashPosition)] = (byte) rawHash;
+        groupIdsByHash[segment(hashPosition)][offset(hashPosition)] = groupId;
         groupAddressByGroupId.set(groupId, address);
 
         // create new page builder if this page is full
@@ -347,37 +367,65 @@ public class MultiChannelGroupByHash
         int newCapacity = (int) newCapacityLong;
 
         int newMask = newCapacity - 1;
-        long[] newKey = new long[newCapacity];
-        byte[] rawHashes = new byte[newCapacity];
-        Arrays.fill(newKey, -1);
-        int[] newValue = new int[newCapacity];
+        int newSegments = newCapacity / SEGMENT_SIZE;
+        long[][] newKey = new long[newSegments][];
+        byte[][] rawHashes = new byte[newSegments][];
+        int[][] newValue = new int[newSegments][];
 
-        int oldIndex = 0;
-        for (int groupId = 0; groupId < nextGroupId; groupId++) {
-            // seek to the next used slot
-            while (groupAddressByHash[oldIndex] == -1) {
-                oldIndex++;
+        newKey[segments - 1] = new long[SEGMENT_SIZE];
+        newValue[segments - 1] = new int[SEGMENT_SIZE];
+        rawHashes[segments - 1] = new byte[SEGMENT_SIZE];
+        newKey[2 * segments - 1] = new long[SEGMENT_SIZE];
+        newValue[2 * segments - 1] = new int[SEGMENT_SIZE];
+        rawHashes[2 * segments - 1] = new byte[SEGMENT_SIZE];
+        Arrays.fill(newKey[segments - 1], -1);
+        Arrays.fill(newKey[2 * segments - 1], -1);
+
+        for (int i = 0; i < segments; i++) {
+            if (i != segments - 1) {
+                newKey[i + segments] = new long[SEGMENT_SIZE];
+                Arrays.fill(newKey[i + segments], -1);
+                newValue[i + segments] = new int[SEGMENT_SIZE];
+                rawHashes[i + segments] = new byte[SEGMENT_SIZE];
+                if (i == 0) {
+                    newKey[i] = new long[SEGMENT_SIZE];
+                    newValue[i] = new int[SEGMENT_SIZE];
+                    rawHashes[i] = new byte[SEGMENT_SIZE];
+                }
+                else {
+                    newKey[i] = groupAddressByHash[i - 1];
+                    newValue[i] = groupIdsByHash[i - 1];
+                    rawHashes[i] = rawHashByHashPosition[i - 1];
+                }
+                Arrays.fill(newKey[i], -1);
             }
 
-            // get the address for this slot
-            long address = groupAddressByHash[oldIndex];
+            for (int j = 0; j < SEGMENT_SIZE; j++) {
+                // seek to the next used slot
+                if (groupAddressByHash[i][j] == -1) {
+                    continue;
+                }
 
-            long rawHash = hashPosition(address);
-            // find an empty slot for the address
-            int pos = (int) getHashPosition(rawHash, newMask);
-            while (newKey[pos] != -1) {
-                pos = (pos + 1) & newMask;
-                hashCollisions++;
+                // get the address for this slot
+                long address = groupAddressByHash[i][j];
+
+                long rawHash = hashPosition(address);
+                // find an empty slot for the address
+                int position = (int) getHashPosition(rawHash, newMask);
+                while (newKey[segment(position)][offset(position)] != -1) {
+                    position = (position + 1) & newMask;
+                    hashCollisions++;
+                }
+
+                // record the mapping
+                newKey[segment(position)][offset(position)] = address;
+                rawHashes[segment(position)][offset(position)] = (byte) rawHash;
+                newValue[segment(position)][offset(position)] = groupIdsByHash[i][j];
             }
-
-            // record the mapping
-            newKey[pos] = address;
-            rawHashes[pos] = (byte) rawHash;
-            newValue[pos] = groupIdsByHash[oldIndex];
-            oldIndex++;
         }
 
         this.mask = newMask;
+        this.segments = newSegments;
         this.hashCapacity = newCapacity;
         this.maxFill = calculateMaxFill(newCapacity);
         this.groupAddressByHash = newKey;
@@ -403,10 +451,20 @@ public class MultiChannelGroupByHash
 
     private boolean positionEqualsCurrentRow(long address, int hashPosition, int position, Page page, byte rawHash, int[] hashChannels)
     {
-        if (rawHashByHashPosition[hashPosition] != rawHash) {
+        if (rawHashByHashPosition[segment(hashPosition)][offset(hashPosition)] != rawHash) {
             return false;
         }
         return hashStrategy.positionEqualsRow(decodeSliceIndex(address), decodePosition(address), position, page, hashChannels);
+    }
+
+    private static int segment(int index)
+    {
+        return index >>> SEGMENT_SHIFT;
+    }
+
+    public static int offset(int index)
+    {
+        return index & SEGMENT_MASK;
     }
 
     private static long getHashPosition(long rawHash, int mask)


### PR DESCRIPTION
Prototype only



## The following is a benchmark comparing when we convert arrays to big arrays
# It is irrelative to the current patch; just for referrence

Primitive type arrays used in GroupByHash can grow to GB sizes. Each
rehash can discard an array of the same size that can cause humongous
allocation repeatedly until there is no need to grow capacity. We found
simple queries in production (e.g., `SELECT DISTINCT a from t`) can cause
full GCs. This patch replaces all primitive type arrays with big arrays
to avoid humongous allocation.

## pretty severe regression; need to revise:
Random access benchmark wrt two dimensional arrays vs one dimensional arrays (https://stackoverflow.com/questions/2512082/java-multi-dimensional-array-vs-one-dimensional)
## laptop:
**before:**
```
Benchmark                                   (channelCount)  (groupCount)  (hashEnabled)  Mode  Cnt     Score     Error  Units
BenchmarkGroupByHash.addPagePreCompute                   1       3000000           true  avgt   20   219.102 ±  11.709  ns/op
BenchmarkGroupByHash.addPagePreCompute                   1       3000000          false  avgt   20   226.143 ±  13.646  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000           true  avgt   20   789.242 ±  80.450  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000          false  avgt   20  1168.223 ±  71.983  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000           true  avgt   20  1590.167 ± 135.052  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000          false  avgt   20  2189.896 ±  76.140  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000           true  avgt   20   196.256 ±  11.436  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000          false  avgt   20   239.136 ±   7.145  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000           true  avgt   20   641.710 ±  14.017  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000          false  avgt   20  1109.391 ±  52.217  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000           true  avgt   20  1658.992 ± 178.336  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000          false  avgt   20  2234.991 ± 101.736  ns/op
```
**after:**
```
Benchmark                                   (channelCount)  (groupCount)  (hashEnabled)  Mode  Cnt     Score     Error  Units
BenchmarkGroupByHash.addPagePreCompute                   1       3000000           true  avgt   10   224.806 ±  23.703  ns/op
BenchmarkGroupByHash.addPagePreCompute                   1       3000000          false  avgt   10   250.339 ±   3.986  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000           true  avgt   10   757.254 ± 106.717  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000          false  avgt   10  1181.979 ±  76.400  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000           true  avgt   10  1722.848 ± 308.191  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000          false  avgt   10  2510.248 ± 443.145  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000           true  avgt   10   248.502 ±  35.051  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000          false  avgt   10   289.508 ±  35.033  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000           true  avgt   10   757.911 ±  82.060  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000          false  avgt   10  1468.663 ± 202.592  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000           true  avgt   10  2047.919 ± 311.392  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000          false  avgt   10  3018.833 ± 613.826  ns/op
```

## Server:
**before:**
```
Benchmark                                   (channelCount)  (groupCount)  (hashEnabled)  Mode  Cnt     Score     Error  Units
BenchmarkGroupByHash.addPagePreCompute                   1       3000000           true  avgt   40   252.108 ±  15.141  ns/op
BenchmarkGroupByHash.addPagePreCompute                   1       3000000          false  avgt   40   278.329 ±  17.196  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000           true  avgt   40   999.718 ±  42.933  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000          false  avgt   40  1654.101 ± 108.303  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000           true  avgt   40  2227.519 ±  92.364  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000          false  avgt   40  3347.404 ± 129.901  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000           true  avgt   40   304.079 ±  18.457  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000          false  avgt   40   299.655 ±  16.705  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000           true  avgt   40  1013.963 ±  45.575  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000          false  avgt   40  1713.749 ±  82.685  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000           true  avgt   40  2305.849 ± 104.726  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000          false  avgt   40  3493.750 ± 141.248  ns/op
```

**after (`long[]` => `LongBigArray`, `int[]` => `IntBigArray`, and `byte[]` => `ByteBigArray`):**
```
Benchmark                                   (channelCount)  (groupCount)  (hashEnabled)  Mode  Cnt     Score     Error  Units
BenchmarkGroupByHash.addPagePreCompute                   1       3000000           true  avgt   40   312.157 ±  13.091  ns/op
BenchmarkGroupByHash.addPagePreCompute                   1       3000000          false  avgt   40   352.682 ±  19.351  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000           true  avgt   40  1039.557 ±  44.293  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000          false  avgt   40  1778.058 ±  78.182  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000           true  avgt   40  2363.148 ±  92.150  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000          false  avgt   40  3559.444 ± 146.411  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000           true  avgt   40   338.067 ±  18.628  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000          false  avgt   40   379.388 ±  14.095  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000           true  avgt   40  1144.029 ±  22.583  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000          false  avgt   40  1682.492 ±  92.457  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000           true  avgt   40  2436.306 ±  79.558  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000          false  avgt   40  3617.578 ± 119.018  ns/op
```
**after (`long[]` remains unchanged, `int[]` => `IntBigArray`, and `byte[]` => `ByteBigArray`):**
```
Benchmark                                   (channelCount)  (groupCount)  (hashEnabled)  Mode  Cnt     Score     Error  Units
BenchmarkGroupByHash.addPagePreCompute                   1       3000000           true  avgt   40   290.396 ±  18.097  ns/op
BenchmarkGroupByHash.addPagePreCompute                   1       3000000          false  avgt   40   320.971 ±  19.822  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000           true  avgt   40  1047.571 ±  41.309  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000          false  avgt   40  1791.248 ±  81.908  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000           true  avgt   40  2267.405 ±  85.051  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000          false  avgt   40  3569.935 ± 120.969  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000           true  avgt   40   313.321 ±  20.825  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000          false  avgt   40   335.576 ±  16.511  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000           true  avgt   40  1048.885 ±  39.247  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000          false  avgt   40  1708.691 ±  70.837  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000           true  avgt   40  2294.402 ± 100.122  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000          false  avgt   40  3478.707 ± 113.066  ns/op
```
**after (`long[]` remains unchanged, `int[]` remains unchanged, and `byte[]` => `ByteBigArray`):**
```
Benchmark                                   (channelCount)  (groupCount)  (hashEnabled)  Mode  Cnt     Score     Error  Units
BenchmarkGroupByHash.addPagePreCompute                   1       3000000           true  avgt   40   268.928 ±  15.794  ns/op
BenchmarkGroupByHash.addPagePreCompute                   1       3000000          false  avgt   40   303.769 ±  19.028  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000           true  avgt   40  1041.915 ±  52.588  ns/op
BenchmarkGroupByHash.addPagePreCompute                  10       3000000          false  avgt   40  1689.601 ±  62.508  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000           true  avgt   40  2206.633 ± 108.120  ns/op
BenchmarkGroupByHash.addPagePreCompute                  20       3000000          false  avgt   40  3588.593 ± 168.011  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000           true  avgt   40   321.344 ±  18.841  ns/op
BenchmarkGroupByHash.groupByHashPreCompute               1       3000000          false  avgt   40   346.114 ±  23.600  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000           true  avgt   40  1081.986 ±  39.844  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              10       3000000          false  avgt   40  1765.118 ±  83.795  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000           true  avgt   40  2260.910 ± 105.671  ns/op
BenchmarkGroupByHash.groupByHashPreCompute              20       3000000          false  avgt   40  3575.890 ± 135.284  ns/op
```