### PR TITLE
Update to aircompressor 0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>0.8</version>
+                <version>0.9</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- Fixes a possible buffer overrun on corrupt input
- Improves error message when encountering legacy (v0.7) format