### PR TITLE
Remove 0 from the documented index range of element_at

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -84,7 +84,7 @@ Array Functions
 .. function:: element_at(array<E>, index) -> E
 
     Returns element of ``array`` at given ``index``.
-    If ``index`` >= 0, this function provides the same functionality as the SQL-standard subscript operator (``[]``).
+    If ``index`` > 0, this function provides the same functionality as the SQL-standard subscript operator (``[]``).
     If ``index`` < 0, ``element_at`` accesses elements from the last to the first.
 
 .. function:: filter(array, function) -> array


### PR DESCRIPTION
The element_at function was incorrectly documented as accepting
index values in the range >= 0. However, SQL array indices start
from 1.