### PR TITLE
applied diamond operator where i could.

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayMaxNAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayMaxNAggregation.java
@@ -108,7 +108,7 @@ public class TestArrayMaxNAggregation
 
     private void testCustomAggregation(Long[] values, int n)
     {
-        PriorityQueue<Long> heap = new PriorityQueue<Long>(n);
+        PriorityQueue<Long> heap = new PriorityQueue<>(n);
         Arrays.stream(values).filter(x -> x != null).forEach(heap::add);
         ImmutableList.Builder<List<Long>> expected = new ImmutableList.Builder<>();
         for (int i = heap.size() - 1; i >= 0; i--) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongMaxNAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongMaxNAggregation.java
@@ -82,7 +82,7 @@ public class TestLongMaxNAggregation
 
     private void testCustomAggregation(Long[] values, int n)
     {
-        PriorityQueue<Long> heap = new PriorityQueue<Long>(n);
+        PriorityQueue<Long> heap = new PriorityQueue<>(n);
         Arrays.stream(values).filter(x -> x != null).forEach(heap::add);
         Long[] expected = new Long[heap.size()];
         for (int i = heap.size() - 1; i >= 0; i--) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Primitives.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Primitives.java
@@ -47,8 +47,8 @@ final class Primitives
     // Sad that we can't use a BiMap. :(
 
     static {
-        Map<Class<?>, Class<?>> primToWrap = new HashMap<Class<?>, Class<?>>(16);
-        Map<Class<?>, Class<?>> wrapToPrim = new HashMap<Class<?>, Class<?>>(16);
+        Map<Class<?>, Class<?>> primToWrap = new HashMap<>(16);
+        Map<Class<?>, Class<?>> wrapToPrim = new HashMap<>(16);
 
         add(primToWrap, wrapToPrim, boolean.class, Boolean.class);
         add(primToWrap, wrapToPrim, byte.class, Byte.class);


### PR DESCRIPTION
Since Java 7, we can use the diamond operator to make the code easy to undestand and smaller. I changed some files where were possible to use the diamond operator instead of declaring the type. So the only thing this pull-request does is updating part of the code to new functions java provide us.