### PR TITLE
Update to slice 0.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dep.antlr.version>4.6</dep.antlr.version>
         <dep.airlift.version>0.148</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.slice.version>0.29</dep.slice.version>
+        <dep.slice.version>0.30</dep.slice.version>
         <dep.aws-sdk.version>1.11.165</dep.aws-sdk.version>
         <dep.okhttp.version>3.8.1</dep.okhttp.version>
         <dep.tempto.version>1.36</dep.tempto.version>

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/SerializedPage.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/SerializedPage.java
@@ -53,7 +53,7 @@ public class SerializedPage
         return uncompressedSizeInBytes;
     }
 
-    public int getRetainedSizeInBytes()
+    public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + slice.getRetainedSize() + PAGE_COMPRESSION_SIZE;
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/ChunkedSliceOutput.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ChunkedSliceOutput.java
@@ -105,9 +105,9 @@ public final class ChunkedSliceOutput
     }
 
     @Override
-    public int getRetainedSize()
+    public long getRetainedSize()
     {
-        return toIntExact(slice.getRetainedSize() + closedSlicesRetainedSize + INSTANCE_SIZE);
+        return slice.getRetainedSize() + closedSlicesRetainedSize + INSTANCE_SIZE;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -144,9 +144,9 @@ public class OrcOutputBuffer
     }
 
     @Override
-    public int getRetainedSize()
+    public long getRetainedSize()
     {
-        return toIntExact(INSTANCE_SIZE + compressedOutputStream.getRetainedSize() + slice.getRetainedSize() + SizeOf.sizeOf(compressionBuffer));
+        return INSTANCE_SIZE + compressedOutputStream.getRetainedSize() + slice.getRetainedSize() + SizeOf.sizeOf(compressionBuffer);
     }
 
     @Override

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/BufferedOutputStreamSliceOutput.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/BufferedOutputStreamSliceOutput.java
@@ -103,7 +103,7 @@ public class BufferedOutputStreamSliceOutput
     }
 
     @Override
-    public int getRetainedSize()
+    public long getRetainedSize()
     {
         return slice.getRetainedSize() + INSTANCE_SIZE;
     }

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/ChunkedSliceOutput.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/ChunkedSliceOutput.java
@@ -105,9 +105,9 @@ public final class ChunkedSliceOutput
     }
 
     @Override
-    public int getRetainedSize()
+    public long getRetainedSize()
     {
-        return toIntExact(slice.getRetainedSize() + closedSlicesRetainedSize + INSTANCE_SIZE);
+        return slice.getRetainedSize() + closedSlicesRetainedSize + INSTANCE_SIZE;
     }
 
     @Override

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileCompressor.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileCompressor.java
@@ -55,7 +55,7 @@ public interface RcFileCompressor
         }
 
         @Override
-        public int getRetainedSize()
+        public long getRetainedSize()
         {
             return super.getRetainedSize() + bufferedOutput.getRetainedSize();
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlock.java
@@ -86,8 +86,8 @@ public class FixedWidthBlock
     @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
-        consumer.accept(slice, (long) slice.getRetainedSize());
-        consumer.accept(valueIsNull, (long) valueIsNull.getRetainedSize());
+        consumer.accept(slice, slice.getRetainedSize());
+        consumer.accept(valueIsNull, valueIsNull.getRetainedSize());
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -103,8 +103,8 @@ public class FixedWidthBlockBuilder
     @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
-        consumer.accept(sliceOutput, (long) sliceOutput.getRetainedSize());
-        consumer.accept(valueIsNull, (long) valueIsNull.getRetainedSize());
+        consumer.accept(sliceOutput, sliceOutput.getRetainedSize());
+        consumer.accept(valueIsNull, valueIsNull.getRetainedSize());
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
@@ -121,7 +121,7 @@ public class VariableWidthBlock
     @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
-        consumer.accept(slice, (long) slice.getRetainedSize());
+        consumer.accept(slice, slice.getRetainedSize());
         consumer.accept(offsets, sizeOf(offsets));
         consumer.accept(valueIsNull, sizeOf(valueIsNull));
         consumer.accept(this, (long) INSTANCE_SIZE);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -127,7 +127,7 @@ public class VariableWidthBlockBuilder
     @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
-        consumer.accept(sliceOutput, (long) sliceOutput.getRetainedSize());
+        consumer.accept(sliceOutput, sliceOutput.getRetainedSize());
         consumer.accept(offsets, sizeOf(offsets));
         consumer.accept(valueIsNull, sizeOf(valueIsNull));
         consumer.accept(this, (long) INSTANCE_SIZE);


### PR DESCRIPTION
This release updates retained size related methods to return `long` instead of `int`.