### PR TITLE
Yield HashAggregationOperator if rehash will exceed memory limit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/GroupByHashPageIndexer.java
+++ b/presto-main/src/main/java/com/facebook/presto/GroupByHashPageIndexer.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
+import static com.facebook.presto.operator.UpdateMemory.NOOP;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -40,7 +41,8 @@ public class GroupByHashPageIndexer
                 Optional.empty(),
                 20,
                 false,
-                joinCompiler));
+                joinCompiler,
+                NOOP));
     }
 
     public GroupByHashPageIndexer(GroupByHash hash)

--- a/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.BigintOperators;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -202,6 +203,13 @@ public class BigintGroupByHash
         return BigintType.hash(valuesByGroupId.get(groupId));
     }
 
+    @VisibleForTesting
+    @Override
+    public int getCapacity()
+    {
+        return hashCapacity;
+    }
+
     private int putIfAbsent(int position, Block block)
     {
         if (block.isNull(position)) {
@@ -264,8 +272,7 @@ public class BigintGroupByHash
         preallocatedMemoryInBytes = (newCapacity - hashCapacity) * (long) (Long.BYTES + Integer.BYTES) + (calculateMaxFill(newCapacity) - maxFill) * Long.BYTES + currentPageSizeInBytes;
         if (!updateMemory.update()) {
             // reserved memory but has exceeded the limit
-            // TODO enable this
-            // return false;
+            return false;
         }
         preallocatedMemoryInBytes = 0;
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
@@ -34,7 +34,6 @@ import static com.facebook.presto.type.TypeUtils.NULL_HASH_CODE;
 import static com.facebook.presto.util.HashCollisionsEstimator.estimateNumberOfHashCollisions;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
 import static it.unimi.dsi.fastutil.HashCommon.murmurHash3;
 import static java.lang.Math.toIntExact;
@@ -158,23 +157,17 @@ public class BigintGroupByHash
     }
 
     @Override
-    public void addPage(Page page)
+    public Work<?> addPage(Page page)
     {
         currentPageSizeInBytes = page.getRetainedSizeInBytes();
-        boolean done = new AddPageWork(page.getBlock(hashChannel)).process();
-        // TODO: (1) change the interface and (2) remove this with yield enabled
-        verify(done);
+        return new AddPageWork(page.getBlock(hashChannel));
     }
 
     @Override
-    public GroupByIdBlock getGroupIds(Page page)
+    public Work<GroupByIdBlock> getGroupIds(Page page)
     {
         currentPageSizeInBytes = page.getRetainedSizeInBytes();
-        Work<GroupByIdBlock> work = new GetGroupIdsWork(page.getBlock(hashChannel));
-        boolean done = work.process();
-        // TODO: (1) change the interface and (2) remove this with yield enabled
-        verify(done);
-        return work.getResult();
+        return new GetGroupIdsWork(page.getBlock(hashChannel));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
@@ -203,13 +203,6 @@ public class BigintGroupByHash
     }
 
     @Override
-    public int putIfAbsent(int position, Page page)
-    {
-        Block block = page.getBlock(hashChannel);
-        return putIfAbsent(position, block);
-    }
-
-    @Override
     public long getRawHash(int groupId)
     {
         return BigintType.hash(valuesByGroupId.get(groupId));

--- a/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.google.common.base.Verify.verify;
 
 public class ChannelSet
 {
@@ -101,7 +102,10 @@ public class ChannelSet
 
         public void addPage(Page page)
         {
-            hash.addPage(page);
+            Work<?> work = hash.addPage(page);
+            boolean done = work.process();
+            // TODO: this class does not yield wrt memory limit; enable it
+            verify(done);
 
             if (operatorContext != null) {
                 operatorContext.setMemoryReservation(hash.getEstimatedSize());

--- a/presto-main/src/main/java/com/facebook/presto/operator/DistinctLimitOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DistinctLimitOperator.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class DistinctLimitOperator
@@ -166,7 +167,11 @@ public class DistinctLimitOperator
 
         pageBuilder.reset();
 
-        GroupByIdBlock ids = groupByHash.getGroupIds(page);
+        Work<GroupByIdBlock> work = groupByHash.getGroupIds(page);
+        boolean done = work.process();
+        // TODO: this class does not yield wrt memory limit; enable it
+        verify(done);
+        GroupByIdBlock ids = work.getResult();
         for (int position = 0; position < ids.getPositionCount(); position++) {
             if (ids.getGroupId(position) == nextDistinctId) {
                 pageBuilder.declarePosition();

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
@@ -70,7 +70,5 @@ public interface GroupByHash
 
     boolean contains(int position, Page page, int[] hashChannels);
 
-    int putIfAbsent(int position, Page page);
-
     long getRawHash(int groupyId);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
@@ -66,9 +66,9 @@ public interface GroupByHash
 
     void appendValuesTo(int groupId, PageBuilder pageBuilder, int outputChannelOffset);
 
-    void addPage(Page page);
+    Work<?> addPage(Page page);
 
-    GroupByIdBlock getGroupIds(Page page);
+    Work<GroupByIdBlock> getGroupIds(Page page);
 
     boolean contains(int position, Page page, int[] hashChannels);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
+import com.google.common.annotations.VisibleForTesting;
 
 import java.util.List;
 import java.util.Optional;
@@ -73,4 +74,7 @@ public interface GroupByHash
     boolean contains(int position, Page page, int[] hashChannels);
 
     long getRawHash(int groupyId);
+
+    @VisibleForTesting
+    int getCapacity();
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.isDictionaryAggregationEnabled;
+import static com.facebook.presto.operator.UpdateMemory.NOOP;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 
 public interface GroupByHash
@@ -35,7 +36,7 @@ public interface GroupByHash
             int expectedSize,
             JoinCompiler joinCompiler)
     {
-        return createGroupByHash(hashTypes, hashChannels, inputHashChannel, expectedSize, isDictionaryAggregationEnabled(session), joinCompiler);
+        return createGroupByHash(hashTypes, hashChannels, inputHashChannel, expectedSize, isDictionaryAggregationEnabled(session), joinCompiler, NOOP);
     }
 
     static GroupByHash createGroupByHash(
@@ -44,12 +45,13 @@ public interface GroupByHash
             Optional<Integer> inputHashChannel,
             int expectedSize,
             boolean processDictionary,
-            JoinCompiler joinCompiler)
+            JoinCompiler joinCompiler,
+            UpdateMemory updateMemory)
     {
         if (hashTypes.size() == 1 && hashTypes.get(0).equals(BIGINT) && hashChannels.length == 1) {
-            return new BigintGroupByHash(hashChannels[0], inputHashChannel.isPresent(), expectedSize);
+            return new BigintGroupByHash(hashChannels[0], inputHashChannel.isPresent(), expectedSize, updateMemory);
         }
-        return new MultiChannelGroupByHash(hashTypes, hashChannels, inputHashChannel, expectedSize, processDictionary, joinCompiler);
+        return new MultiChannelGroupByHash(hashTypes, hashChannels, inputHashChannel, expectedSize, processDictionary, joinCompiler, updateMemory);
     }
 
     long getEstimatedSize();

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.operator.aggregation.builder.InMemoryHashAggre
 import static com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer.INITIAL_HASH_VALUE;
 import static com.facebook.presto.type.TypeUtils.NULL_HASH_CODE;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 
@@ -375,7 +376,8 @@ public class HashAggregationOperator
                         hashChannel,
                         operatorContext,
                         maxPartialMemory,
-                        joinCompiler);
+                        joinCompiler,
+                        true);
             }
             else {
                 aggregationBuilder = new SpillableHashAggregationBuilder(
@@ -397,7 +399,9 @@ public class HashAggregationOperator
         else {
             checkState(!aggregationBuilder.isFull(), "Aggregation buffer is full");
         }
-        aggregationBuilder.processPage(page);
+        boolean done = aggregationBuilder.processPage(page).process();
+        // TODO: enable yield and remove this
+        verify(done);
         aggregationBuilder.updateMemory();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctHash.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.google.common.base.Verify.verify;
 
 public class MarkDistinctHash
 {
@@ -49,7 +50,11 @@ public class MarkDistinctHash
 
     public Block markDistinctRows(Page page)
     {
-        GroupByIdBlock ids = groupByHash.getGroupIds(page);
+        Work<GroupByIdBlock> work = groupByHash.getGroupIds(page);
+        boolean done = work.process();
+        // TODO: this class does not yield wrt memory limit; enable it
+        verify(done);
+        GroupByIdBlock ids = work.getResult();
         BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), ids.getPositionCount());
         for (int i = 0; i < ids.getPositionCount(); i++) {
             if (ids.getGroupId(i) == nextDistinctId) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
@@ -241,6 +242,13 @@ public class MultiChannelGroupByHash
         return false;
     }
 
+    @VisibleForTesting
+    @Override
+    public int getCapacity()
+    {
+        return hashCapacity;
+    }
+
     private int putIfAbsent(int position, Page page)
     {
         long rawHash = hashGenerator.hashPosition(position, page);
@@ -343,8 +351,7 @@ public class MultiChannelGroupByHash
                 currentPageSizeInBytes;
         if (!updateMemory.update()) {
             // reserved memory but has exceeded the limit
-            // TODO enable this
-            // return false;
+            return false;
         }
         preallocatedMemoryInBytes = 0;
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -254,8 +254,7 @@ public class MultiChannelGroupByHash
         return false;
     }
 
-    @Override
-    public int putIfAbsent(int position, Page page)
+    private int putIfAbsent(int position, Page page)
     {
         long rawHash = hashGenerator.hashPosition(position, page);
         return putIfAbsent(position, page, rawHash);

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -209,38 +209,17 @@ public class MultiChannelGroupByHash
     }
 
     @Override
-    public void addPage(Page page)
+    public Work<?> addPage(Page page)
     {
         currentPageSizeInBytes = page.getRetainedSizeInBytes();
-        if (canProcessDictionary(page)) {
-            boolean done = new AddDictionaryPageWork(page).process();
-            // TODO: (1) change the interface and (2) remove this with yield enabled
-            verify(done);
-            return;
-        }
-
-        boolean done = new AddNonDictionaryPageWork(page).process();
-        // TODO: (1) change the interface and (2) remove this with yield enabled
-        verify(done);
+        return canProcessDictionary(page) ? new AddDictionaryPageWork(page) : new AddNonDictionaryPageWork(page);
     }
 
     @Override
-    public GroupByIdBlock getGroupIds(Page page)
+    public Work<GroupByIdBlock> getGroupIds(Page page)
     {
         currentPageSizeInBytes = page.getRetainedSizeInBytes();
-        if (canProcessDictionary(page)) {
-            Work<GroupByIdBlock> work = new GetDictionaryGroupIdsWork(page);
-            boolean done = work.process();
-            // TODO: (1) change the interface and (2) remove this with yield enabled
-            verify(done);
-            return work.getResult();
-        }
-
-        Work<GroupByIdBlock> work = new GetNonDictionaryGroupIdsWork(page);
-        boolean done = work.process();
-        // TODO: (1) change the interface and (2) remove this with yield enabled
-        verify(done);
-        return work.getResult();
+        return canProcessDictionary(page) ? new GetDictionaryGroupIdsWork(page) : new GetNonDictionaryGroupIdsWork(page);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/RowNumberOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RowNumberOperator.java
@@ -32,6 +32,7 @@ import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class RowNumberOperator
@@ -210,7 +211,11 @@ public class RowNumberOperator
         checkState(inputPage == null);
         inputPage = page;
         if (groupByHash.isPresent()) {
-            partitionIds = groupByHash.get().getGroupIds(inputPage);
+            Work<GroupByIdBlock> work = groupByHash.get().getGroupIds(inputPage);
+            boolean done = work.process();
+            // TODO: this class does not yield wrt memory limit; enable it
+            verify(done);
+            partitionIds = work.getResult();
             partitionRowCount.ensureCapacity(partitionIds.getGroupCount());
         }
         operatorContext.setMemoryReservation(getEstimatedByteSize());

--- a/presto-main/src/main/java/com/facebook/presto/operator/UpdateMemory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/UpdateMemory.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+public interface UpdateMemory
+{
+    UpdateMemory NOOP = () -> true;
+
+    /**
+     * Update memory reservation.
+     *
+     * @return false if the caller should yield because requested memory reservation cannot be satisfied
+     */
+    boolean update();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/Work.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Work.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+/**
+ * The interface is used when a function call needs to yield/pause during the process.
+ * Users need to call {@link #process()} until it returns True before getting the result.
+ */
+public interface Work<T>
+{
+    /**
+     * Call the method to do the work.
+     * The caller can keep calling this method until it returns true (i.e., the work is done).
+     * @return boolean to indicate if the work has finished.
+     */
+    boolean process();
+
+    /**
+     * Get the result once the work is done.
+     */
+    T getResult();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/HashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/HashAggregationBuilder.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.aggregation.builder;
 
 import com.facebook.presto.operator.HashCollisionsCounter;
+import com.facebook.presto.operator.Work;
 import com.facebook.presto.spi.Page;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -22,7 +23,7 @@ import java.util.Iterator;
 public interface HashAggregationBuilder
         extends AutoCloseable
 {
-    void processPage(Page page);
+    Work<?> processPage(Page page);
 
     Iterator<Page> buildResult();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
@@ -265,6 +266,12 @@ public class InMemoryHashAggregationBuilder
             types.add(aggregator.getIntermediateType());
         }
         return types;
+    }
+
+    @VisibleForTesting
+    public int getCapacity()
+    {
+        return groupByHash.getCapacity();
     }
 
     private Iterator<Page> buildResult(IntIterator groupIds)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation.builder;
 import com.facebook.presto.operator.HashCollisionsCounter;
 import com.facebook.presto.operator.MergeHashSort;
 import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.Work;
 import com.facebook.presto.operator.aggregation.AccumulatorFactory;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.Type;
@@ -93,11 +94,12 @@ public class SpillableHashAggregationBuilder
     }
 
     @Override
-    public void processPage(Page page)
+    public Work<?> processPage(Page page)
     {
         checkState(hasPreviousSpillCompletedSuccessfully(), "Previous spill hasn't yet finished");
-
-        hashAggregationBuilder.processPage(page);
+        // hashAggregationBuilder is constructed with yieldForMemoryReservation = false
+        // Therefore the processing of the returned Work should always be true
+        return hashAggregationBuilder.processPage(page);
     }
 
     @Override
@@ -284,7 +286,8 @@ public class SpillableHashAggregationBuilder
                 hashChannel,
                 operatorContext,
                 DataSize.succinctBytes(0),
-                joinCompiler);
+                joinCompiler,
+                false);
         emptyHashAggregationBuilderSize = hashAggregationBuilder.getSizeInMemory();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/UnloadedIndexKeyRecordSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/UnloadedIndexKeyRecordSet.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.index;
 import com.facebook.presto.Session;
 import com.facebook.presto.operator.GroupByHash;
 import com.facebook.presto.operator.GroupByIdBlock;
+import com.facebook.presto.operator.Work;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
@@ -39,6 +40,7 @@ import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
 import static com.facebook.presto.operator.index.IndexSnapshot.UNLOADED_INDEX_KEY;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class UnloadedIndexKeyRecordSet
@@ -79,7 +81,11 @@ public class UnloadedIndexKeyRecordSet
             }
 
             // Move through the positions while advancing the cursors in lockstep
-            GroupByIdBlock groupIds = groupByHash.getGroupIds(new Page(distinctBlocks));
+            Work<GroupByIdBlock> work = groupByHash.getGroupIds(new Page(distinctBlocks));
+            boolean done = work.process();
+            // TODO: this class does not yield wrt memory limit; enable it
+            verify(done);
+            GroupByIdBlock groupIds = work.getResult();
             int positionCount = blocks[0].getPositionCount();
             long nextDistinctId = -1;
             checkArgument(groupIds.getGroupCount() <= Integer.MAX_VALUE);

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.operator.UpdateMemory.NOOP;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
 
@@ -70,7 +71,7 @@ public class BenchmarkGroupByHash
     @OperationsPerInvocation(POSITIONS)
     public Object groupByHashPreCompute(BenchmarkData data)
     {
-        GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), data.getHashChannel(), EXPECTED_SIZE, false, JOIN_COMPILER);
+        GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), data.getHashChannel(), EXPECTED_SIZE, false, JOIN_COMPILER, NOOP);
         data.getPages().forEach(groupByHash::getGroupIds);
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
@@ -91,7 +92,7 @@ public class BenchmarkGroupByHash
     @OperationsPerInvocation(POSITIONS)
     public Object addPagePreCompute(BenchmarkData data)
     {
-        GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), data.getHashChannel(), EXPECTED_SIZE, false, JOIN_COMPILER);
+        GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), data.getHashChannel(), EXPECTED_SIZE, false, JOIN_COMPILER, NOOP);
         data.getPages().forEach(groupByHash::addPage);
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
@@ -112,7 +113,7 @@ public class BenchmarkGroupByHash
     @OperationsPerInvocation(POSITIONS)
     public Object bigintGroupByHash(SingleChannelBenchmarkData data)
     {
-        GroupByHash groupByHash = new BigintGroupByHash(0, data.getHashEnabled(), EXPECTED_SIZE);
+        GroupByHash groupByHash = new BigintGroupByHash(0, data.getHashEnabled(), EXPECTED_SIZE, NOOP);
         data.getPages().forEach(groupByHash::addPage);
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
@@ -72,7 +72,7 @@ public class BenchmarkGroupByHash
     public Object groupByHashPreCompute(BenchmarkData data)
     {
         GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), data.getHashChannel(), EXPECTED_SIZE, false, JOIN_COMPILER, NOOP);
