### PR TITLE
Allow rolling aggregations for window functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxBy.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.bytecode.Access.FINAL;
 import static com.facebook.presto.bytecode.Access.PRIVATE;
@@ -124,6 +125,7 @@ public abstract class AbstractMinMaxBy
                 generateAggregationName(getSignature().getName(), valueType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(valueType, keyType),
                 inputMethod,
+                Optional.empty(),
                 combineMethod,
                 outputMethod,
                 stateClazz,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxByNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxByNAggregationFunction.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
@@ -155,6 +156,7 @@ public abstract class AbstractMinMaxByNAggregationFunction
                 generateAggregationName(name, valueType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 inputParameterMetadata,
                 INPUT_FUNCTION.bindTo(comparator).bindTo(valueType).bindTo(keyType),
+                Optional.empty(),
                 COMBINE_FUNCTION,
                 OUTPUT_FUNCTION.bindTo(outputType),
                 MinMaxByNState.class,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static com.facebook.presto.metadata.Signature.orderableTypeParameter;
@@ -95,6 +96,7 @@ public abstract class AbstractMinMaxNAggregationFunction
                 generateAggregationName(getSignature().getName(), type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 inputParameterMetadata,
                 INPUT_FUNCTION.bindTo(comparator).bindTo(type),
+                Optional.empty(),
                 COMBINE_FUNCTION,
                 OUTPUT_FUNCTION.bindTo(outputType),
                 MinMaxNState.class,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Accumulator.java
@@ -33,6 +33,8 @@ public interface Accumulator
 
     void addInput(WindowIndex index, List<Integer> channels, int startPosition, int endPosition);
 
+    void removeInput(WindowIndex index, List<Integer> channels, int startPosition, int endPosition);
+
     void addIntermediate(Block block);
 
     void evaluateIntermediate(BlockBuilder blockBuilder);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationMetadata.java
@@ -25,6 +25,7 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
@@ -43,6 +44,7 @@ public class AggregationMetadata
     private final String name;
     private final List<ParameterMetadata> inputMetadata;
     private final MethodHandle inputFunction;
+    private final Optional<MethodHandle> removeInputFunction;
     private final MethodHandle combineFunction;
     private final MethodHandle outputFunction;
     private final AccumulatorStateSerializer<?> stateSerializer;
@@ -53,6 +55,7 @@ public class AggregationMetadata
             String name,
             List<ParameterMetadata> inputMetadata,
             MethodHandle inputFunction,
+            Optional<MethodHandle> removeInputFunction,
             MethodHandle combineFunction,
             MethodHandle outputFunction,
             Class<?> stateInterface,
@@ -64,6 +67,7 @@ public class AggregationMetadata
         this.inputMetadata = ImmutableList.copyOf(requireNonNull(inputMetadata, "inputMetadata is null"));
         this.name = requireNonNull(name, "name is null");
         this.inputFunction = requireNonNull(inputFunction, "inputFunction is null");
+        this.removeInputFunction = requireNonNull(removeInputFunction, "removeInputFunction is null");
         this.combineFunction = requireNonNull(combineFunction, "combineFunction is null");
         this.outputFunction = requireNonNull(outputFunction, "outputFunction is null");
         this.stateSerializer = requireNonNull(stateSerializer, "stateSerializer is null");
@@ -92,6 +96,11 @@ public class AggregationMetadata
     public MethodHandle getInputFunction()
     {
         return inputFunction;
+    }
+
+    public Optional<MethodHandle> getRemoveInputFunction()
+    {
+        return removeInputFunction;
     }
 
     public MethodHandle getCombineFunction()

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
@@ -35,6 +35,7 @@ import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
@@ -147,6 +148,7 @@ public class ArbitraryAggregationFunction
                 generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 inputParameterMetadata,
                 inputFunction,
+                Optional.empty(),
                 combineFunction,
                 outputFunction.bindTo(type),
                 stateInterface,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArrayAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArrayAggregationFunction.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
@@ -98,6 +99,7 @@ public class ArrayAggregationFunction
                 generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 inputParameterMetadata,
                 inputFunction,
+                Optional.empty(),
                 combineFunction,
                 outputFunction,
                 stateInterface,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AverageAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AverageAggregations.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.function.AggregationState;
 import com.facebook.presto.spi.function.CombineFunction;
 import com.facebook.presto.spi.function.InputFunction;
 import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.RemoveInputFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 
@@ -42,6 +43,20 @@ public final class AverageAggregations
     {
         state.setLong(state.getLong() + 1);
         state.setDouble(state.getDouble() + value);
+    }
+
+    @RemoveInputFunction
+    public static void removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.BIGINT) long value)
+    {
+        state.setLong(state.getLong() - 1);
+        state.setDouble(state.getDouble() - value);
+    }
+
+    @RemoveInputFunction
+    public static void removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+    {
+        state.setLong(state.getLong() - 1);
+        state.setDouble(state.getDouble() - value);
     }
 
     @CombineFunction

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ChecksumAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ChecksumAggregationFunction.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
@@ -86,6 +87,7 @@ public class ChecksumAggregationFunction
                 generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(type),
                 INPUT_FUNCTION.bindTo(type),
+                Optional.empty(),
                 COMBINE_FUNCTION,
                 OUTPUT_FUNCTION,
                 NullableLongState.class,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountAggregation.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.function.AggregationState;
 import com.facebook.presto.spi.function.CombineFunction;
 import com.facebook.presto.spi.function.InputFunction;
 import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.RemoveInputFunction;
 import com.facebook.presto.spi.type.StandardTypes;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -35,6 +36,12 @@ public final class CountAggregation
     public static void input(@AggregationState LongState state)
     {
         state.setLong(state.getLong() + 1);
+    }
+
+    @RemoveInputFunction
+    public static void removeInput(@AggregationState LongState state)
+    {
+        state.setLong(state.getLong() - 1);
     }
 
     @CombineFunction

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountColumn.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountColumn.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.typeVariable;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
@@ -48,6 +49,7 @@ public class CountColumn
     public static final CountColumn COUNT_COLUMN = new CountColumn();
     private static final String NAME = "count";
     private static final MethodHandle INPUT_FUNCTION = methodHandle(CountColumn.class, "input", LongState.class, Block.class, int.class);
+    private static final MethodHandle REMOVE_INPUT_FUNCTION = methodHandle(CountColumn.class, "removeInput", LongState.class, Block.class, int.class);
     private static final MethodHandle COMBINE_FUNCTION = methodHandle(CountColumn.class, "combine", LongState.class, LongState.class);
     private static final MethodHandle OUTPUT_FUNCTION = methodHandle(CountColumn.class, "output", LongState.class, BlockBuilder.class);
 
@@ -87,6 +89,7 @@ public class CountColumn
                 generateAggregationName(NAME, BIGINT.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(type),
                 INPUT_FUNCTION,
+                Optional.of(REMOVE_INPUT_FUNCTION),
                 COMBINE_FUNCTION,
                 OUTPUT_FUNCTION,
                 LongState.class,
@@ -106,6 +109,11 @@ public class CountColumn
     public static void input(LongState state, Block block, int index)
     {
         state.setLong(state.getLong() + 1);
+    }
+
+    public static void removeInput(LongState state, Block block, int index)
+    {
+        state.setLong(state.getLong() - 1);
     }
 
     public static void combine(LongState state, LongState otherState)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountIfAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountIfAggregation.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.function.AggregationState;
 import com.facebook.presto.spi.function.CombineFunction;
 import com.facebook.presto.spi.function.InputFunction;
 import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.RemoveInputFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 
@@ -35,6 +36,14 @@ public final class CountIfAggregation
     {
         if (value) {
             state.setLong(state.getLong() + 1);
+        }
+    }
+
+    @RemoveInputFunction
+    public static void removeInput(@AggregationState LongState state, @SqlType(StandardTypes.BOOLEAN) boolean value)
+    {
+        if (value) {
+            state.setLong(state.getLong() - 1);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalAverageAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalAverageAggregation.java
@@ -38,6 +38,7 @@ import java.lang.invoke.MethodHandle;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
@@ -118,6 +119,7 @@ public class DecimalAverageAggregation
                 generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(type),
                 inputFunction,
+                Optional.empty(),
                 COMBINE_FUNCTION,
                 outputFunction,
                 stateInterface,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalSumAggregation.java
@@ -35,6 +35,7 @@ import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
@@ -107,6 +108,7 @@ public class DecimalSumAggregation
                 generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(inputType),
                 inputFunction.bindTo(inputType),
+                Optional.empty(),
                 COMBINE_FUNCTION,
                 LONG_DECIMAL_OUTPUT_FUNCTION.bindTo(outputType),
                 stateInterface,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
@@ -34,11 +34,13 @@ public class GenericAccumulatorFactory
     private final Constructor<? extends GroupedAccumulator> groupedAccumulatorConstructor;
     private final Optional<Integer> maskChannel;
     private final List<Integer> inputChannels;
+    private final boolean accumulatorHasRemoveInput;
 
     public GenericAccumulatorFactory(
             AccumulatorStateSerializer<?> stateSerializer,
             AccumulatorStateFactory<?> stateFactory,
             Constructor<? extends Accumulator> accumulatorConstructor,
+            boolean accumulatorHasRemoveInput,
             Constructor<? extends GroupedAccumulator> groupedAccumulatorConstructor,
             List<Integer> inputChannels,
             Optional<Integer> maskChannel)
@@ -46,6 +48,7 @@ public class GenericAccumulatorFactory
         this.stateSerializer = requireNonNull(stateSerializer, "stateSerializer is null");
         this.stateFactory = requireNonNull(stateFactory, "stateFactory is null");
         this.accumulatorConstructor = requireNonNull(accumulatorConstructor, "accumulatorConstructor is null");
+        this.accumulatorHasRemoveInput = accumulatorHasRemoveInput;
         this.groupedAccumulatorConstructor = requireNonNull(groupedAccumulatorConstructor, "groupedAccumulatorConstructor is null");
         this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
         this.inputChannels = ImmutableList.copyOf(requireNonNull(inputChannels, "inputChannels is null"));
@@ -55,6 +58,12 @@ public class GenericAccumulatorFactory
     public List<Integer> getInputChannels()
     {
         return inputChannels;
+    }
+
+    @Override
+    public boolean hasRemoveInput()
+    {
+        return accumulatorHasRemoveInput;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactoryBinder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactoryBinder.java
@@ -30,12 +30,14 @@ public class GenericAccumulatorFactoryBinder
     private final AccumulatorStateSerializer<?> stateSerializer;
     private final AccumulatorStateFactory<?> stateFactory;
     private final Constructor<? extends Accumulator> accumulatorConstructor;
+    private final boolean accumulatorHasRemoveInput;
     private final Constructor<? extends GroupedAccumulator> groupedAccumulatorConstructor;
 
     public GenericAccumulatorFactoryBinder(
             AccumulatorStateSerializer<?> stateSerializer,
             AccumulatorStateFactory<?> stateFactory,
             Class<? extends Accumulator> accumulatorClass,
+            boolean accumulatorHasRemoveInput,
             Class<? extends GroupedAccumulator> groupedAccumulatorClass)
     {
         this.stateSerializer = requireNonNull(stateSerializer, "stateSerializer is null");
@@ -47,6 +49,8 @@ public class GenericAccumulatorFactoryBinder
                     AccumulatorStateFactory.class,
                     List.class,
                     Optional.class);
+
+            this.accumulatorHasRemoveInput = accumulatorHasRemoveInput;
 
             groupedAccumulatorConstructor = groupedAccumulatorClass.getConstructor(
                     AccumulatorStateSerializer.class,
@@ -62,7 +66,7 @@ public class GenericAccumulatorFactoryBinder
     @Override
     public AccumulatorFactory bind(List<Integer> argumentChannels, Optional<Integer> maskChannel)
     {
-        return new GenericAccumulatorFactory(stateSerializer, stateFactory, accumulatorConstructor, groupedAccumulatorConstructor, argumentChannels, maskChannel);
+        return new GenericAccumulatorFactory(stateSerializer, stateFactory, accumulatorConstructor, accumulatorHasRemoveInput, groupedAccumulatorConstructor, argumentChannels, maskChannel);
     }
 
     @VisibleForTesting

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Histogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Histogram.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
@@ -95,6 +96,7 @@ public class Histogram
                 generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(keyType),
                 inputFunction,
+                Optional.empty(),
                 COMBINE_FUNCTION,
                 outputFunction,
                 HistogramState.class,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.typeVariable;
@@ -90,6 +91,7 @@ public class MapAggregationFunction
                 generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(keyType, valueType),
                 INPUT_FUNCTION.bindTo(keyType).bindTo(valueType),
+                Optional.empty(),
                 COMBINE_FUNCTION,
                 OUTPUT_FUNCTION,
                 KeyValuePairsState.class,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionAggregation.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.typeVariable;
@@ -84,6 +85,7 @@ public class MapUnionAggregation
                 generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(outputType),
                 INPUT_FUNCTION.bindTo(keyType).bindTo(valueType),
+                Optional.empty(),
                 COMBINE_FUNCTION,
                 OUTPUT_FUNCTION,
                 KeyValuePairsState.class,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultimapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultimapAggregationFunction.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
 import static com.facebook.presto.metadata.Signature.typeVariable;
@@ -90,6 +91,7 @@ public class MultimapAggregationFunction
                 generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(keyType, valueType),
                 INPUT_FUNCTION,
+                Optional.empty(),
                 COMBINE_FUNCTION,
                 OUTPUT_FUNCTION,
                 MultiKeyValuePairsState.class,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
@@ -84,6 +84,13 @@ public class ParametricAggregation
 
         // Bind provided dependencies to aggregation method handlers
         MethodHandle inputHandle = bindDependencies(concreteImplementation.getInputFunction(), concreteImplementation.getInputDependencies(), variables, typeManager, functionRegistry);
+        Optional<MethodHandle> removeInputHandle = concreteImplementation.getRemoveInputFunction().map(
+                removeInputFunction -> bindDependencies(
+                        removeInputFunction,
+                        concreteImplementation.getRemoveInputDependencies(),
+                        variables,
+                        typeManager,
+                        functionRegistry));
         MethodHandle combineHandle = bindDependencies(concreteImplementation.getCombineFunction(), concreteImplementation.getCombineDependencies(), variables, typeManager, functionRegistry);
         MethodHandle outputHandle = bindDependencies(concreteImplementation.getOutputFunction(), concreteImplementation.getOutputDependencies(), variables, typeManager, functionRegistry);
 
@@ -98,6 +105,7 @@ public class ParametricAggregation
                 aggregationName,
                 parametersMetadata,
                 inputHandle,
+                removeInputHandle,
                 combineHandle,
                 outputHandle,
                 stateClass,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealAverageAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealAverageAggregation.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.function.AggregationState;
 import com.facebook.presto.spi.function.CombineFunction;
 import com.facebook.presto.spi.function.InputFunction;
 import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.RemoveInputFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 
@@ -37,6 +38,13 @@ public final class RealAverageAggregation
     {
         state.setLong(state.getLong() + 1);
         state.setDouble(state.getDouble() + intBitsToFloat((int) value));
+    }
+
+    @RemoveInputFunction
+    public static void removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.REAL) long value)
+    {
+        state.setLong(state.getLong() - 1);
+        state.setDouble(state.getDouble() - intBitsToFloat((int) value));
     }
 
     @CombineFunction

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
@@ -33,6 +33,7 @@ public class AggregateWindowFunction
     private final InternalAggregationFunction function;
     private final List<Integer> argumentChannels;
     private final AccumulatorFactory accumulatorFactory;
+    private final boolean accumulatorHasRemoveInput;
 
     private WindowIndex windowIndex;
     private Accumulator accumulator;
@@ -44,6 +45,7 @@ public class AggregateWindowFunction
         this.function = requireNonNull(function, "function is null");
         this.argumentChannels = ImmutableList.copyOf(argumentChannels);
         this.accumulatorFactory = function.bind(createArgs(function), Optional.empty());
+        this.accumulatorHasRemoveInput = accumulatorFactory.hasRemoveInput();
     }
 
     @Override
@@ -66,19 +68,59 @@ public class AggregateWindowFunction
             currentEnd = frameEnd;
         }
         else {
-            // different frame
-            resetAccumulator();
-            accumulate(frameStart, frameEnd);
-            currentStart = frameStart;
-            currentEnd = frameEnd;
+            buildNewFrame(frameStart, frameEnd);
         }
 
         accumulator.evaluateFinal(output);
     }
 
+    private void buildNewFrame(int frameStart, int frameEnd)
+    {
+        if (accumulatorHasRemoveInput) {
+            // Note that all the start/end intervals are inclusive on both ends!
+            if (currentStart < 0) {
+                currentStart = 0;
+                currentEnd = -1;
+            }
+            int overlapStart = Integer.max(frameStart, currentStart);
+            int overlapEnd = Integer.min(frameEnd, currentEnd);
+            int prefixRemoveLength = overlapStart - currentStart;
+            int suffixRemoveLength = currentEnd - overlapEnd;
+
+            if ((overlapEnd - overlapStart + 1) > (prefixRemoveLength + suffixRemoveLength)) {
+                // It's worth keeping the overlap, and removing the now-unused prefix
+                if (currentStart < frameStart) {
+                    remove(currentStart, frameStart - 1);
+                }
+                if (frameEnd < currentEnd) {
+                    remove(frameEnd + 1, currentEnd);
+                }
+                if (frameStart < currentStart) {
+                    accumulate(frameStart, currentStart - 1);
+                }
+                if (currentEnd < frameEnd) {
+                    accumulate(currentEnd + 1, frameEnd);
+                }
+                currentStart = frameStart;
+                currentEnd = frameEnd;
+                return;
+            }
+        }
+        // We couldn't or didn't want to modify the accumulation:  instead, discard the current accumulation and start fresh.
+        resetAccumulator();
+        accumulate(frameStart, frameEnd);
+        currentStart = frameStart;
+        currentEnd = frameEnd;
+    }
+
     private void accumulate(int start, int end)
     {
         accumulator.addInput(windowIndex, argumentChannels, start, end);
+    }
+
+    private void remove(int start, int end)
+    {
+        accumulator.removeInput(windowIndex, argumentChannels, start, end);
     }
 
     private void resetAccumulator()

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -93,8 +93,8 @@ public class TestHashAggregationOperator
 
     private static final InternalAggregationFunction LONG_AVERAGE = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
             new Signature("avg", AGGREGATE, DOUBLE.getTypeSignature(), BIGINT.getTypeSignature()));
