### PR TITLE
Improve hash computation for MapType

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapHashCodeOperator.java
@@ -66,8 +66,7 @@ public class MapHashCodeOperator
     {
         long result = 0;
         for (int position = 0; position < block.getPositionCount(); position += 2) {
-            result += hashPosition(keyHashCodeFunction, keyType, block, position);
-            result += hashPosition(valueHashCodeFunction, valueType, block, position + 1);
+            result += hashPosition(keyHashCodeFunction, keyType, block, position) ^ hashPosition(valueHashCodeFunction, valueType, block, position + 1);
         }
         return result;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -99,8 +99,7 @@ public class MapType
         long result = 0;
 
         for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
-            result += hashPosition(keyType, mapBlock, i);
-            result += hashPosition(valueType, mapBlock, i + 1);
+            result += hashPosition(keyType, mapBlock, i) ^ hashPosition(valueType, mapBlock, i + 1);
         }
         return result;
     }


### PR DESCRIPTION
The hash value for MapType is computed via adding the hash values of
all the keys and values. This will produce same hash value for the map
with same key set and value set, even the mapping is different.