### PR TITLE
Use new Travis image with _JAVA_OPTIONS unset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 
 sudo: required
 dist: trusty
-group: deprecated-2017Q3
+
 addons:
   apt:
     packages:
@@ -35,6 +35,9 @@ cache:
 
 services:
   - docker
+
+before_install:
+  - unset _JAVA_OPTIONS
 
 install:
   - ./mvnw -v


### PR DESCRIPTION
Per Travis support:

  As part of the Trusty image updates we've capped Java memory by setting
  the _JAVA_OPTIONS environment variable, which seems to be interfering
  with your build. Since you are running in our sudo:required environment
  and your build is memory-heavy, I'd suggest unsetting this (it was
  mostly aimed at our users running Java inside Docker). For example,
  adding "before_install: unset _JAVA_OPTIONS" should do the trick.