-    private static final InternalAggregationFunction LONG_SUM = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
-            new Signature("sum", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature()));
+    private static final InternalAggregationFunction LONG_MIN = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("min", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature()));
     private static final InternalAggregationFunction COUNT = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
             new Signature("count", AGGREGATE, BIGINT.getTypeSignature()));
 
@@ -164,7 +164,7 @@ public class TestHashAggregationOperator
                 Step.SINGLE,
                 false,
                 ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty()),
-                        LONG_SUM.bind(ImmutableList.of(3), Optional.empty()),
+                        LONG_MIN.bind(ImmutableList.of(3), Optional.empty()),
                         LONG_AVERAGE.bind(ImmutableList.of(3), Optional.empty()),
                         maxVarcharColumn.bind(ImmutableList.of(2), Optional.empty()),
                         countVarcharColumn.bind(ImmutableList.of(0), Optional.empty()),
@@ -183,15 +183,15 @@ public class TestHashAggregationOperator
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, BIGINT, BIGINT, DOUBLE, VARCHAR, BIGINT, BIGINT)
                 .row("0", 3L, 0L, 0.0, "300", 3L, 3L)
-                .row("1", 3L, 3L, 1.0, "301", 3L, 3L)
-                .row("2", 3L, 6L, 2.0, "302", 3L, 3L)
-                .row("3", 3L, 9L, 3.0, "303", 3L, 3L)
-                .row("4", 3L, 12L, 4.0, "304", 3L, 3L)
-                .row("5", 3L, 15L, 5.0, "305", 3L, 3L)
-                .row("6", 3L, 18L, 6.0, "306", 3L, 3L)
-                .row("7", 3L, 21L, 7.0, "307", 3L, 3L)
-                .row("8", 3L, 24L, 8.0, "308", 3L, 3L)
-                .row("9", 3L, 27L, 9.0, "309", 3L, 3L)
+                .row("1", 3L, 1L, 1.0, "301", 3L, 3L)
+                .row("2", 3L, 2L, 2.0, "302", 3L, 3L)
+                .row("3", 3L, 3L, 3.0, "303", 3L, 3L)
+                .row("4", 3L, 4L, 4.0, "304", 3L, 3L)
+                .row("5", 3L, 5L, 5.0, "305", 3L, 3L)
+                .row("6", 3L, 6L, 6.0, "306", 3L, 3L)
+                .row("7", 3L, 7L, 7.0, "307", 3L, 3L)
+                .row("8", 3L, 8L, 8.0, "308", 3L, 3L)
+                .row("9", 3L, 9L, 9.0, "309", 3L, 3L)
                 .build();
 
         assertOperatorEqualsIgnoreOrder(operatorFactory, driverContext, input, expected, hashEnabled, Optional.of(hashChannels.size()));
