### PR TITLE
Fix incorrect column names in QueryCompletedEvent

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -153,7 +153,7 @@ public class QueryMonitor
                         input.getSchema(),
                         input.getTable(),
                         input.getColumns().stream()
-                                .map(Column::toString).collect(Collectors.toList()),
+                                .map(Column::getName).collect(Collectors.toList()),
                         input.getConnectorInfo()));
             }
 


### PR DESCRIPTION
The names were being derived from the toString representation
of Column, which causes them to be incorrectly formatted as
"Column{xyz, varchar}".