### PR TITLE
Fix query failure race in BroadcastOutputBuffer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
@@ -299,23 +299,28 @@ public class BroadcastOutputBuffer
         // NOTE: buffers are allowed to be created in the FINISHED state because destroy() can move to the finished state
         // without a clean "no-more-buffers" message from the scheduler.  This happens with limit queries and is ok because
         // the buffer will be immediately destroyed.
-        checkState(state.get().canAddBuffers() || !outputBuffers.isNoMoreBufferIds(), "No more buffers already set");
+        BufferState state = this.state.get();
+        checkState(state.canAddBuffers() || !outputBuffers.isNoMoreBufferIds(), "No more buffers already set");
 
         // NOTE: buffers are allowed to be created before they are explicitly declared by setOutputBuffers
         // When no-more-buffers is set, we verify that all created buffers have been declared
         buffer = new ClientBuffer(taskInstanceId, id);
 
-        // add initial pages
-        buffer.enqueuePages(initialPagesForNewBuffers);
+        // do not setup the new buffer if we are already failed
+        if (state != FAILED) {
+            // add initial pages
+            buffer.enqueuePages(initialPagesForNewBuffers);
 
-        // update state
-        if (!state.get().canAddPages()) {
-            buffer.setNoMorePages();
-        }
+            // update state
+            if (!state.canAddPages()) {
+                // BE CAREFUL: set no more pages only if not FAILED, because this allows clients to FINISH 
+                buffer.setNoMorePages();
+            }
 
-        // buffer may have finished immediately before calling this method
-        if (state.get() == FINISHED) {
-            buffer.destroy();
+            // buffer may have finished immediately before calling this method
+            if (state == FINISHED) {
+                buffer.destroy();
+            }
         }
 
         buffers.put(id, buffer);

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -769,6 +769,51 @@ public class TestArbitraryOutputBuffer
     }
 
     @Test
+    public void testAddBufferAfterFail()
+            throws Exception
+    {
+        OutputBuffers outputBuffers = createInitialEmptyOutputBuffers(ARBITRARY)
+                .withBuffer(FIRST, BROADCAST_PARTITION_ID);
+        ArbitraryOutputBuffer buffer = createArbitraryBuffer(outputBuffers, sizeOfPages(5));
+        assertFalse(buffer.isFinished());
+
+        // attempt to get a page
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+
+        // verify we are waiting for a page
+        assertFalse(future.isDone());
+
+        // add one page
+        addPage(buffer, createPage(0));
+
+        // verify we got one page
+        assertBufferResultEquals(TYPES, getFuture(future, NO_WAIT), bufferResult(0, createPage(0)));
+
+        // fail the buffer
+        buffer.fail();
+
+        // add a buffer
+        outputBuffers = outputBuffers.withBuffer(SECOND, BROADCAST_PARTITION_ID);
+        buffer.setOutputBuffers(outputBuffers);
+
+        // attempt to get page, and verify we are blocked
+        future = buffer.get(FIRST, 1, sizeOfPages(10));
+        assertFalse(future.isDone());
+        future = buffer.get(SECOND, 0, sizeOfPages(10));
+        assertFalse(future.isDone());
+
+        // set no more buffers
+        outputBuffers = outputBuffers.withNoMoreBufferIds();
+        buffer.setOutputBuffers(outputBuffers);
+
+        // attempt to get page, and verify we are blocked
+        future = buffer.get(FIRST, 1, sizeOfPages(10));
+        assertFalse(future.isDone());
+        future = buffer.get(SECOND, 0, sizeOfPages(10));
+        assertFalse(future.isDone());
+    }
+
+    @Test
     public void testBufferCompletion()
             throws Exception
     {

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -840,6 +840,51 @@ public class TestBroadcastOutputBuffer
     }
 
     @Test
+    public void testAddBufferAfterFail()
+            throws Exception
+    {
+        OutputBuffers outputBuffers = createInitialEmptyOutputBuffers(BROADCAST)
+                .withBuffer(FIRST, BROADCAST_PARTITION_ID);
+        BroadcastOutputBuffer buffer = createBroadcastBuffer(outputBuffers, sizeOfPages(5));
+        assertFalse(buffer.isFinished());
+
+        // attempt to get a page
+        ListenableFuture<BufferResult> future = buffer.get(FIRST, 0, sizeOfPages(10));
+
+        // verify we are waiting for a page
+        assertFalse(future.isDone());
+
+        // add one page
+        addPage(buffer, createPage(0));
+
+        // verify we got one page
+        assertBufferResultEquals(TYPES, getFuture(future, NO_WAIT), bufferResult(0, createPage(0)));
+
+        // fail the buffer
+        buffer.fail();
+
+        // add a buffer
+        outputBuffers = outputBuffers.withBuffer(SECOND, BROADCAST_PARTITION_ID);
+        buffer.setOutputBuffers(outputBuffers);
+
+        // attempt to get page, and verify we are blocked
+        future = buffer.get(FIRST, 1, sizeOfPages(10));
+        assertFalse(future.isDone());
+        future = buffer.get(SECOND, 0, sizeOfPages(10));
+        assertFalse(future.isDone());
+
+        // set no more buffers
+        outputBuffers = outputBuffers.withNoMoreBufferIds();
+        buffer.setOutputBuffers(outputBuffers);
+
+        // attempt to get page, and verify we are blocked
+        future = buffer.get(FIRST, 1, sizeOfPages(10));
+        assertFalse(future.isDone());
+        future = buffer.get(SECOND, 0, sizeOfPages(10));
+        assertFalse(future.isDone());
+    }
+
+    @Test
     public void testBufferCompletion()
             throws Exception
     {


### PR DESCRIPTION
Client buffer added to a broadcast output buffer were being allowed to be completed
cleanly. This means, if a broadcast buffer is failed before any client buffers are
added, the client stage will see a finished buffer and will initiate stage shutdown.
This results in a race between the propigation of the failure, and the client stage
shutting down.  In rare cases this can cause a query to incorrectly report a susccess
state.