@@ -225,7 +225,7 @@ public class TestHashAggregationOperator
                 Step.SINGLE,
                 true,
                 ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty()),
-                        LONG_SUM.bind(ImmutableList.of(4), Optional.empty()),
+                        LONG_MIN.bind(ImmutableList.of(4), Optional.empty()),
                         LONG_AVERAGE.bind(ImmutableList.of(4), Optional.empty()),
                         maxVarcharColumn.bind(ImmutableList.of(2), Optional.empty()),
                         countVarcharColumn.bind(ImmutableList.of(0), Optional.empty()),
@@ -319,7 +319,7 @@ public class TestHashAggregationOperator
                 ImmutableList.of(),
                 Step.SINGLE,
                 ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty()),
-                        LONG_SUM.bind(ImmutableList.of(3), Optional.empty()),
+                        LONG_MIN.bind(ImmutableList.of(3), Optional.empty()),
                         LONG_AVERAGE.bind(ImmutableList.of(3), Optional.empty()),
                         maxVarcharColumn.bind(ImmutableList.of(2), Optional.empty())),
                 rowPagesBuilder.getHashChannel(),
@@ -458,7 +458,7 @@ public class TestHashAggregationOperator
                 hashChannels,
                 ImmutableList.of(),
                 Step.PARTIAL,
