### PR TITLE
Spill for join (v2)

### DIFF
--- a/presto-benchmark/pom.xml
+++ b/presto-benchmark/pom.xml
@@ -48,6 +48,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -22,6 +22,7 @@ import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spiller.SingleStreamSpillerFactory;
 import com.facebook.presto.sql.gen.JoinProbeCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
@@ -38,6 +39,7 @@ import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQuer
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunnerHashEnabled;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spiller.PartitioningSpillerFactory.unsupportedPartitioningSpillerFactory;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 
 public class HashBuildAndJoinBenchmark
@@ -77,7 +79,23 @@ public class HashBuildAndJoinBenchmark
         }
 
         // hash build
-        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(2, new PlanNodeId("test"), source.getTypes(), ImmutableList.of(0, 1), ImmutableMap.of(), Ints.asList(0), hashChannel, false, Optional.empty(), Optional.empty(), ImmutableList.of(), 1_500_000, 1, new PagesIndex.TestingFactory());
+        HashBuilderOperatorFactory hashBuilder = new HashBuilderOperatorFactory(
+                2,
+                new PlanNodeId("test"),
+                source.getTypes(),
+                ImmutableList.of(0, 1),
+                ImmutableMap.of(),
+                Ints.asList(0),
+                hashChannel,
+                false,
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of(),
+                1_500_000,
+                1,
+                new PagesIndex.TestingFactory(),
+                false,
+                SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
         driversBuilder.add(hashBuilder);
         DriverFactory hashBuildDriverFactory = new DriverFactory(0, true, false, driversBuilder.build(), OptionalInt.empty());
         Driver hashBuildDriver = hashBuildDriverFactory.createDriver(taskContext.addPipelineContext(0, true, false).addDriverContext());
@@ -94,7 +112,7 @@ public class HashBuildAndJoinBenchmark
             hashChannel = Optional.of(2);
         }
 
-        OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel, Optional.empty());
+        OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel, Optional.empty(), OptionalInt.empty(), unsupportedPartitioningSpillerFactory());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));
         DriverFactory joinDriverFactory = new DriverFactory(1, true, true, joinDriversBuilder.build(), OptionalInt.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -71,11 +71,11 @@ public class HashBuildAndJoinBenchmark
         ImmutableList.Builder<OperatorFactory> driversBuilder = ImmutableList.builder();
         driversBuilder.add(ordersTableScan);
         OperatorFactory source = ordersTableScan;
-        Optional<Integer> hashChannel = Optional.empty();
+        OptionalInt hashChannel = OptionalInt.empty();
         if (hashEnabled) {
             source = createHashProjectOperator(1, new PlanNodeId("test"), ImmutableList.of(BIGINT, DOUBLE));
             driversBuilder.add(source);
-            hashChannel = Optional.of(2);
+            hashChannel = OptionalInt.of(2);
         }
 
         // hash build
@@ -105,11 +105,11 @@ public class HashBuildAndJoinBenchmark
         ImmutableList.Builder<OperatorFactory> joinDriversBuilder = ImmutableList.builder();
         joinDriversBuilder.add(lineItemTableScan);
         source = lineItemTableScan;
-        hashChannel = Optional.empty();
+        hashChannel = OptionalInt.empty();
         if (hashEnabled) {
             source = createHashProjectOperator(1, new PlanNodeId("test"), ImmutableList.of(BIGINT, BIGINT));
             joinDriversBuilder.add(source);
-            hashChannel = Optional.of(2);
+            hashChannel = OptionalInt.of(2);
         }
 
         OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(2, new PlanNodeId("test"), hashBuilder.getLookupSourceFactory(), source.getTypes(), Ints.asList(0), hashChannel, Optional.empty(), OptionalInt.empty(), unsupportedPartitioningSpillerFactory());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -21,6 +21,7 @@ import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.ValuesOperator.ValuesOperatorFactory;
+import com.facebook.presto.spiller.SingleStreamSpillerFactory;
 import com.facebook.presto.sql.gen.JoinProbeCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
@@ -35,6 +36,7 @@ import java.util.OptionalInt;
 
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spiller.PartitioningSpillerFactory.unsupportedPartitioningSpillerFactory;
 
 public class HashBuildBenchmark
         extends AbstractOperatorBenchmark
@@ -65,7 +67,9 @@ public class HashBuildBenchmark
                 ImmutableList.of(),
                 1_500_000,
                 1,
-                new PagesIndex.TestingFactory());
+                new PagesIndex.TestingFactory(),
+                false,
+                SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
         DriverFactory hashBuildDriverFactory = new DriverFactory(0, true, true, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty());
         Driver hashBuildDriver = hashBuildDriverFactory.createDriver(taskContext.addPipelineContext(0, true, true).addDriverContext());
         hashBuildDriverFactory.close();
@@ -78,7 +82,9 @@ public class HashBuildBenchmark
                 ImmutableList.of(BIGINT),
                 Ints.asList(0),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.empty(),
+                unsupportedPartitioningSpillerFactory());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test"), joinOperator.getTypes()));
         DriverFactory joinDriverFactory = new DriverFactory(1, true, true, joinDriversBuilder.build(), OptionalInt.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -60,7 +60,7 @@ public class HashBuildBenchmark
                 ImmutableList.of(0, 1),
                 ImmutableMap.of(),
                 Ints.asList(0),
-                Optional.empty(),
+                OptionalInt.empty(),
                 false,
                 Optional.empty(),
                 Optional.empty(),
@@ -81,7 +81,7 @@ public class HashBuildBenchmark
                 hashBuilder.getLookupSourceFactory(),
                 ImmutableList.of(BIGINT),
                 Ints.asList(0),
-                Optional.empty(),
+                OptionalInt.empty(),
                 Optional.empty(),
                 OptionalInt.empty(),
                 unsupportedPartitioningSpillerFactory());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -22,6 +22,7 @@ import com.facebook.presto.operator.LookupSourceFactory;
 import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spiller.SingleStreamSpillerFactory;
 import com.facebook.presto.sql.gen.JoinProbeCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
@@ -35,6 +36,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+import static com.facebook.presto.spiller.PartitioningSpillerFactory.unsupportedPartitioningSpillerFactory;
 
 public class HashJoinBenchmark
         extends AbstractOperatorBenchmark
@@ -71,7 +73,9 @@ public class HashJoinBenchmark
                     ImmutableList.of(),
                     1_500_000,
                     1,
-                    new PagesIndex.TestingFactory());
+                    new PagesIndex.TestingFactory(),
+                    false,
+                    SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
 
             DriverContext driverContext = taskContext.addPipelineContext(0, false, false).addDriverContext();
             Driver driver = new DriverFactory(0, false, false, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty()).createDriver(driverContext);
@@ -83,7 +87,7 @@ public class HashJoinBenchmark
 
         OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
 
-        OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty(), Optional.empty());
+        OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty(), Optional.empty(), OptionalInt.empty(), unsupportedPartitioningSpillerFactory());
 
         NullOutputOperatorFactory output = new NullOutputOperatorFactory(2, new PlanNodeId("test"), joinOperator.getTypes());
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -69,7 +69,7 @@ public class HashJoinBenchmark
                     ImmutableList.of(0, 1),
                     ImmutableMap.of(),
                     Ints.asList(0),
-                    Optional.empty(),
+                    OptionalInt.empty(),
                     false,
                     Optional.empty(),
                     Optional.empty(),
@@ -92,7 +92,7 @@ public class HashJoinBenchmark
 
         OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
 
-        OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), Optional.empty(), Optional.empty(), OptionalInt.empty(), unsupportedPartitioningSpillerFactory());
+        OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(1, new PlanNodeId("test"), lookupSourceFactory, lineItemTableScan.getTypes(), Ints.asList(0), OptionalInt.empty(), Optional.empty(), OptionalInt.empty(), unsupportedPartitioningSpillerFactory());
 
         NullOutputOperatorFactory output = new NullOutputOperatorFactory(2, new PlanNodeId("test"), joinOperator.getTypes());
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -19,6 +19,7 @@ import com.facebook.presto.operator.DriverFactory;
 import com.facebook.presto.operator.HashBuilderOperator.HashBuilderOperatorFactory;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.LookupSourceFactory;
+import com.facebook.presto.operator.LookupSourceProvider;
 import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TaskContext;
@@ -34,9 +35,11 @@ import com.google.common.primitives.Ints;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.concurrent.Future;
 
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static com.facebook.presto.spiller.PartitioningSpillerFactory.unsupportedPartitioningSpillerFactory;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 
 public class HashJoinBenchmark
         extends AbstractOperatorBenchmark
@@ -79,9 +82,11 @@ public class HashJoinBenchmark
 
             DriverContext driverContext = taskContext.addPipelineContext(0, false, false).addDriverContext();
             Driver driver = new DriverFactory(0, false, false, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty()).createDriver(driverContext);
-            while (!hashBuilder.getLookupSourceFactory().createLookupSource().isDone()) {
+            Future<LookupSourceProvider> lookupSourceProvider = hashBuilder.getLookupSourceFactory().createLookupSourceProvider();
+            while (!lookupSourceProvider.isDone()) {
                 driver.process();
             }
+            getFutureValue(lookupSourceProvider).close();
             lookupSourceFactory = hashBuilder.getLookupSourceFactory();
         }
 

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -202,6 +202,7 @@ communication issues or improve network utilization.
     improve network throughput for data transferred between stages if the
     network has high latency or if there are many nodes in the cluster.
 
+.. _task-properties:
 
 Task Properties
 ---------------

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -58,6 +58,74 @@ General Properties
     enough that the JVM does not fail with ``OutOfMemoryError``.
 
 
+.. _tuning-spilling:
+
+Properties controlling spilling
+-------------------------------
+
+``experimental.spill-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``Boolean``
+    * **Default value:** ``false``
+    * **Description:** Try spilling memory to disk to avoid exceeding memory limits for the query.
+
+    Spilling works by offloading memory to disk. This process can allow a query with a large memory
+    footprint to pass at the cost of slower execution times. Currently, spilling is supported only for
+    aggregations and joins (inner and outer), so this property will not reduce memory usage required for
+    window functions, sorting and other join types.
+
+    Be aware that this is an experimental feature and should be used with care.
+
+    This config property can be overridden by the ``spill_enabled`` session property.
+
+``experimental.spiller-spill-path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``String``
+    * **No default value.** Must be set when spilling is enabled
+    * **Description:** Directory where spilled content will be written. It can be a comma separated list to
+
+    spill simultaneously to multiple directories, which helps to utilize multiple drives installed in the system.
+    It is not recommended to spill to system drives. Especially do not spill on a drive, to which are
+    written JVM logs, as disk overutilization might cause JVM to pause for lengthy periods causing queries to fail.
+
+``experimental.spiller-minimum-free-space-threshold``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ * **Type:** ``Double``
+ * **Default value:** ``0.9``
+ * **Description:** If disk space usage of a given spill path is above this threshold, this spill path will not be eligible for spilling.
+
+``experimental.spiller-threads``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ * **Type:** ``Integer``
+ * **Default value:** ``4``
+ * **Description:** Number of spiller threads. Increase this value if the default is not able to saturate the underlying spilling device (for example, when using a RAID matrix with multiple disks)
+
+``experimental.max-spill-per-node``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ * **Type:** ``String`` (data size)
+ * **Default value:** ``100 GB``
+ * **Description:** Max spill space to be used by all queries on a single node.
+
+``experimental.query-max-spill-per-node``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ * **Type:** ``String`` (data size)
+ * **Default value:** ``100 GB``
+ * **Description:** Max spill space to be used by a single query on a single node.
+
+``experimental.aggregation-operator-unspill-memory-limit``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ * **Type:** ``String`` (data size)
+ * **Default value:** ``4 MB``
+ * **Description:** Limit for memory used for unspilling a single aggregation operator instance.
+
+
 Exchange Properties
 -------------------
 

--- a/presto-docs/src/main/sphinx/index.rst
+++ b/presto-docs/src/main/sphinx/index.rst
@@ -15,6 +15,7 @@ Presto Documentation
     language
     sql
     migration
+    spill
     develop
     release
 

--- a/presto-docs/src/main/sphinx/spill.rst
+++ b/presto-docs/src/main/sphinx/spill.rst
@@ -1,0 +1,8 @@
+****************
+Spilling to disk
+****************
+
+.. toctree::
+   :maxdepth: 1
+
+   spill/overview

--- a/presto-docs/src/main/sphinx/spill/overview.rst
+++ b/presto-docs/src/main/sphinx/spill/overview.rst
@@ -1,0 +1,103 @@
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+Overview
+--------
+
+In the case of memory intensive operations, Presto allows offloading
+intermediate operation results to disk. The goal of this mechanism is to
+enable execution of queries that require amounts of memory exceeding per query
+or per node limits.
+
+The mechanism is similar to OS level page swapping. However, it is
+implemented on the application level to address specific needs of Presto.
+
+Properties related to spilling are described in :ref:`tuning-spilling`.
+
+Memory management and spill
+---------------------------
+
+By default, Presto kills queries if the memory requested by the query execution
+exceeds session properties ``query_max_memory`` or
+``query_max_memory_per_node``. This mechanism ensures fairness in allocation
+of memory to queries and prevents deadlock caused by memory allocation.
+It is efficient when there is a lot of small queries in the cluster, but
+leads to killing large queries that don't stay within the limits.
+
+To overcome this inefficiency, the concept of revocable memory was introduced. A
+query can request memory that does not count toward the limits, but this memory
+can be revoked by the memory manager at any time. When memory is revoked, the
+query runner spills intermediate data from memory to disk and continues to
+process it later.
+
+In practice, when the cluster is idle, and all memory is available, a memory
+intensive query may use all of the memory in the cluster. On the other hand,
+when the cluster does not have much free memory, the same query may be forced to
+use disk as storage for intermediate data. A query that is forced to spill to
+disk may have a longer execution time by orders of magnitude than a query that
+runs completely in memory.
+
+Please note that enabling spill-to-disk does not guarantee execution of all
+memory intensive queries. It is still possible that the query runner will fail
+to divide intermediate data into chunks small enough that every chunk fits into
+memory, leading to `Out of memory` errors while loading the data from disk.
+
+Spill disk space
+----------------
+
+Spilling intermediate results to disk and retrieving them back is expensive
+in terms of IO operations. Thus, queries that use spill likely become
+throttled by disk. To increase query performance it is recommended to
+provide multiple paths on separate local devices for spill (property
+``spiller-spill-path`` in :ref:`tuning-spilling`).
+
+The system drive should not be used for spilling, especially not to the drive where the JVM
+is running and writing logs. Doing so may lead to cluster instability. Additionally,
+it is recommended to monitor the disk saturation of the configured spill paths.
+
+Presto treats spill paths as independent disks (see `JBOD
+<https://en.wikipedia.org/wiki/Non-RAID_drive_architectures#JBOD>`_), so
+there is no need to use RAID matrices for spill.
+
+Supported operations
+------------------------
+
+Not all operations support spilling to disk, and each handles spilling
+differently. Currently, the mechanism is implemented for the following
+operations.
+
+Joins
+^^^^^
+
+During the join operation, one of the tables being joined is stored in memory.
+This table is called the build table. The rows from the other table stream
+through and are passed onto the next operation if they match rows in the build
+table. The most memory-intensive part of the join is this build table.
+
+When the task concurrency is greater than one, the build table is partitioned.
+The number of partitions is equal to the value of the ``task.concurrency``
+configuration parameter (see :ref:`task-properties`).
+
+When the build table is partitioned, the spill-to-disk mechanism can decrease
+the peak memory usage needed by the join operation. When a query approaches the
+memory limit, a subset of the partitions of the build table gets spilled to disk,
+along with rows from the other table that fall into those same partitions. The
+number of partitions that get spilled influences the amount of disk space needed.
+
+Afterward, the spilled partitions are read back one-by-one to finish the join
+operation.
+
+With this mechanism, the peak memory used by the join operator can be decreased
+to the size of the largest build table partition. Assuming no data skew, this will
+be ``1 / task.concurrency`` times the size of the whole build table.
+
+Aggregations
+^^^^^^^^^^^^
+
+Aggregation functions perform an operation on a group of values and return one
+value. If the number of groups you're aggregating over is large, a significant
+amount of memory may be needed. When spill-to-disk is enabled, if there is not
+enough memory, intermediate cumulated aggregation results are written to disk.
+They are loaded back and merged when memory is available.

