### PR TITLE
Clean up PositionsPageProcessorIterator::processBatch() return value

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
@@ -135,10 +135,8 @@ public class PageProcessor
         private long retainedSizeInBytes;
 
         // remember if we need to re-use the same batch size if we yield last time
-        // TODO: make this a local variable in computeNext
-        // processBatch() should return multiple values instead of using a field variable as part of its return
-        private boolean forceYieldFinish;
-        private int previousBatchSize;
+        private boolean lastComputeYielded;
+        private int lastComputeBatchSize;
         private Optional<PageProjectionOutput> pageProjectOutput = Optional.empty();
 
         public PositionsPageProcessorIterator(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
@@ -163,35 +161,39 @@ public class PageProcessor
             while (true) {
                 if (selectedPositions.isEmpty()) {
                     updateRetainedSize();
-                    verify(!forceYieldFinish);
+                    verify(!lastComputeYielded);
                     return endOfData();
                 }
 
                 // we always process one chunk
-                if (forceYieldFinish) {
+                if (lastComputeYielded) {
                     // re-use the batch size from the last checkpoint
-                    verify(previousBatchSize > 0);
-                    batchSize = previousBatchSize;
-                    forceYieldFinish = false;
+                    verify(lastComputeBatchSize > 0);
+                    batchSize = lastComputeBatchSize;
+                    lastComputeYielded = false;
+                    lastComputeBatchSize = 0;
                 }
                 else {
                     batchSize = Math.min(selectedPositions.size(), projectBatchSize);
                 }
-                Optional<Page> result = processBatch(batchSize);
+                ProcessBatchResult result = processBatch(batchSize);
 
-                if (!result.isPresent()) {
-                    // if we are running out of time
-                    if (forceYieldFinish) {
-                        return Optional.empty();
-                    }
+                if (result.isYieldFinish()) {
+                    // if we are running out of time, save the batch size and continue next time
+                    lastComputeYielded = true;
+                    lastComputeBatchSize = batchSize;
+                    return Optional.empty();
+                }
 
+                if (result.isPageTooLarge()) {
                     // if the page buffer filled up, so halve the batch size and retry
                     verify(batchSize > 1);
                     projectBatchSize = projectBatchSize / 2;
                     continue;
                 }
 
-                Page page = result.get();
+                verify(result.isSuccess());
+                Page page = result.getPage();
 
                 // if we produced a large page, halve the batch size for the next call
                 long pageSize = page.getSizeInBytes();
@@ -245,7 +247,7 @@ public class PageProcessor
             }
         }
 
-        private Optional<Page> processBatch(int batchSize)
+        private ProcessBatchResult processBatch(int batchSize)
         {
             Block[] blocks = new Block[projections.size()];
 
@@ -253,14 +255,11 @@ public class PageProcessor
             SelectedPositions positionsBatch = selectedPositions.subRange(0, batchSize);
             for (int i = 0; i < projections.size(); i++) {
                 if (yieldSignal.isSet()) {
-                    // save current batch size
-                    forceYieldFinish = true;
-                    previousBatchSize = batchSize;
-                    return Optional.empty();
+                    return ProcessBatchResult.processBatchYield();
                 }
 
                 if (positionsBatch.size() > 1 && pageSize > MAX_PAGE_SIZE_IN_BYTES) {
-                    return Optional.empty();
+                    return ProcessBatchResult.processBatchTooLarge();
                 }
 
                 // if possible, use previouslyComputedResults produced in prior optimistic failure attempt
@@ -274,9 +273,7 @@ public class PageProcessor
                     }
                     Optional<Block> block = pageProjectOutput.get().compute();
                     if (!block.isPresent()) {
-                        forceYieldFinish = true;
-                        previousBatchSize = batchSize;
-                        return Optional.empty();
+                        return ProcessBatchResult.processBatchYield();
                     }
                     pageProjectOutput = Optional.empty();
                     previouslyComputedResults[i] = block.get();
@@ -285,7 +282,7 @@ public class PageProcessor
 
                 pageSize += blocks[i].getSizeInBytes();
             }
-            return Optional.of(new Page(positionsBatch.size(), blocks));
+            return ProcessBatchResult.processBatchSuccess(new Page(positionsBatch.size(), blocks));
         }
     }
 
@@ -304,6 +301,62 @@ public class PageProcessor
         public void reset()
         {
             dictionarySourceIds.clear();
+        }
+    }
+
+    private static class ProcessBatchResult
+    {
+        private final ProcessBatchState state;
+        private final Page page;
+
+        private ProcessBatchResult(ProcessBatchState state, Page page)
+        {
+            this.state = state;
+            this.page = page;
+        }
+
+        public static ProcessBatchResult processBatchYield()
+        {
+            return new ProcessBatchResult(ProcessBatchState.YIELD, null);
+        }
+
+        public static ProcessBatchResult processBatchTooLarge()
+        {
+            return new ProcessBatchResult(ProcessBatchState.PAGE_TOO_LARGE, null);
+        }
+
+        public static ProcessBatchResult processBatchSuccess(Page page)
+        {
+            return new ProcessBatchResult(ProcessBatchState.SUCCESS, requireNonNull(page));
+        }
+
+        public boolean isYieldFinish()
+        {
+            return state == ProcessBatchState.YIELD;
+        }
+
+        public boolean isPageTooLarge()
+        {
+            return state == ProcessBatchState.PAGE_TOO_LARGE;
+        }
+
+        public boolean isSuccess()
+        {
+            return state == ProcessBatchState.SUCCESS;
+        }
+
+        public Page getPage()
+        {
+            verify(page != null);
+            verify(state == ProcessBatchState.SUCCESS);
+            return page;
+        }
+
+        private enum ProcessBatchState
+        {
+            YIELD,
+            PAGE_TOO_LARGE,
+            SUCCESS
         }
     }
 }


### PR DESCRIPTION
processBatch() is responsible for telling the caller if it has produced
a page, yields to time, or needs to shrink the batch size. Currently
there is a local variable and a global variable to pass the information
back to the caller, which is not elegant. Unify the interface to return
a class to informm the caller the state returned by processBatch().