### PR TITLE
Bing tile functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -187,3 +187,45 @@ Accessors
 .. function:: ST_NumInteriorRing(Geometry) -> bigint
 
     Returns the cardinality of the collection of interior rings of a polygon.
+
+===================
+Bing Tile Functions
+===================
+
+A set of functions to convert between geometries and `Bing tiles <https://msdn.microsoft.com/en-us/library/bb259689.aspx>`_.
+
+.. function:: bing_tile(x, y, zoom_level) => BingTile
+
+    Creates a Bing tile object from XY coordinates and a zoom level.
+    Zoom levels from 1 to 23 are supported.
+
+.. function:: bing_tile(quadKey) => BingTile
+
+    Creates a Bing tile object from a quadkey.
+
+.. function:: bing_tile_at(latitude, longitude, zoom_level) => BingTile
+
+    Returns a Bing tile at a given zoom level containing a point at a given latitude
+    and longitude. Latitude must be within ``[-85.05112878, 85.05112878]`` range.
+    Longitude must be within ``[-180, 180]`` range. Zoom levels from 1 to 23 are supported.
+
+.. function:: bing_tile_coordinates(tile) => row(x, y)
+
+    Returns the XY coordinates of a given Bing tile.
+
+.. function:: bing_tile_polygon(tile) => Geometry
+
+    Returns the polygon representation of a given Bing tile.
+
+.. function:: bing_tile_quadkey(tile) => varchar
+
+    Returns the quadkey of a given Bing tile.
+
+.. function:: bing_tile_zoom_level(tile) => tinyint
+
+    Returns the zoom level of a given Bing tile.
+
+.. function:: geometry_to_bing_tiles(geometry, zoom_level) => array(BingTile)
+
+    Returns the minimum set of Bing tiles that fully covers a given geometry at
+    a given zoom level. Zoom levels from 1 to 23 are supported.

