### PR TITLE
Add url_extract_raw_parameter / url_extract_raw_query functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/url.rst
+++ b/presto-docs/src/main/sphinx/functions/url.rst
@@ -33,7 +33,7 @@ such as ``:`` or ``?``.
 .. function:: url_extract_raw_parameter(url, name) -> varchar
 
     Returns the value of the first query string parameter named ``name``
-    from ``url`` without decode. Parameter extraction is handled in the typical manner
+    from ``url`` without decoding any escaped characters. Parameter extraction is handled in the typical manner
     as specified by :rfc:`1866#section-8.2.1`.
 
 .. function:: url_extract_path(url) -> varchar
@@ -54,7 +54,7 @@ such as ``:`` or ``?``.
 
 .. function:: url_extract_raw_query(url) -> varchar
 
-    Returns the query string from ``url`` without decode.
+    Returns the query string from ``url`` without decoding any escaped characters.
 
 Encoding Functions
 ------------------

--- a/presto-docs/src/main/sphinx/functions/url.rst
+++ b/presto-docs/src/main/sphinx/functions/url.rst
@@ -30,6 +30,12 @@ such as ``:`` or ``?``.
     from ``url``. Parameter extraction is handled in the typical manner
     as specified by :rfc:`1866#section-8.2.1`.
 
+.. function:: url_extract_raw_parameter(url, name) -> varchar
+
+    Returns the value of the first query string parameter named ``name``
+    from ``url`` without decode. Parameter extraction is handled in the typical manner
+    as specified by :rfc:`1866#section-8.2.1`.
+
 .. function:: url_extract_path(url) -> varchar
 
     Returns the path from ``url``.
@@ -45,6 +51,10 @@ such as ``:`` or ``?``.
 .. function:: url_extract_query(url) -> varchar
 
     Returns the query string from ``url``.
+
+.. function:: url_extract_raw_query(url) -> varchar
+
+    Returns the query string from ``url`` without decode.
 
 Encoding Functions
 ------------------

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/UrlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/UrlFunctions.java
@@ -139,23 +139,7 @@ public final class UrlFunctions
             return null;
         }
 
-        Slice query = slice(uri.getQuery());
-        String parameter = parameterName.toStringUtf8();
-        Iterable<String> queryArgs = QUERY_SPLITTER.split(query.toStringUtf8());
-
-        for (String queryArg : queryArgs) {
-            Iterator<String> arg = ARG_SPLITTER.split(queryArg).iterator();
-            if (arg.next().equals(parameter)) {
-                if (arg.hasNext()) {
-                    return utf8Slice(arg.next());
-                }
-                // first matched key is empty
-                return Slices.EMPTY_SLICE;
-            }
-        }
-
-        // no key matched
-        return null;
+        return extractParameter(uri.getQuery(), parameterName);
     }
 
     @SqlNullable
@@ -170,23 +154,7 @@ public final class UrlFunctions
             return null;
         }
 
-        Slice query = slice(uri.getRawQuery());
-        String parameter = parameterName.toStringUtf8();
-        Iterable<String> queryArgs = QUERY_SPLITTER.split(query.toStringUtf8());
-
-        for (String queryArg : queryArgs) {
-            Iterator<String> arg = ARG_SPLITTER.split(queryArg).iterator();
-            if (arg.next().equals(parameter)) {
-                if (arg.hasNext()) {
-                    return utf8Slice(arg.next());
-                }
-                // first matched key is empty
-                return Slices.EMPTY_SLICE;
-            }
-        }
-
-        // no key matched
-        return null;
+        return extractParameter(uri.getRawQuery(), parameterName);
     }
 
     @Description("escape a string for use in URL query parameter names and values")
@@ -231,5 +199,26 @@ public final class UrlFunctions
         catch (URISyntaxException e) {
             return null;
         }
