### PR TITLE
Add inverse_normal_cdf math function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -60,6 +60,13 @@ Mathematical Functions
 
     Returns the value of ``string`` interpreted as a base-``radix`` number.
 
+.. function:: inverse_normal_cdf(mean, sd, p) -> double
+
+    Compute the inverse of the Normal cdf with given mean and standard
+    deviation (sd) for the cumulative probability (p): P(N < n). The mean must be
+    a real value and the standard deviation must be a real and positive value.
+    The probability p must lie on the interval (0, 1).
+
 .. function:: ln(x) -> double
 
     Returns the natural logarithm of ``x``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -59,6 +59,7 @@ import static java.lang.Character.MIN_RADIX;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
+import org.apache.commons.math3.special.Erf;
 
 public final class MathFunctions
 {
@@ -598,6 +599,18 @@ public final class MathFunctions
     {
         checkCondition(value > 0, INVALID_FUNCTION_ARGUMENT, "bound must be positive");
         return ThreadLocalRandom.current().nextLong(value);
+    }
+
+    @Description("a pseudo-random number from a normal distribution with mean, std, and p")
+    @ScalarFunction(alias = "rand_normal", deterministic = false)
+    @SqlType(StandardTypes.DOUBLE)
+    public static double randomNormal(@SqlNullable @SqlType(StandardTypes.DOUBLE) Double mean, @SqlNullable @SqlType(StandardTypes.DOUBLE) Double sd, @SqlNullable @SqlType(StandardTypes.DOUBLE) Double p)
+    {
+        checkCondition(p != null && p > 0 && p < 1, INVALID_FUNCTION_ARGUMENT, "p must be 0 > p > 1");
+        checkCondition(mean != null, INVALID_FUNCTION_ARGUMENT, "mean must not be null");
+        checkCondition(sd != null && sd > 0, INVALID_FUNCTION_ARGUMENT, "sd must > 0");
+
+        return mean + sd * 1.4142135623730951 * Erf.erfInv(2 * p - 1);
     }
 
     @Description("round to nearest integer")

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -601,11 +601,8 @@ public final class MathFunctions
         return ThreadLocalRandom.current().nextLong(value);
     }
 
-    @Description("Compute the inverse of the Normal cdf with given mean and\n" +
-            " standard deviation for the cumulative probability: P(N < n).\n" +
-            " The mean must be a real value and the standard deviation must\n" +
-            " be a real and positive value. The probability p must lie on the interval (0, 1).")
-    @ScalarFunction(deterministic = true)
+    @Description("inverse of normal cdf given a mean, std, and probability")
+    @ScalarFunction
     @SqlType(StandardTypes.DOUBLE)
     public static double inverseNormalCdf(@SqlType(StandardTypes.DOUBLE) double mean, @SqlType(StandardTypes.DOUBLE) double sd, @SqlType(StandardTypes.DOUBLE) double p)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -30,6 +30,7 @@ import com.facebook.presto.type.Constraint;
 import com.facebook.presto.type.LiteralParameter;
 import com.google.common.primitives.Doubles;
 import io.airlift.slice.Slice;
+import org.apache.commons.math3.special.Erf;
 
 import java.math.BigInteger;
 import java.util.concurrent.ThreadLocalRandom;
@@ -59,7 +60,6 @@ import static java.lang.Character.MIN_RADIX;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
-import org.apache.commons.math3.special.Erf;
 
 public final class MathFunctions
 {
@@ -601,14 +601,16 @@ public final class MathFunctions
         return ThreadLocalRandom.current().nextLong(value);
     }
 
-    @Description("a pseudo-random number from a normal distribution with mean, std, and p")
-    @ScalarFunction(alias = "rand_normal", deterministic = false)
+    @Description("Compute the inverse of the Normal cdf with given mean and\n" +
+            " standard deviation for the cumulative probability: P(N < n).\n" +
+            " The mean must be a real value and the standard deviation must\n" +
+            " be a real and positive value. The probability p must lie on the interval (0, 1).")
+    @ScalarFunction(deterministic = true)
     @SqlType(StandardTypes.DOUBLE)