-        data.getPages().forEach(groupByHash::getGroupIds);
+        data.getPages().forEach(p -> groupByHash.getGroupIds(p).process());
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         PageBuilder pageBuilder = new PageBuilder(groupByHash.getTypes());
@@ -93,7 +93,7 @@ public class BenchmarkGroupByHash
     public Object addPagePreCompute(BenchmarkData data)
     {
         GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), data.getHashChannel(), EXPECTED_SIZE, false, JOIN_COMPILER, NOOP);
-        data.getPages().forEach(groupByHash::addPage);
+        data.getPages().forEach(p -> groupByHash.addPage(p).process());
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         PageBuilder pageBuilder = new PageBuilder(groupByHash.getTypes());
@@ -114,7 +114,7 @@ public class BenchmarkGroupByHash
     public Object bigintGroupByHash(SingleChannelBenchmarkData data)
     {
         GroupByHash groupByHash = new BigintGroupByHash(0, data.getHashEnabled(), EXPECTED_SIZE, NOOP);
-        data.getPages().forEach(groupByHash::addPage);
+        data.getPages().forEach(p -> groupByHash.addPage(p).process());
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         PageBuilder pageBuilder = new PageBuilder(groupByHash.getTypes());

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -16,16 +16,23 @@ package com.facebook.presto.operator;
 import com.facebook.presto.ExceededMemoryLimitException;
 import com.facebook.presto.RowPagesBuilder;
 import com.facebook.presto.memory.AggregatedMemoryContext;
+import com.facebook.presto.memory.MemoryPool;
+import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.HashAggregationOperator.HashAggregationOperatorFactory;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.operator.aggregation.builder.HashAggregationBuilder;
+import com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder;
 import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.SpillSpaceTracker;
 import com.facebook.presto.spiller.Spiller;
 import com.facebook.presto.spiller.SpillerFactory;
 import com.facebook.presto.sql.gen.JoinCompiler;
@@ -57,6 +64,7 @@ import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEqualsIgnoreOrder;
 import static com.facebook.presto.operator.OperatorAssertion.dropChannel;
+import static com.facebook.presto.operator.OperatorAssertion.finishOperator;
 import static com.facebook.presto.operator.OperatorAssertion.toMaterializedResult;
 import static com.facebook.presto.operator.OperatorAssertion.toPages;
 import static com.facebook.presto.operator.OperatorAssertion.without;
@@ -75,7 +83,11 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.testing.Assertions.assertBetweenInclusive;
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
+import static io.airlift.testing.Assertions.assertGreaterThan;
+import static io.airlift.testing.Assertions.assertLessThan;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.airlift.units.DataSize.succinctBytes;
@@ -83,6 +95,8 @@ import static java.lang.String.format;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -125,6 +139,12 @@ public class TestHashAggregationOperator
                 {false, 0, 0},
                 {false, 8, 0},
                 {false, 8, Integer.MAX_VALUE}};