-                ImmutableList.of(LONG_SUM.bind(ImmutableList.of(0), Optional.empty())),
+                ImmutableList.of(LONG_MIN.bind(ImmutableList.of(0), Optional.empty())),
                 rowPagesBuilder.getHashChannel(),
                 Optional.empty(),
                 100_000,
@@ -538,7 +538,7 @@ public class TestHashAggregationOperator
                 ImmutableList.of(),
                 Step.SINGLE,
                 false,
-                ImmutableList.of(LONG_SUM.bind(ImmutableList.of(0), Optional.empty())),
+                ImmutableList.of(LONG_MIN.bind(ImmutableList.of(0), Optional.empty())),
                 rowPagesBuilder.getHashChannel(),
                 Optional.empty(),
                 1,
@@ -592,7 +592,7 @@ public class TestHashAggregationOperator
                 Step.SINGLE,
                 false,
                 ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty()),
-                        LONG_SUM.bind(ImmutableList.of(3), Optional.empty()),
+                        LONG_MIN.bind(ImmutableList.of(3), Optional.empty()),
                         LONG_AVERAGE.bind(ImmutableList.of(3), Optional.empty()),
                         maxVarcharColumn.bind(ImmutableList.of(2), Optional.empty())),
                 rowPagesBuilder.getHashChannel(),

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBooleanAndAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBooleanAndAggregation.java
@@ -45,7 +45,7 @@ public class TestBooleanAndAggregation
         if (length == 0) {
             return null;
         }
