### PR TITLE
Fix leak in running query counter for failed queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -421,6 +421,7 @@ public class SqlQueryManager
                 queryMonitor.queryCreatedEvent(queryInfo);
                 queryMonitor.queryCompletedEvent(queryInfo);
                 stats.queryStarted();
+                stats.queryStopped();
                 stats.queryFinished(queryInfo);
             }
             finally {


### PR DESCRIPTION
Queries that fail before they get to run cause the running queries
counter to increment but never decrement. This is a result of the
change in 516801ab482c9189344304b97ff4e4429488dfc7, which missed
a call to queryStopped.

Fixes #9056