-    public static double randomNormal(@SqlNullable @SqlType(StandardTypes.DOUBLE) Double mean, @SqlNullable @SqlType(StandardTypes.DOUBLE) Double sd, @SqlNullable @SqlType(StandardTypes.DOUBLE) Double p)
+    public static double inverseNormalCdf(@SqlType(StandardTypes.DOUBLE) double mean, @SqlType(StandardTypes.DOUBLE) double sd, @SqlType(StandardTypes.DOUBLE) double p)
     {
-        checkCondition(p != null && p > 0 && p < 1, INVALID_FUNCTION_ARGUMENT, "p must be 0 > p > 1");
-        checkCondition(mean != null, INVALID_FUNCTION_ARGUMENT, "mean must not be null");
-        checkCondition(sd != null && sd > 0, INVALID_FUNCTION_ARGUMENT, "sd must > 0");
+        checkCondition(p > 0 && p < 1, INVALID_FUNCTION_ARGUMENT, "p must be 0 > p > 1");
+        checkCondition(sd > 0, INVALID_FUNCTION_ARGUMENT, "sd must > 0");
 
         return mean + sd * 1.4142135623730951 * Erf.erfInv(2 * p - 1);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1299,14 +1299,14 @@ public class TestMathFunctions
     }
 
     @Test
-    public void testRandNormal()
+    public void testInverseNormalCdf()
             throws Exception
     {
-        assertFunction("rand_normal(0, 1, 0.3)", DOUBLE, -0.52440051270804089);
-        assertFunction("rand_normal(10, 9, 0.9)", DOUBLE, 21.533964089901406);
-        assertFunction("rand_normal(0.5, 0.25, 0.65)", DOUBLE, 0.59633011660189195);
-        assertFunction("rand_normal(4, 48, 0)", DOUBLE, null);
-        assertFunction("rand_normal(4, 48, 1)", DOUBLE, null);
-        assertFunction("rand_normal(4, 0, 0.4)", DOUBLE, null);
+        assertFunction("inverse_normal_cdf(0, 1, 0.3)", DOUBLE, -0.52440051270804089);
+        assertFunction("inverse_normal_cdf(10, 9, 0.9)", DOUBLE, 21.533964089901406);
+        assertFunction("inverse_normal_cdf(0.5, 0.25, 0.65)", DOUBLE, 0.59633011660189195);
+        assertInvalidFunction("inverse_normal_cdf(4, 48, 0)");
+        assertInvalidFunction("inverse_normal_cdf(4, 48, 1)");
+        assertInvalidFunction("inverse_normal_cdf(4, 0, 0.4)");
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1297,4 +1297,16 @@ public class TestMathFunctions
                 DOUBLE,
                 null);
     }
+
+    @Test
+    public void testRandNormal()
+            throws Exception
+    {
+        assertFunction("rand_normal(0, 1, 0.3)", DOUBLE, -0.52440051270804089);
+        assertFunction("rand_normal(10, 9, 0.9)", DOUBLE, 21.533964089901406);
+        assertFunction("rand_normal(0.5, 0.25, 0.65)", DOUBLE, 0.59633011660189195);
+        assertFunction("rand_normal(4, 48, 0)", DOUBLE, null);
+        assertFunction("rand_normal(4, 48, 1)", DOUBLE, null);
+        assertFunction("rand_normal(4, 0, 0.4)", DOUBLE, null);
+    }
 }


### PR DESCRIPTION
Add inverse_normal_cdf math function

Compute the inverse of the Normal cdf with given mean and 
standard deviation for the cumulative probability: P(N < n). 
The mean must be a real value and the standard deviation must
be a real and positive value. The probability p must lie on the interval (0, 1).