--- a/presto-main/src/main/java/com/facebook/presto/memory/SynchronizedAggregatedMemoryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/SynchronizedAggregatedMemoryContext.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.google.common.io.Closer;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public final class SynchronizedAggregatedMemoryContext
+        extends AbstractAggregatedMemoryContext
+        implements AutoCloseable
+{
+    /**
+     * Creates synchronized wrapper for the {@code delegate} context. The delegate won't be closed when returned instance is closed.
+     */
+    public static SynchronizedAggregatedMemoryContext synchronizedMemoryContext(AbstractAggregatedMemoryContext delegate)
+    {
+        return new SynchronizedAggregatedMemoryContext(delegate);
+    }
+
+    private final AbstractAggregatedMemoryContext delegate;
+    private final Closer closer = Closer.create();
+
+    private SynchronizedAggregatedMemoryContext(AggregatedMemoryContext delegate, boolean ownDelegate)
+    {
+        this(delegate);
+
+        if (ownDelegate) {
+            closer.register(delegate::close);
+        }
+    }
+
+    private SynchronizedAggregatedMemoryContext(AbstractAggregatedMemoryContext delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    protected synchronized void updateBytes(long bytes)
+    {
+        delegate.updateBytes(bytes);
+    }
+
+    @Override
+    public AggregatedMemoryContext newAggregatedMemoryContext()
+    {
+        // Due to concrete return type we cannot provide thread safe implementation
+        throw new UnsupportedOperationException("Use newSynchronizedAggregatedMemoryContext() instead");
+    }
+
+    public SynchronizedAggregatedMemoryContext newSynchronizedAggregatedMemoryContext()
+    {
+        return new SynchronizedAggregatedMemoryContext(super.newAggregatedMemoryContext(), true);
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            closer.close();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ArrayPositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ArrayPositionLinks.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.Page;
+import io.airlift.slice.Slices;
+import io.airlift.slice.XxHash64;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
@@ -47,9 +50,22 @@ public final class ArrayPositionLinks
         }
 
         @Override
-        public Factory build()
+        public PositionLinks.Factory build()
         {
-            return searchFunctions -> new ArrayPositionLinks(positionLinks);
+            return new PositionLinks.Factory()
+            {
+                @Override
+                public PositionLinks create(List<JoinFilterFunction> searchFunctions)
+                {
+                    return new ArrayPositionLinks(positionLinks);
+                }
+
+                @Override
+                public long checksum()
+                {
+                    return XxHash64.hash(Slices.wrappedIntArray(positionLinks));
+                }
+            };
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/BucketPartitionFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BucketPartitionFunction.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.BucketFunction;
+import com.facebook.presto.spi.Page;
+
+import java.util.stream.IntStream;
+
+import static java.util.Objects.requireNonNull;
+
+public class BucketPartitionFunction
+        implements PartitionFunction
+{
+    private final BucketFunction bucketFunction;
+    private final int[] bucketToPartition;
+    private final int partitionCount;
+
+    public BucketPartitionFunction(BucketFunction bucketFunction, int[] bucketToPartition)
+    {
+        this.bucketFunction = requireNonNull(bucketFunction, "bucketFunction is null");
+        this.bucketToPartition = requireNonNull(bucketToPartition, "bucketToPartition is null").clone();
+        partitionCount = IntStream.of(bucketToPartition).max().getAsInt() + 1;
+    }
+
+    public int getPartitionCount()
+    {
+        return partitionCount;
+    }
+
+    /**
+     * @param functionArguments the arguments to bucketing function in order (no extra columns)
+     */
+    public int getPartition(Page functionArguments, int position)
+    {
+        int bucket = bucketFunction.getBucket(functionArguments, position);
+        return bucketToPartition[bucket];
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -205,39 +205,18 @@ public class HashBuilderOperator
     }
 
     @Override
-    public void finish()
-    {
-        if (finishing) {
-            return;
-        }
-        finishing = true;
-
-        LookupSourceSupplier partition = index.createLookupSourceSupplier(operatorContext.getSession(), hashChannels, preComputedHashChannel, filterFunctionFactory, sortChannel, searchFunctionFactories, Optional.of(outputChannels));
-        lookupSourceFactory.setPartitionLookupSourceSupplier(partitionIndex, partition);
-
-        operatorContext.setMemoryReservation(partition.get().getInMemorySizeInBytes());
-        hashCollisionsCounter.recordHashCollision(partition.getHashCollisions(), partition.getExpectedHashCollisions());
-    }
-
-    @Override
-    public boolean isFinished()
-    {
-        return finishing && lookupSourceFactory.isDestroyed().isDone();
-    }
-
-    @Override
-    public boolean needsInput()
-    {
-        return !finishing;
-    }
-
-    @Override
     public ListenableFuture<?> isBlocked()
     {
         if (!finishing) {
             return NOT_BLOCKED;
         }
         return lookupSourceFactory.isDestroyed();
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finishing;
     }
 
     @Override
@@ -258,5 +237,26 @@ public class HashBuilderOperator
     public Page getOutput()
     {
         return null;
+    }
+
+    @Override
+    public void finish()
+    {
+        if (finishing) {
+            return;
+        }
+        finishing = true;
+
+        LookupSourceSupplier partition = index.createLookupSourceSupplier(operatorContext.getSession(), hashChannels, preComputedHashChannel, filterFunctionFactory, sortChannel, searchFunctionFactories, Optional.of(outputChannels));
+        lookupSourceFactory.setPartitionLookupSourceSupplier(partitionIndex, partition);
+
+        operatorContext.setMemoryReservation(partition.get().getInMemorySizeInBytes());
+        hashCollisionsCounter.recordHashCollision(partition.getHashCollisions(), partition.getExpectedHashCollisions());
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finishing && lookupSourceFactory.isDestroyed().isDone();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -15,22 +15,33 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.SingleStreamSpiller;
 import com.facebook.presto.spiller.SingleStreamSpillerFactory;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 
+import static com.facebook.presto.operator.Operators.checkSuccess;
+import static com.facebook.presto.operator.Operators.getDone;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
@@ -117,7 +128,7 @@ public class HashBuilderOperator
         }
 
         @Override
-        public Operator createOperator(DriverContext driverContext)
+        public HashBuilderOperator createOperator(DriverContext driverContext)
         {
             checkState(!closed, "Factory is already closed");
             OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, HashBuilderOperator.class.getSimpleName());
@@ -153,8 +164,48 @@ public class HashBuilderOperator
         }
     }
 
+    @VisibleForTesting
+    public enum State
+    {
+        /**
+         * Operator accepts input
+         */
+        CONSUMING_INPUT,
+
+        /**
+         * Memory revoking occurred during {@link #CONSUMING_INPUT}. Operator accepts input and spills it
+         */
+        SPILLING_INPUT,
+
+        /**
+         * LookupSource has been built and passed on without any spill occurring
+         */
+        LOOKUP_SOURCE_BUILT,
+
+        /**
+         * Input has been finished and spilled
+         */
+        INPUT_SPILLED,
+
+        /**
+         * Spilled input is being unspilled
+         */
+        INPUT_UNSPILLING,
+
+        /**
+         * Spilled input has been unspilled, LookupSource built from it
+         */
+        INPUT_UNSPILLED_AND_BUILT,
+
+        /**
+         * No longer needed
+         */
+        DISPOSED
+    }
+
     private final OperatorContext operatorContext;
     private final PartitionedLookupSourceFactory lookupSourceFactory;
+    private final ListenableFuture<?> lookupSourceFactoryDestroyed;
     private final int partitionIndex;
 
     private final List<Integer> outputChannels;
@@ -169,8 +220,14 @@ public class HashBuilderOperator
     private final boolean spillEnabled;
     private final SingleStreamSpillerFactory singleStreamSpillerFactory;
 
-    private boolean finishing;
     private final HashCollisionsCounter hashCollisionsCounter;
+
+    private State state = State.CONSUMING_INPUT;
+    private Optional<ListenableFuture<?>> lookupSourceNotNeeded = Optional.empty();
+    private SpilledLookupSourceHandle spilledLookupSourceHandle = new SpilledLookupSourceHandle();
+    private Optional<SingleStreamSpiller> spiller = Optional.empty();
+    private ListenableFuture<?> spillInProgress = NOT_BLOCKED;
+    private Optional<ListenableFuture<List<Page>>> unspillInProgress = Optional.empty();
 
     public HashBuilderOperator(
             OperatorContext operatorContext,
@@ -197,6 +254,7 @@ public class HashBuilderOperator
 
         this.index = pagesIndexFactory.newPagesIndex(lookupSourceFactory.getTypes(), expectedPositions);
         this.lookupSourceFactory = lookupSourceFactory;
+        lookupSourceFactoryDestroyed = lookupSourceFactory.isDestroyed();
 
         this.outputChannels = outputChannels;
         this.hashChannels = hashChannels;
@@ -221,33 +279,145 @@ public class HashBuilderOperator
         return lookupSourceFactory.getTypes();
     }
 
+    @VisibleForTesting
+    public State getState()
+    {
+        return state;
+    }
+
     @Override
     public ListenableFuture<?> isBlocked()
     {
-        if (!finishing) {
-            return NOT_BLOCKED;
+        switch (state) {
+            case CONSUMING_INPUT:
+                return NOT_BLOCKED;
+
+            case SPILLING_INPUT:
+                return spillInProgress;
+
+            case LOOKUP_SOURCE_BUILT:
+                return lookupSourceNotNeeded.orElseThrow(() -> new IllegalStateException("Lookup source built, but disposal future not set"));
+
+            case INPUT_SPILLED:
+                return spilledLookupSourceHandle.getUnspillingOrDisposeRequested();
+
+            case INPUT_UNSPILLING:
+                return unspillInProgress.orElseThrow(() -> new IllegalStateException("Unspilling in progress, but unspilling future not set"));
+
+            case INPUT_UNSPILLED_AND_BUILT:
+                return spilledLookupSourceHandle.getDisposeRequested();
+
+            case DISPOSED:
+                return lookupSourceFactoryDestroyed;
         }
-        return lookupSourceFactory.isDestroyed();
+        throw new IllegalStateException("Unhandled state: " + state);
     }
 
     @Override
     public boolean needsInput()
     {
-        return !finishing;
+        boolean stateNeedsInput = (state == State.CONSUMING_INPUT)
+                || (state == State.SPILLING_INPUT && spillInProgress.isDone());
+
+        return stateNeedsInput && !lookupSourceFactoryDestroyed.isDone();
     }
 
     @Override
     public void addInput(Page page)
     {
         requireNonNull(page, "page is null");
-        checkState(!isFinished(), "Operator is already finished");
 
-        index.addPage(page);
-        if (!operatorContext.trySetMemoryReservation(index.getEstimatedSize().toBytes())) {
-            index.compact();
+        if (lookupSourceFactoryDestroyed.isDone()) {
+            close();
+            return;
         }
-        operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
+
+        if (state == State.SPILLING_INPUT) {
+            spillInput(page);
+            return;
+        }
+
+        checkState(state == State.CONSUMING_INPUT);
+        updateIndex(page);
+    }
+
+    private void updateIndex(Page page)
+    {
+        index.addPage(page);
+
+        if (spillEnabled) {
+            // TODO trySetRevocableMemoryReservation else index.compact()
+
+            operatorContext.setRevocableMemoryReservation(index.getEstimatedSize().toBytes());
+        }
+        else {
+            if (!operatorContext.trySetMemoryReservation(index.getEstimatedSize().toBytes())) {
+                index.compact();
+                operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
+            }
+        }
         operatorContext.recordGeneratedOutput(page.getSizeInBytes(), page.getPositionCount());
+    }
+
+    private void spillInput(Page page)
+    {
+        checkState(spillInProgress.isDone(), "Previous spill still in progress");
+        checkSuccess(spillInProgress, "spilling failed");
+        spillInProgress = getSpiller().spill(page);
+    }
+
+    @Override
+    public ListenableFuture<?> startMemoryRevoke()
+    {
+        checkState(spillEnabled, "Spill not enabled, no revokable memory should be reserved");
+
+        if (state == State.LOOKUP_SOURCE_BUILT) {
+            // TODO compute checksum of lookupSource's position links for validation when lookupSource is rebuilt
+        }
+
+        if (state == State.CONSUMING_INPUT || state == State.LOOKUP_SOURCE_BUILT) {
+            checkState(!spiller.isPresent(), "Spiller already created");
+            spiller = Optional.of(singleStreamSpillerFactory.create(
+                    index.getTypes(),
+                    operatorContext.getSpillContext().newLocalSpillContext(),
+                    operatorContext.getSystemMemoryContext().newLocalMemoryContext()));
+            return getSpiller().spill(index.getPages());
+        }
+
+        // Otherwise this is stale revoking request
+        long reservedRevocableBytes = operatorContext.getReservedRevocableBytes();
+        if (reservedRevocableBytes == 0) {
+            return immediateFuture(null);
+        }
+        throw new IllegalStateException(format("State %s can not have revocable memory, but has %s revocable bytes", state, operatorContext.getReservedRevocableBytes()));
+    }
+
+    @Override
+    public void finishMemoryRevoke()
+    {
+        if (state == State.CONSUMING_INPUT) {
+            index.clear();
+            operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
+            operatorContext.setRevocableMemoryReservation(0L);
+            state = State.SPILLING_INPUT;
+            return;
+        }
+
+        if (state == State.LOOKUP_SOURCE_BUILT) {
+            lookupSourceFactory.setPartitionSpilledLookupSourceHandle(partitionIndex, spilledLookupSourceHandle);
+            lookupSourceNotNeeded = Optional.empty();
+            index.clear();
+            operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
+            operatorContext.setRevocableMemoryReservation(0L);
+            state = State.INPUT_SPILLED;
+            return;
+        }
+
+        long reservedRevocableBytes = operatorContext.getReservedRevocableBytes();
+        if (reservedRevocableBytes == 0) {
+            return;
+        }
+        throw new IllegalStateException(format("State %s can not have revocable memory, but has %s revocable bytes", state, operatorContext.getReservedRevocableBytes()));
     }
 
     @Override
@@ -259,21 +429,196 @@ public class HashBuilderOperator
     @Override
     public void finish()
     {
-        if (finishing) {
+        if (lookupSourceFactoryDestroyed.isDone()) {
+            close();
             return;
         }
-        finishing = true;
 
-        LookupSourceSupplier partition = index.createLookupSourceSupplier(operatorContext.getSession(), hashChannels, preComputedHashChannel, filterFunctionFactory, sortChannel, searchFunctionFactories, Optional.of(outputChannels));
-        lookupSourceFactory.setPartitionLookupSourceSupplier(partitionIndex, partition);
+        switch (state) {
+            case CONSUMING_INPUT:
+                finishInput();
+                return;
 
+            case LOOKUP_SOURCE_BUILT:
+                disposeLookupSourceIfRequested();
+                return;
+
+            case SPILLING_INPUT:
+                finishSpilledInput();
+                return;
+
+            case INPUT_SPILLED:
+                if (spilledLookupSourceHandle.getDisposeRequested().isDone()) {
+                    close();
+                }
+                else {
+                    unspillLookupSourceIfRequested();
+                }
+                return;
+
+            case INPUT_UNSPILLING:
+                finishLookupSourceUnspilling();
+                return;
+
+            case INPUT_UNSPILLED_AND_BUILT:
+                disposeUnspilledLookupSourceIfRequested();
+                return;
+
+            case DISPOSED:
+                // no-op
+                return;
+        }
+
+        throw new IllegalStateException("Unhandled state: " + state);
+    }
+
+    private void finishInput()
+    {
+        checkState(state == State.CONSUMING_INPUT);
+        if (lookupSourceFactoryDestroyed.isDone()) {
+            close();
+            return;
+        }
+
+        LookupSourceSupplier partition = buildLookupSource();
+        if (spillEnabled) {
+            operatorContext.setRevocableMemoryReservation(partition.get().getInMemorySizeInBytes());
+        }
+        else {
+            operatorContext.setMemoryReservation(partition.get().getInMemorySizeInBytes());
+        }
+        lookupSourceNotNeeded = Optional.of(lookupSourceFactory.lendPartitionLookupSource(partitionIndex, partition));
+
+        state = State.LOOKUP_SOURCE_BUILT;
+    }
+
+    private void disposeLookupSourceIfRequested()
+    {
+        checkState(state == State.LOOKUP_SOURCE_BUILT);
+        verify(lookupSourceNotNeeded.isPresent());
+        if (!lookupSourceNotNeeded.get().isDone()) {
+            return;
+        }
+
+        index.clear();
+        operatorContext.setRevocableMemoryReservation(0L);
+        operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
+        state = State.DISPOSED;
+    }
+
+    private void finishSpilledInput()
+    {
+        checkState(state == State.SPILLING_INPUT);
+        if (!spillInProgress.isDone()) {
+            // Not ready to handle finish() yet
+            return;
+        }
+        checkSuccess(spillInProgress, "spilling failed");
+        lookupSourceFactory.setPartitionSpilledLookupSourceHandle(partitionIndex, spilledLookupSourceHandle);
+
+        state = State.INPUT_SPILLED;
+    }
+
+    private void unspillLookupSourceIfRequested()
+    {
+        checkState(state == State.INPUT_SPILLED);
+        if (!spilledLookupSourceHandle.getUnspillingRequested().isDone()) {
+            // Nothing to do yet.
+            return;
+        }
+
+        verify(spiller.isPresent());
+        verify(!unspillInProgress.isPresent());
+
+        operatorContext.setMemoryReservation(getSpiller().getSpilledPagesInMemorySize() + index.getEstimatedSize().toBytes());
+        unspillInProgress = Optional.of(getSpiller().getAllSpilledPages());
+
+        state = State.INPUT_UNSPILLING;
+    }
+
+    private void finishLookupSourceUnspilling()
+    {
+        checkState(state == State.INPUT_UNSPILLING);
+        if (!unspillInProgress.get().isDone()) {
+            // Pages have not be unspilled yet.
+            return;
+        }
+
+        // Use Queue so that Pages already consumed by Index are not retained by us.
+        Queue<Page> pages = new ArrayDeque<>(getDone(unspillInProgress.get()));
+        long memoryRetainedByRemainingPages = pages.stream()
+                .mapToLong(Page::getRetainedSizeInBytes)
+                .sum();
+        operatorContext.setMemoryReservation(memoryRetainedByRemainingPages + index.getEstimatedSize().toBytes());
+
+        while (!pages.isEmpty()) {
+            Page next = pages.remove();
+            index.addPage(next);
+            // There is no attempt to compact index, since unspilled pages are unlikely to have blocks with retained size > logical size.
+            memoryRetainedByRemainingPages -= next.getRetainedSizeInBytes();
+            operatorContext.setMemoryReservation(memoryRetainedByRemainingPages + index.getEstimatedSize().toBytes());
+        }
+
+        LookupSourceSupplier partition = buildLookupSource();
         operatorContext.setMemoryReservation(partition.get().getInMemorySizeInBytes());
+
+        spilledLookupSourceHandle.setLookupSource(partition);
+
+        state = State.INPUT_UNSPILLED_AND_BUILT;
+    }
+
+    private void disposeUnspilledLookupSourceIfRequested()
+    {
+        checkState(state == State.INPUT_UNSPILLED_AND_BUILT);
+        if (!spilledLookupSourceHandle.getDisposeRequested().isDone()) {
+            return;
+        }
+
+        index.clear();
+        operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
+
+        state = State.DISPOSED;
+    }
+
+    private LookupSourceSupplier buildLookupSource()
+    {
+        LookupSourceSupplier partition = index.createLookupSourceSupplier(operatorContext.getSession(), hashChannels, preComputedHashChannel, filterFunctionFactory, sortChannel, searchFunctionFactories, Optional.of(outputChannels));
         hashCollisionsCounter.recordHashCollision(partition.getHashCollisions(), partition.getExpectedHashCollisions());
+        return partition;
     }
 
     @Override
     public boolean isFinished()
     {
-        return finishing && lookupSourceFactory.isDestroyed().isDone();
+        if (lookupSourceFactoryDestroyed.isDone()) {
+            // Finish early when the probe side is empty
+            close();
+            return true;
+        }
+
+        return state == State.DISPOSED;
+    }
+
+    private SingleStreamSpiller getSpiller()
+    {
+        return spiller.orElseThrow(() -> new IllegalStateException("Spiller not created"));
+    }
+
+    @Override
+    public void close()
+    {
+        // close() can be called in any state, due for example to query failure, and must clean resource up unconditionally
+
+        state = State.DISPOSED;
+
+        try (Closer closer = Closer.create()) {
+            closer.register(index::clear);
+            spiller.ifPresent(closer::register);
+            closer.register(() -> operatorContext.setMemoryReservation(0));
+            closer.register(() -> operatorContext.setRevocableMemoryReservation(0));
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -33,6 +33,7 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Queue;
 
@@ -58,7 +59,7 @@ public class HashBuilderOperator
         private final PartitionedLookupSourceFactory lookupSourceFactory;
         private final List<Integer> outputChannels;
         private final List<Integer> hashChannels;
-        private final Optional<Integer> preComputedHashChannel;
+        private final OptionalInt preComputedHashChannel;
         private final Optional<JoinFilterFunctionFactory> filterFunctionFactory;
         private final Optional<Integer> sortChannel;
         private final List<JoinFilterFunctionFactory> searchFunctionFactories;
@@ -78,7 +79,7 @@ public class HashBuilderOperator
                 List<Integer> outputChannels,
                 Map<Symbol, Integer> layout,
                 List<Integer> hashChannels,
-                Optional<Integer> preComputedHashChannel,
+                OptionalInt preComputedHashChannel,
                 boolean outer,
                 Optional<JoinFilterFunctionFactory> filterFunctionFactory,
                 Optional<Integer> sortChannel,
@@ -214,7 +215,7 @@ public class HashBuilderOperator
 
     private final List<Integer> outputChannels;
     private final List<Integer> hashChannels;
-    private final Optional<Integer> preComputedHashChannel;
+    private final OptionalInt preComputedHashChannel;
     private final Optional<JoinFilterFunctionFactory> filterFunctionFactory;
     private final Optional<Integer> sortChannel;
     private final List<JoinFilterFunctionFactory> searchFunctionFactories;
@@ -244,7 +245,7 @@ public class HashBuilderOperator
             int partitionIndex,
             List<Integer> outputChannels,
             List<Integer> hashChannels,
-            Optional<Integer> preComputedHashChannel,
+            OptionalInt preComputedHashChannel,
             Optional<JoinFilterFunctionFactory> filterFunctionFactory,
             Optional<Integer> sortChannel,
             List<JoinFilterFunctionFactory> searchFunctionFactories,

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -234,6 +234,8 @@ public class HashBuilderOperator
     private LookupSourceSupplier lookupSourceSupplier;
     private OptionalLong lookupSourceChecksum = OptionalLong.empty();
 
+    private Optional<Runnable> finishMemoryRevoke = Optional.empty();
+
     public HashBuilderOperator(
             OperatorContext operatorContext,
             PartitionedLookupSourceFactory lookupSourceFactory,
@@ -376,51 +378,53 @@ public class HashBuilderOperator
     {
         checkState(spillEnabled, "Spill not enabled, no revokable memory should be reserved");
 
-        if (state == State.CONSUMING_INPUT || state == State.LOOKUP_SOURCE_BUILT) {
-            checkState(!spiller.isPresent(), "Spiller already created");
-            spiller = Optional.of(singleStreamSpillerFactory.create(
-                    index.getTypes(),
-                    operatorContext.getSpillContext().newLocalSpillContext(),
-                    operatorContext.getSystemMemoryContext().newLocalMemoryContext()));
-            return getSpiller().spill(index.getPages());
+        if (state == State.CONSUMING_INPUT) {
+            finishMemoryRevoke = Optional.of(() -> {
+                index.clear();
+                operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
+                operatorContext.setRevocableMemoryReservation(0L);
+                state = State.SPILLING_INPUT;
+            });
+            return spillIndex();
         }
-
-        // Otherwise this is stale revoking request
-        long reservedRevocableBytes = operatorContext.getReservedRevocableBytes();
-        if (reservedRevocableBytes == 0) {
+        else if (state == State.LOOKUP_SOURCE_BUILT) {
+            finishMemoryRevoke = Optional.of(() -> {
+                lookupSourceFactory.setPartitionSpilledLookupSourceHandle(partitionIndex, spilledLookupSourceHandle);
+                lookupSourceNotNeeded = Optional.empty();
+                index.clear();
+                operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
+                operatorContext.setRevocableMemoryReservation(0L);
+                lookupSourceChecksum = OptionalLong.of(lookupSourceSupplier.checksum());
+                lookupSourceSupplier = null;
+                state = State.INPUT_SPILLED;
+            });
+            return spillIndex();
+        }
+        else if (operatorContext.getReservedRevocableBytes() == 0) {
+            // Probably stale revoking request
+            finishMemoryRevoke = Optional.of(() -> {});
             return immediateFuture(null);
         }
+
         throw new IllegalStateException(format("State %s can not have revocable memory, but has %s revocable bytes", state, operatorContext.getReservedRevocableBytes()));
+    }
+
+    private ListenableFuture<?> spillIndex()
+    {
+        checkState(!spiller.isPresent(), "Spiller already created");
+        spiller = Optional.of(singleStreamSpillerFactory.create(
+                index.getTypes(),
+                operatorContext.getSpillContext().newLocalSpillContext(),
+                operatorContext.getSystemMemoryContext().newLocalMemoryContext()));
+        return getSpiller().spill(index.getPages());
     }
 
     @Override
     public void finishMemoryRevoke()
     {
-        if (state == State.CONSUMING_INPUT) {
-            index.clear();
-            operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
-            operatorContext.setRevocableMemoryReservation(0L);
-            state = State.SPILLING_INPUT;
-            return;
-        }
-
-        if (state == State.LOOKUP_SOURCE_BUILT) {
-            lookupSourceFactory.setPartitionSpilledLookupSourceHandle(partitionIndex, spilledLookupSourceHandle);
-            lookupSourceNotNeeded = Optional.empty();
-            index.clear();
-            operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
-            operatorContext.setRevocableMemoryReservation(0L);
-            lookupSourceChecksum = OptionalLong.of(lookupSourceSupplier.checksum());
-            lookupSourceSupplier = null;
-            state = State.INPUT_SPILLED;
-            return;
-        }
-
-        long reservedRevocableBytes = operatorContext.getReservedRevocableBytes();
-        if (reservedRevocableBytes == 0) {
-            return;
-        }
-        throw new IllegalStateException(format("State %s can not have revocable memory, but has %s revocable bytes", state, operatorContext.getReservedRevocableBytes()));
+        checkState(finishMemoryRevoke.isPresent(), "Cannot finish unknown revoking");
+        finishMemoryRevoke.get().run();
+        finishMemoryRevoke = Optional.empty();
     }
 
     @Override
@@ -434,6 +438,10 @@ public class HashBuilderOperator
     {
         if (lookupSourceFactoryDestroyed.isDone()) {
             close();
+            return;
+        }
+
+        if (finishMemoryRevoke.isPresent()) {
             return;
         }
 
@@ -619,6 +627,7 @@ public class HashBuilderOperator
 
         lookupSourceSupplier = null;
         state = State.DISPOSED;
+        finishMemoryRevoke = finishMemoryRevoke.map(ifPresent -> () -> {});
 
         try (Closer closer = Closer.create()) {
             closer.register(index::clear);

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -205,6 +205,8 @@ public class HashBuilderOperator
         DISPOSED
     }
 
+    private static final double INDEX_COMPACTION_ON_REVOCATION_TARGET = 0.8;
+
     private final OperatorContext operatorContext;
     private final PartitionedLookupSourceFactory lookupSourceFactory;
     private final ListenableFuture<?> lookupSourceFactoryDestroyed;
@@ -353,8 +355,6 @@ public class HashBuilderOperator
         index.addPage(page);
 
         if (spillEnabled) {
-            // TODO trySetRevocableMemoryReservation else index.compact()
-
             operatorContext.setRevocableMemoryReservation(index.getEstimatedSize().toBytes());
         }
         else {
@@ -379,6 +379,14 @@ public class HashBuilderOperator
         checkState(spillEnabled, "Spill not enabled, no revokable memory should be reserved");
 
         if (state == State.CONSUMING_INPUT) {
+            long indexSizeBeforeCompaction = index.getEstimatedSize().toBytes();
+            index.compact();
+            long indexSizeAfterCompaction = index.getEstimatedSize().toBytes();
+            if (indexSizeAfterCompaction < indexSizeBeforeCompaction * INDEX_COMPACTION_ON_REVOCATION_TARGET) {
+                finishMemoryRevoke = Optional.of(() -> {});
+                return immediateFuture(null);
+            }
+
             finishMemoryRevoke = Optional.of(() -> {
                 index.clear();
                 operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -391,6 +391,7 @@ public class HashBuilderOperator
                 index.clear();
                 operatorContext.setMemoryReservation(index.getEstimatedSize().toBytes());
                 operatorContext.setRevocableMemoryReservation(0L);
+                lookupSourceFactory.setPartitionSpilledLookupSourceHandle(partitionIndex, spilledLookupSourceHandle);
                 state = State.SPILLING_INPUT;
             });
             return spillIndex();
@@ -534,8 +535,6 @@ public class HashBuilderOperator
             return;
         }
         checkSuccess(spillInProgress, "spilling failed");
-        lookupSourceFactory.setPartitionSpilledLookupSourceHandle(partitionIndex, spilledLookupSourceHandle);
-
         state = State.INPUT_SPILLED;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/InterpretedHashGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InterpretedHashGenerator.java
@@ -32,6 +32,11 @@ public class InterpretedHashGenerator
     private final List<Type> hashChannelTypes;
     private final int[] hashChannels;
 
+    public InterpretedHashGenerator(List<Type> hashChannelTypes, List<Integer> hashChannels)
+    {
+        this(hashChannelTypes, requireNonNull(hashChannels).stream().mapToInt(i -> i).toArray());
+    }
+
     public InterpretedHashGenerator(List<Type> hashChannelTypes, int[] hashChannels)
     {
         this.hashChannels = requireNonNull(hashChannels, "hashChannels is null");

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinHash.java
@@ -67,6 +67,12 @@ public final class JoinHash
     }
 
     @Override
+    public long joinPositionWithinPartition(long joinPosition)
+    {
+        return joinPosition;
+    }
+
+    @Override
     public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage)
     {
         int addressIndex = pagesHash.getAddressIndex(position, hashChannelsPage);

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
@@ -84,6 +84,12 @@ public class JoinHashSupplier
     }
 
     @Override
+    public long checksum()
+    {
+        return positionLinks.map(PositionLinks.Factory::checksum).orElse(0L);
+    }
+
+    @Override
     public JoinHash get()
     {
         // We need to create new JoinFilterFunction per each thread using it, since those functions

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinOperatorInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinOperatorInfo.java
@@ -75,6 +75,7 @@ public class JoinOperatorInfo
         return logHistogramOutput;
     }
 
+    /** Estimated number of positions in on the build side */
     @JsonProperty
     public long getLookupSourcePositions()
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinProbe.java
@@ -22,7 +22,7 @@ public interface JoinProbe
 
     boolean advanceNextPosition();
 
-    long getCurrentJoinPosition();
+    long getCurrentJoinPosition(LookupSource lookupSource);
 
     void appendTo(PageBuilder pageBuilder);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinProbeFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinProbeFactory.java
@@ -17,5 +17,5 @@ import com.facebook.presto.spi.Page;
 
 public interface JoinProbeFactory
 {
-    JoinProbe createJoinProbe(LookupSource lookupSource, Page page);
+    JoinProbe createJoinProbe(Page page);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinStatisticsCounter.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinStatisticsCounter.java
@@ -34,6 +34,8 @@ public class JoinStatisticsCounter
     //      [2*bucket]      count probe positions that produced "bucket" rows on source side,
     //      [2*bucket + 1]  total count of rows that were produces by probe rows in this bucket.
     private final long[] logHistogramCounters = new long[HISTOGRAM_BUCKETS * 2];
+
+    /** Estimated number of positions in on the build side */
     private long lookupSourcePositions = -1;
 
     public JoinStatisticsCounter(JoinType joinType)
@@ -41,9 +43,12 @@ public class JoinStatisticsCounter
         this.joinType = requireNonNull(joinType, "joinType is null");
     }
 
-    public void setLookupSourcePositions(long lookupSourcePositions)
+    public void updateLookupSourcePositions(long lookupSourcePositionsDelta)
     {
-        this.lookupSourcePositions = lookupSourcePositions;
+        if (this.lookupSourcePositions == -1) {
+            this.lookupSourcePositions = 0;
+        }
+        this.lookupSourcePositions += lookupSourcePositionsDelta;
     }
 
     public void recordProbe(int numSourcePositions)

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -43,7 +43,6 @@ import static com.facebook.presto.operator.LookupJoinOperators.JoinType.FULL_OUT
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.PROBE_OUTER;
 import static com.facebook.presto.operator.Operators.checkSuccess;
 import static com.facebook.presto.operator.Operators.getDone;
-import static com.facebook.presto.spi.Page.mask;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static java.lang.String.format;
@@ -650,7 +649,7 @@ public class LookupJoinOperator
 
         public SavedRow(Page page, int position, long joinPositionWithinPartition, boolean currentProbePositionProducedRow, int joinSourcePositions)
         {
-            this.row = mask(page, new int[] {position});
+            this.row = page.mask(new int[] {position});
             this.row.compact();
 
             this.joinPositionWithinPartition = joinPositionWithinPartition;

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -513,7 +513,7 @@ public class LookupJoinOperator
      * for the current probe position, calling this again will produce rows that wasn't been produced in previous
      * invocations.
      *
-     * @return true if all eligible rows have been produced; false otherwise (because pageBuilder became full)
+     * @return true if all eligible rows have been produced; false otherwise
      */
     private boolean joinCurrentPosition(LookupSource lookupSource, DriverYieldSignal yieldSignal)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -17,11 +17,13 @@ import com.facebook.presto.operator.LookupJoinOperators.JoinType;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.PartitioningSpillerFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.FULL_OUTER;
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.PROBE_OUTER;
@@ -33,10 +35,14 @@ public class LookupJoinOperator
         implements Operator, Closeable
 {
     private final OperatorContext operatorContext;
-    private final List<Type> types;
+    private final List<Type> allTypes;
+    private final List<Type> probeTypes;
     private final ListenableFuture<? extends LookupSource> lookupSourceFuture;
     private final JoinProbeFactory joinProbeFactory;
     private final Runnable onClose;
+    private final OptionalInt lookupJoinsCount;
+    private final HashGenerator hashGenerator;
+    private final PartitioningSpillerFactory partitioningSpillerFactory;
 
     private final JoinStatisticsCounter statisticsCounter;
 
@@ -56,14 +62,19 @@ public class LookupJoinOperator
 
     public LookupJoinOperator(
             OperatorContext operatorContext,
-            List<Type> types,
+            List<Type> allTypes,
+            List<Type> probeTypes,
             JoinType joinType,
             ListenableFuture<LookupSource> lookupSourceFuture,
             JoinProbeFactory joinProbeFactory,
-            Runnable onClose)
+            Runnable onClose,
+            OptionalInt lookupJoinsCount,
+            HashGenerator hashGenerator,
+            PartitioningSpillerFactory partitioningSpillerFactory)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.allTypes = ImmutableList.copyOf(requireNonNull(allTypes, "allTypes is null"));
+        this.probeTypes = ImmutableList.copyOf(requireNonNull(probeTypes, "probeTypes is null"));
 
         requireNonNull(joinType, "joinType is null");
         // Cannot use switch case here, because javac will synthesize an inner class and cause IllegalAccessError
@@ -72,11 +83,14 @@ public class LookupJoinOperator
         this.lookupSourceFuture = requireNonNull(lookupSourceFuture, "lookupSourceFuture is null");
         this.joinProbeFactory = requireNonNull(joinProbeFactory, "joinProbeFactory is null");
         this.onClose = requireNonNull(onClose, "onClose is null");
+        this.lookupJoinsCount = requireNonNull(lookupJoinsCount, "lookupJoinsCount is null");
+        this.hashGenerator = requireNonNull(hashGenerator, "hashGenerator is null");
+        this.partitioningSpillerFactory = requireNonNull(partitioningSpillerFactory, "partitioningSpillerFactory is null");
 
         this.statisticsCounter = new JoinStatisticsCounter(joinType);
         operatorContext.setInfoSupplier(this.statisticsCounter);
 
-        this.pageBuilder = new PageBuilder(types);
+        this.pageBuilder = new PageBuilder(allTypes);
     }
 
     @Override
@@ -88,7 +102,7 @@ public class LookupJoinOperator
     @Override
     public List<Type> getTypes()
     {
-        return types;
+        return allTypes;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -14,25 +14,44 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.operator.LookupJoinOperators.JoinType;
+import com.facebook.presto.operator.LookupSourceProvider.LookupSourceLease;
+import com.facebook.presto.operator.PartitionedConsumption.Partition;
+import com.facebook.presto.operator.exchange.LocalPartitionGenerator;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.PartitioningSpiller;
+import com.facebook.presto.spiller.PartitioningSpiller.PartitioningSpillResult;
 import com.facebook.presto.spiller.PartitioningSpillerFactory;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
 import com.google.common.util.concurrent.ListenableFuture;
 
-import java.io.Closeable;
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.IntPredicate;
+import java.util.function.Supplier;
 
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.FULL_OUTER;
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.PROBE_OUTER;
+import static com.facebook.presto.operator.Operators.checkSuccess;
+import static com.facebook.presto.operator.Operators.getDone;
+import static com.facebook.presto.spi.Page.mask;
 import static com.google.common.base.Preconditions.checkState;
-import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
+import static java.util.Collections.emptyIterator;
 import static java.util.Objects.requireNonNull;
 
 public class LookupJoinOperator
-        implements Operator, Closeable
+        implements Operator
 {
     private final OperatorContext operatorContext;
     private final List<Type> allTypes;
@@ -41,6 +60,7 @@ public class LookupJoinOperator
     private final Runnable onClose;
     private final OptionalInt lookupJoinsCount;
     private final HashGenerator hashGenerator;
+    private final LookupSourceFactory lookupSourceFactory;
     private final PartitioningSpillerFactory partitioningSpillerFactory;
 
     private final JoinStatisticsCounter statisticsCounter;
@@ -53,19 +73,34 @@ public class LookupJoinOperator
     private LookupSourceProvider lookupSourceProvider;
     private JoinProbe probe;
 
+    private Optional<PartitioningSpiller> spiller = Optional.empty();
+    private Optional<LocalPartitionGenerator> partitionGenerator = Optional.empty();
+    private ListenableFuture<?> spillInProgress = NOT_BLOCKED;
+    private long inputPageSpillEpoch;
     private boolean closed;
     private boolean finishing;
+    private boolean unspilling;
+    private boolean finished;
     private long joinPosition = -1;
     private int joinSourcePositions = 0;
 
     private boolean currentProbePositionProducedRow;
+
+    private final Map<Integer, SavedRow> savedRows = new HashMap<>();
+    @Nullable
+    private ListenableFuture<PartitionedConsumption<Supplier<LookupSource>>> partitionedConsumption;
+    @Nullable
+    private Iterator<Partition<Supplier<LookupSource>>> lookupPartitions;
+    private Optional<Partition<Supplier<LookupSource>>> currentPartition = Optional.empty();
+    private Optional<ListenableFuture<Supplier<LookupSource>>> unspilledLookupSource = Optional.empty();
+    private Iterator<Page> unspilledInputPages = emptyIterator();
 
     public LookupJoinOperator(
             OperatorContext operatorContext,
             List<Type> allTypes,
             List<Type> probeTypes,
             JoinType joinType,
-            ListenableFuture<LookupSourceProvider> lookupSourceProviderFuture,
+            LookupSourceFactory lookupSourceFactory,
             JoinProbeFactory joinProbeFactory,
             Runnable onClose,
             OptionalInt lookupJoinsCount,
@@ -84,8 +119,9 @@ public class LookupJoinOperator
         this.onClose = requireNonNull(onClose, "onClose is null");
         this.lookupJoinsCount = requireNonNull(lookupJoinsCount, "lookupJoinsCount is null");
         this.hashGenerator = requireNonNull(hashGenerator, "hashGenerator is null");
+        this.lookupSourceFactory = requireNonNull(lookupSourceFactory, "lookupSourceFactory is null");
         this.partitioningSpillerFactory = requireNonNull(partitioningSpillerFactory, "partitioningSpillerFactory is null");
-        this.lookupSourceProviderFuture = requireNonNull(lookupSourceProviderFuture, "lookupSourceProviderFuture is null");
+        this.lookupSourceProviderFuture = lookupSourceFactory.createLookupSourceProvider();
 
         this.statisticsCounter = new JoinStatisticsCounter(joinType);
         operatorContext.setInfoSupplier(this.statisticsCounter);
@@ -108,13 +144,22 @@ public class LookupJoinOperator
     @Override
     public void finish()
     {
+        if (finishing) {
+            return;
+        }
+
+        if (!spillInProgress.isDone()) {
+            return;
+        }
+
+        checkSuccess(spillInProgress, "spilling failed");
         finishing = true;
     }
 
     @Override
     public boolean isFinished()
     {
-        boolean finished = finishing && probe == null && pageBuilder.isEmpty();
+        boolean finished = this.finished && probe == null && pageBuilder.isEmpty();
 
         // if finished drop references so memory is freed early
         if (finished) {
@@ -126,6 +171,15 @@ public class LookupJoinOperator
     @Override
     public ListenableFuture<?> isBlocked()
     {
+        if (!spillInProgress.isDone()) {
+            // Input spilling can happen only after lookupSourceProviderFuture was done.
+            return spillInProgress;
+        }
+        if (unspilledLookupSource.isPresent()) {
+            // Unspilling can happen only after lookupSourceProviderFuture was done.
+            return unspilledLookupSource.get();
+        }
+
         return lookupSourceProviderFuture;
     }
 
@@ -134,6 +188,7 @@ public class LookupJoinOperator
     {
         return !finishing
                 && lookupSourceProviderFuture.isDone()
+                && spillInProgress.isDone()
                 && probe == null;
     }
 
@@ -141,88 +196,317 @@ public class LookupJoinOperator
     public void addInput(Page page)
     {
         requireNonNull(page, "page is null");
-        checkState(!finishing, "Operator is finishing");
         checkState(probe == null, "Current page has not been completely processed yet");
 
-        if (lookupSourceProvider == null) {
-            checkState(lookupSourceProviderFuture.isDone(), "Not ready to handle input yet");
-            lookupSourceProvider = requireNonNull(getFutureValue(lookupSourceProviderFuture));
-            statisticsCounter.setLookupSourcePositions(lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().getJoinPositionCount()));
+        checkState(tryFetchLookupSourceProvider(), "Not ready to handle input yet");
+
+        SpillInfoSnapshot spillInfoSnapshot = lookupSourceProvider.withLease(SpillInfoSnapshot::from);
+        addInput(page, spillInfoSnapshot);
+    }
+
+    private void addInput(Page page, SpillInfoSnapshot spillInfoSnapshot)
+    {
+        requireNonNull(spillInfoSnapshot, "spillInfoSnapshot is null");
+
+        if (spillInfoSnapshot.hasSpilled()) {
+            page = spillAndMaskSpilledPositions(page, spillInfoSnapshot.getSpillMask());
+            if (page.getPositionCount() == 0) {
+                return;
+            }
         }
 
         // create probe
+        inputPageSpillEpoch = spillInfoSnapshot.getSpillEpoch();
         probe = joinProbeFactory.createJoinProbe(page);
 
         // initialize to invalid join position to force output code to advance the cursors
         joinPosition = -1;
     }
 
+    private boolean tryFetchLookupSourceProvider()
+    {
+        if (lookupSourceProvider == null) {
+            if (!lookupSourceProviderFuture.isDone()) {
+                return false;
+            }
+            lookupSourceProvider = requireNonNull(getDone(lookupSourceProviderFuture));
+            statisticsCounter.updateLookupSourcePositions(lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().getJoinPositionCount()));
+        }
+        return true;
+    }
+
+    private Page spillAndMaskSpilledPositions(Page page, IntPredicate spillMask)
+    {
+        checkState(spillInProgress.isDone(), "Previous spill still in progress");
+        checkSuccess(spillInProgress, "spilling failed");
+
+        if (!spiller.isPresent()) {
+            spiller = Optional.of(partitioningSpillerFactory.create(
+                    probeTypes,
+                    getPartitionGenerator(),
+                    operatorContext.getSpillContext().newLocalSpillContext(),
+                    operatorContext.getSystemMemoryContext().newAggregatedMemoryContext()));
+        }
+
+        PartitioningSpillResult result = spiller.get().partitionAndSpill(page, spillMask);
+        spillInProgress = result.getSpillingFuture();
+        return result.getRetained();
+    }
+
+    public LocalPartitionGenerator getPartitionGenerator()
+    {
+        if (!partitionGenerator.isPresent()) {
+            partitionGenerator = Optional.of(new LocalPartitionGenerator(hashGenerator, lookupSourceFactory.partitions()));
+        }
+        return partitionGenerator.get();
+    }
+
     @Override
     public Page getOutput()
     {
-        if (probe == null && pageBuilder.isEmpty()) {
-            // Fast exit path when lookup source is still being build
+        // TODO introduce explicit state (enum), like in HBO
+
+        if (!spillInProgress.isDone()) {
+            /*
+             * We cannot produce output when there is some previous input spilling. This is because getOutput() may result in additional portion of input being spilled
+             * (when spilling state has changed in partitioned lookup source since last time) and spiller does not allow multiple concurrent spills.
+             */
+            return null;
+        }
+        checkSuccess(spillInProgress, "spilling failed");
+
+        if (probe == null && pageBuilder.isEmpty() && !finishing) {
             return null;
         }
 
-        checkState(lookupSourceProvider != null, "Input has been accepted before lookup source provided");
-
-        return lookupSourceProvider.withLease(lookupSourceLease -> {
-            return getOutput(lookupSourceLease.getLookupSource());
-        });
-    }
-
-    private Page getOutput(LookupSource lookupSource)
-    {
-        // join probe page with the lookup source
-        DriverYieldSignal yieldSignal = operatorContext.getDriverContext().getYieldSignal();
-        if (probe != null) {
-            while (!yieldSignal.isSet()) {
-                if (probe.getPosition() >= 0) {
-                    if (!joinCurrentPosition(lookupSource, yieldSignal)) {
-                        break;
-                    }
-                    if (!currentProbePositionProducedRow) {
-                        currentProbePositionProducedRow = true;
-                        if (!outerJoinCurrentPosition(lookupSource)) {
-                            break;
-                        }
-                    }
-                }
-                currentProbePositionProducedRow = false;
-                if (!advanceProbePosition(lookupSource)) {
-                    break;
-                }
-                statisticsCounter.recordProbe(joinSourcePositions);
-                joinSourcePositions = 0;
-            }
+        if (!tryFetchLookupSourceProvider()) {
+            return null;
         }
 
-        // only flush full pages unless we are done
-        if (pageBuilder.isFull() || (finishing && !pageBuilder.isEmpty() && probe == null)) {
+        if (probe == null && finishing && !unspilling) {
+            /*
+             * We do not have input probe and we won't have any, as we're finishing.
+             * Let LookupSourceFactory know LookupSources can be disposed as far as we're concerned.
+             */
+            verify(partitionedConsumption == null, "partitioned consumption already started");
+            partitionedConsumption = lookupSourceFactory.finishProbeOperator(lookupJoinsCount);
+            unspilling = true;
+        }
+
+        if (probe == null && unspilling && !finished) {
+            /*
+             * If no current partition or it was exhausted, unspill next one.
+             * Add input there when it needs one, produce output. Be Happy.
+             */
+            tryUnspillNext();
+        }
+
+        if (probe != null) {
+            processProbe();
+        }
+
+        if (pageBuilder.isFull() || (!pageBuilder.isEmpty() && probe == null && finished)) {
             Page page = pageBuilder.build();
             pageBuilder.reset();
             return page;
         }
-
         return null;
+    }
+
+    private void tryUnspillNext()
+    {
+        verify(probe == null);
+
+        if (!partitionedConsumption.isDone()) {
+            return;
+        }
+
+        if (lookupPartitions == null) {
+            lookupPartitions = getDone(partitionedConsumption).beginConsumption();
+        }
+
+        if (unspilledInputPages.hasNext()) {
+            addInput(unspilledInputPages.next());
+            return;
+        }
+
+        if (unspilledLookupSource.isPresent()) {
+            if (!unspilledLookupSource.get().isDone()) {
+                // Not unspilled yet
+                return;
+            }
+            LookupSource lookupSource = getDone(unspilledLookupSource.get()).get();
+            unspilledLookupSource = Optional.empty();
+
+            // Close previous lookupSourceProvider (either supplied initially or for the previous partition)
+            lookupSourceProvider.close();
+            lookupSourceProvider = new StaticLookupSourceProvider(lookupSource);
+            // If the partition was spilled during processing, its position count will be considered twice.
+            statisticsCounter.updateLookupSourcePositions(lookupSource.getJoinPositionCount());
+
+            int partition = currentPartition.get().number();
+            unspilledInputPages = spiller.map(spiller -> spiller.getSpilledPages(partition))
+                    .orElse(emptyIterator());
+
+            Optional.ofNullable(savedRows.remove(partition)).ifPresent(savedRow -> {
+                restoreProbe(
+                        savedRow.row,
+                        savedRow.joinPositionWithinPartition,
+                        savedRow.currentProbePositionProducedRow,
+                        savedRow.joinSourcePositions,
+                        SpillInfoSnapshot.noSpill());
+            });
+
+            return;
+        }
+
+        if (lookupPartitions.hasNext()) {
+            currentPartition.ifPresent(Partition::release);
+            currentPartition = Optional.of(lookupPartitions.next());
+            unspilledLookupSource = Optional.of(currentPartition.get().load());
+
+            return;
+        }
+
+        currentPartition.ifPresent(Partition::release);
+        if (lookupSourceProvider != null) {
+            // There are no more partitions to process, so clean up everything
+            lookupSourceProvider.close();
+            lookupSourceProvider = null;
+        }
+        spiller.ifPresent(PartitioningSpiller::verifyAllPartitionsRead);
+        finished = true;
+    }
+
+    private void processProbe()
+    {
+        verify(probe != null);
+
+        Optional<SpillInfoSnapshot> spillInfoSnapshotIfSpillChanged = lookupSourceProvider.withLease(lookupSourceLease -> {
+            if (lookupSourceLease.spillEpoch() == inputPageSpillEpoch) {
+                // Spill state didn't change, so process as usual.
+                processProbe(lookupSourceLease.getLookupSource());
+                return Optional.empty();
+            }
+
+            return Optional.of(SpillInfoSnapshot.from(lookupSourceLease));
+        });
+
+        if (!spillInfoSnapshotIfSpillChanged.isPresent()) {
+            return;
+        }
+        SpillInfoSnapshot spillInfoSnapshot = spillInfoSnapshotIfSpillChanged.get();
+        long joinPositionWithinPartition;
+        if (joinPosition >= 0) {
+            joinPositionWithinPartition = lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().joinPositionWithinPartition(joinPosition));
+        }
+        else {
+            joinPositionWithinPartition = -1;
+        }
+
+        /*
+         * Spill state changed. All probe rows that were not processed yet should be treated as regular input (and be partially spilled).
+         * If current row maps to the now-spilled partition, it needs to be saved for later. If it maps to a partition still in memory, it
+         * should be added together with not-yet-processed rows. In either case we need to resume processing the row starting at its
+         * current position in the lookup source.
+         */
+        verify(spillInfoSnapshot.hasSpilled());
+        verify(spillInfoSnapshot.getSpillEpoch() > inputPageSpillEpoch);
+
+        Page currentPage = probe.getPage();
+        int currentPosition = probe.getPosition();
+        long currentJoinPosition = this.joinPosition;
+        boolean currentProbePositionProducedRow = this.currentProbePositionProducedRow;
+
+        probe = null;
+
+        if (currentPosition < 0) {
+            // Processing of the page hasn't been started yet.
+            addInput(currentPage, spillInfoSnapshot);
+        }
+        else {
+            int currentRowPartition = getPartitionGenerator().getPartition(currentPage, currentPosition);
+            boolean currentRowSpilled = spillInfoSnapshot.getSpillMask().test(currentRowPartition);
+
+            if (currentRowSpilled) {
+                savedRows.merge(
+                        currentRowPartition,
+                        new SavedRow(currentPage, currentPosition, joinPositionWithinPartition, currentProbePositionProducedRow, joinSourcePositions),
+                        (oldValue, newValue) -> {
+                            throw new IllegalStateException(format("Partition %s is already spilled", currentRowPartition));
+                        });
+                joinSourcePositions = 0;
+                Page unprocessed = pageTail(currentPage, currentPosition + 1);
+                addInput(unprocessed, spillInfoSnapshot);
+            }
+            else {
+                Page remaining = pageTail(currentPage, currentPosition);
+                restoreProbe(remaining, currentJoinPosition, currentProbePositionProducedRow, joinSourcePositions, spillInfoSnapshot);
+            }
+        }
+    }
+
+    private void processProbe(LookupSource lookupSource)
+    {
+        verify(probe != null);
+
+        DriverYieldSignal yieldSignal = operatorContext.getDriverContext().getYieldSignal();
+        while (!yieldSignal.isSet()) {
+            if (probe.getPosition() >= 0) {
+                if (!joinCurrentPosition(lookupSource, yieldSignal)) {
+                    break;
+                }
+                if (!currentProbePositionProducedRow) {
+                    currentProbePositionProducedRow = true;
+                    if (!outerJoinCurrentPosition(lookupSource)) {
+                        break;
+                    }
+                }
+            }
+            currentProbePositionProducedRow = false;
+            if (!advanceProbePosition(lookupSource)) {
+                break;
+            }
+            statisticsCounter.recordProbe(joinSourcePositions);
+            joinSourcePositions = 0;
+        }
+    }
+
+    private void restoreProbe(Page probePage, long joinPosition, boolean currentProbePositionProducedRow, int joinSourcePositions, SpillInfoSnapshot spillInfoSnapshot)
+    {
+        verify(probe == null);
+
+        addInput(probePage, spillInfoSnapshot);
+        verify(probe.advanceNextPosition());
+        this.joinPosition = joinPosition;
+        this.currentProbePositionProducedRow = currentProbePositionProducedRow;
+        this.joinSourcePositions = joinSourcePositions;
+    }
+
+    private Page pageTail(Page currentPage, int startAtPosition)
+    {
+        verify(currentPage.getPositionCount() - startAtPosition >= 0);
+        return currentPage.getRegion(startAtPosition, currentPage.getPositionCount() - startAtPosition);
     }
 
     @Override
     public void close()
     {
-        // Closing the lookupSource is always safe to do, but we don't want to release the supplier multiple times, since its reference counted
         if (closed) {
             return;
         }
         closed = true;
         probe = null;
-        pageBuilder.reset();
-        // closing lookup source is only here for index join
-        if (lookupSourceProvider != null) {
-            lookupSourceProvider.close();
+
+        try (Closer closer = Closer.create()) {
+            closer.register(pageBuilder::reset);
+            closer.register(() -> Optional.ofNullable(lookupSourceProvider).ifPresent(LookupSourceProvider::close));
+            spiller.ifPresent(closer::register);
+            closer.register(onClose::run);
         }
-        onClose.run();
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
@@ -295,5 +579,83 @@ public class LookupJoinOperator
             }
         }
         return true;
+    }
+
+    // This class must be public because LookupJoinOperator is isolated.
+    public static class SpillInfoSnapshot
+    {
+        private final boolean hasSpilled;
+        private final long spillEpoch;
+        private final IntPredicate spillMask;
+
+        public SpillInfoSnapshot(boolean hasSpilled, long spillEpoch, IntPredicate spillMask)
+        {
+            this.hasSpilled = hasSpilled;
+            this.spillEpoch = spillEpoch;
+            this.spillMask = requireNonNull(spillMask, "spillMask is null");
+        }
+
+        public static SpillInfoSnapshot from(LookupSourceLease lookupSourceLease)
+        {
+            return new SpillInfoSnapshot(
+                    lookupSourceLease.hasSpilled(),
+                    lookupSourceLease.spillEpoch(),
+                    lookupSourceLease.getSpillMask());
+        }
+
+        public static SpillInfoSnapshot noSpill()
+        {
+            return new SpillInfoSnapshot(false, 0, i -> false);
+        }
+
+        public boolean hasSpilled()
+        {
+            return hasSpilled;
+        }
+
+        public long getSpillEpoch()
+        {
+            return spillEpoch;
+        }
+
+        public IntPredicate getSpillMask()
+        {
+            return spillMask;
+        }
+    }
+
+    // This class must be public because LookupJoinOperator is isolated.
+    public static class SavedRow
+    {
+        /**
+         * A page with exactly one {@link Page#getPositionCount}, representing saved row.
+         */
+        public final Page row;
+
+        /**
+         * A snapshot of {@link LookupJoinOperator#joinPosition} "de-partitioned", i.e. {@link LookupJoinOperator#joinPosition} is a join position
+         * with respect to (potentially) partitioned lookup source, while this value is a join position with respect to containing partition.
+         */
+        public final long joinPositionWithinPartition;
+
+        /**
+         * A snapshot of {@link LookupJoinOperator#currentProbePositionProducedRow}
+         */
+        public final boolean currentProbePositionProducedRow;
+
+        /**
+         * A snapshot of {@link LookupJoinOperator#joinSourcePositions}
+         */
+        public final int joinSourcePositions;
+
+        public SavedRow(Page page, int position, long joinPositionWithinPartition, boolean currentProbePositionProducedRow, int joinSourcePositions)
+        {
+            this.row = mask(page, new int[] {position});
+            this.row.compact();
+
+            this.joinPositionWithinPartition = joinPositionWithinPartition;
+            this.currentProbePositionProducedRow = currentProbePositionProducedRow;
+            this.joinSourcePositions = joinSourcePositions;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -154,7 +154,7 @@ public class LookupJoinOperator
         checkState(probe == null, "Current page has not been completely processed yet");
 
         // create probe
-        probe = joinProbeFactory.createJoinProbe(lookupSource, page);
+        probe = joinProbeFactory.createJoinProbe(page);
 
         // initialize to invalid join position to force output code to advance the cursors
         joinPosition = -1;
@@ -261,7 +261,7 @@ public class LookupJoinOperator
         }
 
         // update join position
-        joinPosition = probe.getCurrentJoinPosition();
+        joinPosition = probe.getCurrentJoinPosition(lookupSource);
         return true;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -90,9 +90,11 @@ public class LookupJoinOperatorFactory
         }
         else {
             // when all join operators finish (and lookup source is ready), set the outer position future to start the outer operator
-            ListenableFuture<LookupSource> lookupSourceAfterProbeFinished = transformAsync(probeReferenceCount.getFreeFuture(), ignored -> lookupSourceFactory.createLookupSource());
-            ListenableFuture<OuterPositionIterator> outerPositionsFuture = transform(lookupSourceAfterProbeFinished, lookupSource -> {
-                lookupSource.close();
+            ListenableFuture<LookupSourceProvider> lookupSourceAfterProbeFinished = transformAsync(
+                    probeReferenceCount.getFreeFuture(),
+                    ignored -> lookupSourceFactory.createLookupSourceProvider());
+            ListenableFuture<OuterPositionIterator> outerPositionsFuture = transform(lookupSourceAfterProbeFinished, lookupSourceProvider -> {
+                lookupSourceProvider.close();
                 return lookupSourceFactory.getOuterPositionIterator();
             });
 
@@ -166,7 +168,7 @@ public class LookupJoinOperatorFactory
                 getTypes(),
                 probeTypes,
                 joinType,
-                lookupSourceFactory.createLookupSource(),
+                lookupSourceFactory.createLookupSourceProvider(),
                 joinProbeFactory,
                 probeReferenceCount::release,
                 totalOperatorsCount,

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperatorFactory.java
@@ -168,7 +168,7 @@ public class LookupJoinOperatorFactory
                 getTypes(),
                 probeTypes,
                 joinType,
-                lookupSourceFactory.createLookupSourceProvider(),
+                lookupSourceFactory,
                 joinProbeFactory,
                 probeReferenceCount::release,
                 totalOperatorsCount,

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.PartitioningSpillerFactory;
 import com.facebook.presto.sql.gen.JoinProbeCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 
@@ -21,6 +22,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -44,24 +46,24 @@ public class LookupJoinOperators
         this.joinProbeCompiler = requireNonNull(joinProbeCompiler, "joinProbeCompiler is null");
     }
 
-    public OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
+    public OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
     {
-        return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.INNER);
+        return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.INNER, totalOperatorsCount, partitioningSpillerFactory);
     }
 
-    public OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
+    public OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
     {
-        return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.PROBE_OUTER);
+        return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.PROBE_OUTER, totalOperatorsCount, partitioningSpillerFactory);
     }
 
-    public OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
+    public OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
     {
-        return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.LOOKUP_OUTER);
+        return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.LOOKUP_OUTER, totalOperatorsCount, partitioningSpillerFactory);
     }
 
-    public OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels)
+    public OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
     {
-        return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.FULL_OUTER);
+        return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.FULL_OUTER, totalOperatorsCount, partitioningSpillerFactory);
     }
 
     private static List<Integer> rangeList(int endExclusive)

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperators.java
@@ -46,22 +46,22 @@ public class LookupJoinOperators
         this.joinProbeCompiler = requireNonNull(joinProbeCompiler, "joinProbeCompiler is null");
     }
 
-    public OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
+    public OperatorFactory innerJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, OptionalInt probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
     {
         return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.INNER, totalOperatorsCount, partitioningSpillerFactory);
     }
 
-    public OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
+    public OperatorFactory probeOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, OptionalInt probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
     {
         return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.PROBE_OUTER, totalOperatorsCount, partitioningSpillerFactory);
     }
 
-    public OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
+    public OperatorFactory lookupOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, OptionalInt probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
     {
         return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.LOOKUP_OUTER, totalOperatorsCount, partitioningSpillerFactory);
     }
 
-    public OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, Optional<Integer> probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
+    public OperatorFactory fullOuterJoin(int operatorId, PlanNodeId planNodeId, LookupSourceFactory lookupSourceFactory, List<? extends Type> probeTypes, List<Integer> probeJoinChannel, OptionalInt probeHashChannel, Optional<List<Integer>> probeOutputChannels, OptionalInt totalOperatorsCount, PartitioningSpillerFactory partitioningSpillerFactory)
     {
         return joinProbeCompiler.compileJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeJoinChannel, probeHashChannel, probeOutputChannels.orElse(rangeList(probeTypes.size())), JoinType.FULL_OUTER, totalOperatorsCount, partitioningSpillerFactory);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
@@ -30,6 +30,8 @@ public interface LookupSource
 
     long getJoinPositionCount();
 
+    long joinPositionWithinPartition(long joinPosition);
+
     long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage, long rawHash);
 
     long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage);

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
@@ -26,10 +26,10 @@ public interface LookupSourceFactory
 
     List<Type> getOutputTypes();
 
-    ListenableFuture<LookupSource> createLookupSource();
+    ListenableFuture<LookupSourceProvider> createLookupSourceProvider();
 
     /**
-     * Can be called only after {@link #createLookupSource()} is done and all users of {@link LookupSource}-s finished.
+     * Can be called only after {@link #createLookupSourceProvider()} is done and all users of {@link LookupSource}-s finished.
      */
     OuterPositionIterator getOuterPositionIterator();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceFactory.java
@@ -19,6 +19,11 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
+import java.util.function.Supplier;
+
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.util.Collections.emptyList;
 
 public interface LookupSourceFactory
 {
@@ -27,6 +32,19 @@ public interface LookupSourceFactory
     List<Type> getOutputTypes();
 
     ListenableFuture<LookupSourceProvider> createLookupSourceProvider();
+
+    int partitions();
+
+    default ListenableFuture<PartitionedConsumption<Supplier<LookupSource>>> finishProbeOperator(OptionalInt lookupJoinsCount)
+    {
+        return immediateFuture(new PartitionedConsumption<>(
+                1,
+                emptyList(),
+                i -> {
+                    throw new UnsupportedOperationException();
+                },
+                i -> {}));
+    }
 
     /**
      * Can be called only after {@link #createLookupSourceProvider()} is done and all users of {@link LookupSource}-s finished.

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import java.util.function.Function;
+
+public interface LookupSourceProvider
+        extends AutoCloseable
+{
+    <R> R withLease(Function<LookupSourceLease, R> action);
+
+    @Override
+    void close();
+
+    interface LookupSourceLease
+    {
+        LookupSource getLookupSource();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import java.util.function.Function;
+import java.util.function.IntPredicate;
 
 public interface LookupSourceProvider
         extends AutoCloseable
@@ -26,5 +27,11 @@ public interface LookupSourceProvider
     interface LookupSourceLease
     {
         LookupSource getLookupSource();
+
+        boolean hasSpilled();
+
+        long spillEpoch();
+
+        IntPredicate getSpillMask();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSourceSupplier.java
@@ -21,4 +21,9 @@ public interface LookupSourceSupplier
     long getHashCollisions();
 
     double getExpectedHashCollisions();
+
+    /**
+     * @return checksum of this entity for heuristic checking equivalence of two instances
+     */
+    long checksum();
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/Operators.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Operators.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import java.util.concurrent.Future;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static java.util.Objects.requireNonNull;
+
+public class Operators
+{
+    private Operators() {}
+
+    // TODO replace with MoreFutures.getDone
+    public static <T> T getDone(Future<T> future)
+    {
+        requireNonNull(future, "future is null");
+        checkArgument(future.isDone(), "future not done yet");
+        return getFutureValue(future);
+    }
+
+    /**
+     * Checks that the completed future completed successfully.
+     */
+    // TODO replace with MoreFutures.checkSuccess
+    public static void checkSuccess(Future<?> future, String errorMessage)
+    {
+        requireNonNull(future, "future is null");
+        requireNonNull(errorMessage, "errorMessage is null");
+        checkArgument(future.isDone(), "future not done yet");
+        try {
+            getFutureValue(future);
+        }
+        catch (RuntimeException e) {
+            throw new IllegalArgumentException(errorMessage, e);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/OuterLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OuterLookupSource.java
@@ -64,6 +64,12 @@ public final class OuterLookupSource
     }
 
     @Override
+    public long joinPositionWithinPartition(long joinPosition)
+    {
+        return lookupSource.joinPositionWithinPartition(joinPosition);
+    }
+
+    @Override
     public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage, long rawHash)
     {
         return lookupSource.getJoinPosition(position, hashChannelsPage, allChannelsPage, rawHash);

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -39,6 +39,7 @@ import javax.inject.Inject;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -375,15 +376,15 @@ public class PagesIndex
 
     public Supplier<LookupSource> createLookupSourceSupplier(Session session, List<Integer> joinChannels)
     {
-        return createLookupSourceSupplier(session, joinChannels, Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of());
+        return createLookupSourceSupplier(session, joinChannels, OptionalInt.empty(), Optional.empty(), Optional.empty(), ImmutableList.of());
     }
 
-    public PagesHashStrategy createPagesHashStrategy(List<Integer> joinChannels, Optional<Integer> hashChannel)
+    public PagesHashStrategy createPagesHashStrategy(List<Integer> joinChannels, OptionalInt hashChannel)
     {
         return createPagesHashStrategy(joinChannels, hashChannel, Optional.empty());
     }
 
-    public PagesHashStrategy createPagesHashStrategy(List<Integer> joinChannels, Optional<Integer> hashChannel, Optional<List<Integer>> outputChannels)
+    public PagesHashStrategy createPagesHashStrategy(List<Integer> joinChannels, OptionalInt hashChannel, Optional<List<Integer>> outputChannels)
     {
         try {
             return joinCompiler.compilePagesHashStrategyFactory(types, joinChannels, outputChannels)
@@ -406,7 +407,7 @@ public class PagesIndex
     public LookupSourceSupplier createLookupSourceSupplier(
             Session session,
             List<Integer> joinChannels,
-            Optional<Integer> hashChannel,
+            OptionalInt hashChannel,
             Optional<JoinFilterFunctionFactory> filterFunctionFactory,
             Optional<Integer> sortChannel,
             List<JoinFilterFunctionFactory> searchFunctionFactories)
@@ -417,7 +418,7 @@ public class PagesIndex
     public LookupSourceSupplier createLookupSourceSupplier(
             Session session,
             List<Integer> joinChannels,
-            Optional<Integer> hashChannel,
+            OptionalInt hashChannel,
             Optional<JoinFilterFunctionFactory> filterFunctionFactory,
             Optional<Integer> sortChannel,
             List<JoinFilterFunctionFactory> searchFunctionFactories,

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler.LookupSourceSupplierFactory;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import com.facebook.presto.sql.gen.OrderingCompiler;
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
@@ -35,10 +36,12 @@ import org.openjdk.jol.info.ClassLayout;
 
 import javax.inject.Inject;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
 import static com.facebook.presto.operator.SyntheticAddress.decodeSliceIndex;
@@ -476,5 +479,27 @@ public class PagesIndex
                 .add("types", types)
                 .add("estimatedSize", estimatedSize)
                 .toString();
+    }
+
+    public Iterator<Page> getPages()
+    {
+        return new AbstractIterator<Page>()
+        {
+            private int pageCounter;
+
+            @Override
+            protected Page computeNext()
+            {
+                if (pageCounter == channels[0].size()) {
+                    return endOfData();
+                }
+
+                Block[] blocks = Stream.of(channels)
+                        .map(channel -> channel.get(pageCounter))
+                        .toArray(Block[]::new);
+                pageCounter++;
+                return new Page(blocks);
+            }
+        };
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionFunction.java
@@ -13,37 +13,11 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.spi.BucketFunction;
 import com.facebook.presto.spi.Page;
 
-import java.util.stream.IntStream;
-
-import static java.util.Objects.requireNonNull;
-
-public class PartitionFunction
+public interface PartitionFunction
 {
-    private final BucketFunction bucketFunction;
-    private final int[] bucketToPartition;
-    private final int partitionCount;
+    int getPartitionCount();
 
-    public PartitionFunction(BucketFunction bucketFunction, int[] bucketToPartition)
-    {
-        this.bucketFunction = requireNonNull(bucketFunction, "bucketFunction is null");
-        this.bucketToPartition = requireNonNull(bucketToPartition, "bucketToPartition is null").clone();
-        partitionCount = IntStream.of(bucketToPartition).max().getAsInt() + 1;
-    }
-
-    public int getPartitionCount()
-    {
-        return partitionCount;
-    }
-
-    /**
-     * @param functionArguments the arguments to partition function in order (no extra columns)
-     */
-    public int getPartition(Page functionArguments, int position)
-    {
-        int bucket = bucketFunction.getBucket(functionArguments, position);
-        return bucketToPartition[bucket];
-    }
+    int getPartition(Page page, int position);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedConsumption.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedConsumption.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import io.airlift.log.Logger;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntConsumer;
+import java.util.function.IntFunction;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.allAsList;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public final class PartitionedConsumption<T>
+{
+    private static final Logger log = Logger.get(PartitionedConsumption.class);
+
+    private final int consumersCount;
+    private final AtomicInteger consumed = new AtomicInteger();
+    @Nullable
+    private List<Partition<T>> partitions;
+
+    public PartitionedConsumption(int consumersCount, Iterable<Integer> partitionNumbers, IntFunction<ListenableFuture<T>> loader, IntConsumer disposer)
+    {
+        this(consumersCount, immediateFuture(null), partitionNumbers, loader, disposer);
+    }
+
+    public PartitionedConsumption(
+            int consumersCount,
+            ListenableFuture<?> activator,
+            Iterable<Integer> partitionNumbers,
+            IntFunction<ListenableFuture<T>> loader,
+            IntConsumer disposer)
+    {
+        checkArgument(consumersCount > 0, "consumersCount must be positive");
+        this.consumersCount = consumersCount;
+        this.partitions = createPartitions(activator, partitionNumbers, loader, disposer);
+    }
+
+    private List<Partition<T>> createPartitions(
+            ListenableFuture<?> activator,
+            Iterable<Integer> partitionNumbers,
+            IntFunction<ListenableFuture<T>> loader,
+            IntConsumer disposer)
+    {
+        requireNonNull(partitionNumbers, "partitionNumbers is null");
+        requireNonNull(loader, "loader is null");
+        requireNonNull(disposer, "disposer is null");
+
+        ImmutableList.Builder<Partition<T>> partitions = ImmutableList.builder();
+        ListenableFuture<?> partitionActivator = activator;
+        for (Integer partitionNumber : partitionNumbers) {
+            Partition<T> partition = new Partition<>(consumersCount, partitionNumber, loader, partitionActivator, disposer);
+            partitions.add(partition);
+            partitionActivator = partition.released;
+        }
+        return partitions.build();
+    }
+
+    public int getConsumersCount()
+    {
+        return consumersCount;
+    }
+
+    public Iterator<Partition<T>> beginConsumption()
+    {
+        Queue<Partition<T>> partitions = new ArrayDeque<>(requireNonNull(this.partitions, "partitions is already null"));
+        if (consumed.incrementAndGet() >= consumersCount) {
+            // Unreference futures to allow GC
+            this.partitions = null;
+        }
+        return new AbstractIterator<Partition<T>>()
+        {
+            @Override
+            protected Partition<T> computeNext()
+            {
+                Partition<T> next = partitions.poll();
+                if (next != null) {
+                    return next;
+                }
+                else {
+                    return endOfData();
+                }
+            }
+        };
+    }
+
+    public static class Partition<T>
+    {
+        private final int partitionNumber;
+        private final SettableFuture<?> requested;
+        private final ListenableFuture<T> loaded;
+        private final SettableFuture<?> released;
+
+        @GuardedBy("this")
+        private int pendingReleases;
+
+        public Partition(
+                int consumersCount,
+                int partitionNumber,
+                IntFunction<ListenableFuture<T>> loader,
+                ListenableFuture<?> previousReleased,
+                IntConsumer disposer)
+        {
+            this.partitionNumber = partitionNumber;
+            this.requested = SettableFuture.create();
+            this.loaded = Futures.transformAsync(
+                    allAsList(requested, previousReleased),
+                    ignored -> loader.apply(partitionNumber));
+            this.released = SettableFuture.create();
+            released.addListener(() -> disposer.accept(partitionNumber), directExecutor());
+            this.pendingReleases = consumersCount;
+        }
+
+        public int number()
+        {
+            return partitionNumber;
+        }
+
+        public ListenableFuture<T> load()
+        {
+            requested.set(null);
+            return loaded;
+        }
+
+        public synchronized void release()
+        {
+            checkState(loaded.isDone());
+            pendingReleases--;
+            checkState(pendingReleases >= 0);
+            if (pendingReleases == 0) {
+                released.set(null);
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
@@ -170,6 +170,12 @@ public class PartitionedLookupSource
     }
 
     @Override
+    public long joinPositionWithinPartition(long joinPosition)
+    {
+        return decodeJoinPosition(joinPosition);
+    }
+
+    @Override
     public void close()
     {
         if (outerPositionTracker != null) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
@@ -121,7 +121,7 @@ public class PartitionedLookupSource
     @Override
     public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage)
     {
-        return getJoinPosition(position, hashChannelsPage, allChannelsPage, partitionGenerator.getRawHash(position, hashChannelsPage));
+        return getJoinPosition(position, hashChannelsPage, allChannelsPage, partitionGenerator.getRawHash(hashChannelsPage, position));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
@@ -93,6 +95,15 @@ public final class PartitionedLookupSourceFactory
 
     @GuardedBy("lock")
     private SettableFuture<PartitionedConsumption<Supplier<LookupSource>>> partitionedConsumption = SettableFuture.create();
+
+    /**
+     * Cached LookupSource on behalf of LookupJoinOperator (represented by SpillAwareLookupSourceProvider). LookupSource instantiation has non-negligible cost.
+     * <p>
+     * Whole-sale modifications guarded by rwLock.writeLock(). Modifications (addition, update, removal) of entry for key K is confined to object K.
+     * Important note: this cannot be replaced with regular map guarded by the read-write lock. This is because read lock is held in {@code withLease} for
+     * the prolong time, and other threads would not be able to insert new (cached) lookup sources in this map, harming work concurrency.
+     */
+    private final ConcurrentHashMap<SpillAwareLookupSourceProvider, LookupSource> suppliedLookupSources = new ConcurrentHashMap<>();
 
     public PartitionedLookupSourceFactory(List<Type> types, List<Type> outputTypes, List<Integer> hashChannels, int partitionCount, Map<Symbol, Integer> layout, boolean outer)
     {
@@ -218,6 +229,10 @@ public final class PartitionedLookupSourceFactory
                 verify(!outer, "It is not possible to reset lookupSourceSupplier which is tracking for outer join");
                 verify(partitions.length > 1, "Spill occurred when only one partition");
                 lookupSourceSupplier = createPartitionedLookupSourceSupplier(ImmutableList.copyOf(partitions), hashChannelTypes, outer);
+                closeCachedLookupSources();
+            }
+            else {
+                verify(suppliedLookupSources.isEmpty(), "There are cached LookupSources even though lookupSourceSupplier does not exist");
             }
         }
         finally {
@@ -372,6 +387,19 @@ public final class PartitionedLookupSourceFactory
             // Remove out references to partitions to actually free memory
             Arrays.fill(partitions, null);
             lookupSourceSupplier = null;
+            closeCachedLookupSources();
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void closeCachedLookupSources()
+    {
+        lock.writeLock().lock();
+        try {
+            suppliedLookupSources.values().forEach(LookupSource::close);
+            suppliedLookupSources.clear();
         }
         finally {
             lock.writeLock().unlock();
@@ -383,6 +411,7 @@ public final class PartitionedLookupSourceFactory
         return nonCancellationPropagating(destroyed);
     }
 
+    @NotThreadSafe
     private class SpillAwareLookupSourceProvider
             implements LookupSourceProvider
     {
@@ -391,10 +420,9 @@ public final class PartitionedLookupSourceFactory
         {
             lock.readLock().lock();
             try {
-                try (LookupSource lookupSource = lookupSourceSupplier.getLookupSource()) {
-                    LookupSourceLease lease = new SpillAwareLookupSourceLease(lookupSource, spillingInfo);
-                    return action.apply(lease);
-                }
+                LookupSource lookupSource = suppliedLookupSources.computeIfAbsent(this, k -> lookupSourceSupplier.getLookupSource());
+                LookupSourceLease lease = new SpillAwareLookupSourceLease(lookupSource, spillingInfo);
+                return action.apply(lease);
             }
             finally {
                 lock.readLock().unlock();
@@ -404,6 +432,10 @@ public final class PartitionedLookupSourceFactory
         @Override
         public void close()
         {
+            LookupSource lookupSource = suppliedLookupSources.remove(this);
+            if (lookupSource != null) {
+                lookupSource.close();
+            }
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -26,6 +26,7 @@ import javax.annotation.concurrent.GuardedBy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.operator.OuterLookupSource.createOuterLookupSourceSupplier;
@@ -33,7 +34,6 @@ import static com.facebook.presto.operator.PartitionedLookupSource.createPartiti
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
-import static java.lang.Thread.holdsLock;
 import static java.util.Objects.requireNonNull;
 
 public final class PartitionedLookupSourceFactory
@@ -46,16 +46,18 @@ public final class PartitionedLookupSourceFactory
     private final boolean outer;
     private final SettableFuture<?> destroyed = SettableFuture.create();
 
-    @GuardedBy("this")
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    @GuardedBy("lock")
     private final Supplier<LookupSource>[] partitions;
 
-    @GuardedBy("this")
+    @GuardedBy("lock")
     private int partitionsSet;
 
-    @GuardedBy("this")
+    @GuardedBy("lock")
     private TrackingLookupSourceSupplier lookupSourceSupplier;
 
-    @GuardedBy("this")
+    @GuardedBy("lock")
     private final List<SettableFuture<LookupSourceProvider>> lookupSourceFutures = new ArrayList<>();
 
     public PartitionedLookupSourceFactory(List<Type> types, List<Type> outputTypes, List<Integer> hashChannels, int partitionCount, Map<Symbol, Integer> layout, boolean outer)
@@ -90,15 +92,21 @@ public final class PartitionedLookupSourceFactory
     }
 
     @Override
-    public synchronized ListenableFuture<LookupSourceProvider> createLookupSourceProvider()
+    public ListenableFuture<LookupSourceProvider> createLookupSourceProvider()
     {
-        if (lookupSourceSupplier != null) {
-            return Futures.immediateFuture(new StaticLookupSourceProvider(lookupSourceSupplier.getLookupSource()));
-        }
+        lock.writeLock().lock();
+        try {
+            if (lookupSourceSupplier != null) {
+                return Futures.immediateFuture(new StaticLookupSourceProvider(lookupSourceSupplier.getLookupSource()));
+            }
 
-        SettableFuture<LookupSourceProvider> lookupSourceFuture = SettableFuture.create();
-        lookupSourceFutures.add(lookupSourceFuture);
-        return lookupSourceFuture;
+            SettableFuture<LookupSourceProvider> lookupSourceFuture = SettableFuture.create();
+            lookupSourceFutures.add(lookupSourceFuture);
+            return lookupSourceFuture;
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
     }
 
     public void setPartitionLookupSourceSupplier(int partitionIndex, Supplier<LookupSource> partitionLookupSource)
@@ -106,7 +114,9 @@ public final class PartitionedLookupSourceFactory
         requireNonNull(partitionLookupSource, "partitionLookupSource is null");
 
         boolean completed;
-        synchronized (this) {
+
+        lock.writeLock().lock();
+        try {
             if (destroyed.isDone()) {
                 return;
             }
@@ -116,6 +126,10 @@ public final class PartitionedLookupSourceFactory
             partitionsSet++;
             completed = (partitionsSet == partitions.length);
         }
+        finally {
+            lock.writeLock().unlock();
+        }
+
         if (completed) {
             supplyLookupSources();
         }
@@ -123,11 +137,13 @@ public final class PartitionedLookupSourceFactory
 
     private void supplyLookupSources()
     {
-        checkState(!holdsLock(this));
+        checkState(!lock.isWriteLockedByCurrentThread());
 
         TrackingLookupSourceSupplier lookupSourceSupplier;
         List<SettableFuture<LookupSourceProvider>> lookupSourceFutures;
-        synchronized (this) {
+
+        lock.writeLock().lock();
+        try {
             checkState(partitionsSet == partitions.length, "Not all set yet");
             checkState(this.lookupSourceSupplier == null, "Already supplied");
 
@@ -146,6 +162,9 @@ public final class PartitionedLookupSourceFactory
             lookupSourceSupplier = this.lookupSourceSupplier;
             lookupSourceFutures = ImmutableList.copyOf(this.lookupSourceFutures);
         }
+        finally {
+            lock.writeLock().unlock();
+        }
 
         for (SettableFuture<LookupSourceProvider> lookupSourceFuture : lookupSourceFutures) {
             lookupSourceFuture.set(new StaticLookupSourceProvider(lookupSourceSupplier.getLookupSource()));
@@ -156,10 +175,16 @@ public final class PartitionedLookupSourceFactory
     public OuterPositionIterator getOuterPositionIterator()
     {
         TrackingLookupSourceSupplier lookupSourceSupplier;
-        synchronized (this) {
+
+        lock.writeLock().lock();
+        try {
             checkState(this.lookupSourceSupplier != null, "lookup source not ready yet");
             lookupSourceSupplier = this.lookupSourceSupplier;
         }
+        finally {
+            lock.writeLock().unlock();
+        }
+
         return lookupSourceSupplier.getOuterPositionIterator();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -13,27 +13,41 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.operator.LookupSourceProvider.LookupSourceLease;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.Symbol;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.Futures;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
 import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.Immutable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
+import java.util.function.IntPredicate;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.operator.OuterLookupSource.createOuterLookupSourceSupplier;
 import static com.facebook.presto.operator.PartitionedLookupSource.createPartitionedLookupSourceSupplier;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
+import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 public final class PartitionedLookupSourceFactory
@@ -44,15 +58,26 @@ public final class PartitionedLookupSourceFactory
     private final Map<Symbol, Integer> layout;
     private final List<Type> hashChannelTypes;
     private final boolean outer;
-    private final SettableFuture<?> destroyed = SettableFuture.create();
+    private final SpilledLookupSource spilledLookupSource;
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     @GuardedBy("lock")
     private final Supplier<LookupSource>[] partitions;
 
+    private final SettableFuture<?> partitionsNoLongerNeeded = SettableFuture.create();
+
+    @GuardedBy("lock")
+    private final SettableFuture<?> destroyed = SettableFuture.create();
+
     @GuardedBy("lock")
     private int partitionsSet;
+
+    @GuardedBy("lock")
+    private SpillingInfo spillingInfo = new SpillingInfo(0, ImmutableSet.of());
+
+    @GuardedBy("lock")
+    private Map<Integer, SpilledLookupSourceHandle> spilledPartitions = new HashMap<>();
 
     @GuardedBy("lock")
     private TrackingLookupSourceSupplier lookupSourceSupplier;
@@ -60,17 +85,29 @@ public final class PartitionedLookupSourceFactory
     @GuardedBy("lock")
     private final List<SettableFuture<LookupSourceProvider>> lookupSourceFutures = new ArrayList<>();
 
+    @GuardedBy("lock")
+    private int finishedProbeOperators;
+
+    @GuardedBy("lock")
+    private OptionalInt partitionedConsumptionParticipants = OptionalInt.empty();
+
+    @GuardedBy("lock")
+    private SettableFuture<PartitionedConsumption<Supplier<LookupSource>>> partitionedConsumption = SettableFuture.create();
+
     public PartitionedLookupSourceFactory(List<Type> types, List<Type> outputTypes, List<Integer> hashChannels, int partitionCount, Map<Symbol, Integer> layout, boolean outer)
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.outputTypes = ImmutableList.copyOf(requireNonNull(outputTypes, "outputTypes is null"));
         this.layout = ImmutableMap.copyOf(layout);
+        checkArgument(partitionCount > 0);
         this.partitions = (Supplier<LookupSource>[]) new Supplier<?>[partitionCount];
         this.outer = outer;
 
         hashChannelTypes = hashChannels.stream()
                 .map(types::get)
                 .collect(toImmutableList());
+
+        spilledLookupSource = new SpilledLookupSource(outputTypes.size());
     }
 
     @Override
@@ -92,12 +129,18 @@ public final class PartitionedLookupSourceFactory
     }
 
     @Override
+    public int partitions()
+    {
+        return partitions.length;
+    }
+
+    @Override
     public ListenableFuture<LookupSourceProvider> createLookupSourceProvider()
     {
         lock.writeLock().lock();
         try {
             if (lookupSourceSupplier != null) {
-                return Futures.immediateFuture(new StaticLookupSourceProvider(lookupSourceSupplier.getLookupSource()));
+                return immediateFuture(new SpillAwareLookupSourceProvider());
             }
 
             SettableFuture<LookupSourceProvider> lookupSourceFuture = SettableFuture.create();
@@ -109,7 +152,7 @@ public final class PartitionedLookupSourceFactory
         }
     }
 
-    public void setPartitionLookupSourceSupplier(int partitionIndex, Supplier<LookupSource> partitionLookupSource)
+    public ListenableFuture<?> lendPartitionLookupSource(int partitionIndex, Supplier<LookupSource> partitionLookupSource)
     {
         requireNonNull(partitionLookupSource, "partitionLookupSource is null");
 
@@ -118,13 +161,64 @@ public final class PartitionedLookupSourceFactory
         lock.writeLock().lock();
         try {
             if (destroyed.isDone()) {
-                return;
+                return immediateFuture(null);
             }
 
             checkState(partitions[partitionIndex] == null, "Partition already set");
+            checkState(!spilledPartitions.containsKey(partitionIndex), "Partition already set as spilled");
             partitions[partitionIndex] = partitionLookupSource;
             partitionsSet++;
             completed = (partitionsSet == partitions.length);
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
+
+        if (completed) {
+            supplyLookupSources();
+        }
+
+        return partitionsNoLongerNeeded;
+    }
+
+    public void setPartitionSpilledLookupSourceHandle(int partitionIndex, SpilledLookupSourceHandle spilledLookupSourceHandle)
+    {
+        requireNonNull(spilledLookupSourceHandle, "spilledLookupSourceHandle is null");
+
+        boolean completed;
+
+        lock.writeLock().lock();
+        try {
+            if (destroyed.isDone()) {
+                spilledLookupSourceHandle.dispose();
+                return;
+            }
+
+            checkState(!spilledPartitions.containsKey(partitionIndex), "Partition already set as spilled");
+            spilledPartitions.put(partitionIndex, spilledLookupSourceHandle);
+            spillingInfo = new SpillingInfo(spillingInfo.spillEpoch() + 1, spilledPartitions.keySet());
+
+            if (partitions[partitionIndex] != null) {
+                // Was present and now it's spilled
+                completed = false;
+            }
+            else {
+                partitionsSet++;
+                completed = (partitionsSet == partitions.length);
+            }
+
+            partitions[partitionIndex] = () -> spilledLookupSource;
+
+            if (lookupSourceSupplier != null) {
+                /*
+                 * lookupSourceSupplier exists so the now-spilled partition is still referenced by it. Need to re-create lookupSourceSupplier to let the memory go
+                 * and to prevent probe side accessing the partition.
+                 */
+                verify(!completed, "lookupSourceSupplier already exist when completing");
+                verify(!outer, "It is not possible to reset lookupSourceSupplier which is tracking for outer join");
+                verify(partitions.length > 1, "Spill occurred when only one partition");
+                lookupSourceSupplier = createPartitionedLookupSourceSupplier(ImmutableList.copyOf(partitions), hashChannelTypes, outer);
+            }
         }
         finally {
             lock.writeLock().unlock();
@@ -139,7 +233,6 @@ public final class PartitionedLookupSourceFactory
     {
         checkState(!lock.isWriteLockedByCurrentThread());
 
-        TrackingLookupSourceSupplier lookupSourceSupplier;
         List<SettableFuture<LookupSourceProvider>> lookupSourceFutures;
 
         lock.writeLock().lock();
@@ -155,11 +248,11 @@ public final class PartitionedLookupSourceFactory
                 this.lookupSourceSupplier = createOuterLookupSourceSupplier(partitions[0]);
             }
             else {
+                checkState(!spillingInfo.hasSpilled(), "Spill not supported when there is single partition");
                 this.lookupSourceSupplier = TrackingLookupSourceSupplier.nonTracking(partitions[0]);
             }
 
-            // store lookup source supplier and futures into local variables so they can be used outside of the lock
-            lookupSourceSupplier = this.lookupSourceSupplier;
+            // store futures into local variables so they can be used outside of the lock
             lookupSourceFutures = ImmutableList.copyOf(this.lookupSourceFutures);
         }
         finally {
@@ -167,7 +260,72 @@ public final class PartitionedLookupSourceFactory
         }
 
         for (SettableFuture<LookupSourceProvider> lookupSourceFuture : lookupSourceFutures) {
-            lookupSourceFuture.set(new StaticLookupSourceProvider(lookupSourceSupplier.getLookupSource()));
+            lookupSourceFuture.set(new SpillAwareLookupSourceProvider());
+        }
+    }
+
+    @Override
+    public ListenableFuture<PartitionedConsumption<Supplier<LookupSource>>> finishProbeOperator(OptionalInt lookupJoinsCount)
+    {
+        lock.writeLock().lock();
+        try {
+            if (!spillingInfo.hasSpilled()) {
+                finishedProbeOperators++;
+                return immediateFuture(new PartitionedConsumption<>(
+                        1,
+                        emptyList(),
+                        i -> {
+                            throw new UnsupportedOperationException();
+                        },
+                        i -> {}));
+            }
+
+            int operatorsCount = lookupJoinsCount
+                    .orElseThrow(() -> new IllegalStateException("A fixed distribution is required for JOIN when spilling is enabled"));
+            checkState(finishedProbeOperators < operatorsCount, "%s probe operators finished out of %s declared", finishedProbeOperators + 1, operatorsCount);
+
+            if (!partitionedConsumptionParticipants.isPresent()) {
+                // This is the first probe to finish after anything has been spilled.
+                partitionedConsumptionParticipants = OptionalInt.of(operatorsCount - finishedProbeOperators);
+            }
+
+            finishedProbeOperators++;
+            if (finishedProbeOperators == operatorsCount) {
+                // We can dispose partitions now since as right outer is not supported with spill
+                freePartitions();
+                verify(!partitionedConsumption.isDone());
+                partitionedConsumption.set(new PartitionedConsumption<>(
+                        partitionedConsumptionParticipants.getAsInt(),
+                        spilledPartitions.keySet(),
+                        this::loadSpilledLookupSource,
+                        this::disposeSpilledLookupSource));
+            }
+
+            return partitionedConsumption;
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private ListenableFuture<Supplier<LookupSource>> loadSpilledLookupSource(int partitionNumber)
+    {
+        return getSpilledLookupSourceHandle(partitionNumber).getLookupSource();
+    }
+
+    private void disposeSpilledLookupSource(int partitionNumber)
+    {
+        getSpilledLookupSourceHandle(partitionNumber).dispose();
+    }
+
+    private SpilledLookupSourceHandle getSpilledLookupSourceHandle(int partitionNumber)
+    {
+        lock.readLock().lock();
+        try {
+            return requireNonNull(spilledPartitions.get(partitionNumber), "spilledPartitions.get(partitionNumber) is null");
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -191,11 +349,197 @@ public final class PartitionedLookupSourceFactory
     @Override
     public void destroy()
     {
-        destroyed.set(null);
+        lock.writeLock().lock();
+        try {
+            freePartitions();
+            spilledPartitions.values().forEach(SpilledLookupSourceHandle::dispose);
+
+            // Setting destroyed must be last because it's a part of the state exposed by isDestroyed() without synchronization.
+            destroyed.set(null);
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void freePartitions()
+    {
+        // Let the HashBuilderOperators reduce their accounted memory
+        partitionsNoLongerNeeded.set(null);
+
+        lock.writeLock().lock();
+        try {
+            // Remove out references to partitions to actually free memory
+            Arrays.fill(partitions, null);
+            lookupSourceSupplier = null;
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
     }
 
     public ListenableFuture<?> isDestroyed()
     {
         return nonCancellationPropagating(destroyed);
+    }
+
+    private class SpillAwareLookupSourceProvider
+            implements LookupSourceProvider
+    {
+        @Override
+        public <R> R withLease(Function<LookupSourceLease, R> action)
+        {
+            lock.readLock().lock();
+            try {
+                try (LookupSource lookupSource = lookupSourceSupplier.getLookupSource()) {
+                    LookupSourceLease lease = new SpillAwareLookupSourceLease(lookupSource, spillingInfo);
+                    return action.apply(lease);
+                }
+            }
+            finally {
+                lock.readLock().unlock();
+            }
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    }
+
+    private static class SpillAwareLookupSourceLease
+            implements LookupSourceLease
+    {
+        private final LookupSource lookupSource;
+        private final SpillingInfo spillingInfo;
+
+        public SpillAwareLookupSourceLease(LookupSource lookupSource, SpillingInfo spillingInfo)
+        {
+            this.lookupSource = requireNonNull(lookupSource, "lookupSource is null");
+            this.spillingInfo = requireNonNull(spillingInfo, "spillingInfo is null");
+        }
+
+        @Override
+        public LookupSource getLookupSource()
+        {
+            return lookupSource;
+        }
+
+        @Override
+        public boolean hasSpilled()
+        {
+            return spillingInfo.hasSpilled();
+        }
+
+        @Override
+        public long spillEpoch()
+        {
+            return spillingInfo.spillEpoch();
+        }
+
+        @Override
+        public IntPredicate getSpillMask()
+        {
+            return spillingInfo.getSpillMask();
+        }
+    }
+
+    private static class SpilledLookupSource
+            implements LookupSource
+    {
+        private final int channelCount;
+
+        public SpilledLookupSource(int channelCount)
+        {
+            this.channelCount = channelCount;
+        }
+
+        @Override
+        public int getChannelCount()
+        {
+            return channelCount;
+        }
+
+        @Override
+        public long getInMemorySizeInBytes()
+        {
+            return 0;
+        }
+
+        @Override
+        public long joinPositionWithinPartition(long joinPosition)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getJoinPositionCount()
+        {
+            // Will be counted after unspilling.
+            return 0;
+        }
+
+        @Override
+        public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage, long rawHash)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getNextJoinPosition(long currentJoinPosition, int probePosition, Page allProbeChannelsPage)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void appendTo(long position, PageBuilder pageBuilder, int outputChannelOffset)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isJoinPositionEligible(long currentJoinPosition, int probePosition, Page allProbeChannelsPage)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    }
+
+    @Immutable
+    private static final class SpillingInfo
+    {
+        private final long spillEpoch;
+        private final Set<Integer> spilledPartitions;
+
+        SpillingInfo(long spillEpoch, Set<Integer> spilledPartitions)
+        {
+            this.spillEpoch = spillEpoch;
+            this.spilledPartitions = ImmutableSet.copyOf(requireNonNull(spilledPartitions, "spilledPartitions is null"));
+        }
+
+        boolean hasSpilled()
+        {
+            return !spilledPartitions.isEmpty();
+        }
+
+        long spillEpoch()
+        {
+            return spillEpoch;
+        }
+
+        IntPredicate getSpillMask()
+        {
+            return spilledPartitions::contains;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -53,7 +53,7 @@ public final class PartitionedLookupSourceFactory
     private TrackingLookupSourceSupplier lookupSourceSupplier;
 
     @GuardedBy("this")
-    private final List<SettableFuture<LookupSource>> lookupSourceFutures = new ArrayList<>();
+    private final List<SettableFuture<LookupSourceProvider>> lookupSourceFutures = new ArrayList<>();
 
     public PartitionedLookupSourceFactory(List<Type> types, List<Type> outputTypes, List<Integer> hashChannels, int partitionCount, Map<Symbol, Integer> layout, boolean outer)
     {
@@ -87,13 +87,13 @@ public final class PartitionedLookupSourceFactory
     }
 
     @Override
-    public synchronized ListenableFuture<LookupSource> createLookupSource()
+    public synchronized ListenableFuture<LookupSourceProvider> createLookupSourceProvider()
     {
         if (lookupSourceSupplier != null) {
-            return Futures.immediateFuture(lookupSourceSupplier.getLookupSource());
+            return Futures.immediateFuture(new StaticLookupSourceProvider(lookupSourceSupplier.getLookupSource()));
         }
 
-        SettableFuture<LookupSource> lookupSourceFuture = SettableFuture.create();
+        SettableFuture<LookupSourceProvider> lookupSourceFuture = SettableFuture.create();
         lookupSourceFutures.add(lookupSourceFuture);
         return lookupSourceFuture;
     }
@@ -103,7 +103,7 @@ public final class PartitionedLookupSourceFactory
         requireNonNull(partitionLookupSource, "partitionLookupSource is null");
 
         TrackingLookupSourceSupplier lookupSourceSupplier = null;
-        List<SettableFuture<LookupSource>> lookupSourceFutures = null;
+        List<SettableFuture<LookupSourceProvider>> lookupSourceFutures = null;
         synchronized (this) {
             if (destroyed.isDone()) {
                 return;
@@ -132,8 +132,8 @@ public final class PartitionedLookupSourceFactory
         }
 
         if (lookupSourceSupplier != null) {
-            for (SettableFuture<LookupSource> lookupSourceFuture : lookupSourceFutures) {
-                lookupSourceFuture.set(lookupSourceSupplier.getLookupSource());
+            for (SettableFuture<LookupSourceProvider> lookupSourceFuture : lookupSourceFutures) {
+                lookupSourceFuture.set(new StaticLookupSourceProvider(lookupSourceSupplier.getLookupSource()));
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -33,6 +33,7 @@ import static com.facebook.presto.operator.PartitionedLookupSource.createPartiti
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
+import static java.lang.Thread.holdsLock;
 import static java.util.Objects.requireNonNull;
 
 public final class PartitionedLookupSourceFactory
@@ -42,9 +43,11 @@ public final class PartitionedLookupSourceFactory
     private final List<Type> outputTypes;
     private final Map<Symbol, Integer> layout;
     private final List<Type> hashChannelTypes;
-    private final Supplier<LookupSource>[] partitions;
     private final boolean outer;
     private final SettableFuture<?> destroyed = SettableFuture.create();
+
+    @GuardedBy("this")
+    private final Supplier<LookupSource>[] partitions;
 
     @GuardedBy("this")
     private int partitionsSet;
@@ -102,8 +105,7 @@ public final class PartitionedLookupSourceFactory
     {
         requireNonNull(partitionLookupSource, "partitionLookupSource is null");
 
-        TrackingLookupSourceSupplier lookupSourceSupplier = null;
-        List<SettableFuture<LookupSourceProvider>> lookupSourceFutures = null;
+        boolean completed;
         synchronized (this) {
             if (destroyed.isDone()) {
                 return;
@@ -112,29 +114,41 @@ public final class PartitionedLookupSourceFactory
             checkState(partitions[partitionIndex] == null, "Partition already set");
             partitions[partitionIndex] = partitionLookupSource;
             partitionsSet++;
+            completed = (partitionsSet == partitions.length);
+        }
+        if (completed) {
+            supplyLookupSources();
+        }
+    }
 
-            if (partitionsSet == partitions.length) {
-                if (partitionsSet != 1) {
-                    List<Supplier<LookupSource>> partitions = ImmutableList.copyOf(this.partitions);
-                    this.lookupSourceSupplier = createPartitionedLookupSourceSupplier(partitions, hashChannelTypes, outer);
-                }
-                else if (outer) {
-                    this.lookupSourceSupplier = createOuterLookupSourceSupplier(partitionLookupSource);
-                }
-                else {
-                    this.lookupSourceSupplier = TrackingLookupSourceSupplier.nonTracking(partitionLookupSource);
-                }
+    private void supplyLookupSources()
+    {
+        checkState(!holdsLock(this));
 
-                // store lookup source supplier and futures into local variables so they can be used outside of the lock
-                lookupSourceSupplier = this.lookupSourceSupplier;
-                lookupSourceFutures = ImmutableList.copyOf(this.lookupSourceFutures);
+        TrackingLookupSourceSupplier lookupSourceSupplier;
+        List<SettableFuture<LookupSourceProvider>> lookupSourceFutures;
+        synchronized (this) {
+            checkState(partitionsSet == partitions.length, "Not all set yet");
+            checkState(this.lookupSourceSupplier == null, "Already supplied");
+
+            if (partitionsSet != 1) {
+                List<Supplier<LookupSource>> partitions = ImmutableList.copyOf(this.partitions);
+                this.lookupSourceSupplier = createPartitionedLookupSourceSupplier(partitions, hashChannelTypes, outer);
             }
+            else if (outer) {
+                this.lookupSourceSupplier = createOuterLookupSourceSupplier(partitions[0]);
+            }
+            else {
+                this.lookupSourceSupplier = TrackingLookupSourceSupplier.nonTracking(partitions[0]);
+            }
+
+            // store lookup source supplier and futures into local variables so they can be used outside of the lock
+            lookupSourceSupplier = this.lookupSourceSupplier;
+            lookupSourceFutures = ImmutableList.copyOf(this.lookupSourceFutures);
         }
 
-        if (lookupSourceSupplier != null) {
-            for (SettableFuture<LookupSourceProvider> lookupSourceFuture : lookupSourceFutures) {
-                lookupSourceFuture.set(new StaticLookupSourceProvider(lookupSourceSupplier.getLookupSource()));
-            }
+        for (SettableFuture<LookupSourceProvider> lookupSourceFuture : lookupSourceFutures) {
+            lookupSourceFuture.set(new StaticLookupSourceProvider(lookupSourceSupplier.getLookupSource()));
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/PositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PositionLinks.java
@@ -66,5 +66,10 @@ public interface PositionLinks
          * since JoinFilterFunction is not thread safe...
          */
         PositionLinks create(List<JoinFilterFunction> searchFunctions);
+
+        /**
+         * @return a checksum for this {@link PositionLinks}, useful when entity is restored from spilled data
+         */
+        long checksum();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
@@ -43,15 +43,14 @@ public class SimpleJoinProbe
         }
 
         @Override
-        public JoinProbe createJoinProbe(LookupSource lookupSource, Page page)
+        public JoinProbe createJoinProbe(Page page)
         {
-            return new SimpleJoinProbe(types, probeOutputChannels, lookupSource, page, probeJoinChannels, probeHashChannel);
+            return new SimpleJoinProbe(types, probeOutputChannels, page, probeJoinChannels, probeHashChannel);
         }
     }
 
     private final List<Type> types;
     private final List<Integer> probeOutputChannels;
-    private final LookupSource lookupSource;
     private final int positionCount;
     private final Block[] blocks;
     private final Block[] probeBlocks;
@@ -61,11 +60,10 @@ public class SimpleJoinProbe
 
     private int position = -1;
 
-    private SimpleJoinProbe(List<Type> types, List<Integer> probeOutputChannels, LookupSource lookupSource, Page page, List<Integer> probeJoinChannels, Optional<Integer> hashChannel)
+    private SimpleJoinProbe(List<Type> types, List<Integer> probeOutputChannels, Page page, List<Integer> probeJoinChannels, Optional<Integer> hashChannel)
     {
         this.types = types;
         this.probeOutputChannels = probeOutputChannels;
-        this.lookupSource = lookupSource;
         this.positionCount = page.getPositionCount();
         this.blocks = new Block[page.getChannelCount()];
         this.probeBlocks = new Block[probeJoinChannels.size()];
@@ -107,7 +105,7 @@ public class SimpleJoinProbe
     }
 
     @Override
-    public long getCurrentJoinPosition()
+    public long getCurrentJoinPosition(LookupSource lookupSource)
     {
         if (currentRowContainsNull()) {
             return -1;

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimpleJoinProbe.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 
@@ -32,9 +33,9 @@ public class SimpleJoinProbe
         private List<Type> types;
         private List<Integer> probeOutputChannels;
         private List<Integer> probeJoinChannels;
-        private final Optional<Integer> probeHashChannel;
+        private final OptionalInt probeHashChannel;
 
-        public SimpleJoinProbeFactory(List<Type> types, List<Integer> probeOutputChannels, List<Integer> probeJoinChannels, Optional<Integer> probeHashChannel)
+        public SimpleJoinProbeFactory(List<Type> types, List<Integer> probeOutputChannels, List<Integer> probeJoinChannels, OptionalInt probeHashChannel)
         {
             this.types = types;
             this.probeOutputChannels = probeOutputChannels;
@@ -60,7 +61,7 @@ public class SimpleJoinProbe
 
     private int position = -1;
 
-    private SimpleJoinProbe(List<Type> types, List<Integer> probeOutputChannels, Page page, List<Integer> probeJoinChannels, Optional<Integer> hashChannel)
+    private SimpleJoinProbe(List<Type> types, List<Integer> probeOutputChannels, Page page, List<Integer> probeJoinChannels, OptionalInt probeHashChannel)
     {
         this.types = types;
         this.probeOutputChannels = probeOutputChannels;
@@ -77,7 +78,7 @@ public class SimpleJoinProbe
         }
         this.page = page;
         this.probePage = new Page(page.getPositionCount(), probeBlocks);
-        this.probeHashBlock = hashChannel.isPresent() ? Optional.of(page.getBlock(hashChannel.get())) : Optional.empty();
+        this.probeHashBlock = probeHashChannel.isPresent() ? Optional.of(page.getBlock(probeHashChannel.getAsInt())) : Optional.empty();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesHashStrategy.java
@@ -23,6 +23,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -44,7 +45,7 @@ public class SimplePagesHashStrategy
             List<Integer> outputChannels,
             List<List<Block>> channels,
             List<Integer> hashChannels,
-            Optional<Integer> precomputedHashChannel,
+            OptionalInt precomputedHashChannel,
             Optional<Integer> sortChannel)
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
@@ -54,7 +55,7 @@ public class SimplePagesHashStrategy
         checkArgument(types.size() == channels.size(), "Expected types and channels to be the same length");
         this.hashChannels = ImmutableList.copyOf(requireNonNull(hashChannels, "hashChannels is null"));
         if (precomputedHashChannel.isPresent()) {
-            this.precomputedHashChannel = channels.get(precomputedHashChannel.get());
+            this.precomputedHashChannel = channels.get(precomputedHashChannel.getAsInt());
         }
         else {
             this.precomputedHashChannel = null;

--- a/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
@@ -131,10 +131,26 @@ public final class SortedPositionLinks
                 }
             }
 
-            return searchFunctions -> new SortedPositionLinks(
-                    arrayPositionLinksFactoryBuilder.build().create(ImmutableList.of()),
-                    sortedPositionLinks,
-                    searchFunctions);
+            Factory arrayPositionLinksFactory = arrayPositionLinksFactoryBuilder.build();
+
+            return new Factory()
+            {
+                @Override
+                public PositionLinks create(List<JoinFilterFunction> searchFunctions)
+                {
+                    return new SortedPositionLinks(
+                            arrayPositionLinksFactory.create(ImmutableList.of()),
+                            sortedPositionLinks,
+                            searchFunctions);
+                }
+
+                @Override
+                public long checksum()
+                {
+                    // For spill/unspill state restoration, sorted position links do not matter
+                    return arrayPositionLinksFactory.checksum();
+                }
+            };
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/SpilledLookupSourceHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SpilledLookupSourceHandle.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.MoreFutures.whenAnyComplete;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+final class SpilledLookupSourceHandle
+{
+    private enum State
+    {
+        SPILLED,
+        UNSPILLING,
+        PRODUCED,
+        DISPOSED
+    }
+
+    @GuardedBy("this")
+    private State state = State.SPILLED;
+
+    private final SettableFuture<?> unspillingRequested = SettableFuture.create();
+
+    @GuardedBy("this")
+    @Nullable
+    private SettableFuture<Supplier<LookupSource>> unspilledLookupSource;
+
+    private final SettableFuture<?> disposeRequested = SettableFuture.create();
+
+    private final ListenableFuture<?> unspillingOrDisposeRequested = whenAnyComplete(ImmutableList.of(unspillingRequested, disposeRequested));
+
+    public SettableFuture<?> getUnspillingRequested()
+    {
+        return unspillingRequested;
+    }
+
+    public synchronized ListenableFuture<Supplier<LookupSource>> getLookupSource()
+    {
+        assertState(State.SPILLED);
+        unspillingRequested.set(null);
+        setState(State.UNSPILLING);
+        checkState(unspilledLookupSource == null, "unspilledLookupSource already set");
+        unspilledLookupSource = SettableFuture.create();
+        return unspilledLookupSource;
+    }
+
+    public synchronized void setLookupSource(Supplier<LookupSource> lookupSource)
+    {
+        requireNonNull(lookupSource, "lookupSource is null");
+
+        if (state == State.DISPOSED) {
+            return;
+        }
+
+        assertState(State.UNSPILLING);
+        checkState(unspilledLookupSource != null, "unspilledLookupSource not set");
+        unspilledLookupSource.set(lookupSource);
+        unspilledLookupSource = null; // let the memory go
+        setState(State.PRODUCED);
+    }
+
+    public synchronized void dispose()
+    {
+        disposeRequested.set(null);
+        unspilledLookupSource = null; // let the memory go
+        setState(State.DISPOSED);
+    }
+
+    public SettableFuture<?> getDisposeRequested()
+    {
+        return disposeRequested;
+    }
+
+    public ListenableFuture<?> getUnspillingOrDisposeRequested()
+    {
+        return unspillingOrDisposeRequested;
+    }
+
+    @GuardedBy("this")
+    private void assertState(State expectedState)
+    {
+        State currentState = state;
+        checkState(currentState == expectedState, "Expected state %s, but state is %s", expectedState, currentState);
+    }
+
+    @GuardedBy("this")
+    private void setState(State newState)
+    {
+        //this.state.set(requireNonNull(newState, "newState is null"));
+        this.state = requireNonNull(newState, "newState is null");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/StaticLookupSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StaticLookupSourceProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import java.util.function.Function;
+import java.util.function.IntPredicate;
 
 import static java.util.Objects.requireNonNull;
 
@@ -46,6 +47,24 @@ public final class StaticLookupSourceProvider
         public LookupSource getLookupSource()
         {
             return lookupSource;
+        }
+
+        @Override
+        public boolean hasSpilled()
+        {
+            return false;
+        }
+
+        @Override
+        public long spillEpoch()
+        {
+            return 0;
+        }
+
+        @Override
+        public IntPredicate getSpillMask()
+        {
+            return i -> false;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/StaticLookupSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StaticLookupSourceProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public final class StaticLookupSourceProvider
+        implements LookupSourceProvider
+{
+    private final LookupSource lookupSource;
+
+    public StaticLookupSourceProvider(LookupSource lookupSource)
+    {
+        this.lookupSource = requireNonNull(lookupSource, "lookupSource is null");
+    }
+
+    @Override
+    public <R> R withLease(Function<LookupSourceLease, R> action)
+    {
+        return action.apply(new SimpleLookupSourceLease());
+    }
+
+    @Override
+    public void close()
+    {
+        lookupSource.close();
+    }
+
+    private class SimpleLookupSourceLease
+            implements LookupSourceLease
+    {
+        @Override
+        public LookupSource getLookupSource()
+        {
+            return lookupSource;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/TwoChannelJoinProbe.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TwoChannelJoinProbe.java
@@ -48,13 +48,12 @@ public class TwoChannelJoinProbe
         }
 
         @Override
-        public JoinProbe createJoinProbe(LookupSource lookupSource, Page page)
+        public JoinProbe createJoinProbe(Page page)
         {
-            return new TwoChannelJoinProbe(types, lookupSource, page);
+            return new TwoChannelJoinProbe(types, page);
         }
     }
 
-    private final LookupSource lookupSource;
     private final int positionCount;
     private final Type typeA;
     private final Type typeB;
@@ -67,9 +66,8 @@ public class TwoChannelJoinProbe
     private final Page probePage;
     private int position = -1;
 
-    public TwoChannelJoinProbe(List<Type> types, LookupSource lookupSource, Page page)
+    public TwoChannelJoinProbe(List<Type> types, Page page)
     {
-        this.lookupSource = lookupSource;
         this.positionCount = page.getPositionCount();
         this.typeA = types.get(0);
         this.typeB = types.get(1);
@@ -105,7 +103,7 @@ public class TwoChannelJoinProbe
     }
 
     @Override
-    public long getCurrentJoinPosition()
+    public long getCurrentJoinPosition(LookupSource lookupSource)
     {
         if (currentRowContainsNull()) {
             return -1;

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -29,6 +29,7 @@ import com.google.common.primitives.Ints;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
 import java.util.stream.Stream;
@@ -238,16 +239,16 @@ public class WindowOperator
 
         this.pagesIndex = pagesIndexFactory.newPagesIndex(sourceTypes, expectedPositions);
         this.preGroupedChannels = Ints.toArray(preGroupedChannels);
-        this.preGroupedPartitionHashStrategy = pagesIndex.createPagesHashStrategy(preGroupedChannels, Optional.empty());
+        this.preGroupedPartitionHashStrategy = pagesIndex.createPagesHashStrategy(preGroupedChannels, OptionalInt.empty());
         List<Integer> unGroupedPartitionChannels = partitionChannels.stream()
                 .filter(channel -> !preGroupedChannels.contains(channel))
                 .collect(toImmutableList());
-        this.unGroupedPartitionHashStrategy = pagesIndex.createPagesHashStrategy(unGroupedPartitionChannels, Optional.empty());
+        this.unGroupedPartitionHashStrategy = pagesIndex.createPagesHashStrategy(unGroupedPartitionChannels, OptionalInt.empty());
         List<Integer> preSortedChannels = sortChannels.stream()
                 .limit(preSortedChannelPrefix)
                 .collect(toImmutableList());
-        this.preSortedPartitionHashStrategy = pagesIndex.createPagesHashStrategy(preSortedChannels, Optional.empty());
-        this.peerGroupHashStrategy = pagesIndex.createPagesHashStrategy(sortChannels, Optional.empty());
+        this.preSortedPartitionHashStrategy = pagesIndex.createPagesHashStrategy(preSortedChannels, OptionalInt.empty());
+        this.peerGroupHashStrategy = pagesIndex.createPagesHashStrategy(sortChannels, OptionalInt.empty());
 
         this.pageBuilder = new PageBuilder(this.types);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalPartitionGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalPartitionGenerator.java
@@ -14,30 +14,39 @@
 package com.facebook.presto.operator.exchange;
 
 import com.facebook.presto.operator.HashGenerator;
+import com.facebook.presto.operator.PartitionFunction;
 import com.facebook.presto.spi.Page;
 import io.airlift.slice.XxHash64;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class LocalPartitionGenerator
+        implements PartitionFunction
 {
     private final HashGenerator hashGenerator;
+    private final int partitionCount;
     private final int hashMask;
 
     public LocalPartitionGenerator(HashGenerator hashGenerator, int partitionCount)
     {
         this.hashGenerator = hashGenerator;
         checkArgument(Integer.bitCount(partitionCount) == 1, "partitionCount must be a power of 2");
+        this.partitionCount = partitionCount;
         hashMask = partitionCount - 1;
     }
 
-    public int getPartition(int position, Page page)
+    public int getPartitionCount()
     {
-        long rawHash = getRawHash(position, page);
+        return partitionCount;
+    }
+
+    public int getPartition(Page page, int position)
+    {
+        long rawHash = getRawHash(page, position);
         return processRawHash(rawHash) & hashMask;
     }
 
-    public long getRawHash(int position, Page page)
+    public long getRawHash(Page page, int position)
     {
         return hashGenerator.hashPosition(position, page);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/PartitioningExchanger.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/PartitioningExchanger.java
@@ -78,7 +78,7 @@ class PartitioningExchanger
 
         // assign each row to a partition
         for (int position = 0; position < page.getPositionCount(); position++) {
-            int partition = partitionGenerator.getPartition(position, page);
+            int partition = partitionGenerator.getPartition(page, position);
             partitionAssignments[partition].add(position);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -409,6 +409,12 @@ public class IndexLoader
         }
 
         @Override
+        public long joinPositionWithinPartition(long joinPosition)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public long getJoinPosition(int position, Page page, Page allChannelsPage, long rawHash)
         {
             return IndexSnapshot.UNLOADED_INDEX_KEY;

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -43,7 +43,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -71,7 +71,7 @@ public class IndexLoader
     private final AtomicReference<TaskContext> taskContextReference = new AtomicReference<>();
     private final Set<Integer> lookupSourceInputChannels;
     private final List<Integer> keyOutputChannels;
-    private final Optional<Integer> keyOutputHashChannel;
+    private final OptionalInt keyOutputHashChannel;
     private final List<Type> keyTypes;
     private final PagesIndex.Factory pagesIndexFactory;
     private final JoinCompiler joinCompiler;
@@ -88,7 +88,7 @@ public class IndexLoader
     public IndexLoader(
             Set<Integer> lookupSourceInputChannels,
             List<Integer> keyOutputChannels,
-            Optional<Integer> keyOutputHashChannel,
+            OptionalInt keyOutputHashChannel,
             List<Type> outputTypes,
             IndexBuildDriverFactoryProvider indexBuildDriverFactoryProvider,
             int expectedPositions,
@@ -298,7 +298,7 @@ public class IndexLoader
                 Set<Integer> lookupSourceInputChannels,
                 List<Type> indexTypes,
                 List<Integer> keyOutputChannels,
-                Optional<Integer> keyOutputHashChannel,
+                OptionalInt keyOutputHashChannel,
                 int expectedPositions,
                 DataSize maxIndexMemorySize,
                 PagesIndex.Factory pagesIndexFactory,

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
@@ -56,6 +56,12 @@ public class IndexLookupSource
     }
 
     @Override
+    public long joinPositionWithinPartition(long joinPosition)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage, long rawHash)
     {
         // TODO update to take advantage of precomputed hash

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
@@ -105,6 +105,12 @@ public class IndexLookupSourceFactory
     }
 
     @Override
+    public int partitions()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public OuterPositionIterator getOuterPositionIterator()
     {
         throw new UnsupportedOperationException();

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
@@ -30,7 +30,7 @@ import io.airlift.units.DataSize;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -48,7 +48,7 @@ public class IndexLookupSourceFactory
     public IndexLookupSourceFactory(
             Set<Integer> lookupSourceInputChannels,
             List<Integer> keyOutputChannels,
-            Optional<Integer> keyOutputHashChannel,
+            OptionalInt keyOutputHashChannel,
             List<Type> outputTypes,
             Map<Symbol, Integer> layout,
             IndexBuildDriverFactoryProvider indexBuildDriverFactoryProvider,

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSourceFactory.java
@@ -13,10 +13,11 @@
  */
 package com.facebook.presto.operator.index;
 
-import com.facebook.presto.operator.LookupSource;
 import com.facebook.presto.operator.LookupSourceFactory;
+import com.facebook.presto.operator.LookupSourceProvider;
 import com.facebook.presto.operator.OuterPositionIterator;
 import com.facebook.presto.operator.PagesIndex;
+import com.facebook.presto.operator.StaticLookupSourceProvider;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
@@ -94,13 +95,13 @@ public class IndexLookupSourceFactory
     }
 
     @Override
-    public ListenableFuture<LookupSource> createLookupSource()
+    public ListenableFuture<LookupSourceProvider> createLookupSourceProvider()
     {
         checkState(taskContext != null, "taskContext not set");
 
         IndexLoader indexLoader = indexLoaderSupplier.get();
         indexLoader.setContext(taskContext);
-        return Futures.immediateFuture(new IndexLookupSource(indexLoader));
+        return Futures.immediateFuture(new StaticLookupSourceProvider(new IndexLookupSource(indexLoader)));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshotBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshotBuilder.java
@@ -28,6 +28,7 @@ import io.airlift.units.DataSize;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -40,7 +41,7 @@ public class IndexSnapshotBuilder
     private final List<Type> outputTypes;
     private final List<Type> missingKeysTypes;
     private final List<Integer> keyOutputChannels;
-    private final Optional<Integer> keyOutputHashChannel;
+    private final OptionalInt keyOutputHashChannel;
     private final List<Integer> missingKeysChannels;
     private final PagesIndex.Factory pagesIndexFactory;
 
@@ -54,7 +55,7 @@ public class IndexSnapshotBuilder
 
     public IndexSnapshotBuilder(List<Type> outputTypes,
             List<Integer> keyOutputChannels,
-            Optional<Integer> keyOutputHashChannel,
+            OptionalInt keyOutputHashChannel,
             DriverContext driverContext,
             DataSize maxMemoryInBytes,
             int expectedPositions,

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -92,9 +92,11 @@ import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spiller.FileSingleStreamSpillerFactory;
+import com.facebook.presto.spiller.GenericPartitioningSpillerFactory;
 import com.facebook.presto.spiller.GenericSpillerFactory;
 import com.facebook.presto.spiller.LocalSpillManager;
 import com.facebook.presto.spiller.NodeSpillConfig;
+import com.facebook.presto.spiller.PartitioningSpillerFactory;
 import com.facebook.presto.spiller.SingleStreamSpillerFactory;
 import com.facebook.presto.spiller.SpillerFactory;
 import com.facebook.presto.spiller.SpillerStats;
@@ -458,6 +460,7 @@ public class ServerMainModule
         // Spiller
         binder.bind(SpillerFactory.class).to(GenericSpillerFactory.class).in(Scopes.SINGLETON);
         binder.bind(SingleStreamSpillerFactory.class).to(FileSingleStreamSpillerFactory.class).in(Scopes.SINGLETON);
+        binder.bind(PartitioningSpillerFactory.class).to(GenericPartitioningSpillerFactory.class).in(Scopes.SINGLETON);
         binder.bind(SpillerStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(SpillerFactory.class).withGeneratedName();
         binder.bind(LocalSpillManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileHolder.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileHolder.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spiller;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+final class FileHolder
+        implements Closeable
+{
+    private final Path filePath;
+
+    @GuardedBy("this")
+    private boolean deleted;
+
+    public FileHolder(Path filePath)
+    {
+        this.filePath = requireNonNull(filePath, "filePath is null");
+    }
+
+    public synchronized OutputStream newOutputStream(OpenOption... options)
+            throws IOException
+    {
+        checkState(!deleted, "File already deleted");
+        return Files.newOutputStream(filePath, options);
+    }
+
+    public synchronized InputStream newInputStream(OpenOption... options)
+            throws IOException
+    {
+        checkState(!deleted, "File already deleted");
+        return Files.newInputStream(filePath, options);
+    }
+
+    @Override
+    public synchronized void close()
+    {
+        if (deleted) {
+            return;
+        }
+        deleted = true;
+
+        try {
+            Files.delete(filePath);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
@@ -20,6 +20,7 @@ import com.facebook.presto.memory.LocalMemoryContext;
 import com.facebook.presto.operator.SpillContext;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.util.PrestoIterators;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
@@ -32,6 +33,7 @@ import io.airlift.slice.SliceOutput;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -46,6 +48,7 @@ import static com.facebook.presto.execution.buffer.PagesSerdeUtil.writeSerialize
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spiller.FileSingleStreamSpillerFactory.SPILL_FILE_PREFIX;
 import static com.facebook.presto.spiller.FileSingleStreamSpillerFactory.SPILL_FILE_SUFFIX;
+import static com.facebook.presto.util.PrestoCloseables.combineCloseables;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -148,10 +151,10 @@ public class FileSingleStreamSpiller
 
         try {
             InputStream input = new FileInputStream(targetFileName.toFile());
+            Closeable resources = closer.register(combineCloseables(input, () -> memoryContext.setBytes(0)));
             memoryContext.setBytes(BUFFER_SIZE);
-            closer.register(input);
-            closer.register(() -> memoryContext.setBytes(0));
-            return PagesSerdeUtil.readPages(serde, new InputStreamSliceInput(input, BUFFER_SIZE));
+            Iterator<Page> pages = PagesSerdeUtil.readPages(serde, new InputStreamSliceInput(input, BUFFER_SIZE));
+            return PrestoIterators.closeWhenExhausted(pages, resources);
         }
         catch (IOException e) {
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to read spilled pages", e);

--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
@@ -21,6 +21,7 @@ import com.facebook.presto.operator.SpillContext;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -39,6 +40,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.List;
 
 import static com.facebook.presto.execution.buffer.PagesSerdeUtil.writeSerializedPage;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -64,6 +66,7 @@ public class FileSingleStreamSpiller
     private final ListeningExecutorService executor;
 
     private boolean writable = true;
+    private long spilledPagesInMemorySize;
     private ListenableFuture<?> spillInProgress = Futures.immediateFuture(null);
 
     public FileSingleStreamSpiller(
@@ -96,10 +99,22 @@ public class FileSingleStreamSpiller
     }
 
     @Override
+    public long getSpilledPagesInMemorySize()
+    {
+        return spilledPagesInMemorySize;
+    }
+
+    @Override
     public Iterator<Page> getSpilledPages()
     {
         checkNoSpillInProgress();
         return readPages();
+    }
+
+    @Override
+    public ListenableFuture<List<Page>> getAllSpilledPages()
+    {
+        return executor.submit(() -> ImmutableList.copyOf(getSpilledPages()));
     }
 
     private void writePages(Iterator<Page> pageIterator)
@@ -110,6 +125,7 @@ public class FileSingleStreamSpiller
             memoryContext.setBytes(BUFFER_SIZE);
             while (pageIterator.hasNext()) {
                 Page page = pageIterator.next();
+                spilledPagesInMemorySize += page.getSizeInBytes();
                 SerializedPage serializedPage = serde.serialize(page);
                 long pageSize = serializedPage.getSizeInBytes();
                 localSpillContext.updateBytes(pageSize);

--- a/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/FileSingleStreamSpiller.java
@@ -34,8 +34,6 @@ import io.airlift.slice.SliceOutput;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.Closeable;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -50,6 +48,7 @@ import static com.facebook.presto.spiller.FileSingleStreamSpillerFactory.SPILL_F
 import static com.facebook.presto.spiller.FileSingleStreamSpillerFactory.SPILL_FILE_SUFFIX;
 import static com.facebook.presto.util.PrestoCloseables.combineCloseables;
 import static com.google.common.base.Preconditions.checkState;
+import static java.nio.file.StandardOpenOption.APPEND;
 import static java.util.Objects.requireNonNull;
 
 @NotThreadSafe
@@ -59,7 +58,7 @@ public class FileSingleStreamSpiller
     @VisibleForTesting
     static final int BUFFER_SIZE = 4 * 1024;
 
-    private final Path targetFileName;
+    private final FileHolder targetFile;
     private final Closer closer = Closer.create();
     private final PagesSerde serde;
     private final SpillerStats spillerStats;
@@ -86,7 +85,7 @@ public class FileSingleStreamSpiller
         this.localSpillContext = spillContext.newLocalSpillContext();
         this.memoryContext = requireNonNull(memoryContext, "memoryContext can not be null");
         try {
-            targetFileName = Files.createTempFile(spillPath, SPILL_FILE_PREFIX, SPILL_FILE_SUFFIX);
+            this.targetFile = closer.register(new FileHolder(Files.createTempFile(spillPath, SPILL_FILE_PREFIX, SPILL_FILE_SUFFIX)));
         }
         catch (IOException e) {
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to create spill file", e);
@@ -96,6 +95,7 @@ public class FileSingleStreamSpiller
     @Override
     public ListenableFuture<?> spill(Iterator<Page> pageIterator)
     {
+        requireNonNull(pageIterator, "pageIterator is null");
         checkNoSpillInProgress();
         spillInProgress = executor.submit(() -> writePages(pageIterator));
         return spillInProgress;
@@ -124,7 +124,7 @@ public class FileSingleStreamSpiller
     {
         checkState(writable, "Spilling no longer allowed. The spiller has been made non-writable on first read for subsequent reads to be consistent");
 
-        try (SliceOutput output = new OutputStreamSliceOutput(new FileOutputStream(targetFileName.toFile(), true), BUFFER_SIZE)) {
+        try (SliceOutput output = new OutputStreamSliceOutput(targetFile.newOutputStream(APPEND), BUFFER_SIZE)) {
             memoryContext.setBytes(BUFFER_SIZE);
             while (pageIterator.hasNext()) {
                 Page page = pageIterator.next();
@@ -150,7 +150,7 @@ public class FileSingleStreamSpiller
         writable = false;
 
         try {
-            InputStream input = new FileInputStream(targetFileName.toFile());
+            InputStream input = targetFile.newInputStream();
             Closeable resources = closer.register(combineCloseables(input, () -> memoryContext.setBytes(0)));
             memoryContext.setBytes(BUFFER_SIZE);
             Iterator<Page> pages = PagesSerdeUtil.readPages(serde, new InputStreamSliceInput(input, BUFFER_SIZE));
@@ -164,7 +164,6 @@ public class FileSingleStreamSpiller
     @Override
     public void close()
     {
-        closer.register(() -> Files.delete(targetFileName));
         closer.register(localSpillContext);
 
         try {

--- a/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpiller.java
@@ -39,7 +39,6 @@ import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.memory.SynchronizedAggregatedMemoryContext.synchronizedMemoryContext;
-import static com.facebook.presto.spi.Page.mask;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -118,7 +117,7 @@ public class GenericPartitioningSpiller
         IntArrayList unspilledPositions = partitionPage(page, spillPartitionMask);
         ListenableFuture<?> future = flushFullBuilders();
 
-        return new PartitioningSpillResult(future, mask(page, unspilledPositions.toIntArray()));
+        return new PartitioningSpillResult(future, page.mask(unspilledPositions.toIntArray()));
     }
 
     private synchronized IntArrayList partitionPage(Page page, IntPredicate spillPartitionMask)

--- a/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpiller.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spiller;
+
+import com.facebook.presto.memory.AggregatedMemoryContext;
+import com.facebook.presto.memory.LocalMemoryContext;
+import com.facebook.presto.operator.PartitionFunction;
+import com.facebook.presto.operator.SpillContext;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.memory.SynchronizedAggregatedMemoryContext.synchronizedMemoryContext;
+import static com.facebook.presto.spi.Page.mask;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class GenericPartitioningSpiller
+        implements PartitioningSpiller
+{
+    private final List<Type> types;
+    private final PageBuilder[] pageBuilders;
+    private final PartitionFunction partitionFunction;
+    private final SingleStreamSpiller[] spillers;
+    private final Closer closer = Closer.create();
+    private boolean readingStarted;
+    private Set<Integer> spilledPartitions = new HashSet<>();
+
+    public GenericPartitioningSpiller(
+            List<Type> types,
+            PartitionFunction partitionFunction,
+            SpillContext spillContext,
+            AggregatedMemoryContext memoryContext,
+            SingleStreamSpillerFactory spillerFactory)
+    {
+        requireNonNull(spillContext, "spillContext is null");
+
+        this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
+
+        requireNonNull(memoryContext, "memoryContext is null");
+        closer.register(memoryContext::close);
+        Supplier<LocalMemoryContext> childMemoryContextSupplier = synchronizedMemoryContext(memoryContext)::newLocalMemoryContext;
+
+        int partitionCount = partitionFunction.getPartitionCount();
+        this.spillers = new SingleStreamSpiller[partitionCount];
+        this.pageBuilders = new PageBuilder[partitionCount];
+
+        for (int partition = 0; partition < partitionCount; partition++) {
+            pageBuilders[partition] = new PageBuilder(types);
+            spillers[partition] = closer.register(spillerFactory.create(types, spillContext, childMemoryContextSupplier.get()));
+        }
+    }
+
+    @Override
+    public synchronized Iterator<Page> getSpilledPages(int partition)
+    {
+        readingStarted = true;
+        getFutureValue(flush(partition));
+        spilledPartitions.remove(partition);
+        return spillers[partition].getSpilledPages();
+    }
+
+    @Override
+    public synchronized void verifyAllPartitionsRead()
+    {
+        verify(spilledPartitions.isEmpty(), "Some partitions were spilled but not read: %s", spilledPartitions);
+    }
+
+    @Override
+    public synchronized PartitioningSpillResult partitionAndSpill(Page page, IntPredicate spillPartitionMask)
+    {
+        requireNonNull(page, "page is null");
+        requireNonNull(spillPartitionMask, "spillPartitionMask is null");
+        checkArgument(page.getChannelCount() == types.size(), "Wrong page channel count, expected %s but got %s", types.size(), page.getChannelCount());
+
+        checkState(!readingStarted, "reading already started");
+        IntArrayList unspilledPositions = partitionPage(page, spillPartitionMask);
+        ListenableFuture<?> future = flushFullBuilders();
+
+        return new PartitioningSpillResult(future, mask(page, unspilledPositions.toIntArray()));
+    }
+
+    private synchronized IntArrayList partitionPage(Page page, IntPredicate spillPartitionMask)
+    {
+        IntArrayList unspilledPositions = new IntArrayList();
+
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            int partition = partitionFunction.getPartition(page, position);
+
+            if (!spillPartitionMask.test(partition)) {
+                unspilledPositions.add(position);
+                continue;
+            }
+
+            spilledPartitions.add(partition);
+            PageBuilder pageBuilder = pageBuilders[partition];
+            pageBuilder.declarePosition();
+            for (int channel = 0; channel < types.size(); channel++) {
+                Type type = types.get(channel);
+                type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
+            }
+        }
+
+        return unspilledPositions;
+    }
+
+    private ListenableFuture<?> flushFullBuilders()
+    {
+        return flush(PageBuilder::isFull);
+    }
+
+    @VisibleForTesting
+    ListenableFuture<?> flush()
+    {
+        return flush(pageBuilder -> true);
+    }
+
+    private synchronized ListenableFuture<?> flush(Predicate<PageBuilder> flushCondition)
+    {
+        requireNonNull(flushCondition, "flushCondition is null");
+        ImmutableList.Builder<ListenableFuture<?>> futures = ImmutableList.builder();
+
+        for (int partition = 0; partition < spillers.length; partition++) {
+            PageBuilder pageBuilder = pageBuilders[partition];
+            if (flushCondition.test(pageBuilder)) {
+                futures.add(flush(partition));
+            }
+        }
+
+        return Futures.allAsList(futures.build());
+    }
+
+    private synchronized ListenableFuture<?> flush(int partition)
+    {
+        PageBuilder pageBuilder = pageBuilders[partition];
+        if (pageBuilder.isEmpty()) {
+            return Futures.immediateFuture(null);
+        }
+        Page page = pageBuilder.build();
+        pageBuilder.reset();
+        return spillers[partition].spill(page);
+    }
+
+    @Override
+    public synchronized void close()
+            throws IOException
+    {
+        closer.close();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpillerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spiller;
+
+import com.facebook.presto.memory.AggregatedMemoryContext;
+import com.facebook.presto.operator.PartitionFunction;
+import com.facebook.presto.operator.SpillContext;
+import com.facebook.presto.spi.type.Type;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class GenericPartitioningSpillerFactory
+        implements PartitioningSpillerFactory
+{
+    private final SingleStreamSpillerFactory singleStreamSpillerFactory;
+
+    @Inject
+    public GenericPartitioningSpillerFactory(SingleStreamSpillerFactory singleStreamSpillerFactory)
+    {
+        this.singleStreamSpillerFactory = requireNonNull(singleStreamSpillerFactory, "singleStreamSpillerFactory can not be null");
+    }
+
+    @Override
+    public PartitioningSpiller create(
+            List<Type> types,
+            PartitionFunction partitionFunction,
+            SpillContext spillContext,
+            AggregatedMemoryContext memoryContext)
+    {
+        return new GenericPartitioningSpiller(types, partitionFunction, spillContext, memoryContext, singleStreamSpillerFactory);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/spiller/PartitioningSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/PartitioningSpiller.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spiller;
+
+import com.facebook.presto.spi.Page;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.function.IntPredicate;
+
+import static java.util.Objects.requireNonNull;
+
+public interface PartitioningSpiller
+        extends Closeable
+{
+    /**
+     * Partition page and enqueue partitioned pages to spill writers.
+     * {@link PartitioningSpillResult#getSpillingFuture} is completed when spilling is finished.
+     * <p>
+     * This method may not be called if previously initiated spilling is not finished yet.
+     */
+    PartitioningSpillResult partitionAndSpill(Page page, IntPredicate spillPartitionMask);
+
+    /**
+     * Returns iterator of previously spilled pages from given partition. Callers are expected to call
+     * this method once. Calling multiple times can results in undefined behavior.
+     * <p>
+     * This method may not be called if previously initiated spilling is not finished yet.
+     * <p>
+     * This method may perform blocking I/O to flush internal buffers.
+     */
+    // TODO getSpilledPages should not need flush last buffer to disk
+    Iterator<Page> getSpilledPages(int partition);
+
+    void verifyAllPartitionsRead();
+
+    /**
+     * Closes and removes all underlying resources used during spilling.
+     */
+    @Override
+    void close()
+            throws IOException;
+
+    class PartitioningSpillResult
+    {
+        private ListenableFuture<?> spillingFuture;
+        private Page retained;
+
+        public PartitioningSpillResult(ListenableFuture<?> spillingFuture, Page retained)
+        {
+            this.spillingFuture = requireNonNull(spillingFuture, "spillingFuture is null");
+            this.retained = requireNonNull(retained, "retained is null");
+        }
+
+        public ListenableFuture<?> getSpillingFuture()
+        {
+            return spillingFuture;
+        }
+
+        public Page getRetained()
+        {
+            return retained;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/spiller/PartitioningSpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/PartitioningSpillerFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spiller;
+
+import com.facebook.presto.memory.AggregatedMemoryContext;
+import com.facebook.presto.operator.PartitionFunction;
+import com.facebook.presto.operator.SpillContext;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.List;
+
+public interface PartitioningSpillerFactory
+{
+    PartitioningSpiller create(
+            List<Type> types,
+            PartitionFunction partitionFunction,
+            SpillContext spillContext,
+            AggregatedMemoryContext memoryContext);
+
+    static PartitioningSpillerFactory unsupportedPartitioningSpillerFactory()
+    {
+        return (types, partitionFunction, spillContext, memoryContext) -> {
+            throw new UnsupportedOperationException();
+        };
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/spiller/SingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/SingleStreamSpiller.java
@@ -18,6 +18,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.Closeable;
 import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Future;
 
 import static com.google.common.collect.Iterators.singletonIterator;
 
@@ -44,6 +46,16 @@ public interface SingleStreamSpiller
      * as they were spilled. Method requires the issued spill request to be completed.
      */
     Iterator<Page> getSpilledPages();
+
+    /**
+     * Returns estimate size of pages that would be returned by {@link #getAllSpilledPages()}.
+     */
+    long getSpilledPagesInMemorySize();
+
+    /**
+     * Initiates read of previously spilled pages. The returned {@link Future} will be complete once all pages are read.
+     */
+    ListenableFuture<List<Page>> getAllSpilledPages();
 
     /**
      * Close releases/removes all underlying resources used during spilling

--- a/presto-main/src/main/java/com/facebook/presto/spiller/SingleStreamSpillerFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/SingleStreamSpillerFactory.java
@@ -22,4 +22,11 @@ import java.util.List;
 public interface SingleStreamSpillerFactory
 {
     SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext);
+
+    static SingleStreamSpillerFactory unsupportedSingleStreamSpillerFactory()
+    {
+        return (types, spillContext, memoryContext) -> {
+            throw new UnsupportedOperationException();
+        };
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 
@@ -254,7 +255,7 @@ public class JoinCompiler
             FieldDefinition hashChannelField)
     {
         Parameter channels = arg("channels", type(List.class, type(List.class, Block.class)));
-        Parameter hashChannel = arg("hashChannel", type(Optional.class, Integer.class));
+        Parameter hashChannel = arg("hashChannel", type(OptionalInt.class));
         MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC), channels, hashChannel);
 
         Variable thisVariable = constructorDefinition.getThis();
@@ -313,7 +314,7 @@ public class JoinCompiler
                 .condition(hashChannel.invoke("isPresent", boolean.class))
                 .ifTrue(thisVariable.setField(
                         hashChannelField,
-                        channels.invoke("get", Object.class, hashChannel.invoke("get", Object.class).cast(Integer.class).cast(int.class))))
+                        channels.invoke("get", Object.class, hashChannel.invoke("getAsInt", int.class))))
                 .ifFalse(thisVariable.setField(
                         hashChannelField,
                         constantNull(hashChannelField.getType()))));
@@ -845,7 +846,7 @@ public class JoinCompiler
                 Session session,
                 LongArrayList addresses,
                 List<List<Block>> channels,
-                Optional<Integer> hashChannel,
+                OptionalInt hashChannel,
                 Optional<JoinFilterFunctionFactory> filterFunctionFactory,
                 Optional<Integer> sortChannel,
                 List<JoinFilterFunctionFactory> searchFunctionFactories)
@@ -867,14 +868,14 @@ public class JoinCompiler
         public PagesHashStrategyFactory(Class<? extends PagesHashStrategy> pagesHashStrategyClass)
         {
             try {
-                constructor = pagesHashStrategyClass.getConstructor(List.class, Optional.class);
+                constructor = pagesHashStrategyClass.getConstructor(List.class, OptionalInt.class);
             }
             catch (NoSuchMethodException e) {
                 throw Throwables.propagate(e);
             }
         }
 
-        public PagesHashStrategy createPagesHashStrategy(List<? extends List<Block>> channels, Optional<Integer> hashChannel)
+        public PagesHashStrategy createPagesHashStrategy(List<? extends List<Block>> channels, OptionalInt hashChannel)
         {
             try {
                 return constructor.newInstance(channels, hashChannel);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.PartitioningSpillerFactory;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
@@ -56,6 +57,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.ExecutionException;
 
 import static com.facebook.presto.bytecode.Access.FINAL;
@@ -101,7 +103,9 @@ public class JoinProbeCompiler
             List<Integer> probeJoinChannel,
             Optional<Integer> probeHashChannel,
             List<Integer> probeOutputChannels,
-            JoinType joinType)
+            JoinType joinType,
+            OptionalInt totalOperatorsCount,
+            PartitioningSpillerFactory partitioningSpillerFactory)
     {
         try {
             List<Type> probeOutputChannelTypes = probeOutputChannels.stream()
@@ -114,7 +118,17 @@ public class JoinProbeCompiler
                     probeJoinChannel,
                     probeHashChannel,
                     joinType));
-            return operatorFactoryFactory.createHashJoinOperatorFactory(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeOutputChannelTypes, joinType);
+            return operatorFactoryFactory.createHashJoinOperatorFactory(
+                    operatorId,
+                    planNodeId,
+                    lookupSourceFactory,
+                    probeTypes,
+                    probeOutputChannelTypes,
+                    joinType,
+                    totalOperatorsCount,
+                    probeJoinChannel,
+                    probeHashChannel.map(OptionalInt::of).orElse(OptionalInt.empty()),
+                    partitioningSpillerFactory);
         }
         catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
             throw Throwables.propagate(e.getCause());
@@ -568,7 +582,18 @@ public class JoinProbeCompiler
             this.joinProbeFactory = joinProbeFactory;
 
             try {
-                constructor = operatorFactoryClass.getConstructor(int.class, PlanNodeId.class, LookupSourceFactory.class, List.class, List.class, JoinType.class, JoinProbeFactory.class);
+                constructor = operatorFactoryClass.getConstructor(
+                        int.class,
+                        PlanNodeId.class,
+                        LookupSourceFactory.class,
+                        List.class,
+                        List.class,
+                        JoinType.class,
+                        JoinProbeFactory.class,
+                        OptionalInt.class,
+                        List.class,
+                        OptionalInt.class,
+                        PartitioningSpillerFactory.class);
             }
             catch (NoSuchMethodException e) {
                 throw Throwables.propagate(e);
@@ -581,10 +606,25 @@ public class JoinProbeCompiler
                 LookupSourceFactory lookupSourceFactory,
                 List<? extends Type> probeTypes,
                 List<? extends Type> probeOutputTypes,
-                JoinType joinType)
+                JoinType joinType,
+                OptionalInt totalOperatorsCount,
+                List<Integer> probeJoinChannels,
+                OptionalInt probeHashChannel,
+                PartitioningSpillerFactory partitioningSpillerFactory)
         {
             try {
-                return constructor.newInstance(operatorId, planNodeId, lookupSourceFactory, probeTypes, probeOutputTypes, joinType, joinProbeFactory);
+                return constructor.newInstance(
+                        operatorId,
+                        planNodeId,
+                        lookupSourceFactory,
+                        probeTypes,
+                        probeOutputTypes,
+                        joinType,
+                        joinProbeFactory,
+                        totalOperatorsCount,
+                        probeJoinChannels,
+                        probeHashChannel,
+                        partitioningSpillerFactory);
             }
             catch (Exception e) {
                 throw Throwables.propagate(e);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinProbeCompiler.java
@@ -148,16 +148,14 @@ public class JoinProbeCompiler
 
         classDefinition.declareDefaultConstructor(a(PUBLIC));
 
-        Parameter lookupSource = arg("lookupSource", LookupSource.class);
         Parameter page = arg("page", Page.class);
-        MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "createJoinProbe", type(JoinProbe.class), lookupSource, page);
+        MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "createJoinProbe", type(JoinProbe.class), page);
 
         method.getBody()
                 .newObject(joinProbeClass)
                 .dup()
-                .append(lookupSource)
                 .append(page)
-                .invokeConstructor(joinProbeClass, LookupSource.class, Page.class)
+                .invokeConstructor(joinProbeClass, Page.class)
                 .retObject();
 
         DynamicClassLoader classLoader = new DynamicClassLoader(joinProbeClass.getClassLoader());
@@ -203,7 +201,6 @@ public class JoinProbeCompiler
                 type(JoinProbe.class));
 
         // declare fields
-        FieldDefinition lookupSourceField = classDefinition.declareField(a(PRIVATE, FINAL), "lookupSource", LookupSource.class);
         FieldDefinition positionCountField = classDefinition.declareField(a(PRIVATE, FINAL), "positionCount", int.class);
         List<FieldDefinition> blockFields = new ArrayList<>();
         for (int i = 0; i < types.size(); i++) {
@@ -221,11 +218,11 @@ public class JoinProbeCompiler
         FieldDefinition positionField = classDefinition.declareField(a(PRIVATE), "position", int.class);
         FieldDefinition probeHashBlockField = classDefinition.declareField(a(PRIVATE, FINAL), "probeHashBlock", Block.class);
 
-        generateConstructor(classDefinition, probeChannels, probeHashChannel, lookupSourceField, blockFields, probeBlockFields, probeBlocksArrayField, probePageField, pageField, probeHashBlockField, positionField, positionCountField);
+        generateConstructor(classDefinition, probeChannels, probeHashChannel, blockFields, probeBlockFields, probeBlocksArrayField, probePageField, pageField, probeHashBlockField, positionField, positionCountField);
         generateGetChannelCountMethod(classDefinition, probeOutputChannels.size());
         generateAppendToMethod(classDefinition, callSiteBinder, types, probeOutputChannels, blockFields, positionField);
         generateAdvanceNextPosition(classDefinition, positionField, positionCountField);
-        generateGetCurrentJoinPosition(classDefinition, callSiteBinder, lookupSourceField, probePageField, pageField, probeHashChannel, probeHashBlockField, positionField);
+        generateGetCurrentJoinPosition(classDefinition, callSiteBinder, probePageField, pageField, probeHashChannel, probeHashBlockField, positionField);
         generateCurrentRowContainsNull(classDefinition, probeBlockFields, positionField);
         generateGetPosition(classDefinition, positionField);
         generateGetPage(classDefinition, pageField);
@@ -236,7 +233,6 @@ public class JoinProbeCompiler
     private static void generateConstructor(ClassDefinition classDefinition,
             List<Integer> probeChannels,
             Optional<Integer> probeHashChannel,
-            FieldDefinition lookupSourceField,
             List<FieldDefinition> blockFields,
             List<FieldDefinition> probeChannelFields,
             FieldDefinition probeBlocksArrayField,
@@ -246,9 +242,8 @@ public class JoinProbeCompiler
             FieldDefinition positionField,
             FieldDefinition positionCountField)
     {
-        Parameter lookupSource = arg("lookupSource", LookupSource.class);
         Parameter page = arg("page", Page.class);
-        MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC), lookupSource, page);
+        MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC), page);
 
         Variable thisVariable = constructorDefinition.getThis();
 
@@ -257,9 +252,6 @@ public class JoinProbeCompiler
                 .comment("super();")
                 .append(thisVariable)
                 .invokeConstructor(Object.class);
-
-        constructor.comment("this.lookupSource = lookupSource;")
-                .append(thisVariable.setField(lookupSourceField, lookupSource));
 
         constructor.comment("this.positionCount = page.getPositionCount();")
                 .append(thisVariable.setField(positionCountField, page.invoke("getPositionCount", int.class)));
@@ -391,17 +383,18 @@ public class JoinProbeCompiler
 
     private static void generateGetCurrentJoinPosition(ClassDefinition classDefinition,
             CallSiteBinder callSiteBinder,
-            FieldDefinition lookupSourceField,
             FieldDefinition probePageField,
             FieldDefinition pageField,
             Optional<Integer> probeHashChannel,
             FieldDefinition probeHashBlockField,
             FieldDefinition positionField)
     {
+        Parameter lookupSource = arg("lookupSource", LookupSource.class);
         MethodDefinition method = classDefinition.declareMethod(
                 a(PUBLIC),
                 "getCurrentJoinPosition",
-                type(long.class));
+                type(long.class),
+                lookupSource);
 
         Variable thisVariable = method.getThis();
         BytecodeBlock body = method.getBody()
@@ -414,7 +407,7 @@ public class JoinProbeCompiler
         BytecodeExpression allChannelsPage = thisVariable.getField(pageField);
         BytecodeExpression probeHashBlock = thisVariable.getField(probeHashBlockField);
         if (probeHashChannel.isPresent()) {
-            body.append(thisVariable.getField(lookupSourceField).invoke("getJoinPosition", long.class,
+            body.append(lookupSource.invoke("getJoinPosition", long.class,
                     position,
                     hashChannelsPage,
                     allChannelsPage,
@@ -425,7 +418,7 @@ public class JoinProbeCompiler
                     .retLong();
         }
         else {
-            body.append(thisVariable.getField(lookupSourceField).invoke("getJoinPosition", long.class, position, hashChannelsPage, allChannelsPage)).retLong();
+            body.append(lookupSource.invoke("getJoinPosition", long.class, position, hashChannelsPage, allChannelsPage)).retLong();
         }
     }
 
@@ -488,7 +481,7 @@ public class JoinProbeCompiler
         public ReflectionJoinProbeFactory(Class<? extends JoinProbe> joinProbeClass)
         {
             try {
-                constructor = joinProbeClass.getConstructor(LookupSource.class, Page.class);
+                constructor = joinProbeClass.getConstructor(Page.class);
             }
             catch (NoSuchMethodException e) {
                 throw Throwables.propagate(e);
@@ -496,10 +489,10 @@ public class JoinProbeCompiler
         }
 
         @Override
-        public JoinProbe createJoinProbe(LookupSource lookupSource, Page page)
+        public JoinProbe createJoinProbe(Page page)
         {
             try {
-                return constructor.newInstance(lookupSource, page);
+                return constructor.newInstance(page);
             }
             catch (Exception e) {
                 throw Throwables.propagate(e);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -94,6 +94,8 @@ import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.PartitioningSpillerFactory;
+import com.facebook.presto.spiller.SingleStreamSpillerFactory;
 import com.facebook.presto.spiller.SpillerFactory;
 import com.facebook.presto.split.MappedRecordSet;
 import com.facebook.presto.split.PageSinkManager;
@@ -247,6 +249,8 @@ public class LocalExecutionPlanner
     private final DataSize maxPartialAggregationMemorySize;
     private final DataSize maxPagePartitioningBufferSize;
     private final SpillerFactory spillerFactory;
+    private final SingleStreamSpillerFactory singleStreamSpillerFactory;
+    private final PartitioningSpillerFactory partitioningSpillerFactory;
     private final BlockEncodingSerde blockEncodingSerde;
     private final PagesIndex.Factory pagesIndexFactory;
     private final JoinCompiler joinCompiler;
@@ -270,6 +274,8 @@ public class LocalExecutionPlanner
             CompilerConfig compilerConfig,
             TaskManagerConfig taskManagerConfig,
             SpillerFactory spillerFactory,
+            SingleStreamSpillerFactory singleStreamSpillerFactory,
+            PartitioningSpillerFactory partitioningSpillerFactory,
             BlockEncodingSerde blockEncodingSerde,
             PagesIndex.Factory pagesIndexFactory,
             JoinCompiler joinCompiler,
@@ -291,6 +297,8 @@ public class LocalExecutionPlanner
         this.indexJoinLookupStats = requireNonNull(indexJoinLookupStats, "indexJoinLookupStats is null");
         this.maxIndexMemorySize = requireNonNull(taskManagerConfig, "taskManagerConfig is null").getMaxIndexMemoryUsage();
         this.spillerFactory = requireNonNull(spillerFactory, "spillerFactory is null");
+        this.singleStreamSpillerFactory = requireNonNull(singleStreamSpillerFactory, "singleStreamSpillerFactory is null");
+        this.partitioningSpillerFactory = requireNonNull(partitioningSpillerFactory, "partitioningSpillerFactory is null");
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.maxPartialAggregationMemorySize = taskManagerConfig.getMaxPartialAggregationMemoryUsage();
         this.maxPagePartitioningBufferSize = taskManagerConfig.getMaxPagePartitioningBufferSize();
@@ -1465,12 +1473,13 @@ public class LocalExecutionPlanner
             }
 
             OperatorFactory lookupJoinOperatorFactory;
+            OptionalInt totalOperatorsCount = getJoinOperatorsCountForSpill(context, session);
             switch (node.getType()) {
                 case INNER:
-                    lookupJoinOperatorFactory = lookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, Optional.empty());
+                    lookupJoinOperatorFactory = lookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, Optional.empty(), totalOperatorsCount, partitioningSpillerFactory);
                     break;
                 case SOURCE_OUTER:
-                    lookupJoinOperatorFactory = lookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, Optional.empty());
+                    lookupJoinOperatorFactory = lookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), indexLookupSourceFactory, probeSource.getTypes(), probeChannels, probeHashChannel, Optional.empty(), totalOperatorsCount, partitioningSpillerFactory);
                     break;
                 default:
                     throw new AssertionError("Unknown type: " + node.getType());
@@ -1624,7 +1633,9 @@ public class LocalExecutionPlanner
                     searchFunctionFactories,
                     10_000,
                     buildContext.getDriverInstanceCount().orElse(1),
-                    pagesIndexFactory);
+                    pagesIndexFactory,
+                    false,
+                    singleStreamSpillerFactory);
 
             context.addDriverFactory(
                     buildContext.isInputDriver(),
@@ -1689,19 +1700,29 @@ public class LocalExecutionPlanner
             List<Integer> probeOutputChannels = ImmutableList.copyOf(getChannelsForSymbols(probeOutputSymbols, probeSource.getLayout()));
             List<Integer> probeJoinChannels = ImmutableList.copyOf(getChannelsForSymbols(probeSymbols, probeSource.getLayout()));
             Optional<Integer> probeHashChannel = probeHashSymbol.map(channelGetter(probeSource));
+            OptionalInt totalOperatorsCount = getJoinOperatorsCountForSpill(context, session);
 
             switch (node.getType()) {
                 case INNER:
-                    return lookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels));
+                    return lookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels), totalOperatorsCount, partitioningSpillerFactory);
                 case LEFT:
-                    return lookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels));
+                    return lookupJoinOperators.probeOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels), totalOperatorsCount, partitioningSpillerFactory);
                 case RIGHT:
-                    return lookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels));
+                    return lookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels), totalOperatorsCount, partitioningSpillerFactory);
                 case FULL:
-                    return lookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels));
+                    return lookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactory, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels), totalOperatorsCount, partitioningSpillerFactory);
                 default:
                     throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }
+        }
+
+        private OptionalInt getJoinOperatorsCountForSpill(LocalExecutionPlanContext context, Session session)
+        {
+            OptionalInt driverInstanceCount = context.getDriverInstanceCount();
+            if (isSpillEnabled(session)) {
+                checkState(driverInstanceCount.isPresent(), "A fixed distribution is required for JOIN when spilling is enabled");
+            }
+            return driverInstanceCount;
         }
 
         private Map<Symbol, Integer> createJoinSourcesLayout(Map<Symbol, Integer> lookupSourceLayout, Map<Symbol, Integer> probeSourceLayout)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1392,7 +1392,8 @@ public class LocalExecutionPlanner
             // Plan probe side
             PhysicalOperation probeSource = node.getProbeSource().accept(this, context);
             List<Integer> probeChannels = getChannelsForSymbols(probeSymbols, probeSource.getLayout());
-            Optional<Integer> probeHashChannel = node.getProbeHashSymbol().map(channelGetter(probeSource));
+            OptionalInt probeHashChannel = node.getProbeHashSymbol().map(channelGetter(probeSource))
+                    .map(OptionalInt::of).orElse(OptionalInt.empty());
 
             // The probe key channels will be handed to the index according to probeSymbol order
             Map<Symbol, Integer> probeKeyLayout = new HashMap<>();
@@ -1406,7 +1407,8 @@ public class LocalExecutionPlanner
             LocalExecutionPlanContext indexContext = context.createIndexSourceSubContext(new IndexSourceContext(indexLookupToProbeInput));
             PhysicalOperation indexSource = node.getIndexSource().accept(this, indexContext);
             List<Integer> indexOutputChannels = getChannelsForSymbols(indexSymbols, indexSource.getLayout());
-            Optional<Integer> indexHashChannel = node.getIndexHashSymbol().map(channelGetter(indexSource));
+            OptionalInt indexHashChannel = node.getIndexHashSymbol().map(channelGetter(indexSource))
+                    .map(OptionalInt::of).orElse(OptionalInt.empty());
 
             // Identify just the join keys/channels needed for lookup by the index source (does not have to use all of them).
             Set<Symbol> indexSymbolsNeededBySource = IndexJoinOptimizer.IndexKeyTracer.trace(node.getIndexSource(), ImmutableSet.copyOf(indexSymbols)).keySet();
@@ -1588,7 +1590,8 @@ public class LocalExecutionPlanner
                     .collect(toImmutableList());
             List<Integer> buildOutputChannels = ImmutableList.copyOf(getChannelsForSymbols(buildOutputSymbols, buildSource.getLayout()));
             List<Integer> buildChannels = ImmutableList.copyOf(getChannelsForSymbols(buildSymbols, buildSource.getLayout()));
-            Optional<Integer> buildHashChannel = buildHashSymbol.map(channelGetter(buildSource));
+            OptionalInt buildHashChannel = buildHashSymbol.map(channelGetter(buildSource))
+                    .map(OptionalInt::of).orElse(OptionalInt.empty());
 
             boolean spillEnabled = isSpillEnabled(context.getSession());
             boolean buildOuter = node.getType() == RIGHT || node.getType() == FULL;
@@ -1703,7 +1706,8 @@ public class LocalExecutionPlanner
                     .collect(toImmutableList());
             List<Integer> probeOutputChannels = ImmutableList.copyOf(getChannelsForSymbols(probeOutputSymbols, probeSource.getLayout()));
             List<Integer> probeJoinChannels = ImmutableList.copyOf(getChannelsForSymbols(probeSymbols, probeSource.getLayout()));
-            Optional<Integer> probeHashChannel = probeHashSymbol.map(channelGetter(probeSource));
+            OptionalInt probeHashChannel = probeHashSymbol.map(channelGetter(probeSource))
+                    .map(OptionalInt::of).orElse(OptionalInt.empty());
             OptionalInt totalOperatorsCount = getJoinOperatorsCountForSpill(context, session);
 
             switch (node.getType()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner;
 import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
+import com.facebook.presto.operator.BucketPartitionFunction;
 import com.facebook.presto.operator.PartitionFunction;
 import com.facebook.presto.spi.BucketFunction;
 import com.facebook.presto.spi.ConnectorSplit;
@@ -93,7 +94,7 @@ public class NodePartitioningManager
 
             checkArgument(bucketFunction != null, "No function %s", partitioningHandle);
         }
-        return new PartitionFunction(bucketFunction, partitioningScheme.getBucketToPartition().get());
+        return new BucketPartitionFunction(bucketFunction, partitioningScheme.getBucketToPartition().get());
     }
 
     public NodePartitionMap getNodePartitioningMap(Session session, PartitioningHandle partitioningHandle)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSelector;
+import com.facebook.presto.operator.BucketPartitionFunction;
 import com.facebook.presto.operator.HashGenerator;
 import com.facebook.presto.operator.InterpretedHashGenerator;
 import com.facebook.presto.operator.PartitionFunction;
@@ -164,7 +165,7 @@ public final class SystemPartitioningHandle
         requireNonNull(bucketToPartition, "bucketToPartition is null");
 
         BucketFunction bucketFunction = function.createBucketFunction(partitionChannelTypes, isHashPrecomputed, bucketToPartition.length);
-        return new PartitionFunction(bucketFunction, bucketToPartition);
+        return new BucketPartitionFunction(bucketFunction, bucketToPartition);
     }
 
     public enum SystemPartitionFunction

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -37,6 +37,7 @@ import java.util.function.Function;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.util.MoreLists.filteredCopy;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.Iterables.transform;
 import static java.util.Objects.requireNonNull;
@@ -198,6 +199,7 @@ class ActualProperties
         private Global global;
         private List<LocalProperty<Symbol>> localProperties;
         private Map<Symbol, NullableValue> constants;
+        private boolean unordered;
 
         public Builder()
         {
@@ -235,8 +237,18 @@ class ActualProperties
             return this;
         }
 
+        public Builder unordered(boolean unordered)
+        {
+            this.unordered = unordered;
+            return this;
+        }
+
         public ActualProperties build()
         {
+            List<LocalProperty<Symbol>> localProperties = this.localProperties;
+            if (unordered) {
+                localProperties = filteredCopy(this.localProperties, property -> !property.isOrderSensitive());
+            }
             return new ActualProperties(global, localProperties, constants);
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -199,18 +199,16 @@ class ActualProperties
         private List<LocalProperty<Symbol>> localProperties;
         private Map<Symbol, NullableValue> constants;
 
-        public Builder(Global global, List<LocalProperty<Symbol>> localProperties, Map<Symbol, NullableValue> constants)
-        {
-            this.global = global;
-            this.localProperties = localProperties;
-            this.constants = constants;
-        }
-
         public Builder()
         {
-            this.global = Global.arbitraryPartition();
-            this.localProperties = ImmutableList.of();
-            this.constants = ImmutableMap.of();
+            this(Global.arbitraryPartition(), ImmutableList.of(), ImmutableMap.of());
+        }
+
+        public Builder(Global global, List<LocalProperty<Symbol>> localProperties, Map<Symbol, NullableValue> constants)
+        {
+            this.global = requireNonNull(global, "global is null");
+            this.localProperties = ImmutableList.copyOf(localProperties);
+            this.constants = ImmutableMap.copyOf(constants);
         }
 
         public Builder global(Global global)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -64,6 +64,7 @@ import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
 import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
+import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
@@ -446,10 +447,19 @@ public class AddLocalExchanges
         @Override
         public PlanWithProperties visitJoin(JoinNode node, StreamPreferredProperties parentPreferences)
         {
-            PlanWithProperties probe = planAndEnforce(
-                    node.getLeft(),
-                    defaultParallelism(session),
-                    parentPreferences.constrainTo(node.getLeft().getOutputSymbols()).withDefaultParallelism(session));
+            PlanWithProperties probe;
+            if (isSpillEnabled(session)) {
+                probe = planAndEnforce(
+                        node.getLeft(),
+                        fixedParallelism(),
+                        parentPreferences.constrainTo(node.getLeft().getOutputSymbols()).withFixedParallelism());
+            }
+            else {
+                probe = planAndEnforce(
+                        node.getLeft(),
+                        defaultParallelism(session),
+                        parentPreferences.constrainTo(node.getLeft().getOutputSymbols()).withDefaultParallelism(session));
+            }
 
             // this build consumes the input completely, so we do not pass through parent preferences
             List<Symbol> buildHashSymbols = Lists.transform(node.getCriteria(), JoinNode.EquiJoinClause::getRight);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPreferredProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPreferredProperties.java
@@ -96,6 +96,14 @@ class StreamPreferredProperties
         return new StreamPreferredProperties(Optional.of(MULTIPLE), Optional.empty(), orderSensitive);
     }
 
+    public StreamPreferredProperties withFixedParallelism()
+    {
+        if (distribution.isPresent() && distribution.get() == FIXED) {
+            return this;
+        }
+        return fixedParallelism();
+    }
+
     public static StreamPreferredProperties exactlyPartitionedOn(Collection<Symbol> partitionSymbols)
     {
         if (partitionSymbols.isEmpty()) {

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -96,8 +96,10 @@ import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spiller.FileSingleStreamSpillerFactory;
+import com.facebook.presto.spiller.GenericPartitioningSpillerFactory;
 import com.facebook.presto.spiller.GenericSpillerFactory;
 import com.facebook.presto.spiller.NodeSpillConfig;
+import com.facebook.presto.spiller.PartitioningSpillerFactory;
 import com.facebook.presto.spiller.SpillerFactory;
 import com.facebook.presto.spiller.SpillerStats;
 import com.facebook.presto.split.PageSinkManager;
@@ -223,6 +225,7 @@ public class LocalQueryRunner
     private final TransactionManager transactionManager;
     private final FileSingleStreamSpillerFactory singleStreamSpillerFactory;
     private final SpillerFactory spillerFactory;
+    private final PartitioningSpillerFactory partitioningSpillerFactory;
 
     private final PageFunctionCompiler pageFunctionCompiler;
     private final ExpressionCompiler expressionCompiler;
@@ -387,6 +390,7 @@ public class LocalQueryRunner
 
         SpillerStats spillerStats = new SpillerStats();
         this.singleStreamSpillerFactory = new FileSingleStreamSpillerFactory(blockEncodingSerde, spillerStats, featuresConfig);
+        this.partitioningSpillerFactory = new GenericPartitioningSpillerFactory(this.singleStreamSpillerFactory);
         this.spillerFactory = new GenericSpillerFactory(singleStreamSpillerFactory);
     }
 
@@ -631,6 +635,8 @@ public class LocalQueryRunner
                 new CompilerConfig().setInterpreterEnabled(false), // make sure tests fail if compiler breaks
                 new TaskManagerConfig().setTaskConcurrency(4),
                 spillerFactory,
+                singleStreamSpillerFactory,
+                partitioningSpillerFactory,
                 blockEncodingSerde,
                 new PagesIndex.TestingFactory(),
                 new JoinCompiler(),

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
@@ -46,10 +46,22 @@ public final class TestingTaskContext
                 .build();
     }
 
+    public static TaskContext createTaskContext(Executor notificationExecutor, ScheduledExecutorService yieldExecutor, Session session, TaskStateMachine taskStateMachine)
+    {
+        return builder(notificationExecutor, yieldExecutor, session)
+                .setTaskStateMachine(taskStateMachine)
+                .build();
+    }
+
     public static TaskContext createTaskContext(QueryContext queryContext, Executor executor, Session session)
     {
+        return createTaskContext(queryContext, session, new TaskStateMachine(new TaskId("query", 0, 0), executor));
+    }
+
+    private static TaskContext createTaskContext(QueryContext queryContext, Session session, TaskStateMachine taskStateMachine)
+    {
         return queryContext.addTaskContext(
-                new TaskStateMachine(new TaskId("query", 0, 0), executor),
+                taskStateMachine,
                 session,
                 true,
                 true);
@@ -65,6 +77,7 @@ public final class TestingTaskContext
         private final Executor notificationExecutor;
         private final ScheduledExecutorService yieldExecutor;
         private final Session session;
+        private TaskStateMachine taskStateMachine;
         private DataSize queryMaxMemory = new DataSize(256, MEGABYTE);
         private DataSize memoryPoolSize = new DataSize(1, GIGABYTE);
         private DataSize systemMemoryPoolSize = new DataSize(1, GIGABYTE);
@@ -76,6 +89,13 @@ public final class TestingTaskContext
             this.notificationExecutor = notificationExecutor;
             this.yieldExecutor = yieldExecutor;
             this.session = session;
+            this.taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0), notificationExecutor);
+        }
+
+        public Builder setTaskStateMachine(TaskStateMachine taskStateMachine)
+        {
+            this.taskStateMachine = taskStateMachine;
+            return this;
         }
 
         public Builder setQueryMaxMemory(DataSize queryMaxMemory)
@@ -123,7 +143,7 @@ public final class TestingTaskContext
                     queryMaxSpillSize,
                     spillSpaceTracker);
 
-            return createTaskContext(queryContext, notificationExecutor, session);
+            return createTaskContext(queryContext, session, taskStateMachine);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/util/PrestoCloseables.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/PrestoCloseables.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import com.google.common.io.Closer;
+
+import java.io.Closeable;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoCloseables
+{
+    private PrestoCloseables() {}
+
+    public static Closeable combineCloseables(Closeable first, Closeable second)
+    {
+        requireNonNull(first, "first is null");
+        requireNonNull(second, "second is null");
+
+        Closer closer = Closer.create();
+        closer.register(first);
+        closer.register(second);
+        return closer;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/util/PrestoIterators.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/PrestoIterators.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import com.google.common.collect.AbstractIterator;
+
+import java.util.Iterator;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoIterators
+{
+    private PrestoIterators() {}
+
+    public static <T> Iterator<T> closeWhenExhausted(Iterator<T> iterator, AutoCloseable resource)
+    {
+        requireNonNull(iterator, "iterator is null");
+        requireNonNull(resource, "resource is null");
+
+        return new AbstractIterator<T>()
+        {
+            @Override
+            protected T computeNext()
+            {
+                if (iterator.hasNext()) {
+                    return iterator.next();
+                }
+                else {
+                    try {
+                        resource.close();
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    return endOfData();
+                }
+            }
+        };
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -141,6 +141,12 @@ public final class TaskTestUtils
                 new GenericSpillerFactory((types, spillContext, memoryContext) -> {
                     throw new UnsupportedOperationException();
                 }),
+                (types, spillContext, memoryContext) -> {
+                    throw new UnsupportedOperationException();
+                },
+                (types, partitionFunction, spillContext, memoryContext) -> {
+                    throw new UnsupportedOperationException();
+                },
                 new TestingBlockEncodingSerde(new TestingTypeManager()),
                 new PagesIndex.TestingFactory(),
                 new JoinCompiler(),

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -24,6 +24,7 @@ import com.facebook.presto.testing.TestingTaskContext;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -53,6 +54,7 @@ import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spiller.PartitioningSpillerFactory.unsupportedPartitioningSpillerFactory;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static java.lang.String.format;
@@ -303,9 +305,11 @@ public class BenchmarkHashBuildAndJoinOperators
         }
         operator.finish();
 
-        if (!hashBuilderOperatorFactory.getLookupSourceFactory().createLookupSource().isDone()) {
-            throw new AssertionError("Expected lookup source to be done");
+        ListenableFuture<LookupSourceProvider> lookupSourceProvider = hashBuilderOperatorFactory.getLookupSourceFactory().createLookupSourceProvider();
+        if (!lookupSourceProvider.isDone()) {
+            throw new AssertionError("Expected lookup source provider to be ready");
         }
+        getFutureValue(lookupSourceProvider).close();
 
         return hashBuilderOperatorFactory.getLookupSourceFactory();
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -97,7 +97,7 @@ public class BenchmarkHashBuildAndJoinOperators
         protected ExecutorService executor;
         protected ScheduledExecutorService scheduledExecutor;
         protected List<Page> buildPages;
-        protected Optional<Integer> hashChannel;
+        protected OptionalInt hashChannel;
         protected List<Type> types;
         protected List<Integer> hashChannels;
 
@@ -128,7 +128,7 @@ public class BenchmarkHashBuildAndJoinOperators
             return TestingTaskContext.createTaskContext(executor, scheduledExecutor, TEST_SESSION, new DataSize(2, GIGABYTE));
         }
 
-        public Optional<Integer> getHashChannel()
+        public OptionalInt getHashChannel()
         {
             return hashChannel;
         }
@@ -163,7 +163,8 @@ public class BenchmarkHashBuildAndJoinOperators
 
             types = buildPagesBuilder.getTypes();
             buildPages = buildPagesBuilder.build();
-            hashChannel = buildPagesBuilder.getHashChannel();
+            hashChannel = buildPagesBuilder.getHashChannel()
+                    .map(OptionalInt::of).orElse(OptionalInt.empty());
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.ExceededMemoryLimitException;
 import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.memory.LocalMemoryContext;
 import com.facebook.presto.operator.HashBuilderOperator.HashBuilderOperatorFactory;
 import com.facebook.presto.operator.ValuesOperator.ValuesOperatorFactory;
 import com.facebook.presto.operator.exchange.LocalExchange;
@@ -24,6 +25,10 @@ import com.facebook.presto.operator.exchange.LocalExchangeSourceOperator.LocalEx
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.GenericPartitioningSpillerFactory;
+import com.facebook.presto.spiller.PartitioningSpillerFactory;
+import com.facebook.presto.spiller.SingleStreamSpiller;
+import com.facebook.presto.spiller.SingleStreamSpillerFactory;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import com.facebook.presto.sql.gen.JoinProbeCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
@@ -32,15 +37,20 @@ import com.facebook.presto.testing.TestingTaskContext;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -53,8 +63,11 @@ import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEqual
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.Iterators.unmodifiableIterator;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -70,6 +83,8 @@ public class TestHashJoinOperator
 {
     private static final int PARTITION_COUNT = 4;
     private static final LookupJoinOperators LOOKUP_JOIN_OPERATORS = new LookupJoinOperators(new JoinProbeCompiler());
+    private static final SingleStreamSpillerFactory SINGLE_STREAM_SPILLER_FACTORY = new DummySpillerFactory();
+    private static final PartitioningSpillerFactory PARTITIONING_SPILLER_FACTORY = new GenericPartitioningSpillerFactory(SINGLE_STREAM_SPILLER_FACTORY);
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
@@ -125,7 +140,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probePages.getTypesWithoutHash(), buildPages.getTypesWithoutHash()))
@@ -179,7 +196,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         Operator operator = joinOperatorFactory.createOperator(driverContext);
         assertTrue(operator.needsInput());
@@ -239,7 +258,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypesWithoutHash()))
@@ -282,7 +303,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -326,7 +349,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -363,7 +388,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         // expected
@@ -416,7 +443,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -471,7 +500,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -519,7 +550,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -564,7 +597,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -612,7 +647,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -656,7 +693,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypesWithoutHash()))
@@ -705,7 +744,9 @@ public class TestHashJoinOperator
                 probePages.getTypes(),
                 Ints.asList(0),
                 probePages.getHashChannel(),
-                Optional.empty());
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypesWithoutHash()))
@@ -797,7 +838,9 @@ public class TestHashJoinOperator
                 ImmutableList.of(),
                 100,
                 partitionCount,
-                new PagesIndex.TestingFactory());
+                new PagesIndex.TestingFactory(),
+                false,
+                SINGLE_STREAM_SPILLER_FACTORY);
         PipelineContext buildPipeline = taskContext.addPipelineContext(1, true, true);
 
         Driver[] buildDrivers = new Driver[partitionCount];
@@ -844,6 +887,56 @@ public class TestHashJoinOperator
         public boolean filter(int leftPosition, Block[] leftBlocks, int rightPosition, Block[] rightBlocks)
         {
             return lambda.filter(leftPosition, leftBlocks, rightPosition, rightBlocks);
+        }
+    }
+
+    private static class DummySpillerFactory
+            implements SingleStreamSpillerFactory
+    {
+        @Override
+        public SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext)
+        {
+            return new SingleStreamSpiller()
+            {
+                private boolean writing = true;
+                private final List<Page> spills = new ArrayList<>();
+
+                @Override
+                public ListenableFuture<?> spill(Iterator<Page> pageIterator)
+                {
+                    checkState(writing, "writing already finished");
+                    Iterators.addAll(spills, pageIterator);
+                    return immediateFuture(null);
+                }
+
+                @Override
+                public Iterator<Page> getSpilledPages()
+                {
+                    writing = false;
+                    return unmodifiableIterator(spills.iterator());
+                }
+
+                @Override
+                public long getSpilledPagesInMemorySize()
+                {
+                    return spills.stream()
+                            .mapToLong(Page::getSizeInBytes)
+                            .sum();
+                }
+
+                @Override
+                public ListenableFuture<List<Page>> getAllSpilledPages()
+                {
+                    writing = false;
+                    return immediateFuture(ImmutableList.copyOf(spills));
+                }
+
+                @Override
+                public void close()
+                {
+                    writing = false;
+                }
+            };
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -96,7 +96,7 @@ public class TestHashJoinOperator
 {
     private static final int PARTITION_COUNT = 4;
     private static final LookupJoinOperators LOOKUP_JOIN_OPERATORS = new LookupJoinOperators(new JoinProbeCompiler());
-    private static final SingleStreamSpillerFactory SINGLE_STREAM_SPILLER_FACTORY = new DummySpillerFactory();
+    private static final DummySpillerFactory SINGLE_STREAM_SPILLER_FACTORY = new DummySpillerFactory();
     private static final PartitioningSpillerFactory PARTITIONING_SPILLER_FACTORY = new GenericPartitioningSpillerFactory(SINGLE_STREAM_SPILLER_FACTORY);
 
     private ExecutorService executor;
@@ -146,7 +146,7 @@ public class TestHashJoinOperator
         List<Page> probeInput = probePages
                 .addSequencePage(1000, 0, 1000, 2000)
                 .build();
-        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages);
+        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages, PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probePages.getTypesWithoutHash(), buildPages.getTypesWithoutHash()))
@@ -281,7 +281,7 @@ public class TestHashJoinOperator
                 .addSequencePage(30, 0, 123_000)
                 .addSequencePage(10, 30, 123_000);
 
-        try (OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages);
+        try (OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages, PARTITIONING_SPILLER_FACTORY);
                 Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(0, true, true).addDriverContext())) {
             // build LookupSource
 
@@ -396,7 +396,7 @@ public class TestHashJoinOperator
                 .row("a")
                 .row("b")
                 .build();
-        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages);
+        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages, PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypesWithoutHash()))
@@ -432,7 +432,7 @@ public class TestHashJoinOperator
                 .row("b")
                 .row("c")
                 .build();
-        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages);
+        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages, PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -469,7 +469,7 @@ public class TestHashJoinOperator
                 .row((String) null)
                 .row("c")
                 .build();
-        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages);
+        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages, PARTITIONING_SPILLER_FACTORY);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -858,7 +858,7 @@ public class TestHashJoinOperator
                 PARTITIONING_SPILLER_FACTORY);
     }
 
-    private OperatorFactory innerJoinOperatorFactory(LookupSourceFactory lookupSourceFactory, RowPagesBuilder probePages)
+    private OperatorFactory innerJoinOperatorFactory(LookupSourceFactory lookupSourceFactory, RowPagesBuilder probePages, PartitioningSpillerFactory partitioningSpillerFactory)
     {
         return LOOKUP_JOIN_OPERATORS.innerJoin(
                 0,
@@ -869,7 +869,7 @@ public class TestHashJoinOperator
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+                partitioningSpillerFactory);
     }
 
     private LookupSourceFactory buildHash(

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -199,7 +199,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
+                getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
                 PARTITIONING_SPILLER_FACTORY);
@@ -852,7 +852,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
+                getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
                 PARTITIONING_SPILLER_FACTORY);
@@ -866,7 +866,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 Ints.asList(0),
-                probePages.getHashChannel(),
+                getHashChannelAsInt(probePages),
                 Optional.empty(),
                 OptionalInt.of(1),
                 PARTITIONING_SPILLER_FACTORY);
@@ -923,7 +923,8 @@ public class TestHashJoinOperator
                 rangeList(buildPages.getTypes().size()),
                 ImmutableMap.of(),
                 hashChannels,
-                buildPages.getHashChannel(),
+                buildPages.getHashChannel()
+                        .map(OptionalInt::of).orElse(OptionalInt.empty()),
                 false,
                 filterFunctionFactory,
                 Optional.empty(),
@@ -981,6 +982,12 @@ public class TestHashJoinOperator
                 runDriverInThread(executor, driver);
             }
         });
+    }
+
+    private static OptionalInt getHashChannelAsInt(RowPagesBuilder probePages)
+    {
+        return probePages.getHashChannel()
+                .map(OptionalInt::of).orElse(OptionalInt.empty());
     }
 
     private static List<Integer> rangeList(int endExclusive)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -72,6 +72,7 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -727,6 +728,18 @@ public class TestHashJoinOperator
             RowPagesBuilder buildPages,
             Optional<InternalJoinFilterFunction> filterFunction)
     {
+        BuildSideSetup buildSideSetup = setupBuildSide(parallelBuild, taskContext, hashChannels, buildPages, filterFunction);
+        buildLookupSource(buildSideSetup);
+        return buildSideSetup.getLookupSourceFactory();
+    }
+
+    private BuildSideSetup setupBuildSide(
+            boolean parallelBuild,
+            TaskContext taskContext,
+            List<Integer> hashChannels,
+            RowPagesBuilder buildPages,
+            Optional<InternalJoinFilterFunction> filterFunction)
+    {
         Optional<JoinFilterFunctionFactory> filterFunctionFactory = filterFunction
                 .map(function -> (session, addresses, channels) -> new StandardJoinFilterFunction(function, addresses, channels));
 
@@ -739,14 +752,14 @@ public class TestHashJoinOperator
         DriverContext collectDriverContext = taskContext.addPipelineContext(0, true, true).addDriverContext();
         ValuesOperatorFactory valuesOperatorFactory = new ValuesOperatorFactory(0, new PlanNodeId("values"), buildPages.getTypes(), buildPages.build());
         LocalExchangeSinkOperatorFactory sinkOperatorFactory = new LocalExchangeSinkOperatorFactory(1, new PlanNodeId("sink"), sinkFactory, Function.identity());
-        Driver driver = new Driver(collectDriverContext,
+        Driver sourceDriver = new Driver(collectDriverContext,
                 valuesOperatorFactory.createOperator(collectDriverContext),
                 sinkOperatorFactory.createOperator(collectDriverContext));
         valuesOperatorFactory.close();
         sinkOperatorFactory.close();
 
-        while (!driver.isFinished()) {
-            driver.process();
+        while (!sourceDriver.isFinished()) {
+            sourceDriver.process();
         }
 
         // build hash tables
@@ -770,16 +783,26 @@ public class TestHashJoinOperator
                 SINGLE_STREAM_SPILLER_FACTORY);
         PipelineContext buildPipeline = taskContext.addPipelineContext(1, true, true);
 
-        Driver[] buildDrivers = new Driver[partitionCount];
+        List<Driver> buildDrivers = new ArrayList<>();
         for (int i = 0; i < partitionCount; i++) {
             DriverContext buildDriverContext = buildPipeline.addDriverContext();
-            buildDrivers[i] = new Driver(
+            Driver driver = new Driver(
                     buildDriverContext,
                     sourceOperatorFactory.createOperator(buildDriverContext),
                     buildOperatorFactory.createOperator(buildDriverContext));
+            buildDrivers.add(driver);
         }
 
-        Future<LookupSourceProvider> lookupSourceProvider = buildOperatorFactory.getLookupSourceFactory().createLookupSourceProvider();
+        return new BuildSideSetup(buildOperatorFactory.getLookupSourceFactory(), buildDrivers);
+    }
+
+    private void buildLookupSource(BuildSideSetup buildSideSetup)
+    {
+        requireNonNull(buildSideSetup, "buildSideSetup is null");
+
+        Future<LookupSourceProvider> lookupSourceProvider = buildSideSetup.getLookupSourceFactory().createLookupSourceProvider();
+        List<Driver> buildDrivers = buildSideSetup.getBuildDrivers();
+
         while (!lookupSourceProvider.isDone()) {
             for (Driver buildDriver : buildDrivers) {
                 buildDriver.process();
@@ -790,8 +813,6 @@ public class TestHashJoinOperator
         for (Driver buildDriver : buildDrivers) {
             runDriverInThread(executor, buildDriver);
         }
-
-        return buildOperatorFactory.getLookupSourceFactory();
     }
 
     /**
@@ -812,6 +833,28 @@ public class TestHashJoinOperator
         return IntStream.range(0, endExclusive)
                 .boxed()
                 .collect(toImmutableList());
+    }
+
+    private static class BuildSideSetup
+    {
+        private final LookupSourceFactory lookupSourceFactory;
+        private final List<Driver> buildDrivers;
+
+        BuildSideSetup(LookupSourceFactory lookupSourceFactory, List<Driver> buildDrivers)
+        {
+            this.lookupSourceFactory = requireNonNull(lookupSourceFactory, "lookupSourceFactory is null");
+            this.buildDrivers = ImmutableList.copyOf(buildDrivers);
+        }
+
+        LookupSourceFactory getLookupSourceFactory()
+        {
+            return lookupSourceFactory;
+        }
+
+        List<Driver> getBuildDrivers()
+        {
+            return buildDrivers;
+        }
     }
 
     private static class TestInternalJoinFilterFunction

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -135,16 +135,7 @@ public class TestHashJoinOperator
         List<Page> probeInput = probePages
                 .addSequencePage(1000, 0, 1000, 2000)
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.innerJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probePages.getTypesWithoutHash(), buildPages.getTypesWithoutHash()))
@@ -253,16 +244,7 @@ public class TestHashJoinOperator
                 .row("a")
                 .row("b")
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.innerJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypesWithoutHash()))
@@ -298,16 +280,7 @@ public class TestHashJoinOperator
                 .row("b")
                 .row("c")
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.innerJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -344,16 +317,7 @@ public class TestHashJoinOperator
                 .row((String) null)
                 .row("c")
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.innerJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -383,16 +347,7 @@ public class TestHashJoinOperator
         List<Page> probeInput = probePages
                 .addSequencePage(15, 20, 1020, 2020)
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.probeOuterJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = probeOuterJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         // expected
@@ -438,16 +393,7 @@ public class TestHashJoinOperator
         List<Page> probeInput = probePages
                 .addSequencePage(15, 20, 1020, 2020)
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.probeOuterJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = probeOuterJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -495,16 +441,7 @@ public class TestHashJoinOperator
                 .row("a")
                 .row("b")
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.probeOuterJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = probeOuterJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -545,16 +482,7 @@ public class TestHashJoinOperator
                 .row("a")
                 .row("b")
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.probeOuterJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = probeOuterJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -592,16 +520,7 @@ public class TestHashJoinOperator
                 .row("b")
                 .row("c")
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.probeOuterJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = probeOuterJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -642,16 +561,7 @@ public class TestHashJoinOperator
                 .row("b")
                 .row("c")
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.probeOuterJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = probeOuterJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildTypes))
@@ -688,16 +598,7 @@ public class TestHashJoinOperator
                 .row((String) null)
                 .row("c")
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.probeOuterJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = probeOuterJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypesWithoutHash()))
@@ -739,16 +640,7 @@ public class TestHashJoinOperator
                 .row((String) null)
                 .row("c")
                 .build();
-        OperatorFactory joinOperatorFactory = LOOKUP_JOIN_OPERATORS.probeOuterJoin(
-                0,
-                new PlanNodeId("test"),
-                lookupSourceFactory,
-                probePages.getTypes(),
-                Ints.asList(0),
-                probePages.getHashChannel(),
-                Optional.empty(),
-                OptionalInt.of(1),
-                PARTITIONING_SPILLER_FACTORY);
+        OperatorFactory joinOperatorFactory = probeOuterJoinOperatorFactory(lookupSourceFactory, probePages);
 
         // expected
         MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypesWithoutHash()))
@@ -798,6 +690,34 @@ public class TestHashJoinOperator
             hashChannels.add(probe.getTypes().size() + build.getHashChannel().get());
         }
         return hashChannels.build();
+    }
+
+    private OperatorFactory probeOuterJoinOperatorFactory(LookupSourceFactory lookupSourceFactory, RowPagesBuilder probePages)
+    {
+        return LOOKUP_JOIN_OPERATORS.probeOuterJoin(
+                0,
+                new PlanNodeId("test"),
+                lookupSourceFactory,
+                probePages.getTypes(),
+                Ints.asList(0),
+                probePages.getHashChannel(),
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
+    }
+
+    private OperatorFactory innerJoinOperatorFactory(LookupSourceFactory lookupSourceFactory, RowPagesBuilder probePages)
+    {
+        return LOOKUP_JOIN_OPERATORS.innerJoin(
+                0,
+                new PlanNodeId("test"),
+                lookupSourceFactory,
+                probePages.getTypes(),
+                Ints.asList(0),
+                probePages.getHashChannel(),
+                Optional.empty(),
+                OptionalInt.of(1),
+                PARTITIONING_SPILLER_FACTORY);
     }
 
     private LookupSourceFactory buildHash(

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -15,6 +15,8 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.ExceededMemoryLimitException;
 import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskStateMachine;
 import com.facebook.presto.memory.LocalMemoryContext;
 import com.facebook.presto.operator.HashBuilderOperator.HashBuilderOperatorFactory;
 import com.facebook.presto.operator.ValuesOperator.ValuesOperatorFactory;
@@ -22,7 +24,10 @@ import com.facebook.presto.operator.exchange.LocalExchange;
 import com.facebook.presto.operator.exchange.LocalExchange.LocalExchangeSinkFactory;
 import com.facebook.presto.operator.exchange.LocalExchangeSinkOperator.LocalExchangeSinkOperatorFactory;
 import com.facebook.presto.operator.exchange.LocalExchangeSourceOperator.LocalExchangeSourceOperatorFactory;
+import com.facebook.presto.operator.index.PageBuffer;
+import com.facebook.presto.operator.index.PageBufferOperator.PageBufferOperatorFactory;
 import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spiller.GenericPartitioningSpillerFactory;
@@ -48,6 +53,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -55,6 +61,8 @@ import java.util.OptionalInt;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -63,9 +71,8 @@ import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
 import static com.facebook.presto.operator.OperatorAssertion.dropChannel;
-import static com.facebook.presto.operator.OperatorAssertion.toPages;
-import static com.facebook.presto.operator.OperatorAssertion.toPagesPartial;
 import static com.facebook.presto.operator.OperatorAssertion.without;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
@@ -73,13 +80,14 @@ import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterators.singletonIterator;
 import static com.google.common.collect.Iterators.unmodifiableIterator;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.nCopies;
 import static java.util.Collections.singletonList;
@@ -87,16 +95,18 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
 public class TestHashJoinOperator
 {
     private static final int PARTITION_COUNT = 4;
     private static final LookupJoinOperators LOOKUP_JOIN_OPERATORS = new LookupJoinOperators(new JoinProbeCompiler());
-    private static final DummySpillerFactory SINGLE_STREAM_SPILLER_FACTORY = new DummySpillerFactory();
+    private static final SingleStreamSpillerFactory SINGLE_STREAM_SPILLER_FACTORY = new DummySpillerFactory();
     private static final PartitioningSpillerFactory PARTITIONING_SPILLER_FACTORY = new GenericPartitioningSpillerFactory(SINGLE_STREAM_SPILLER_FACTORY);
 
     private ExecutorService executor;
@@ -236,59 +246,143 @@ public class TestHashJoinOperator
         DURING_BUILD, AFTER_BUILD, DURING_USAGE, NEVER
     }
 
+    private enum WhenSpillFails
+    {
+        SPILL_BUILD, SPILL_JOIN, UNSPILL_BUILD, UNSPILL_JOIN
+    }
+
     @DataProvider
     public Object[][] joinWithSpillValues()
     {
-        List<Object[]> result = new ArrayList<>();
+        return joinWithSpillParameters(true).stream()
+                .map(List::toArray)
+                .toArray(Object[][]::new);
+    }
+
+    @DataProvider
+    public Object[][] joinWithFailingSpillValues()
+    {
+        List<List<Object>> spillFailValues = Arrays.stream(WhenSpillFails.values())
+                .map(ImmutableList::<Object>of)
+                .collect(toList());
+        return product(joinWithSpillParameters(false), spillFailValues).stream()
+                .map(List::toArray)
+                .toArray(Object[][]::new);
+    }
+
+    private static List<List<Object>> joinWithSpillParameters(boolean allowNoSpill)
+    {
+        List<List<Object>> result = new ArrayList<>();
         for (boolean probeHashEnabled : ImmutableList.of(false, true)) {
             for (WhenSpill whenSpill : WhenSpill.values()) {
                 // spill all
-                result.add(new Object[] {probeHashEnabled, nCopies(PARTITION_COUNT, whenSpill)});
+                if (allowNoSpill || whenSpill != WhenSpill.NEVER) {
+                    result.add(ImmutableList.of(probeHashEnabled, nCopies(PARTITION_COUNT, whenSpill)));
+                }
 
                 if (whenSpill != WhenSpill.NEVER) {
                     // spill one
-                    result.add(new Object[] {probeHashEnabled, concat(singletonList(whenSpill), nCopies(PARTITION_COUNT - 1, WhenSpill.NEVER))});
+                    result.add(ImmutableList.of(probeHashEnabled, concat(singletonList(whenSpill), nCopies(PARTITION_COUNT - 1, WhenSpill.NEVER))));
                 }
             }
 
-            result.add(new Object[] {probeHashEnabled, concat(asList(WhenSpill.DURING_BUILD, WhenSpill.AFTER_BUILD), nCopies(PARTITION_COUNT - 2, WhenSpill.NEVER))});
-            result.add(new Object[] {probeHashEnabled, concat(asList(WhenSpill.DURING_BUILD, WhenSpill.DURING_USAGE), nCopies(PARTITION_COUNT - 2, WhenSpill.NEVER))});
+            result.add(ImmutableList.of(probeHashEnabled, concat(asList(WhenSpill.DURING_BUILD, WhenSpill.AFTER_BUILD), nCopies(PARTITION_COUNT - 2, WhenSpill.NEVER))));
+            result.add(ImmutableList.of(probeHashEnabled, concat(asList(WhenSpill.DURING_BUILD, WhenSpill.DURING_USAGE), nCopies(PARTITION_COUNT - 2, WhenSpill.NEVER))));
         }
-
-        return result.stream().toArray(Object[][]::new);
+        return result;
     }
 
     @Test(dataProvider = "joinWithSpillValues")
     public void testInnerJoinWithSpill(boolean probeHashEnabled, List<WhenSpill> whenSpill)
             throws Exception
     {
-        TaskContext taskContext = createTaskContext();
+        innerJoinWithSpill(probeHashEnabled, whenSpill, SINGLE_STREAM_SPILLER_FACTORY, PARTITIONING_SPILLER_FACTORY);
+    }
 
-        // build
+    @Test(dataProvider = "joinWithFailingSpillValues")
+    public void testInnerJoinWithFailingSpill(boolean probeHashEnabled, List<WhenSpill> whenSpill, WhenSpillFails whenSpillFails)
+            throws Throwable
+    {
+        DummySpillerFactory buildSpillerFactory = new DummySpillerFactory();
+        DummySpillerFactory joinSpillerFactory = new DummySpillerFactory();
+        PartitioningSpillerFactory partitioningSpillerFactory = new GenericPartitioningSpillerFactory(joinSpillerFactory);
+
+        String expectedMessage;
+        switch (whenSpillFails) {
+            case SPILL_BUILD:
+                buildSpillerFactory.failSpill();
+                expectedMessage = "Spill failed";
+                break;
+            case SPILL_JOIN:
+                joinSpillerFactory.failSpill();
+                expectedMessage = "Spill failed";
+                break;
+            case UNSPILL_BUILD:
+                buildSpillerFactory.failUnspill();
+                expectedMessage = "Unspill failed";
+                break;
+            case UNSPILL_JOIN:
+                joinSpillerFactory.failUnspill();
+                expectedMessage = "Unspill failed";
+                break;
+            default:
+                throw new IllegalArgumentException(format("Unsupported option: %s", whenSpillFails));
+        }
+        try {
+            innerJoinWithSpill(probeHashEnabled, whenSpill, buildSpillerFactory, partitioningSpillerFactory);
+            fail("Exception not thrown");
+        }
+        catch (RuntimeException exception) {
+            assertEquals(exception.getMessage(), expectedMessage);
+        }
+    }
+
+    private void innerJoinWithSpill(boolean probeHashEnabled, List<WhenSpill> whenSpill, SingleStreamSpillerFactory buildSpillerFactory, PartitioningSpillerFactory joinSpillerFactory)
+            throws Exception
+    {
+        TaskStateMachine taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0), executor);
+        TaskContext taskContext = TestingTaskContext.createTaskContext(executor, scheduledExecutor, TEST_SESSION, taskStateMachine);
+
+        DriverContext joinDriverContext = taskContext.addPipelineContext(2, true, true).addDriverContext();
+
+        // force a yield for every match in LookupJoinOperator, set called to true after first
+        AtomicBoolean called = new AtomicBoolean(false);
+        InternalJoinFilterFunction filterFunction = new TestInternalJoinFilterFunction(
+                (leftPosition, leftBlocks, rightPosition, rightBlocks) -> {
+                    called.set(true);
+                    joinDriverContext.getYieldSignal().forceYieldForTesting();
+                    return true;
+                });
+
+        // build side
         RowPagesBuilder buildPages = rowPagesBuilder(ImmutableList.of(VARCHAR, BIGINT))
+                .addSequencePage(4, 20, 200)
                 .addSequencePage(4, 20, 200)
                 .addSequencePage(4, 30, 300)
                 .addSequencePage(4, 40, 400);
 
-        BuildSideSetup buildSideSetup = setupBuildSide(true, taskContext, Ints.asList(0), buildPages, Optional.empty(), true);
+        BuildSideSetup buildSideSetup = setupBuildSide(true, taskContext, Ints.asList(0), buildPages, Optional.of(filterFunction), true, buildSpillerFactory);
         List<Driver> buildDrivers = buildSideSetup.getBuildDrivers();
         int buildOperatorCount = buildDrivers.size();
         checkState(buildOperatorCount == whenSpill.size());
         LookupSourceFactory lookupSourceFactory = buildSideSetup.getLookupSourceFactory();
 
-        // probe
+        // probe side
         RowPagesBuilder probePages = rowPagesBuilder(probeHashEnabled, Ints.asList(0), ImmutableList.of(VARCHAR, BIGINT))
-                .addSequencePage(30, 0, 123_000)
+                .row("20", 123_000L)
+                .row("20", 123_000L)
+                .pageBreak()
+                .addSequencePage(20, 0, 123_000)
                 .addSequencePage(10, 30, 123_000);
 
-        try (OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages, PARTITIONING_SPILLER_FACTORY);
-                Operator joinOperator = joinOperatorFactory.createOperator(taskContext.addPipelineContext(0, true, true).addDriverContext())) {
-            // build LookupSource
-
+        try (OperatorFactory joinOperatorFactory = innerJoinOperatorFactory(lookupSourceFactory, probePages, joinSpillerFactory);
+                Operator joinOperator = joinOperatorFactory.createOperator(joinDriverContext)) {
+            // build lookup source
             ListenableFuture<LookupSourceProvider> lookupSourceProvider = buildSideSetup.getLookupSourceFactory().createLookupSourceProvider();
             List<Boolean> revoked = new ArrayList<>(nCopies(buildOperatorCount, false));
             while (!lookupSourceProvider.isDone()) {
                 for (int i = 0; i < buildOperatorCount; i++) {
+                    checkErrors(taskStateMachine);
                     buildDrivers.get(i).process();
                     HashBuilderOperator buildOperator = buildSideSetup.getBuildOperators().get(i);
                     if (whenSpill.get(i) == WhenSpill.DURING_BUILD && buildOperator.getOperatorContext().getReservedRevocableBytes() > 0) {
@@ -311,41 +405,66 @@ public class TestHashJoinOperator
                 runDriverInThread(executor, buildDriver);
             }
 
-            // process join
-            Iterator<Page> input = probePages.build().iterator();
-            List<Page> actualPages = new ArrayList<>();
-            actualPages.addAll(toPagesPartial(joinOperator, singletonIterator(input.next())));
+            ValuesOperatorFactory valuesOperatorFactory = new ValuesOperatorFactory(17, new PlanNodeId("values"), probePages.getTypes(), probePages.build());
+
+            PageBuffer pageBuffer = new PageBuffer(10);
+            PageBufferOperatorFactory pageBufferOperatorFactory = new PageBufferOperatorFactory(18, new PlanNodeId("pageBuffer"), pageBuffer);
+
+            Driver joinDriver = new Driver(
+                    joinDriverContext,
+                    valuesOperatorFactory.createOperator(joinDriverContext),
+                    joinOperator,
+                    pageBufferOperatorFactory.createOperator(joinDriverContext));
+
+            while (!called.get()) { // process first row of first page of LookupJoinOperator
+                processRow(joinDriver, taskStateMachine);
+            }
 
             for (int i = 0; i < buildOperatorCount; i++) {
                 if (whenSpill.get(i) == WhenSpill.DURING_USAGE) {
-                    checkState(input.hasNext(), "spill requested DURING_USAGE, but input is kind of exhausted");
-                    triggerMemoryRevokingAndWait(buildSideSetup.getBuildOperators().get(i));
+                    triggerMemoryRevokingAndWait(buildSideSetup.getBuildOperators().get(i), taskStateMachine);
                 }
             }
 
-            actualPages.addAll(toPages(joinOperator, input));
+            // process remaining LookupJoinOperator pages
+            while (!joinDriver.isFinished()) {
+                checkErrors(taskStateMachine);
+                processRow(joinDriver, taskStateMachine);
+            }
+            checkErrors(taskStateMachine);
 
-            // expected
+            List<Page> actualPages = getPages(pageBuffer);
+
             MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), concat(probePages.getTypesWithoutHash(), buildPages.getTypesWithoutHash()))
-                    .row("20", 123_020L, "20", 200L)
-                    .row("21", 123_021L, "21", 201L)
-                    .row("22", 123_022L, "22", 202L)
-                    .row("23", 123_023L, "23", 203L)
+                    .row("20", 123_000L, "20", 200L)
+                    .row("20", 123_000L, "20", 200L)
+                    .row("20", 123_000L, "20", 200L)
+                    .row("20", 123_000L, "20", 200L)
                     .row("30", 123_000L, "30", 300L)
                     .row("31", 123_001L, "31", 301L)
                     .row("32", 123_002L, "32", 302L)
                     .row("33", 123_003L, "33", 303L)
                     .build();
 
-            List<Type> types = joinOperator.getTypes();
-            if (probePages.getHashChannel().isPresent()) {
-                List<Integer> hashChannels = ImmutableList.of(probePages.getHashChannel().get());
-                actualPages = dropChannel(actualPages, hashChannels);
-                types = without(types, hashChannels);
-            }
+            assertEqualsIgnoreOrder(getProperColumns(joinOperator, probePages, actualPages).getMaterializedRows(), expected.getMaterializedRows());
+        }
+    }
 
-            MaterializedResult actual = OperatorAssertion.toMaterializedResult(joinOperator.getOperatorContext().getSession(), types, actualPages);
-            assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    private static void processRow(final Driver joinDriver, final TaskStateMachine taskStateMachine)
+            throws Exception
+    {
+        joinDriver.getDriverContext().getYieldSignal().setWithDelay(TimeUnit.SECONDS.toNanos(1), joinDriver.getDriverContext().getYieldExecutor());
+        joinDriver.process();
+        joinDriver.getDriverContext().getYieldSignal().reset();
+        checkErrors(taskStateMachine);
+    }
+
+    private static void checkErrors(TaskStateMachine taskStateMachine)
+            throws Exception
+    {
+        if (taskStateMachine.getFailureCauses().size() > 0) {
+            Throwable exception = requireNonNull(taskStateMachine.getFailureCauses().peek());
+            throw new RuntimeException(exception.getMessage(), exception);
         }
     }
 
@@ -356,20 +475,40 @@ public class TestHashJoinOperator
         checkState(operator.getState() == HashBuilderOperator.State.SPILLING_INPUT || operator.getState() == HashBuilderOperator.State.INPUT_SPILLED);
     }
 
-    private static void triggerMemoryRevokingAndWait(HashBuilderOperator operator)
-            throws InterruptedException
+    private static void triggerMemoryRevokingAndWait(HashBuilderOperator operator, TaskStateMachine taskStateMachine)
+            throws Exception
     {
         // When there is background thread running Driver, we must delegate memory revoking to that thread
         operator.getOperatorContext().requestMemoryRevoking();
         while (operator.getOperatorContext().isMemoryRevokingRequested()) {
+            checkErrors(taskStateMachine);
             Thread.sleep(10);
         }
+        checkErrors(taskStateMachine);
         checkState(operator.getState() == HashBuilderOperator.State.SPILLING_INPUT || operator.getState() == HashBuilderOperator.State.INPUT_SPILLED);
     }
 
-    private static <T> List<T> concat(List<T> initialElements, List<T> moreElements)
+    private static List<Page> getPages(PageBuffer pageBuffer)
     {
-        return ImmutableList.copyOf(Iterables.concat(initialElements, moreElements));
+        List<Page> result = new ArrayList<>();
+
+        Page page = pageBuffer.poll();
+        while (page != null) {
+            result.add(page);
+            page = pageBuffer.poll();
+        }
+        return result;
+    }
+
+    private static MaterializedResult getProperColumns(Operator joinOperator, RowPagesBuilder probePages, List<Page> actualPages)
+    {
+        List<Type> types = joinOperator.getTypes();
+        if (probePages.getHashChannel().isPresent()) {
+            List<Integer> hashChannels = ImmutableList.of(probePages.getHashChannel().get());
+            actualPages = dropChannel(actualPages, hashChannels);
+            types = without(types, hashChannels);
+        }
+        return OperatorAssertion.toMaterializedResult(joinOperator.getOperatorContext().getSession(), types, actualPages);
     }
 
     @Test(dataProvider = "hashEnabledValues")
@@ -879,7 +1018,7 @@ public class TestHashJoinOperator
             RowPagesBuilder buildPages,
             Optional<InternalJoinFilterFunction> filterFunction)
     {
-        BuildSideSetup buildSideSetup = setupBuildSide(parallelBuild, taskContext, hashChannels, buildPages, filterFunction, false);
+        BuildSideSetup buildSideSetup = setupBuildSide(parallelBuild, taskContext, hashChannels, buildPages, filterFunction, false, SINGLE_STREAM_SPILLER_FACTORY);
         buildLookupSource(buildSideSetup);
         return buildSideSetup.getLookupSourceFactory();
     }
@@ -890,7 +1029,8 @@ public class TestHashJoinOperator
             List<Integer> hashChannels,
             RowPagesBuilder buildPages,
             Optional<InternalJoinFilterFunction> filterFunction,
-            boolean spillEnabled)
+            boolean spillEnabled,
+            SingleStreamSpillerFactory singleStreamSpillerFactory)
     {
         Optional<JoinFilterFunctionFactory> filterFunctionFactory = filterFunction
                 .map(function -> (session, addresses, channels) -> new StandardJoinFilterFunction(function, addresses, channels));
@@ -933,7 +1073,7 @@ public class TestHashJoinOperator
                 partitionCount,
                 new PagesIndex.TestingFactory(),
                 spillEnabled,
-                SINGLE_STREAM_SPILLER_FACTORY);
+                singleStreamSpillerFactory);
         PipelineContext buildPipeline = taskContext.addPipelineContext(1, true, true);
 
         List<Driver> buildDrivers = new ArrayList<>();
@@ -978,7 +1118,13 @@ public class TestHashJoinOperator
     {
         executor.execute(() -> {
             if (!driver.isFinished()) {
-                driver.process();
+                try {
+                    driver.process();
+                }
+                catch (PrestoException e) {
+                    driver.getDriverContext().failed(e);
+                    throw e;
+                }
                 runDriverInThread(executor, driver);
             }
         });
@@ -995,6 +1141,22 @@ public class TestHashJoinOperator
         return IntStream.range(0, endExclusive)
                 .boxed()
                 .collect(toImmutableList());
+    }
+
+    private static <T> List<List<T>> product(List<List<T>> left, List<List<T>> right)
+    {
+        List<List<T>> result = new ArrayList<>();
+        for (List<T> l : left) {
+            for (List<T> r : right) {
+                result.add(concat(l, r));
+            }
+        }
+        return result;
+    }
+
+    private static <T> List<T> concat(List<T> initialElements, List<T> moreElements)
+    {
+        return ImmutableList.copyOf(Iterables.concat(initialElements, moreElements));
     }
 
     private static class BuildSideSetup
@@ -1052,6 +1214,19 @@ public class TestHashJoinOperator
     private static class DummySpillerFactory
             implements SingleStreamSpillerFactory
     {
+        private volatile boolean failSpill;
+        private volatile boolean failUnspill;
+
+        void failSpill()
+        {
+            failSpill = true;
+        }
+
+        void failUnspill()
+        {
+            failUnspill = true;
+        }
+
         @Override
         public SingleStreamSpiller create(List<Type> types, SpillContext spillContext, LocalMemoryContext memoryContext)
         {
@@ -1064,6 +1239,9 @@ public class TestHashJoinOperator
                 public ListenableFuture<?> spill(Iterator<Page> pageIterator)
                 {
                     checkState(writing, "writing already finished");
+                    if (failSpill) {
+                        return immediateFailedFuture(new PrestoException(GENERIC_INTERNAL_ERROR, "Spill failed"));
+                    }
                     Iterators.addAll(spills, pageIterator);
                     return immediateFuture(null);
                 }
@@ -1071,6 +1249,9 @@ public class TestHashJoinOperator
                 @Override
                 public Iterator<Page> getSpilledPages()
                 {
+                    if (failUnspill) {
+                        throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unspill failed");
+                    }
                     writing = false;
                     return unmodifiableIterator(spills.iterator());
                 }
@@ -1086,6 +1267,9 @@ public class TestHashJoinOperator
                 @Override
                 public ListenableFuture<List<Page>> getAllSpilledPages()
                 {
+                    if (failUnspill) {
+                        return immediateFailedFuture(new PrestoException(GENERIC_INTERNAL_ERROR, "Unspill failed"));
+                    }
                     writing = false;
                     return immediateFuture(ImmutableList.copyOf(spills));
                 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
@@ -20,6 +20,7 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.operator.SyntheticAddress.encodeSyntheticAddress;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -310,7 +311,7 @@ public class TestPositionLinks
                 ImmutableList.of(),
                 ImmutableList.of(ImmutableList.of(TEST_PAGE.getBlock(0))),
                 ImmutableList.of(),
-                Optional.empty(),
+                OptionalInt.empty(),
                 Optional.of(0));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/exchange/TestLocalExchange.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/exchange/TestLocalExchange.java
@@ -412,7 +412,7 @@ public class TestLocalExchange
 
         LocalPartitionGenerator partitionGenerator = new LocalPartitionGenerator(new InterpretedHashGenerator(TYPES, new int[] {0}), partitionCount);
         for (int position = 0; position < page.getPositionCount(); position++) {
-            assertEquals(partitionGenerator.getPartition(position, page), partition);
+            assertEquals(partitionGenerator.getPartition(page, position), partition);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpiller.java
@@ -33,6 +33,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.util.Iterator;
 import java.util.List;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -81,14 +82,16 @@ public class TestFileSingleStreamSpiller
         // for spilling memory should be accounted only during spill() method is executing
         assertEquals(memoryContext.getBytes(), 0);
 
-        ImmutableList<Page> spilledPages = ImmutableList.copyOf(spiller.getSpilledPages());
+        Iterator<Page> spilledPagesIterator = spiller.getSpilledPages();
+        assertEquals(memoryContext.getBytes(), FileSingleStreamSpiller.BUFFER_SIZE);
+        ImmutableList<Page> spilledPages = ImmutableList.copyOf(spilledPagesIterator);
+        assertEquals(memoryContext.getBytes(), 0);
 
         assertEquals(4, spilledPages.size());
         for (int i = 0; i < 4; ++i) {
             PageAssertions.assertPageEquals(TYPES, page, spilledPages.get(i));
         }
 
-        assertEquals(memoryContext.getBytes(), FileSingleStreamSpiller.BUFFER_SIZE);
         spiller.close();
         assertEquals(listFiles(spillPath.toPath()).size(), 0);
         assertEquals(memoryContext.getBytes(), 0);

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spiller;
+
+import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.SequencePageBuilder;
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.memory.AggregatedMemoryContext;
+import com.facebook.presto.operator.PartitionFunction;
+import com.facebook.presto.operator.SpillContext;
+import com.facebook.presto.operator.TestingOperatorContext;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.PartitioningSpiller.PartitioningSpillResult;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.IntPredicate;
+
+import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static java.lang.Math.toIntExact;
+import static java.nio.file.Files.createTempDirectory;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestGenericPartitioningSpiller
+{
+    private static final int FIRST_PARTITION_START = -10;
+    private static final int SECOND_PARTITION_START = 0;
+    private static final int THIRD_PARTITION_START = 10;
+    private static final int FOURTH_PARTITION_START = 20;
+
+    private static final List<Type> TYPES = ImmutableList.of(BIGINT, VARCHAR, DOUBLE, BIGINT);
+    private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager(new TypeRegistry(ImmutableSet.of(BIGINT, DOUBLE, VARBINARY)));
+
+    private Path tempDirectory;
+    private SingleStreamSpillerFactory singleStreamSpillerFactory;
+    private GenericPartitioningSpillerFactory factory;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        tempDirectory = createTempDirectory(getClass().getSimpleName());
+        FeaturesConfig featuresConfig = new FeaturesConfig();
+        featuresConfig.setSpillerSpillPaths(tempDirectory.toString());
+        featuresConfig.setSpillerThreads(8);
+        singleStreamSpillerFactory = new FileSingleStreamSpillerFactory(blockEncodingSerde, new SpillerStats(), featuresConfig);
+        factory = new GenericPartitioningSpillerFactory(singleStreamSpillerFactory);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        deleteRecursively(tempDirectory, ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testFileSpiller()
+            throws Exception
+    {
+        try (PartitioningSpiller spiller = factory.create(
+                TYPES,
+                new FourFixedPartitionsPartitionFunction(0),
+                mockSpillContext(),
+                mockMemoryContext())) {
+            RowPagesBuilder builder = RowPagesBuilder.rowPagesBuilder(TYPES);
+            builder.addSequencePage(10, SECOND_PARTITION_START, 5, 10, 15);
+            builder.addSequencePage(10, FIRST_PARTITION_START, -5, 0, 5);
+
+            List<Page> firstSpill = builder.build();
+
+            builder = RowPagesBuilder.rowPagesBuilder(TYPES);
+            builder.addSequencePage(10, THIRD_PARTITION_START, 15, 20, 25);
+            builder.addSequencePage(10, FOURTH_PARTITION_START, 25, 30, 35);
+
+            List<Page> secondSpill = builder.build();
+
+            IntPredicate spillPartitionMask = ImmutableSet.of(1, 2)::contains;
+            PartitioningSpillResult result = spiller.partitionAndSpill(firstSpill.get(0), spillPartitionMask);
+            result.getSpillingFuture().get();
+            assertEquals(result.getRetained().getPositionCount(), 0);
+
+            result = spiller.partitionAndSpill(firstSpill.get(1), spillPartitionMask);
+            result.getSpillingFuture().get();
+            assertEquals(result.getRetained().getPositionCount(), 10);
+
+            result = spiller.partitionAndSpill(secondSpill.get(0), spillPartitionMask);
+            result.getSpillingFuture().get();
+            assertEquals(result.getRetained().getPositionCount(), 0);
+
+            result = spiller.partitionAndSpill(secondSpill.get(1), spillPartitionMask);
+            result.getSpillingFuture().get();
+            assertEquals(result.getRetained().getPositionCount(), 10);
+
+            builder = RowPagesBuilder.rowPagesBuilder(TYPES);
+            builder.addSequencePage(10, SECOND_PARTITION_START, 5, 10, 15);
+
+            List<Page> secondPartition = builder.build();
+
+            builder = RowPagesBuilder.rowPagesBuilder(TYPES);
+            builder.addSequencePage(10, THIRD_PARTITION_START, 15, 20, 25);
+
+            List<Page> thirdPartition = builder.build();
+
+            assertSpilledPages(
+                    TYPES,
+                    spiller,
+                    ImmutableList.of(ImmutableList.of(), secondPartition, thirdPartition, ImmutableList.of()));
+        }
+    }
+
+    @Test
+    public void testCloseDuringReading()
+            throws Exception
+    {
+        Iterator<Page> readingInProgress;
+        try (PartitioningSpiller spiller = factory.create(
+                TYPES,
+                new ModuloPartitionFunction(0, 4),
+                mockSpillContext(),
+                mockMemoryContext())) {
+            Page page = SequencePageBuilder.createSequencePage(TYPES, 10, FIRST_PARTITION_START, 5, 10, 15);
+            PartitioningSpillResult spillResult = spiller.partitionAndSpill(page, partition -> true);
+            assertEquals(spillResult.getRetained().getPositionCount(), 0);
+            getFutureValue(spillResult.getSpillingFuture());
+
+            // We get the iterator but we do not exhaust it, so that close happens during reading
+            readingInProgress = spiller.getSpilledPages(0);
+        }
+
+        try {
+            readingInProgress.hasNext();
+            fail("Iterator.hasNext() should fail since underlying resources are closed");
+        }
+        catch (UncheckedIOException ignored) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testWriteManyPartitions()
+            throws Exception
+    {
+        List<Type> types = ImmutableList.of(BIGINT);
+        int partitionCount = 4;
+        AggregatedMemoryContext memoryContext = mockMemoryContext();
+
+        try (GenericPartitioningSpiller spiller = (GenericPartitioningSpiller) factory.create(
+                types,
+                new ModuloPartitionFunction(0, partitionCount),
+                mockSpillContext(),
+                memoryContext)) {
+            for (int i = 0; i < 50_000; i++) {
+                Page page = SequencePageBuilder.createSequencePage(types, partitionCount, 0);
+                PartitioningSpillResult spillResult = spiller.partitionAndSpill(page, partition -> true);
+                assertEquals(spillResult.getRetained().getPositionCount(), 0);
+                getFutureValue(spillResult.getSpillingFuture());
+                getFutureValue(spiller.flush());
+                assertEquals(memoryContext.getBytes(), 0, "Reserved bytes should be zeroed after spill completes");
+            }
+        }
+    }
+
+    private void assertSpilledPages(
+            List<Type> types,
+            PartitioningSpiller spiller,
+            List<List<Page>> expectedPartitions)
+    {
+        for (int partition = 0; partition < expectedPartitions.size(); partition++) {
+            List<Page> actualSpill = ImmutableList.copyOf(spiller.getSpilledPages(partition));
+            List<Page> expectedSpill = expectedPartitions.get(partition);
+
+            assertEquals(actualSpill.size(), expectedSpill.size());
+            for (int j = 0; j < actualSpill.size(); j++) {
+                assertPageEquals(types, actualSpill.get(j), expectedSpill.get(j));
+            }
+        }
+    }
+
+    private static AggregatedMemoryContext mockMemoryContext()
+    {
+        // It's important to use OperatorContext's system memory context, because it does additional bookkeeping.
+        return TestingOperatorContext.create()
+                .getSystemMemoryContext()
+                .newAggregatedMemoryContext();
+    }
+
+    private static SpillContext mockSpillContext()
+    {
+        return bytes -> {};
+    }
+
+    private static class FourFixedPartitionsPartitionFunction
+            implements PartitionFunction
+    {
+        private final int valueChannel;
+
+        FourFixedPartitionsPartitionFunction(int valueChannel)
+        {
+            this.valueChannel = valueChannel;
+        }
+
+        @Override
+        public int getPartitionCount()
+        {
+            return 4;
+        }
+
+        @Override
+        public int getPartition(Page page, int position)
+        {
+            long value = page.getBlock(valueChannel).getLong(position, 0);
+            if (value >= FOURTH_PARTITION_START) {
+                return 3;
+            }
+            if (value >= THIRD_PARTITION_START) {
+                return 2;
+            }
+            if (value >= SECOND_PARTITION_START) {
+                return 1;
+            }
+            return 0;
+        }
+    }
+
+    private static class ModuloPartitionFunction
+            implements PartitionFunction
+    {
+        private final int valueChannel;
+        private final int partitionCount;
+
+        ModuloPartitionFunction(int valueChannel, int partitionCount)
+        {
+            this.valueChannel = valueChannel;
+            checkArgument(partitionCount > 0);
+            this.partitionCount = partitionCount;
+        }
+
+        @Override
+        public int getPartitionCount()
+        {
+            return partitionCount;
+        }
+
+        @Override
+        public int getPartition(Page page, int position)
+        {
+            long value = page.getBlock(valueChannel).getLong(position, 0);
+            return toIntExact(Math.abs(value) % partitionCount);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinCompiler.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.block.BlockAssertions.assertBlockEquals;
 import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
@@ -68,14 +69,14 @@ public class TestJoinCompiler
                 BlockAssertions.createStringSequenceBlock(20, 30),
                 BlockAssertions.createStringSequenceBlock(15, 25));
 
-        Optional<Integer> hashChannel = Optional.empty();
+        OptionalInt hashChannel = OptionalInt.empty();
         List<List<Block>> channels = ImmutableList.of(channel);
         if (hashEnabled) {
             ImmutableList.Builder<Block> hashChannelBuilder = ImmutableList.builder();
             for (Block block : channel) {
                 hashChannelBuilder.add(TypeUtils.getHashBlock(joinTypes, block));
             }
-            hashChannel = Optional.of(1);
+            hashChannel = OptionalInt.of(1);
             channels = ImmutableList.of(channel, hashChannelBuilder.build());
         }
         PagesHashStrategy hashStrategy = pagesHashStrategyFactory.createPagesHashStrategy(channels, hashChannel);
@@ -170,7 +171,7 @@ public class TestJoinCompiler
                 BlockAssertions.createBooleanSequenceBlock(20, 30),
                 BlockAssertions.createBooleanSequenceBlock(15, 25));
 
-        Optional<Integer> hashChannel = Optional.empty();
+        OptionalInt hashChannel = OptionalInt.empty();
         ImmutableList<List<Block>> channels = ImmutableList.of(extraChannel, varcharChannel, longChannel, doubleChannel, booleanChannel, extraUnusedChannel);
         List<Block> precomputedHash = ImmutableList.of();
         if (hashEnabled) {
@@ -178,7 +179,7 @@ public class TestJoinCompiler
             for (int i = 0; i < 3; i++) {
                 hashChannelBuilder.add(TypeUtils.getHashBlock(joinTypes, varcharChannel.get(i), longChannel.get(i), doubleChannel.get(i), booleanChannel.get(i)));
             }
-            hashChannel = Optional.of(6);
+            hashChannel = OptionalInt.of(6);
             precomputedHash = hashChannelBuilder.build();
             channels = ImmutableList.of(extraChannel, varcharChannel, longChannel, doubleChannel, booleanChannel, extraUnusedChannel, precomputedHash);
             types = ImmutableList.of(VARCHAR, VARCHAR, BIGINT, DOUBLE, BOOLEAN, VARCHAR, BIGINT);

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
@@ -36,6 +36,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -108,7 +109,7 @@ public class TestJoinProbeCompiler
             }
         }
 
-        Optional<Integer> hashChannel = Optional.empty();
+        OptionalInt hashChannel = OptionalInt.empty();
         List<List<Block>> channels = ImmutableList.of(varcharChannel, extraUnusedDoubleChannel);
 
         if (hashEnabled) {
@@ -117,7 +118,7 @@ public class TestJoinProbeCompiler
                 hashChannelBuilder.add(TypeUtils.getHashBlock(ImmutableList.<Type>of(VARCHAR), block));
             }
             types = ImmutableList.of(VARCHAR, DOUBLE, BigintType.BIGINT);
-            hashChannel = Optional.of(2);
+            hashChannel = OptionalInt.of(2);
             channels = ImmutableList.of(varcharChannel, extraUnusedDoubleChannel, hashChannelBuilder.build());
             outputChannels = ImmutableList.of(0, 2);
             outputTypes = ImmutableList.of(VARCHAR, BigintType.BIGINT);

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestJoinProbeCompiler.java
@@ -145,7 +145,7 @@ public class TestJoinProbeCompiler
             page = new Page(page.getBlock(0), page.getBlock(1), TypeUtils.getHashBlock(ImmutableList.of(VARCHAR), page.getBlock(0)));
             outputPage = new Page(page.getBlock(0), page.getBlock(2));
         }
-        JoinProbe joinProbe = probeFactory.createJoinProbe(lookupSource, page);
+        JoinProbe joinProbe = probeFactory.createJoinProbe(page);
 
         // verify channel count
         assertEquals(joinProbe.getOutputChannelCount(), outputChannels.size());
@@ -157,7 +157,7 @@ public class TestJoinProbeCompiler
             pageBuilder.declarePosition();
             joinProbe.appendTo(pageBuilder);
 
-            assertEquals(joinProbe.getCurrentJoinPosition(), lookupSource.getJoinPosition(position, page, page));
+            assertEquals(joinProbe.getCurrentJoinPosition(lookupSource), lookupSource.getJoinPosition(position, page, page));
         }
         assertFalse(joinProbe.advanceNextPosition());
         assertPageEquals(outputTypes, pageBuilder.build(), outputPage);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConstantProperty.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConstantProperty.java
@@ -35,6 +35,12 @@ public final class ConstantProperty<E>
         this.column = requireNonNull(column, "column is null");
     }
 
+    @Override
+    public boolean isOrderSensitive()
+    {
+        return false;
+    }
+
     @JsonProperty
     public E getColumn()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/GroupingProperty.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/GroupingProperty.java
@@ -40,6 +40,12 @@ public final class GroupingProperty<E>
         this.columns = Collections.unmodifiableSet(new HashSet<>(columns));
     }
 
+    @Override
+    public boolean isOrderSensitive()
+    {
+        return true;
+    }
+
     @JsonProperty
     public Set<E> getColumns()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/LocalProperty.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/LocalProperty.java
@@ -34,6 +34,11 @@ public interface LocalProperty<E>
     <T> Optional<LocalProperty<T>> translate(Function<E, Optional<T>> translator);
 
     /**
+     * Returns true if reordering breaks this LocalProperty
+     */
+    boolean isOrderSensitive();
+
+    /**
      * Return true if the actual LocalProperty can be used to simplify this LocalProperty
      */
     boolean isSimplifiedBy(LocalProperty<E> actual);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
@@ -252,12 +252,11 @@ public class Page
         return blocks[0].getPositionCount();
     }
 
-    public static Page mask(Page page, int[] retainedPositions)
+    public Page mask(int[] retainedPositions)
     {
-        requireNonNull(page, "page is null");
         requireNonNull(retainedPositions, "retainedPositions is null");
 
-        Block[] blocks = Arrays.stream(page.getBlocks())
+        Block[] blocks = Arrays.stream(this.getBlocks())
                 .map(block -> new DictionaryBlock(block, retainedPositions))
                 .toArray(Block[]::new);
         return new Page(retainedPositions.length, blocks);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SortingProperty.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SortingProperty.java
@@ -43,6 +43,12 @@ public final class SortingProperty<E>
         this.order = order;
     }
 
+    @Override
+    public boolean isOrderSensitive()
+    {
+        return true;
+    }
+
     @JsonProperty
     public E getColumn()
     {


### PR DESCRIPTION
Supersedes #8166.

Spill for join using revocable memory. Fixes #5897.