--- a/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTile.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTile.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial;
+
+import com.facebook.presto.spi.PrestoException;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class BingTile
+{
+    public static final int MAX_ZOOM_LEVEL = 23;
+
+    private final int x;
+    private final int y;
+    private final int zoomLevel;
+
+    private BingTile(int x, int y, int zoomLevel)
+    {
+        checkArgument(zoomLevel <= MAX_ZOOM_LEVEL);
+        this.x = x;
+        this.y = y;
+        this.zoomLevel = zoomLevel;
+    }
+
+    public static BingTile fromCoordinates(int x, int y, int zoomLevel)
+    {
+        return new BingTile(x, y, zoomLevel);
+    }
+
+    public static BingTile fromQuadKey(String quadKey)
+    {
+        int zoomLevel = quadKey.length();
+        checkArgument(zoomLevel <= MAX_ZOOM_LEVEL);
+        int tileX = 0;
+        int tileY = 0;
+        for (int i = zoomLevel; i > 0; i--) {
+            int mask = 1 << (i - 1);
+            switch (quadKey.charAt(zoomLevel - i)) {
+                case '0':
+                    break;
+                case '1':
+                    tileX |= mask;
+                    break;
+                case '2':
+                    tileY |= mask;
+                    break;
+                case '3':
+                    tileX |= mask;
+                    tileY |= mask;
+                    break;
+                default:
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Invalid QuadKey digit sequence: " + quadKey);
+            }
+        }
+
+        return new BingTile(tileX, tileY, zoomLevel);
+    }
+
+    public int getX()
+    {
+        return x;
+    }
+
+    public int getY()
+    {
+        return y;
+    }
+
+    public int getZoomLevel()
+    {
+        return zoomLevel;
+    }
+
+    public String toQuadKey()
+    {
+        char[] quadKey = new char[this.zoomLevel];
+        for (int i = this.zoomLevel; i > 0; i--) {
+            char digit = '0';
+            int mask = 1 << (i - 1);
+            if ((this.x & mask) != 0) {
+                digit++;
+            }
+            if ((this.y & mask) != 0) {
+                digit += 2;
+            }
+            quadKey[this.zoomLevel - i] = digit;
+        }
+        return String.valueOf(quadKey);
+    }
+
+    /**
+     * Encodes Bing tile as a 64-bit long: 23 bits for X, followed by 23 bits for Y,
+     * followed by 5 bits for zoomLevel
+     */
+    public long encode()
+    {
+        return (((long) x) << 28) + (y << 5) + zoomLevel;
+    }
+
+    public static BingTile decode(long tile)
+    {
+        int tileX = (int) (tile >> 28);
+        int tileY = (int) ((tile % (1 << 28)) >> 5);
+        int zoomLevel = (int) (tile % (1 << 5));
+
+        return new BingTile(tileX, tileY, zoomLevel);
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTileFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTileFunctions.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial;
+
+import com.esri.core.geometry.Envelope;
+import com.esri.core.geometry.MultiVertexGeometry;
+import com.esri.core.geometry.Point;
+import com.esri.core.geometry.Polygon;
+import com.esri.core.geometry.Polyline;
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.esri.core.geometry.ogc.OGCPoint;
+import com.esri.core.geometry.ogc.OGCPolygon;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import io.airlift.slice.Slice;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.facebook.presto.geospatial.BingTile.MAX_ZOOM_LEVEL;
+import static com.facebook.presto.geospatial.GeometryType.GEOMETRY_TYPE_NAME;
+import static com.facebook.presto.geospatial.GeometryUtils.deserialize;
+import static com.facebook.presto.geospatial.GeometryUtils.serialize;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+
+/**
+ * A set of functions to convert between geometries and Bing tiles.
+ *
+ * @see <a href="https://msdn.microsoft.com/en-us/library/bb259689.aspx">https://msdn.microsoft.com/en-us/library/bb259689.aspx</a>
+ * for the description of the Bing tiles.
+ */
+public class BingTileFunctions
+{
+    private static final int TILE_PIXELS = 256;
+    private static final double MAX_LATITUDE = 85.05112878;
+    private static final double MIN_LATITUDE = -85.05112878;
+    private static final double MIN_LONGITUDE = -180;
+    private static final double MAX_LONGITUDE = 180;
+
+    private static final String LATITUDE_OUT_OF_RANGE = "Latitude must be between " + MIN_LATITUDE + " and " + MAX_LATITUDE;
+    private static final String LATITUDE_SPAN_OUT_OF_RANGE = String.format("Latitude span for the geometry must be in [%.2f, %.2f] range", MIN_LATITUDE, MAX_LATITUDE);
+    private static final String LONGITUDE_OUT_OF_RANGE = "Longitude must be between " + MIN_LONGITUDE + " and " + MAX_LONGITUDE;
+    private static final String LONGITUDE_SPAN_OUT_OF_RANGE = String.format("Longitude span for the geometry must be in [%.2f, %.2f] range", MIN_LONGITUDE, MAX_LONGITUDE);
+    private static final String QUAD_KEY_EMPTY = "QuadKey must not be empty string";
+    private static final String QUAD_KEY_TOO_LONG = "QuadKey must be " + MAX_ZOOM_LEVEL + " characters or less";
+    private static final String ZOOM_LEVEL_TOO_SMALL = "Zoom level must be > 0";
+    private static final String ZOOM_LEVEL_TOO_LARGE = "Zoom level must be <= " + MAX_ZOOM_LEVEL;
+
+    private BingTileFunctions() {}
+
+    @Description("Creates a Bing tile from XY coordinates and zoom level")
+    @ScalarFunction("bing_tile")
+    @SqlType(BingTileType.NAME)
+    public static long toBingTile(@SqlType(StandardTypes.INTEGER) long tileX, @SqlType(StandardTypes.INTEGER) long tileY, @SqlType(StandardTypes.INTEGER) long zoomLevel)
+    {
+        checkZoomLevel(zoomLevel);
+        checkCoordinate(tileX, zoomLevel);
+        checkCoordinate(tileY, zoomLevel);
+
+        return BingTile.fromCoordinates(toIntExact(tileX), toIntExact(tileY), toIntExact(zoomLevel)).encode();
+    }
+
+    @Description("Given a Bing tile, returns its QuadKey")
+    @ScalarFunction("bing_tile_quadkey")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice toQuadKey(@SqlType(BingTileType.NAME) long input)
+    {
+        return utf8Slice(BingTile.decode(input).toQuadKey());
+    }
+
+    @Description("Given a Bing tile, returns XY coordinates of the tile")
+    @ScalarFunction("bing_tile_coordinates")
+    @SqlType("row(x integer,y integer)")
+    public static Block bingTileCoordinates(@SqlType(BingTileType.NAME) long input)
+    {
+        BingTile tile = BingTile.decode(input);
+
+        BlockBuilder tileBlockBuilder = INTEGER.createBlockBuilder(new BlockBuilderStatus(), 2);
+        INTEGER.writeLong(tileBlockBuilder, tile.getX());
+        INTEGER.writeLong(tileBlockBuilder, tile.getY());
+
+        return tileBlockBuilder.build();
+    }
+
+    @Description("Given a Bing tile, returns zoom level of the tile")
+    @ScalarFunction("bing_tile_zoom_level")
+    @SqlType(StandardTypes.TINYINT)
+    public static long bingTileZoomLevel(@SqlType(BingTileType.NAME) long input)
+    {
+        return BingTile.decode(input).getZoomLevel();
+    }
+
+    @Description("Creates a Bing tile from a QuadKey")
+    @ScalarFunction("bing_tile")
+    @SqlType(BingTileType.NAME)
+    public static long toBingTile(@SqlType(StandardTypes.VARCHAR) Slice quadKey)
+    {
+        checkQuadKey(quadKey);
+        return BingTile.fromQuadKey(quadKey.toStringUtf8()).encode();
+    }
+
+    @Description("Given a (longitude, latitude) point, returns the containing Bing tile at the specified zoom level")
+    @ScalarFunction("bing_tile_at")
+    @SqlType(BingTileType.NAME)
+    public static long bingTileAt(
+            @SqlType(StandardTypes.DOUBLE) double latitude,
+            @SqlType(StandardTypes.DOUBLE) double longitude,
+            @SqlType(StandardTypes.INTEGER) long zoomLevel)
+    {
+        checkLatitude(latitude, LATITUDE_OUT_OF_RANGE);
+        checkLongitude(longitude, LONGITUDE_OUT_OF_RANGE);
+        checkZoomLevel(zoomLevel);
+
+        return latitudeLongitudeToTile(latitude, longitude, toIntExact(zoomLevel)).encode();
+    }
+
+    @Description("Given a Bing tile, returns the polygon representation of the tile")
+    @ScalarFunction("bing_tile_polygon")
+    @SqlType(GEOMETRY_TYPE_NAME)
+    public static Slice bingTilePolygon(@SqlType(BingTileType.NAME) long input)
+    {
+        BingTile tile = BingTile.decode(input);
+
+        return serialize(tileToPolygon(tile));
+    }
+
+    @Description("Given a geometry and a zoom level, returns the minimum set of Bing tiles that fully covers that geometry")
+    @ScalarFunction("geometry_to_bing_tiles")
+    @SqlType("array(" + BingTileType.NAME + ")")
+    public static Block geometryToBingTiles(@SqlType(GEOMETRY_TYPE_NAME) Slice input, @SqlType(StandardTypes.INTEGER) long zoomLevelInput)
+    {
+        checkZoomLevel(zoomLevelInput);
+
+        int zoomLevel = toIntExact(zoomLevelInput);
+
+        OGCGeometry geometry = deserialize(input);
+        checkCondition(!geometry.isEmpty(), "Input geometry must not be empty");
+
+        Envelope envelope = new Envelope();
+        geometry.getEsriGeometry().queryEnvelope(envelope);
+
+        checkLatitude(envelope.getYMin(), LATITUDE_SPAN_OUT_OF_RANGE);
+        checkLatitude(envelope.getYMax(), LATITUDE_SPAN_OUT_OF_RANGE);
+        checkLongitude(envelope.getXMin(), LONGITUDE_SPAN_OUT_OF_RANGE);
+        checkLongitude(envelope.getXMax(), LONGITUDE_SPAN_OUT_OF_RANGE);
+
+        boolean pointOrRectangle = isPointOrRectangle(geometry, envelope);
+
+        BingTile leftUpperTile = latitudeLongitudeToTile(envelope.getYMax(), envelope.getXMin(), zoomLevel);
+        BingTile rightLowerTile = latitudeLongitudeToTile(envelope.getYMin(), envelope.getXMax(), zoomLevel);
+
+        // XY coordinates start at (0,0) in the left upper corner and increase left to right and top to bottom
+        int tileCount = toIntExact((rightLowerTile.getX() - leftUpperTile.getX() + 1) * (rightLowerTile.getY() - leftUpperTile.getY() + 1));
+
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), tileCount);
+        for (int x = leftUpperTile.getX(); x <= rightLowerTile.getX(); x++) {
+            for (int y = leftUpperTile.getY(); y <= rightLowerTile.getY(); y++) {
+                BingTile tile = BingTile.fromCoordinates(x, y, zoomLevel);
+
+                if (pointOrRectangle || !tileToPolygon(tile).disjoint(geometry)) {
+                    BIGINT.writeLong(blockBuilder, tile.encode());
+                }
+            }
+        }
+
+        return blockBuilder.build();
+    }
+
+    private static Point tileXYToLatitudeLongitude(int tileX, int tileY, int zoomLevel)
+    {
+        int mapSize = mapSize(zoomLevel);
+        double x = (clip(tileX * TILE_PIXELS, 0, mapSize - 1) / mapSize) - 0.5;
+        double y = 0.5 - (clip(tileY * TILE_PIXELS, 0, mapSize - 1) / mapSize);
+
+        double latitude = 90 - 360 * Math.atan(Math.exp(-y * 2 * Math.PI)) / Math.PI;
+        double longitude = 360 * x;
+        return new Point(longitude, latitude);
+    }
+
+    private static BingTile latitudeLongitudeToTile(double latitude, double longitude, int zoomLevel)
+    {
+        double x = (longitude + 180) / 360;
+        double sinLatitude = Math.sin(latitude * Math.PI / 180);
+        double y = 0.5 - Math.log((1 + sinLatitude) / (1 - sinLatitude)) / (4 * Math.PI);
+
+        int mapSize = mapSize(zoomLevel);
+        int tileX = (int) clip(x * mapSize + 0.5, 0, mapSize - 1);
+        int tileY = (int) clip(y * mapSize + 0.5, 0, mapSize - 1);
+        return BingTile.fromCoordinates(tileX / TILE_PIXELS, tileY / TILE_PIXELS, zoomLevel);
+    }
+
+    private static OGCGeometry tileToPolygon(BingTile tile)
+    {
+        Point upperLeftCorner = tileXYToLatitudeLongitude(tile.getX(), tile.getY(), tile.getZoomLevel());
+        Point lowerRightCorner = tileXYToLatitudeLongitude(tile.getX() + 1, tile.getY() + 1, tile.getZoomLevel());
+
+        Polyline boundary = new Polyline();
+        boundary.startPath(upperLeftCorner);
+        boundary.lineTo(lowerRightCorner.getX(), upperLeftCorner.getY());
+        boundary.lineTo(lowerRightCorner);
+        boundary.lineTo(upperLeftCorner.getX(), lowerRightCorner.getY());
+
+        Polygon polygon = new Polygon();
+        polygon.add(boundary, false);
+
+        return OGCGeometry.createFromEsriGeometry(polygon, null);
+    }
+
+    /**
+     * @return true if the geometry is a point or a rectangle
+     */
+    private static boolean isPointOrRectangle(OGCGeometry geometry, Envelope envelope)
+    {
+        if (geometry instanceof OGCPoint) {
+            return true;
+        }
+
+        if (!(geometry instanceof OGCPolygon)) {
+            return false;
+        }
+
+        OGCPolygon polygon = (OGCPolygon) geometry;
+        if (polygon.numInteriorRing() > 0) {
+            return false;
+        }
+
+        MultiVertexGeometry multiVertexGeometry = (MultiVertexGeometry) polygon.getEsriGeometry();
+        if (multiVertexGeometry.getPointCount() != 4) {
+            return false;
+        }
+
+        Set<Point> corners = new HashSet<>();
+        corners.add(new Point(envelope.getXMin(), envelope.getYMin()));
+        corners.add(new Point(envelope.getXMin(), envelope.getYMax()));
+        corners.add(new Point(envelope.getXMax(), envelope.getYMin()));
+        corners.add(new Point(envelope.getXMax(), envelope.getYMax()));
+
+        for (int i = 0; i < 4; i++) {
+            Point point = multiVertexGeometry.getPoint(i);
+            if (!corners.contains(point)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void checkZoomLevel(long zoomLevel)
+    {
+        checkCondition(zoomLevel > 0, ZOOM_LEVEL_TOO_SMALL);
+        checkCondition(zoomLevel <= MAX_ZOOM_LEVEL, ZOOM_LEVEL_TOO_LARGE);
+    }
+
+    private static void checkCoordinate(long coordinate, long zoomLevel)
+    {
+        checkCondition(coordinate >= 0 && coordinate < (1 << zoomLevel), "XY coordinates for a Bing tile at zoom level %s must be within [0, %s) range", zoomLevel, 1 << zoomLevel);
+    }
+
+    private static void checkQuadKey(@SqlType(StandardTypes.VARCHAR) Slice quadkey)
+    {
+        checkCondition(quadkey.length() > 0, QUAD_KEY_EMPTY);
+        checkCondition(quadkey.length() <= MAX_ZOOM_LEVEL, QUAD_KEY_TOO_LONG);
+    }
+
+    private static void checkLatitude(double latitude, String errorMessage)
+    {
+        checkCondition(latitude >= MIN_LATITUDE && latitude <= MAX_LATITUDE, errorMessage);
+    }
+
+    private static void checkLongitude(double longitude, String errorMessage)
+    {
+        checkCondition(longitude >= MIN_LONGITUDE && longitude <= MAX_LONGITUDE, errorMessage);
+    }
+
+    private static void checkCondition(boolean condition, String formatString, Object... args)
+    {
+        if (!condition) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format(formatString, args));
+        }
+    }
+
+    private static double clip(double n, double minValue, double maxValue)
+    {
+        return Math.min(Math.max(n, minValue), maxValue);
+    }
+
+    private static int mapSize(int zoomLevel)
+    {
+        return 256 << zoomLevel;
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTileOperators.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTileOperators.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial;
+
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.AbstractLongType;
+import com.facebook.presto.spi.type.StandardTypes;
+
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+
+public final class BingTileOperators
+{
+    private BingTileOperators() {}
+
+    @ScalarOperator(EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean equal(@SqlType(BingTileType.NAME) long left, @SqlType(BingTileType.NAME) long right)
+    {
+        return left == right;
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean notEqual(@SqlType(BingTileType.NAME) long left, @SqlType(BingTileType.NAME) long right)
+    {
+        return left != right;
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @SqlType(StandardTypes.BIGINT)
+    public static long hashCode(@SqlType(BingTileType.NAME) long value)
+    {
+        return AbstractLongType.hash(value);
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTileType.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTileType.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.AbstractLongType;
+import com.facebook.presto.spi.type.TypeSignature;
+
+public class BingTileType
+        extends AbstractLongType
+{
+    public static final BingTileType BING_TILE = new BingTileType();
+    public static final String NAME = "BingTile";
+
+    public BingTileType()
+    {
+        super(new TypeSignature(NAME));
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return false;
+    }
+
+    @Override
+    public Object getObjectValue(ConnectorSession session, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+
+        return BingTile.decode(block.getLong(0, 0));
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/geospatial/GeoPlugin.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/geospatial/GeoPlugin.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
+import static com.facebook.presto.geospatial.BingTileType.BING_TILE;
 import static com.facebook.presto.geospatial.GeometryType.GEOMETRY;
 
 public class GeoPlugin
@@ -28,7 +29,7 @@ public class GeoPlugin
     @Override
     public Iterable<Type> getTypes()
     {
-        return ImmutableList.of(GEOMETRY);
+        return ImmutableList.of(GEOMETRY, BING_TILE);
     }
 
     @Override
@@ -36,6 +37,8 @@ public class GeoPlugin
     {
         return ImmutableSet.<Class<?>>builder()
                 .add(GeoFunctions.class)
+                .add(BingTileOperators.class)
+                .add(BingTileFunctions.class)
                 .build();
     }
 }

--- a/presto-geospatial/src/test/java/com/facebook/presto/geospatial/TestBingTileFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/geospatial/TestBingTileFunctions.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.metadata.FunctionExtractor.extractFunctions;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+public class TestBingTileFunctions
+        extends AbstractTestFunctions
+{
+    @BeforeClass
+    protected void registerFunctions()
+    {
+        GeoPlugin plugin = new GeoPlugin();
+        for (Type type : plugin.getTypes()) {
+            functionAssertions.getTypeRegistry().addType(type);
+        }
+        functionAssertions.getMetadata().addFunctions(extractFunctions(plugin.getFunctions()));
+    }
+
+    @Test
+    public void testBingTile()
+            throws Exception
+    {
+        assertFunction("bing_tile_quadkey(bing_tile('213'))", VARCHAR, "213");
+        assertFunction("bing_tile_quadkey(bing_tile('123030123010121'))", VARCHAR, "123030123010121");
+
+        assertFunction("bing_tile_quadkey(bing_tile(3, 5, 3))", VARCHAR, "213");
+        assertFunction("bing_tile_quadkey(bing_tile(21845, 13506, 15))", VARCHAR, "123030123010121");
+
+        // Invalid calls: corrupt quadkeys
+        assertInvalidFunction("bing_tile('')", "QuadKey must not be empty string");
+        assertInvalidFunction("bing_tile('test')", "Invalid QuadKey digit sequence: test");
+        assertInvalidFunction("bing_tile('12345')", "Invalid QuadKey digit sequence: 12345");
+        assertInvalidFunction("bing_tile('101010101010101010101010101010100101010101001010')", "QuadKey must be 23 characters or less");
+
+        // Invalid calls: XY out of range
+        assertInvalidFunction("bing_tile(10, 2, 3)", "XY coordinates for a Bing tile at zoom level 3 must be within [0, 8) range");
+        assertInvalidFunction("bing_tile(2, 10, 3)", "XY coordinates for a Bing tile at zoom level 3 must be within [0, 8) range");
+
+        // Invalid calls: zoom level out of range
+        assertInvalidFunction("bing_tile(2, 7, 37)", "Zoom level must be <= 23");
+    }
+
+    @Test
+    public void testPointToBingTile()
+            throws Exception
+    {
+        assertFunction("bing_tile_quadkey(bing_tile_at(30.12, 60, 15))", VARCHAR, "123030123010121");
+
+        // Invalid calls
+        // Longitude out of range
+        assertInvalidFunction("bing_tile_at(30.12, 600, 15)", "Longitude must be between -180.0 and 180.0");
+        // Latitude out of range
+        assertInvalidFunction("bing_tile_at(300.12, 60, 15)", "Latitude must be between -85.05112878 and 85.05112878");
+        // Invalid zoom levels
+        assertInvalidFunction("bing_tile_at(30.12, 60, 0)", "Zoom level must be > 0");
+        assertInvalidFunction("bing_tile_at(30.12, 60, 40)", "Zoom level must be <= 23");
+    }
+
+    @Test
+    public void testBingTileCoordinates()
+            throws Exception
+    {
+        assertFunction("bing_tile_coordinates(bing_tile('213')).x", INTEGER, 3);
+        assertFunction("bing_tile_coordinates(bing_tile('213')).y", INTEGER, 5);
+        assertFunction("bing_tile_coordinates(bing_tile('123030123010121')).x", INTEGER, 21845);
+        assertFunction("bing_tile_coordinates(bing_tile('123030123010121')).y", INTEGER, 13506);
+    }
+
+    @Test
+    public void testBingTileZoomLevel()
+            throws Exception
+    {
+        assertFunction("bing_tile_zoom_level(bing_tile('213'))", TINYINT, (byte) 3);
+        assertFunction("bing_tile_zoom_level(bing_tile('123030123010121'))", TINYINT, (byte) 15);
+    }
+
+    @Test
+    public void testBingTilePolygon()
+            throws Exception
+    {
+        assertFunction("ST_AsText(bing_tile_polygon(bing_tile('123030123010121')))", VARCHAR, "POLYGON ((59.996337890625 30.12612436422458, 59.996337890625 30.11662158281937, 60.00732421875 30.11662158281937, 60.00732421875 30.12612436422458, 59.996337890625 30.12612436422458))");
+        assertFunction("ST_AsText(ST_Centroid(bing_tile_polygon(bing_tile('123030123010121'))))", VARCHAR, "POINT (60.00183104425149 30.121372968273892)");
+    }
+
+    @Test
+    public void testGeometryToBingTiles()
+            throws Exception
+    {
+        assertFunction("transform(geometry_to_bing_tiles(ST_Point(60, 30.12), 10), x -> bing_tile_quadkey(x))", new ArrayType(VARCHAR), ImmutableList.of("1230301230"));
+        assertFunction("transform(geometry_to_bing_tiles(ST_Point(60, 30.12), 15), x -> bing_tile_quadkey(x))", new ArrayType(VARCHAR), ImmutableList.of("123030123010121"));
+        assertFunction("transform(geometry_to_bing_tiles(ST_Point(60, 30.12), 16), x -> bing_tile_quadkey(x))", new ArrayType(VARCHAR), ImmutableList.of("1230301230101212"));
+
+        assertFunction("transform(geometry_to_bing_tiles(ST_GeometryFromText('POLYGON ((0 0, 0 10, 10 10, 10 0))'), 6), x -> bing_tile_quadkey(x))", new ArrayType(VARCHAR), ImmutableList.of("122220", "122222", "300000", "122221", "122223", "300001"));
+        assertFunction("transform(geometry_to_bing_tiles(ST_GeometryFromText('POLYGON ((0 0, 0 10, 10 10))'), 6), x -> bing_tile_quadkey(x))", new ArrayType(VARCHAR), ImmutableList.of("122220", "122222", "300000", "122221"));
+
+        assertFunction("transform(geometry_to_bing_tiles(ST_GeometryFromText('POLYGON ((10 10, -10 10, -20 -15, 10 10))'), 3), x -> bing_tile_quadkey(x))", new ArrayType(VARCHAR), ImmutableList.of("033", "211", "122"));
+        assertFunction("transform(geometry_to_bing_tiles(ST_GeometryFromText('POLYGON ((10 10, -10 10, -20 -15, 10 10))'), 6), x -> bing_tile_quadkey(x))", new ArrayType(VARCHAR), ImmutableList.of("211102", "211120", "033321", "033323", "211101", "211103", "211121", "033330", "033332", "211110", "211112", "033331", "033333", "211111", "122220", "122222", "122221"));
+
+        // Invalid input
+        // Longitude out of range
+        assertInvalidFunction("geometry_to_bing_tiles(ST_Point(600, 30.12), 10)", "Longitude span for the geometry must be in [-180.00, 180.00] range");
+        assertInvalidFunction("geometry_to_bing_tiles(ST_GeometryFromText('POLYGON ((1000 10, -10 10, -20 -15))'), 10)", "Longitude span for the geometry must be in [-180.00, 180.00] range");
+        // Latitude out of range
+        assertInvalidFunction("geometry_to_bing_tiles(ST_Point(60, 300.12), 10)", "Latitude span for the geometry must be in [-85.05, 85.05] range");
+        assertInvalidFunction("geometry_to_bing_tiles(ST_GeometryFromText('POLYGON ((10 1000, -10 10, -20 -15))'), 10)", "Latitude span for the geometry must be in [-85.05, 85.05] range");
+        // Invalid zoom levels
+        assertInvalidFunction("geometry_to_bing_tiles(ST_Point(60, 30.12), 0)", "Zoom level must be > 0");
+        assertInvalidFunction("geometry_to_bing_tiles(ST_Point(60, 30.12), 40)", "Zoom level must be <= 23");
+    }
+
+    @Test
+    public void testEqual()
+            throws Exception
+    {
+        assertFunction("bing_tile(3, 5, 3) = bing_tile(3, 5, 3)", BOOLEAN, true);
+        assertFunction("bing_tile('213') = bing_tile(3, 5, 3)", BOOLEAN, true);
+        assertFunction("bing_tile('213') = bing_tile('213')", BOOLEAN, true);
+
+        assertFunction("bing_tile(3, 5, 3) = bing_tile(3, 5, 4)", BOOLEAN, false);
+        assertFunction("bing_tile('213') = bing_tile('2131')", BOOLEAN, false);
+    }
+
+    @Test
+    public void testNotEqual()
+            throws Exception
+    {
+        assertFunction("bing_tile(3, 5, 3) <> bing_tile(3, 5, 3)", BOOLEAN, false);
+        assertFunction("bing_tile('213') <> bing_tile(3, 5, 3)", BOOLEAN, false);
+        assertFunction("bing_tile('213') <> bing_tile('213')", BOOLEAN, false);
+
+        assertFunction("bing_tile(3, 5, 3) <> bing_tile(3, 5, 4)", BOOLEAN, true);
+        assertFunction("bing_tile('213') <> bing_tile('2131')", BOOLEAN, true);
+    }
+}


### PR DESCRIPTION
Add a set of functions to covert between geometries and Bing tiles.

Bing tiles introduced in https://msdn.microsoft.com/en-us/library/bb259689.aspx can be used to aggregate location-specific data at different levels of detail for visualization or to join datasets on spatial relationships 'contains' or 'intersects' by approximating geometries with a set of covering tiles and performing a relation join on tile IDs.