### PR TITLE
Fix check for resource group soft memory limit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -837,7 +837,7 @@ public class InternalResourceGroup
                 maxRunning = Math.max(1, maxRunning);
             }
             return runningQueries.size() + descendantRunningQueries < maxRunning &&
-                    cachedMemoryUsageBytes < softMemoryLimitBytes;
+                    cachedMemoryUsageBytes <= softMemoryLimitBytes;
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -177,7 +177,7 @@ public class TestResourceGroups
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setMaxQueuedQueries(4);
         root.setMaxRunningQueries(3);
-        MockQueryExecution query1 = new MockQueryExecution(1);
+        MockQueryExecution query1 = new MockQueryExecution(2);
         root.run(query1);
         // Process the group to refresh stats
         root.processQueuedQueries();
@@ -207,7 +207,7 @@ public class TestResourceGroups
         subgroup.setMaxQueuedQueries(4);
         subgroup.setMaxRunningQueries(3);
 
-        MockQueryExecution query1 = new MockQueryExecution(1);
+        MockQueryExecution query1 = new MockQueryExecution(2);
         subgroup.run(query1);
         // Process the group to refresh stats
         root.processQueuedQueries();


### PR DESCRIPTION
Previously, queries were not allowed to run if the group was already at
the soft memory limit, which assumed that queries would need to use
memory. In particular, this prevented queries from running at all if
the limit was set to zero, which is the case for the legacy manager.