### PR TITLE
Fix check for resource group soft memory limit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -837,7 +837,7 @@ public class InternalResourceGroup
                 maxRunning = Math.max(1, maxRunning);
             }
             return runningQueries.size() + descendantRunningQueries < maxRunning &&
-                    cachedMemoryUsageBytes < softMemoryLimitBytes;
+                    cachedMemoryUsageBytes <= softMemoryLimitBytes;
         }
     }
 


### PR DESCRIPTION
Previously, queries were not allowed to run if the group was already at
the soft memory limit, which assumed that queries would need to use
memory. In particular, this prevented queries from running at all if
the limit was set to zero, which is the case for the legacy manager.