+    }
+
+    @DataProvider
+    public Object[][] dataType()
+    {
+        return new Object[][] {{VARCHAR}, {BIGINT}};
     }
 
     @AfterMethod
@@ -368,6 +388,154 @@ public class TestHashAggregationOperator
                 joinCompiler);
 
         toPages(operatorFactory, driverContext, input);
+    }
+
+    @Test(dataProvider = "dataType")
+    public void testMemoryReservationYield(Type type)
+    {
+        // create pages with sizes doubling so that we can enforce at least one rehash for every new page added
+        List<Integer> hashChannels = Ints.asList(0);
+        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(true, hashChannels, type);
+        int length = 500;
+        int expectedPositionCount = 0;
+        for (int i = 0; i < 5_000; i++) {
+            expectedPositionCount += length;
+            rowPagesBuilder.addSequencePage(length, length * i);
+        }
+        List<Page> input = rowPagesBuilder.build();
+
+        // mock an adjustable memory pool
+        QueryId queryId = new QueryId("test_query");
+        MemoryPool memoryPool = new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE));
+        QueryContext queryContext = new QueryContext(
+                queryId,
+                new DataSize(512, MEGABYTE),
+                memoryPool,
+                new MemoryPool(new MemoryPoolId("test-system"), new DataSize(512, MEGABYTE)),
+                executor,
+                scheduledExecutor,
+                new DataSize(512, MEGABYTE),
+                new SpillSpaceTracker(new DataSize(512, MEGABYTE)));
+
+        DriverContext driverContext = createTaskContext(queryContext, executor, TEST_SESSION)
+                .addPipelineContext(0, true, true)
+                .addDriverContext();
+
+        HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                ImmutableList.of(type),
+                hashChannels,
+                ImmutableList.of(),
+                Step.SINGLE,
+                ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty())),
+                rowPagesBuilder.getHashChannel(),
+                Optional.empty(),
+                1,
+                new DataSize(16, MEGABYTE),
+                joinCompiler);
+
+        // Pick a relatively small buffer for aggregator's memory usage
+        long maxAggregatorMemoryInBytes = 350_000;
+
+        // test operator behavior
+        int yieldCount = 0;
+        long expectedReservedExtraBytes = 0;
+        Operator operator = operatorFactory.createOperator(driverContext);
+        for (Page page : input) {
+            // unblocked
+            assertTrue(operator.needsInput());
+
+            // saturate the pool with a tiny memory left for aggregator (not GroupByHash)
+            long reservedMemoryInBytes = memoryPool.getFreeBytes() - maxAggregatorMemoryInBytes;
+            memoryPool.reserve(queryId, reservedMemoryInBytes);
+
+            long oldMemoryUsage = operator.getOperatorContext().getDriverContext().getMemoryUsage();
+            int oldCapacity = getHashCapacity(operator);
+
+            // add a page and verify different behaviors
+            operator.addInput(page);
+
+            long newMemoryUsage = operator.getOperatorContext().getDriverContext().getMemoryUsage();
+
+            // We are below the 1MB GUARANTEED_MEMORY limit (also need some buffer for aggregator).
+            // For such cases, the operator is blocked by memory
+            if (newMemoryUsage < (1 << 20) + maxAggregatorMemoryInBytes) {
+                // assert non-blocking
+                assertTrue(operator.needsInput());
+                assertTrue(operator.getOperatorContext().isWaitingForMemory().isDone());
+                // free the pool for the next iteration
+                memoryPool.free(queryId, reservedMemoryInBytes);
+                continue;
+            }
+
+            long actualIncreasedMemory = newMemoryUsage - oldMemoryUsage;
+
+            if (operator.needsInput()) {
+                // We have successfully added a page
+
+                // Assert we are not blocked
+                assertTrue(operator.getOperatorContext().isWaitingForMemory().isDone());
+
+                // assert the hash capacity is not changed; otherwise, we should have yielded
+                assertTrue(oldCapacity == getHashCapacity(operator));
+
+                // We are not going to rehash; therefore, assert the memory increase only comes from the aggregator
+                assertLessThan(actualIncreasedMemory, maxAggregatorMemoryInBytes);
+
+                // free the pool for the next iteration
+                memoryPool.free(queryId, reservedMemoryInBytes);
+            }
+            else {
+                // We failed to finish the page processing i.e. we yielded
+                yieldCount++;
+
+                // Assert we are blocked
+                assertFalse(operator.getOperatorContext().isWaitingForMemory().isDone());
+
+                // Hash table capacity should not change
+                assertEquals(oldCapacity, getHashCapacity(operator));
+
+                // Increased memory is no smaller than the hash table size and no greater than the hash table size + the memory used by aggregator
+                if (type == VARCHAR) {
+                    // groupAddressByHash, groupIdsByHash, and rawHashByHashPosition double by hashCapacity; while groupAddressByGroupId double by maxFill = hashCapacity / 0.75
+                    expectedReservedExtraBytes = oldCapacity * (long) (Long.BYTES * 1.75 + Integer.BYTES + Byte.BYTES) + page.getRetainedSizeInBytes();
+                }
+                else {
+                    // groupIds and values double by hashCapacity; while valuesByGroupId double by maxFill = hashCapacity / 0.75
+                    expectedReservedExtraBytes = oldCapacity * (long) (Long.BYTES * 1.75 + Integer.BYTES) + page.getRetainedSizeInBytes();
+                }
+                assertBetweenInclusive(actualIncreasedMemory, expectedReservedExtraBytes, expectedReservedExtraBytes + maxAggregatorMemoryInBytes);
+
+                // Output should be blocked as well
+                assertNull(operator.getOutput());
+
+                // Free the pool to unblock
+                memoryPool.free(queryId, reservedMemoryInBytes);
+
+                // Trigger a process
+                operator.getOutput();
+
+                // Hash table capacity has increased
+                assertGreaterThan(getHashCapacity(operator), oldCapacity);
+
+                // Assert the estimated reserved memory before rehash is very close to the one after rehash
+                long rehashedMemoryUsage = operator.getOperatorContext().getDriverContext().getMemoryUsage();
+                assertBetweenInclusive(rehashedMemoryUsage * 1.0 / newMemoryUsage, 0.99, 1.01);
+
+                // unblocked
+                assertTrue(operator.needsInput());
+            }
+        }
+        // Assert we both have yielded for couple of times
+        assertGreaterThan(yieldCount, 5);
+
+        // Assert expectedReservedExtraBytes >> maxAggregatorMemoryInBytes
+        assertGreaterThan(expectedReservedExtraBytes, 20L << 20);
+
+        // we have the same number of counts
+        int actualPositionCount = finishOperator(operator).stream().mapToInt(Page::getPositionCount).sum();
+        assertEquals(expectedPositionCount, actualPositionCount);
     }
 
     @Test(dataProvider = "hashEnabled", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 3MB")
@@ -634,6 +802,17 @@ public class TestHashAggregationOperator
                 .build()
                 .addPipelineContext(0, true, true)
                 .addDriverContext();
+    }
+
+    private static int getHashCapacity(Operator operator)
+    {
+        assertTrue(operator instanceof HashAggregationOperator);
+        HashAggregationBuilder aggregationBuilder = ((HashAggregationOperator) operator).getAggregationBuilder();
+        if (aggregationBuilder == null) {
+            return 0;
+        }
+        assertTrue(aggregationBuilder instanceof InMemoryHashAggregationBuilder);
+        return ((InMemoryHashAggregationBuilder) aggregationBuilder).getCapacity();
     }
 
     private static class DummySpillerFactory


