### PR TITLE
Avoid binding per each row in MapToMapCast

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarImplementationValidation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarImplementationValidation.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestScalarImplementationValidation
+{
+    private static final MethodHandle STATE_FACTORY = methodHandle(TestScalarImplementationValidation.class, "createState");
+
+    @Test
+    public void testConnectorSessionPosition()
+    {
+        // Without cached instance factory
+        MethodHandle validFunctionMethodHandle = methodHandle(TestScalarImplementationValidation.class, "validConnectorSessionParameterPosition", ConnectorSession.class, long.class, long.class);
+        ScalarFunctionImplementation validFunction = new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(false, false),
+                validFunctionMethodHandle,
+                false);
+        assertEquals(validFunction.getMethodHandle(), validFunctionMethodHandle);
+
+        try {
+            ScalarFunctionImplementation invalidFunction = new ScalarFunctionImplementation(
+                    false,
+                    ImmutableList.of(false, false),
+                    methodHandle(TestScalarImplementationValidation.class, "invalidConnectorSessionParameterPosition", long.class, long.class, ConnectorSession.class),
+                    false);
+            fail("expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "ConnectorSession must be the first argument when instanceFactory is not present");
+        }
+
+        // With cached instance factory
+        MethodHandle validFunctionWithInstanceFactoryMethodHandle = methodHandle(TestScalarImplementationValidation.class, "validConnectorSessionParameterPosition", Object.class, ConnectorSession.class, long.class, long.class);
+        ScalarFunctionImplementation validFunctionWithInstanceFactory = new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(false, false),
+                ImmutableList.of(false, false),
+                ImmutableList.of(Optional.empty(), Optional.empty()),
+                validFunctionWithInstanceFactoryMethodHandle,
+                Optional.of(STATE_FACTORY),
+                false);
+        assertEquals(validFunctionWithInstanceFactory.getMethodHandle(), validFunctionWithInstanceFactoryMethodHandle);
+
+        try {
+            ScalarFunctionImplementation invalidFunctionWithInstanceFactory = new ScalarFunctionImplementation(
+                    false,
+                    ImmutableList.of(false, false),
+                    ImmutableList.of(false, false),
+                    ImmutableList.of(Optional.empty(), Optional.empty()),
+                    methodHandle(TestScalarImplementationValidation.class, "invalidConnectorSessionParameterPosition", Object.class, long.class, long.class, ConnectorSession.class),
+                    Optional.of(STATE_FACTORY),
+                    false);
+            fail("expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "ConnectorSession must be the second argument when instanceFactory is present");
+        }
+    }
+
+    public static Object createState()
+    {
+        return null;
+    }
+
+    public static long validConnectorSessionParameterPosition(ConnectorSession session, long arg1, long arg2)
+    {
+        return arg1 + arg2;
+    }
+
+    public static long validConnectorSessionParameterPosition(Object state, ConnectorSession session, long arg1, long arg2)
+    {
+        return arg1 + arg2;
+    }
+
+    public static long invalidConnectorSessionParameterPosition(long arg1, long arg2, ConnectorSession session)
+    {
+        return arg1 + arg2;
+    }
+
+    public static long invalidConnectorSessionParameterPosition(Object state, long arg1, long arg2, ConnectorSession session)
+    {
+        return arg1 + arg2;
+    }
+}


### PR DESCRIPTION
When the dependent key or value cast function takes ConnectorSession
as input, MapToMapCast will do the binding per row. This will cause
generating excessive BoundMethodHandle classes and result in full GC due
to Metaspace full when the map contains more than 128 entires.

This issue has the same root cause with https://github.com/prestodb/presto/issues/7935. To reproduce the issue, first prepare the dataset:

```SQL
CREATE TABLE  test_10k_rows AS 
SELECT id as rid
FROM
(
  select sequence(1, 10000) AS seq
) tmp
CROSS JOIN UNNEST(seq) AS t(id)


CREATE TABLE test_map_array AS
SELECT map_from_entries(transform(sequence(1, 128), x->(x,ARRAY[x]))) as mm
FROM test_10k_rows
```

And run the query 

```SQL
SELECT checksum(cast(mm as MAP<integer, ARRAY<integer>>))
FROM test_map_array
```


With the following VM argument enables:

```
-verbose:class
-Djava.lang.invoke.MethodHandle.DUMP_CLASS_FILES=true
```

We will see excessive  `LambdaForm$BMH*.class` files generated without the patch.
