### PR TITLE
Add detailed documentation for json_format and json_parse

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -115,13 +115,11 @@ String
 
         Binary strings with length are not yet supported: ``varbinary(n)``
 
-JSON
-----
-
 ``JSON``
 ^^^^^^^^
 
-    Variable length JSON data.
+    JSON value type, which can be a JSON object, a JSON array, a JSON number, a JSON string,
+    ``true``, ``false`` or ``null``.
 
 Date and Time
 -------------


### PR DESCRIPTION
Explain the difference between:
- json_format vs. CAST(json as VARCHAR)
- json_parse vs. CAST(string as JSON)