### PR TITLE
Disable TestDistributedSpilledQueries.testAssignUniqueId

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
@@ -63,4 +63,11 @@ public class TestDistributedSpilledQueries
             throw e;
         }
     }
+
+    @Override
+    public void testAssignUniqueId()
+    {
+        // TODO: disabled until https://github.com/prestodb/presto/issues/8926 is resolved
+        //       due to long running query test created many spill files on disk.
+    }
 }


### PR DESCRIPTION
The `TestDistributedSpilledQueries.testAssignUniqueId` produced many
spill files on disk. Current merge algorithm in
`SpillableHashAggregationBuilder` opened all the files simultaneously which
resulted in exceedeen system limits of simultaneously opened files.

This is workaround fix until https://github.com/prestodb/presto/issues/8926 is resolved

fixes: #8787