### PR DESCRIPTION
Rehash can cause 2X memory increase in the worst case. It is dangerous to allocate a hash tabe then report memory usage. We could OOM before hitting the memory limit. In production, we found frequent full GCs due to large hash table allocation. This patch caches unfinished page in the operator if the operator needs to rehash the hash table when there is not enough memory. The operator will yield for memory allocation and retry rehashing once unblocked.


Some points worth mentioning:
- I didn't add a 10K limit before `addPage` or `getGroupIds` given the loop now is completed controlled by `Work`. `Work` can decide when to yield.
- I only added yield for `HashAggregationOperator` for now; for all other operators that use `GroupByHash`, we can add them step by step.

benchmark:

before
```
Benchmark                               (channelCount)  (groupCount)  (hashEnabled)  Mode  Cnt    Score   Error  Units
BenchmarkGroupByHash.addPagePreCompute               1       3000000           true  avgt  160  268.448 ± 7.902  ns/op
BenchmarkGroupByHash.bigintGroupByHash               1       3000000           true  avgt  160  139.813 ± 4.279  ns/op
```



after
```
Benchmark                               (channelCount)  (groupCount)  (hashEnabled)  Mode  Cnt    Score   Error  Units
BenchmarkGroupByHash.addPagePreCompute               1       3000000           true  avgt  160  262.753 ± 6.924  ns/op
BenchmarkGroupByHash.bigintGroupByHash               1       3000000           true  avgt  160  140.275 ± 3.867  ns/op
```