### PR TITLE
Fix DROP COLUMN handling for tables with hidden columns

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
@@ -614,7 +614,7 @@ public class MetastoreUtil
             throw new PrestoException(NOT_SUPPORTED, "Cannot drop partition columns");
         }
         if (table.getDataColumns().size() <= 1) {
-            throw new PrestoException(NOT_SUPPORTED, "Cannot drop the only column in a table");
+            throw new PrestoException(NOT_SUPPORTED, "Cannot drop the only non-partition column in a table");
         }
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1908,9 +1908,10 @@ public class TestHiveIntegrationSmokeTest
         assertUpdate(createTable, "SELECT count(*) FROM orders");
         assertQuery("SELECT orderkey, orderstatus FROM test_drop_column", "SELECT orderkey, orderstatus FROM orders");
 
+        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN \"$path\"", ".* Cannot drop hidden column");
         assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN orderstatus", "Cannot drop partition columns");
         assertUpdate("ALTER TABLE test_drop_column DROP COLUMN orderkey");
-        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN custkey", "Cannot drop the only column in a table");
+        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN custkey", "Cannot drop the only non-partition column in a table");
         assertQuery("SELECT * FROM test_drop_column", "SELECT custkey, orderstatus FROM orders");
 
         assertUpdate("DROP TABLE test_drop_column");

--- a/presto-main/src/main/java/com/facebook/presto/execution/DropColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DropColumnTask.java
@@ -26,8 +26,6 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_COLUMN;
@@ -50,23 +48,28 @@ public class DropColumnTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
-        Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
+        TableHandle tableHandle = metadata.getTableHandle(session, tableName)
+                .orElseThrow(() -> new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName));
 
         String column = statement.getColumn().getValue().toLowerCase(ENGLISH);
 
-        if (!tableHandle.isPresent()) {
-            throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
-        }
         accessControl.checkCanDropColumn(session.getRequiredTransactionId(), session.getIdentity(), tableName);
 
-        Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle.get());
-        if (!columnHandles.containsKey(column)) {
+        ColumnHandle columnHandle = metadata.getColumnHandles(session, tableHandle).get(column);
+        if (columnHandle == null) {
             throw new SemanticException(MISSING_COLUMN, statement, "Column '%s' does not exist", column);
         }
-        if (columnHandles.size() == 1) {
-            throw new SemanticException(NOT_SUPPORTED, statement, "Cannot drop column from a table with only one column");
+
+        if (metadata.getColumnMetadata(session, tableHandle, columnHandle).isHidden()) {
+            throw new SemanticException(NOT_SUPPORTED, statement, "Cannot drop hidden column");
         }
-        metadata.dropColumn(session, tableHandle.get(), columnHandles.get(column));
+
+        if (metadata.getTableMetadata(session, tableHandle).getColumns().stream()
+                .filter(info -> !info.isHidden()).count() <= 1) {
+            throw new SemanticException(NOT_SUPPORTED, statement, "Cannot drop the only column in a table");
+        }
+
+        metadata.dropColumn(session, tableHandle, columnHandle);
 
         return immediateFuture(null);
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -366,7 +366,7 @@ public abstract class AbstractTestDistributedQueries
         assertUpdate("ALTER TABLE test_drop_column DROP COLUMN x");
         assertQueryFails("SELECT x FROM test_drop_column", ".* Column 'x' cannot be resolved");
 
-        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN a", "Cannot drop the only column in a table");
+        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN a", ".* Cannot drop the only column in a table");
     }
 
     @Test


### PR DESCRIPTION
Disallow dropping hidden columns and only include visible columns when
determing if a table only has one column.