### PR TITLE
Log split info when it first added into queue

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/PrioritizedSplitRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/PrioritizedSplitRunner.java
@@ -256,6 +256,6 @@ class PrioritizedSplitRunner
     @Override
     public String toString()
     {
-        return String.format("Split %-15s-%d", taskHandle.getTaskId(), splitId);
+        return String.format("Split %-15s-%d %s", taskHandle.getTaskId(), splitId, split.getInfo());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
@@ -412,6 +412,7 @@ public class TaskExecutor
     {
         allSplits.add(split);
         waitingSplits.offer(split);
+        log.debug("Started %s", split);
     }
 
     private synchronized PrioritizedSplitRunner pollNextSplitWorker()


### PR DESCRIPTION
Tested in production:

```
2017-09-07T13:14:35.049-0700    DEBUG   Task-20170907_201431_00000_xdyxi.1.1-174        com.facebook.presto.execution.executor.TaskExecutor     Split 20170907_201431_00000_xdyxi.1.1-2 {path=hdfs://dw-prn2-dfsgold.VOL9:9000/namespace/xx/warehouse/8f974181582c4ec9b34282a0bd59b1c3/eba9bbb62f2b4a49b60205c82a9eec86/......} is started
```