### PR TITLE
Add a row-based threshold for the smallest cardinality lookup

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
@@ -158,7 +158,7 @@ public class ColumnCardinalityCache
                 Optional<Entry<Long, AccumuloColumnConstraint>> smallestCardinality = cardinalityToConstraints.entries().stream().findFirst();
                 if (smallestCardinality.isPresent()) {
                     if (smallestCardinality.get().getKey() <= earlyReturnThreshold) {
-                        LOG.info("Cardinality %s, is below threshold. Returning early while other tasks finish", smallestCardinality);
+                        LOG.info("Cardinality for column %s is below threshold of %s. Returning early while other tasks finish", smallestCardinality.get().getValue().getName(), earlyReturnThreshold);
                         earlyReturn = true;
                     }
                 }

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -489,8 +489,12 @@ Property Name                                 Default Value Description
 ``index_rows_per_split``                      ``10000``     The number of Accumulo row IDs that are packed into a single Presto split
 ``index_threshold``                           ``0.2``       The ratio between number of rows to be scanned based on the index over the total number of rows
                                                             If the ratio is below this threshold, the index will be used.
-``index_lowest_cardinality_threshold``        ``0.01``      The threshold where the column with the lowest cardinality will be used instead of computing an
-                                                            intersection of ranges in the index. Secondary index must be enabled
+``index_lowest_cardinality_threshold``        ``0.01``      The threshold (as a percentage) where the column with the lowest cardinality will be used instead
+                                                            of computing an intersection of ranges in the secondary index. The minimum value of this value times
+                                                            the number of rows in the table and the row threshold will be used. Secondary index must be enabled
+``index_lowest_cardinality_row_threshold``    ``50000``     The threshold (as number of rows) where the column with the lowest cardinality will be used instead
+                                                            of computing an intersection of ranges in the secondary index. The minimum value of this value and
+                                                            the percentage threshold will be used. Secondary index must be enabled
 ``index_metrics_enabled``                     ``true``      Set to true to enable usage of the metrics table to optimize usage of the index
 ``scan_username``                             (config)      User to impersonate when scanning the tables. This property trumps the ``scan_auths`` table property
 ``index_short_circuit_cardinality_fetch``     ``true``      Short circuit the retrieval of index metrics once any column is less than the lowest cardinality threshold


### PR DESCRIPTION
This new session property adds the ability to have a hard threshold for
the cardinality lookup in addition to the percentage-based threshold.
The actual value used for the early return threshold is the minimum
value of the percentage-based threshold multiplied by the number of
rows and the value of the new row-based threshold.