### PR TITLE
Use nextToken method to raise exception on getting unexpected character

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
@@ -103,10 +103,13 @@ public final class JsonFunctions
         // cast(json_parse(x) AS t)` will be optimized into `$internal$json_string_to_array/map/row_cast` in ExpressionOptimizer
         // If you make changes to this function (e.g. use parse JSON string into some internal representation),
         // make sure `$internal$json_string_to_array/map/row_cast` is changed accordingly.
-        try {
+        try (JsonParser parser = createJsonParser(JSON_FACTORY, slice)) {
             byte[] in = slice.getBytes();
             SliceOutput dynamicSliceOutput = new DynamicSliceOutput(in.length);
-            SORTED_MAPPER.writeValue((OutputStream) dynamicSliceOutput, SORTED_MAPPER.readValue(in, Object.class));
+            SORTED_MAPPER.writeValue((OutputStream) dynamicSliceOutput, SORTED_MAPPER.readValue(parser, Object.class));
+            // nextToken() returns null if input is parsed correctly
+            // but will throw exception if it gets unexpected character
+            parser.nextToken();
             return dynamicSliceOutput.slice();
         }
         catch (Exception e) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
@@ -252,6 +252,7 @@ public class TestJsonFunctions
     {
         assertInvalidFunction("JSON 'INVALID'", INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("JSON_PARSE('INVALID')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("JSON_PARSE('\"x\": 1')", INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test


### PR DESCRIPTION
Addresses #9067 

### Root cause
When `Object.class` is provided for reading values, jackson-databind will ignore trailing characters if valid object is formed (as discussed here: https://github.com/FasterXML/jackson-databind/issues/726) 
### Solution
Provide a parser to `readValue` function, and use its `nextToken` to raise an exception in case of invalid character