+    }
+
+    @Nullable
+    private static Slice extractParameter(String query, Slice parameterName)
+    {
+        String parameter = parameterName.toStringUtf8();
+        Iterable<String> queryArgs = QUERY_SPLITTER.split(slice(query).toStringUtf8());
+
+        for (String queryArg : queryArgs) {
+            Iterator<String> arg = ARG_SPLITTER.split(queryArg).iterator();
+            if (arg.next().equals(parameter)) {
+                if (arg.hasNext()) {
+                    return utf8Slice(arg.next());
+                }
+                // first matched key is empty
+                return Slices.EMPTY_SLICE;
+            }
+        }
+
+        // no key matched
+        return null;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
@@ -24,16 +24,17 @@ public class TestUrlFunctions
     @Test
     public void testUrlExtract()
     {
-        validateUrlExtract("http://example.com/path1/p.php?k1=v1&k2=v2#Ref1", "http", "example.com", null, "/path1/p.php", "k1=v1&k2=v2", "Ref1", "k1=v1&k2=v2");
+        validateUrlExtract("http://example.com/path1/p.php?k1=v1&k2=v2#Ref1", "http", "example.com", null, "/path1/p.php", "k1=v1&k2=v2", "k1=v1&k2=v2", "Ref1");
         validateUrlExtract("http://example.com/path1/p.php?", "http", "example.com", null, "/path1/p.php", "", "", "");
         validateUrlExtract("http://example.com/path1/p.php", "http", "example.com", null, "/path1/p.php", "", "", "");
-        validateUrlExtract("http://example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1", "http", "example.com", 8080L, "/path1/p.php", "k1=v1&k2=v2", "Ref1", "k1=v1&k2=v2");
+        validateUrlExtract("http://example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1", "http", "example.com", 8080L, "/path1/p.php", "k1=v1&k2=v2", "k1=v1&k2=v2", "Ref1");
+        validateUrlExtract("http://example.com:8080/path1/p.php?kwd=hello+world&k3=v3", "http", "example.com", 8080L, "/path1/p.php", "kwd=hello+world&k3=v3", "kwd=hello+world&k3=v3", "");
         validateUrlExtract("https://username@example.com", "https", "example.com", null, "", "", "", "");
         validateUrlExtract("https://username:password@example.com", "https", "example.com", null, "", "", "", "");
         validateUrlExtract("mailto:test@example.com", "mailto", "", null, "", "", "", "");
         validateUrlExtract("foo", "", "", null, "foo", "", "", "");
         validateUrlExtract("http://example.com/^", null, null, null, null, null, null, null);
-        validateUrlExtract("http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1#Ref1", "http", "example.com", null, "/path1/p.php", "source_url=http://bar.com?a=foo&b=bar&k1=v1", "Ref1", "source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1");
+        validateUrlExtract("http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1#Ref1", "http", "example.com", null, "/path1/p.php", "source_url=http://bar.com?a=foo&b=bar&k1=v1", "source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1", "Ref1");
     }
 
     @Test
@@ -51,6 +52,7 @@ public class TestUrlFunctions
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k=a=b=c&x=y#Ref1', 'k')", createVarcharType(47), "a=b=c");
         assertFunction("url_extract_parameter('foo', 'k1')", createVarcharType(3), null);
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1', 'source_url')", createVarcharType(88), "http://bar.com?a=foo");
+        assertFunction("url_extract_parameter('http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar%3dkwd=hello+world', 'source_url')", createVarcharType(100), "http://bar.com?a=foo");
     }
 
     @Test
@@ -68,6 +70,7 @@ public class TestUrlFunctions
         assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k=a=b=c&x=y#Ref1', 'k')", createVarcharType(47), "a=b=c");
         assertFunction("url_extract_raw_parameter('foo', 'k1')", createVarcharType(3), null);
         assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1', 'source_url')", createVarcharType(88), "http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar");
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar%3dkwd=hello+world', 'source_url')", createVarcharType(100), "http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar%3dkwd=hello+world");
     }
 
     @Test
@@ -108,7 +111,7 @@ public class TestUrlFunctions
         }
     }
 
-    private void validateUrlExtract(String url, String protocol, String host, Long port, String path, String query, String fragment, String rawquery)
+    private void validateUrlExtract(String url, String protocol, String host, Long port, String path, String query, String rawQuery, String fragment)
     {
         assertFunction("url_extract_protocol('" + url + "')", createVarcharType(url.length()), protocol);
         assertFunction("url_extract_host('" + url + "')", createVarcharType(url.length()), host);
@@ -120,7 +123,7 @@ public class TestUrlFunctions
         }
         assertFunction("url_extract_path('" + url + "')", createVarcharType(url.length()), path);
         assertFunction("url_extract_query('" + url + "')", createVarcharType(url.length()), query);
+        assertFunction("url_extract_raw_query('" + url + "')", createVarcharType(url.length()), rawQuery);
         assertFunction("url_extract_fragment('" + url + "')", createVarcharType(url.length()), fragment);
-        assertFunction("url_extract_raw_query('" + url + "')", createVarcharType(url.length()), rawquery);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUrlFunctions.java
@@ -24,15 +24,16 @@ public class TestUrlFunctions
     @Test
     public void testUrlExtract()
     {
-        validateUrlExtract("http://example.com/path1/p.php?k1=v1&k2=v2#Ref1", "http", "example.com", null, "/path1/p.php", "k1=v1&k2=v2", "Ref1");
-        validateUrlExtract("http://example.com/path1/p.php?", "http", "example.com", null, "/path1/p.php", "", "");
-        validateUrlExtract("http://example.com/path1/p.php", "http", "example.com", null, "/path1/p.php", "", "");
-        validateUrlExtract("http://example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1", "http", "example.com", 8080L, "/path1/p.php", "k1=v1&k2=v2", "Ref1");
-        validateUrlExtract("https://username@example.com", "https", "example.com", null, "", "", "");
-        validateUrlExtract("https://username:password@example.com", "https", "example.com", null, "", "", "");
-        validateUrlExtract("mailto:test@example.com", "mailto", "", null, "", "", "");
-        validateUrlExtract("foo", "", "", null, "foo", "", "");
-        validateUrlExtract("http://example.com/^", null, null, null, null, null, null);
+        validateUrlExtract("http://example.com/path1/p.php?k1=v1&k2=v2#Ref1", "http", "example.com", null, "/path1/p.php", "k1=v1&k2=v2", "Ref1", "k1=v1&k2=v2");
+        validateUrlExtract("http://example.com/path1/p.php?", "http", "example.com", null, "/path1/p.php", "", "", "");
+        validateUrlExtract("http://example.com/path1/p.php", "http", "example.com", null, "/path1/p.php", "", "", "");
+        validateUrlExtract("http://example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1", "http", "example.com", 8080L, "/path1/p.php", "k1=v1&k2=v2", "Ref1", "k1=v1&k2=v2");
+        validateUrlExtract("https://username@example.com", "https", "example.com", null, "", "", "", "");
+        validateUrlExtract("https://username:password@example.com", "https", "example.com", null, "", "", "", "");
+        validateUrlExtract("mailto:test@example.com", "mailto", "", null, "", "", "", "");
+        validateUrlExtract("foo", "", "", null, "foo", "", "", "");
+        validateUrlExtract("http://example.com/^", null, null, null, null, null, null, null);
+        validateUrlExtract("http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1#Ref1", "http", "example.com", null, "/path1/p.php", "source_url=http://bar.com?a=foo&b=bar&k1=v1", "Ref1", "source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1");
     }
 
     @Test
