### PR TITLE
Fix issue with array_min/max not returning NaN.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMinMaxUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayMinMaxUtils.java
@@ -92,6 +92,9 @@ public final class ArrayMinMaxUtils
                     return null;
                 }
                 double value = elementType.getDouble(block, i);
+                if (Double.isNaN(value)) {
+                    return Double.NaN;
+                }
                 if ((boolean) compareMethodHandle.invokeExact(value, selectedValue)) {
                     selectedValue = value;
                 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -533,6 +533,7 @@ public class TestArrayOperators
         assertFunction("ARRAY_MIN(ARRAY ['puppies', 'kittens'])", createVarcharType(7), "kittens");
         assertFunction("ARRAY_MIN(ARRAY [TRUE, FALSE])", BOOLEAN, false);
         assertFunction("ARRAY_MIN(ARRAY [NULL, FALSE])", BOOLEAN, null);
+        assertFunction("ARRAY_MIN(ARRAY [1, nan()])", DOUBLE, Double.NaN);
     }
 
     @Test
@@ -554,6 +555,7 @@ public class TestArrayOperators
         assertFunction("ARRAY_MAX(ARRAY ['puppies', 'kittens'])", createVarcharType(7), "puppies");
         assertFunction("ARRAY_MAX(ARRAY [TRUE, FALSE])", BOOLEAN, true);
         assertFunction("ARRAY_MAX(ARRAY [NULL, FALSE])", BOOLEAN, null);
+        assertFunction("ARRAY_MAX(ARRAY [1, nan()])", DOUBLE, Double.NaN);
     }
 
     @Test


### PR DESCRIPTION
When one if its elems is a NaN array_min and array_max functions should return NaN.
Similar to what happens with NULL values.

Fixes #8836.