### PR TITLE
Add from_timeuuid DateTime function to extract the timestamp from a UUID

### DIFF
--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -104,6 +104,10 @@ Date and Time Functions
 
     Returns ``timestamp`` as a UNIX timestamp.
 
+.. function:: from_timeuuid(string) -> timestamp
+
+    Returns the timestamp extracted from the version 1 UUID contained on the ``string``.
+
 .. note:: The following SQL-standard functions do not use parenthesis:
 
     - ``current_date``

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -967,6 +967,14 @@ public class TestDateTimeFunctions
         assertFunction("to_milliseconds(parse_duration('1d'))", BigintType.BIGINT, DAYS.toMillis(1));
     }
 
+    @Test
+    public void testTimeuuidToTimestamp()
+            throws Exception
+    {
+        assertFunction("from_timeuuid('d9813960-a3f1-11e7-9598-0800200c9a66')", TimestampType.TIMESTAMP, toTimestamp(1506564478966000L));
+        assertInvalidFunction("from_timeuuid('d83be11a-2d18-4770-a52d-60f62cb195f7')", "Not a time-based UUID: d83be11a-2d18-4770-a52d-60f62cb195f7");
+    }
+
     private void assertFunctionString(String projection, Type expectedType, String expected)
     {
         functionAssertions.assertFunctionString(projection, expectedType, expected);


### PR DESCRIPTION
Cassandra TimeUUID type is widely used and is helpful to have this function
to extract the timestamp from a version 1 UUID.