@@ -40,6 +41,8 @@ public class TestUrlFunctions
     {
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k1')", createVarcharType(53), "v1");
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k2')", createVarcharType(53), "v2");
+        assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1=v1%26k2=v2&k3&k4#Ref1', 'k2')", createVarcharType(55), "v2");
+        assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1=v1&k2=v2%26k3&k4#Ref1', 'k2')", createVarcharType(55), "v2");
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k3')", createVarcharType(53), "");
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k4')", createVarcharType(53), "");
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k5')", createVarcharType(53), null);
@@ -47,6 +50,24 @@ public class TestUrlFunctions
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k1&k1=v1&k1&k1#Ref1', 'k1')", createVarcharType(50), "");
         assertFunction("url_extract_parameter('http://example.com/path1/p.php?k=a=b=c&x=y#Ref1', 'k')", createVarcharType(47), "a=b=c");
         assertFunction("url_extract_parameter('foo', 'k1')", createVarcharType(3), null);
+        assertFunction("url_extract_parameter('http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1', 'source_url')", createVarcharType(88), "http://bar.com?a=foo");
+    }
+
+    @Test
+    public void testUrlExtractRawParameter()
+    {
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k1')", createVarcharType(53), "v1");
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k2')", createVarcharType(53), "v2");
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k1=v1%26k2=v2&k3&k4#Ref1', 'k2')", createVarcharType(55), null);
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k1=v1&k2=v2%26k3&k4#Ref1', 'k2')", createVarcharType(55), "v2%26k3");
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k3')", createVarcharType(53), "");
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k4')", createVarcharType(53), "");
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1', 'k5')", createVarcharType(53), null);
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k1=v1&k1=v2&k1&k1#Ref1', 'k1')", createVarcharType(53), "v1");
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k1&k1=v1&k1&k1#Ref1', 'k1')", createVarcharType(50), "");
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?k=a=b=c&x=y#Ref1', 'k')", createVarcharType(47), "a=b=c");
+        assertFunction("url_extract_raw_parameter('foo', 'k1')", createVarcharType(3), null);
+        assertFunction("url_extract_raw_parameter('http://example.com/path1/p.php?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar&k1=v1', 'source_url')", createVarcharType(88), "http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar");
     }
 
     @Test
@@ -87,7 +108,7 @@ public class TestUrlFunctions
         }
     }
 
-    private void validateUrlExtract(String url, String protocol, String host, Long port, String path, String query, String fragment)
+    private void validateUrlExtract(String url, String protocol, String host, Long port, String path, String query, String fragment, String rawquery)
     {
         assertFunction("url_extract_protocol('" + url + "')", createVarcharType(url.length()), protocol);
         assertFunction("url_extract_host('" + url + "')", createVarcharType(url.length()), host);
@@ -100,5 +121,6 @@ public class TestUrlFunctions
         assertFunction("url_extract_path('" + url + "')", createVarcharType(url.length()), path);
         assertFunction("url_extract_query('" + url + "')", createVarcharType(url.length()), query);
         assertFunction("url_extract_fragment('" + url + "')", createVarcharType(url.length()), fragment);
+        assertFunction("url_extract_raw_query('" + url + "')", createVarcharType(url.length()), rawquery);
     }
 }


### PR DESCRIPTION
The initial discussion is here https://github.com/prestodb/presto/pull/6919
In order to avoid breaking existing queries, this PR adds url_extract_raw_parameter / url_extract_raw_query functions, which use `getRawQuery()` instead of `getQuery()` in `urlExtractParameter` method to avoid decode query parameters.

The query examples:

```
presto:default> select url_extract_raw_parameter('http://foo.com?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar', 'source_url');
                  _col0
------------------------------------------
 http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar
```

```
presto:default> select url_extract_raw_query('http://foo.com?source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar');
                        _col0
-----------------------------------------------------
 source_url=http%3a%2f%2fbar.com%3fa%3dfoo%26b%3dbar
```