### PR TITLE
Use Reader to circumvent automatic character encoding detection

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
@@ -43,7 +43,7 @@ import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -105,10 +105,13 @@ public final class JsonUtil
 
     private JsonUtil() {}
 
+    // Using InputStreamReader instead of InputStream
+    // This is because InputStream automatically detects the encoding, which is not expected
+    // Its test case is in @com.facebook.presto.operator.scalar.TestJsonExtract#testNoAutomaticEncodingDetection
     public static JsonParser createJsonParser(JsonFactory factory, Slice json)
             throws IOException
     {
-        return factory.createParser((InputStream) json.getInput());
+        return factory.createParser(new InputStreamReader(json.getInput()));
     }
 
     public static JsonGenerator createJsonGenerator(JsonFactory factory, SliceOutput output)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -30,12 +31,21 @@ import static com.facebook.presto.operator.scalar.JsonExtract.ObjectFieldJsonExt
 import static com.facebook.presto.operator.scalar.JsonExtract.ScalarValueJsonExtractor;
 import static com.facebook.presto.operator.scalar.JsonExtract.generateExtractor;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestJsonExtract
+        extends AbstractTestFunctions
 {
+    @BeforeClass
+    public void setUp()
+    {
+        // required for registering utf8 function declared in TestStringFunctions
+        registerScalar(TestStringFunctions.class);
+    }
+
     @Test
     public void testJsonTokenizer()
     {
@@ -328,6 +338,13 @@ public class TestJsonExtract
         assertInvalidExtract("", " ", "Invalid JSON path: ' '");
         assertInvalidExtract("", ".", "Invalid JSON path: '.'");
         assertInvalidExtract("{ \"store\": { \"book\": [{ \"title\": \"title\" }] } }", "$.store.book[", "Invalid JSON path: '$.store.book['");
+    }
+
+    @Test
+    public void testNoAutomaticEncodingDetection()
+    {
+        // Automatic encoding detection treats the following input as UTF-32
+        assertFunction("JSON_EXTRACT_SCALAR(UTF8(X'00 00 00 00 7b 22 72 22'), '$.x')", VARCHAR, null);
     }
 
     private static String doExtract(JsonExtractor<Slice> jsonExtractor, String json)


### PR DESCRIPTION
As reported in #8975, 

> Root cause is that ByteSourceJsonBootstrapper.constructParser calls detectEncoding under the hood, which is not expected.


