### PR TITLE
Revert Hadoop Kerberos refresh changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hadoop</groupId>
                 <artifactId>hadoop-apache2</artifactId>
-                <version>2.7.3-3</version>
+                <version>2.7.3-1</version>
             </dependency>
 
             <dependency>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -33,7 +33,6 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
-import static java.util.concurrent.TimeUnit.HOURS;
 
 @DefunctConfig({
         "hive.file-system-cache-ttl",
@@ -117,8 +116,6 @@ public class HiveClientConfig
 
     private boolean writesToNonManagedTablesEnabled;
     private boolean tableStatisticsEnabled = true;
-
-    private Duration kerberosTgtMaxCacheDuration = new Duration(1, HOURS);
 
     public int getMaxInitialSplits()
     {
@@ -906,19 +903,5 @@ public class HiveClientConfig
     public boolean isTableStatisticsEnabled()
     {
         return tableStatisticsEnabled;
-    }
-
-    @NotNull
-    public Duration getKerberosTgtMaxCacheDuration()
-    {
-        return kerberosTgtMaxCacheDuration;
-    }
-
-    @Config("hive.kerberos-tgt-max-cache-duration")
-    @ConfigDescription("Kerberos ticket granting ticket max cache duration")
-    public HiveClientConfig setKerberosTgtMaxCacheDuration(Duration kerberosTgtMaxCacheDuration)
-    {
-        this.kerberosTgtMaxCacheDuration = kerberosTgtMaxCacheDuration;
-        return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -44,8 +44,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FilterFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -425,7 +423,7 @@ public final class HiveWriteUtils
     public static boolean isS3FileSystem(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)
     {
         try {
-            return getRawFileSystem(hdfsEnvironment.getFileSystem(context, path)) instanceof PrestoS3FileSystem;
+            return hdfsEnvironment.getFileSystem(context, path) instanceof PrestoS3FileSystem;
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed checking path: " + path, e);
@@ -436,20 +434,12 @@ public final class HiveWriteUtils
     {
         try {
             // Hadoop 1.x does not have the ViewFileSystem class
-            return getRawFileSystem(hdfsEnvironment.getFileSystem(context, path))
+            return hdfsEnvironment.getFileSystem(context, path)
                     .getClass().getName().equals("org.apache.hadoop.fs.viewfs.ViewFileSystem");
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed checking path: " + path, e);
         }
-    }
-
-    private static FileSystem getRawFileSystem(FileSystem fileSystem)
-    {
-        if (fileSystem instanceof FilterFileSystem) {
-            return getRawFileSystem(((FilterFileSystem) fileSystem).getRawFileSystem());
-        }
-        return fileSystem;
     }
 
     private static boolean isDirectory(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/AuthenticationModules.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/AuthenticationModules.java
@@ -15,13 +15,11 @@ package com.facebook.presto.hive.authentication;
 
 import com.facebook.presto.hive.ForHdfs;
 import com.facebook.presto.hive.ForHiveMetastore;
-import com.facebook.presto.hive.HiveClientConfig;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import io.airlift.units.Duration;
 
 import javax.inject.Inject;
 
@@ -56,11 +54,11 @@ public final class AuthenticationModules
             @Provides
             @Singleton
             @ForHiveMetastore
-            HadoopAuthentication createHadoopAuthentication(MetastoreKerberosConfig config, HiveClientConfig hiveClientConfig)
+            HadoopAuthentication createHadoopAuthentication(MetastoreKerberosConfig config)
             {
                 String principal = config.getHiveMetastoreClientPrincipal();
                 String keytabLocation = config.getHiveMetastoreClientKeytab();
-                return createCachingKerberosHadoopAuthentication(principal, keytabLocation, hiveClientConfig.getKerberosTgtMaxCacheDuration());
+                return createCachingKerberosHadoopAuthentication(principal, keytabLocation);
             }
         };
     }
@@ -101,11 +99,11 @@ public final class AuthenticationModules
             @Provides
             @Singleton
             @ForHdfs
-            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config, HiveClientConfig hiveClientConfig)
+            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config)
             {
                 String principal = config.getHdfsPrestoPrincipal();
                 String keytabLocation = config.getHdfsPrestoKeytab();
-                return createCachingKerberosHadoopAuthentication(principal, keytabLocation, hiveClientConfig.getKerberosTgtMaxCacheDuration());
+                return createCachingKerberosHadoopAuthentication(principal, keytabLocation);
             }
         };
     }
@@ -127,19 +125,19 @@ public final class AuthenticationModules
             @Provides
             @Singleton
             @ForHdfs
-            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config, HiveClientConfig hiveClientConfig)
+            HadoopAuthentication createHadoopAuthentication(HdfsKerberosConfig config)
             {
                 String principal = config.getHdfsPrestoPrincipal();
                 String keytabLocation = config.getHdfsPrestoKeytab();
-                return createCachingKerberosHadoopAuthentication(principal, keytabLocation, hiveClientConfig.getKerberosTgtMaxCacheDuration());
+                return createCachingKerberosHadoopAuthentication(principal, keytabLocation);
             }
         };
     }
 