-        return length > 1 ? FALSE : TRUE;
+        return (length > 1 || (start % 2 == 1)) ? FALSE : TRUE;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBooleanOrAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBooleanOrAggregation.java
@@ -45,7 +45,7 @@ public class TestBooleanOrAggregation
         if (length == 0) {
             return null;
         }
-        return length > 1 ? TRUE : FALSE;
+        return (length > 1 || (start % 2 == 1)) ? TRUE : FALSE;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestVarBinaryMaxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestVarBinaryMaxAggregation.java
@@ -34,7 +34,7 @@ public class TestVarBinaryMaxAggregation
     public Block[] getSequenceBlocks(int start, int length)
     {
         BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), length);
-        for (int i = 0; i < length; i++) {
+        for (int i = start; i < start + length; i++) {
             VARBINARY.writeSlice(blockBuilder, Slices.wrappedBuffer(Ints.toByteArray(i)));
         }
         return new Block[] {blockBuilder.build()};
@@ -47,7 +47,7 @@ public class TestVarBinaryMaxAggregation
             return null;
         }
         Slice max = null;
-        for (int i = 0; i < length; i++) {
+        for (int i = start; i < start + length; i++) {
             Slice slice = Slices.wrappedBuffer(Ints.toByteArray(i));
             max = (max == null) ? slice : Ordering.natural().max(max, slice);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestVarBinaryMinAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestVarBinaryMinAggregation.java
@@ -34,7 +34,7 @@ public class TestVarBinaryMinAggregation
     public Block[] getSequenceBlocks(int start, int length)
     {
         BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), length);
-        for (int i = 0; i < length; i++) {
+        for (int i = start; i < start + length; i++) {
             VARBINARY.writeSlice(blockBuilder, Slices.wrappedBuffer(Ints.toByteArray(i)));
         }
         return new Block[] {blockBuilder.build()};
@@ -47,7 +47,7 @@ public class TestVarBinaryMinAggregation
             return null;
         }
         Slice min = null;
-        for (int i = 0; i < length; i++) {
+        for (int i = start; i < start + length; i++) {
             Slice slice = Slices.wrappedBuffer(Ints.toByteArray(i));
             min = (min == null) ? slice : Ordering.natural().min(min, slice);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestAggregateWindowFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestAggregateWindowFunction.java
@@ -58,6 +58,25 @@ public class TestAggregateWindowFunction
     }
 
     @Test
+    public void testCountRowsRolling()
+    {
+        assertWindowQuery("count(*) OVER (ORDER BY orderkey " +
+                        "ROWS BETWEEN 4 PRECEDING AND 1 PRECEDING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(1, "O", 0L)
+                        .row(2, "O", 1L)
+                        .row(3, "F", 2L)
+                        .row(4, "O", 3L)
+                        .row(5, "F", 4L)
+                        .row(6, "F", 4L)
+                        .row(7, "O", 4L)
+                        .row(32, "O", 4L)
+                        .row(33, "F", 4L)
+                        .row(34, "O", 4L)
+                        .build());
+    }
+
+    @Test
     public void testCountRowsUnordered()
     {
         assertWindowQuery("count(*) OVER (PARTITION BY orderstatus)",

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/RemoveInputFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/RemoveInputFunction.java
@@ -11,21 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.operator.aggregation;
+package com.facebook.presto.spi.function;
 
-import java.util.List;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-public interface AccumulatorFactory
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface RemoveInputFunction
 {
-    List<Integer> getInputChannels();
-
-    boolean hasRemoveInput();
-
-    Accumulator createAccumulator();
-
-    Accumulator createIntermediateAccumulator();
-
-    GroupedAccumulator createGroupedAccumulator();
-
-    GroupedAccumulator createGroupedIntermediateAccumulator();
 }


### PR DESCRIPTION
Add a removeInput() function to some Accumulators, and when it exists,
use it in aggregate window functions to roll the aggregation forward
incrementally.  Dramatically speeds up queries such as:
  SELECT COUNT(quantity) OVER
        (ROWS BETWEEN 2000 PRECEDING AND 2000 FOLLOWING)

This PR also includes a commit that adds removeInput() to some SUM
aggregations, but at the cost of increasing the size of the aggregation
state.  That may not be desired, and avoiding the bad effect there would
require refactoring into more window-function-specific code paths.

In the long term, we want to be able to use different algorithms with
different state structures for rolling window aggregations as opposed
to standard grouping.  For example, a rolling min() needs to hold onto
all the values seen, whereas a non-rolling min() just needs to hold onto
the minimum value seen.

See https://github.com/prestodb/presto/issues/8982 for a list of the
aggregations and what changes they would need to support rolling.