### PR TITLE
End deflater properly in orc writer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DeflateCompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DeflateCompressor.java
@@ -42,16 +42,19 @@ public class DeflateCompressor
         }
 
         Deflater deflater = new Deflater(COMPRESSION_LEVEL, true);
+        try {
+            deflater.setInput(input, inputOffset, inputLength);
+            deflater.finish();
 
-        deflater.setInput(input, inputOffset, inputLength);
-        deflater.finish();
-
-        int compressedDataLength = deflater.deflate(output, outputOffset, maxOutputLength, FULL_FLUSH);
-        if (!deflater.finished()) {
-            throw new IllegalStateException("maxCompressedLength formula is incorrect, because deflate produced more data");
+            int compressedDataLength = deflater.deflate(output, outputOffset, maxOutputLength, FULL_FLUSH);
+            if (!deflater.finished()) {
+                throw new IllegalStateException("maxCompressedLength formula is incorrect, because deflate produced more data");
+            }
+            return compressedDataLength;
         }
-        deflater.end();
-        return compressedDataLength;
+        finally {
+            deflater.end();
+        }
     }
 
     @Override


### PR DESCRIPTION
Make sure end() is called to prevent native memory leak.