-    private static HadoopAuthentication createCachingKerberosHadoopAuthentication(String principal, String keytabLocation, Duration maxCacheDuration)
+    private static HadoopAuthentication createCachingKerberosHadoopAuthentication(String principal, String keytabLocation)
     {
         KerberosAuthentication kerberosAuthentication = new KerberosAuthentication(principal, keytabLocation);
         KerberosHadoopAuthentication kerberosHadoopAuthentication = new KerberosHadoopAuthentication(kerberosAuthentication);
-        return new CachingKerberosHadoopAuthentication(kerberosHadoopAuthentication, maxCacheDuration);
+        return new CachingKerberosHadoopAuthentication(kerberosHadoopAuthentication);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -29,8 +29,6 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.hive.TestHiveUtil.nonDefaultTimeZone;
-import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestHiveClientConfig
 {
@@ -95,8 +93,7 @@ public class TestHiveClientConfig
                 .setBucketWritingEnabled(true)
                 .setFileSystemMaxCacheSize(1000)
                 .setTableStatisticsEnabled(true)
-                .setWritesToNonManagedTablesEnabled(false)
-                .setKerberosTgtMaxCacheDuration(new Duration(1, HOURS)));
+                .setWritesToNonManagedTablesEnabled(false));
     }
 
     @Test
@@ -161,7 +158,6 @@ public class TestHiveClientConfig
                 .put("hive.fs.cache.max-size", "1010")
                 .put("hive.table-statistics-enabled", "false")
                 .put("hive.non-managed-table-writes-enabled", "true")
-                .put("hive.kerberos-tgt-max-cache-duration", "1s")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -171,7 +167,7 @@ public class TestHiveClientConfig
                 .setMaxOutstandingSplits(10)
                 .setMaxSplitIteratorThreads(10)
                 .setAllowCorruptWritesForTesting(true)
-                .setMetastoreCacheTtl(new Duration(2, HOURS))
+                .setMetastoreCacheTtl(new Duration(2, TimeUnit.HOURS))
                 .setMetastoreRefreshInterval(new Duration(30, TimeUnit.MINUTES))
                 .setMetastoreCacheMaximumSize(5000)
                 .setPerTransactionMetastoreCacheMaximumSize(500)
@@ -222,8 +218,7 @@ public class TestHiveClientConfig
                 .setBucketWritingEnabled(false)
                 .setFileSystemMaxCacheSize(1010)
                 .setTableStatisticsEnabled(false)
-                .setWritesToNonManagedTablesEnabled(true)
-                .setKerberosTgtMaxCacheDuration(new Duration(1, SECONDS));
+                .setWritesToNonManagedTablesEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -20,7 +20,6 @@ hive.hdfs.impersonation.enabled=true
 hive.hdfs.presto.principal=presto-server/_HOST@LABS.TERADATA.COM
 hive.hdfs.presto.keytab=/etc/presto/conf/presto-server.keytab
 hive.fs.cache.max-size=10
-hive.kerberos-tgt-max-cache-duration=1s
 
 #required for testGrantRevoke() product test
 hive.security=sql-standard

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -25,4 +25,3 @@ hive.hdfs.impersonation.enabled=false
 hive.hdfs.presto.principal=hdfs/hadoop-master@LABS.TERADATA.COM
 hive.hdfs.presto.keytab=/etc/hadoop/conf/hdfs.keytab
 hive.fs.cache.max-size=10
-hive.kerberos-tgt-max-cache-duration=1s


### PR DESCRIPTION
The file system wrapper is not referenced by input or output streams
and thus gets collected and closed too early, which fails queries.