### PR TITLE
Change constructor interface for VariableWidthBlockBuilder

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
@@ -52,7 +52,7 @@ public class TestLongArrayBlock
         Slice[] expectedValues = createTestValue(100);
         BlockBuilder emptyBlockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 0, 0);
 
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), expectedValues.length, 32);
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), expectedValues.length, 32 * expectedValues.length);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
 

--- a/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
@@ -70,7 +70,7 @@ public class TestVariableWidthBlock
         Slice[] expectedValues = createExpectedValues(100);
         BlockBuilder emptyBlockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 0, 0);
 
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), expectedValues.length, 32);
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), expectedValues.length, 32 * expectedValues.length);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
 
@@ -88,7 +88,7 @@ public class TestVariableWidthBlock
     {
         int numEntries = 1000;
         VarcharType unboundedVarcharType = createUnboundedVarcharType();
-        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), numEntries, 20);
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), numEntries, 20 * numEntries);
         for (int i = 0; i < numEntries; i++) {
             unboundedVarcharType.writeString(blockBuilder, String.valueOf(ThreadLocalRandom.current().nextLong()));
         }
@@ -118,7 +118,7 @@ public class TestVariableWidthBlock
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)
     {
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), expectedValues.length, 32);
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), expectedValues.length, 32 * expectedValues.length);
         return writeValues(expectedValues, blockBuilder);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDecimalSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDecimalSumAggregation.java
@@ -128,7 +128,7 @@ public class TestDecimalSumAggregation
         addToState(state, TWO.pow(126));
 
         assertEquals(state.getOverflow(), 1);
-        DecimalSumAggregation.outputLongDecimal(TYPE, state, new VariableWidthBlockBuilder(new BlockBuilderStatus(), 10, 10));
+        DecimalSumAggregation.outputLongDecimal(TYPE, state, new VariableWidthBlockBuilder(new BlockBuilderStatus(), 10, 100));
     }
 
     private static void addToState(LongDecimalWithOverflowState state, BigInteger value)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryBuilder.java
@@ -22,6 +22,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
+import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 // TODO this class is not memory efficient.  We can bypass all of the Presto type and block code
@@ -50,10 +51,12 @@ public class DictionaryBuilder
 
         // todo we can do better
         BlockBuilderStatus blockBuilderStatus = new BlockBuilderStatus();
+        int expectedEntries = min(expectedSize, blockBuilderStatus.getMaxBlockSizeInBytes() / EXPECTED_BYTES_PER_ENTRY);
+        // it is guaranteed expectedEntries * EXPECTED_BYTES_PER_ENTRY will not overflow
         this.elementBlock = new VariableWidthBlockBuilder(
                 blockBuilderStatus,
-                Math.min(expectedSize, blockBuilderStatus.getMaxBlockSizeInBytes() / EXPECTED_BYTES_PER_ENTRY),
-                EXPECTED_BYTES_PER_ENTRY);
+                expectedEntries,
+                expectedEntries * EXPECTED_BYTES_PER_ENTRY);
 
         // first position is always null
         this.elementBlock.appendNull();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.block;
 import java.util.List;
 import java.util.Set;
 
+import static java.lang.Math.ceil;
 import static java.util.stream.Collectors.toSet;
 
 final class BlockUtil
@@ -65,7 +66,7 @@ final class BlockUtil
 
     static int calculateBlockResetSize(int currentSize)
     {
-        long newSize = (long) Math.ceil(currentSize * BLOCK_RESET_SKEW);
+        long newSize = (long) ceil(currentSize * BLOCK_RESET_SKEW);
 
         // verify new size is within reasonable bounds
         if (newSize < DEFAULT_CAPACITY) {
@@ -75,5 +76,14 @@ final class BlockUtil
             newSize = MAX_ARRAY_SIZE;
         }
         return (int) newSize;
+    }
+
+    static int calculateBlockResetBytes(int currentBytes)
+    {
+        long newBytes = (long) ceil(currentBytes * BLOCK_RESET_SKEW);
+        if (newBytes > MAX_ARRAY_SIZE) {
+            return MAX_ARRAY_SIZE;
+        }
+        return (int) newBytes;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 
+import static java.lang.Math.min;
+
 public abstract class AbstractVariableWidthType
         extends AbstractType
         implements VariableWidthType
@@ -38,10 +40,13 @@ public abstract class AbstractVariableWidthType
         else {
             maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
         }
+
+        // it is guaranteed Math.min will not overflow; safe to cast
+        int expectedBytes = (int) min((long) expectedEntries * expectedBytesPerEntry, maxBlockSizeInBytes);
         return new VariableWidthBlockBuilder(
                 blockBuilderStatus,
                 expectedBytesPerEntry == 0 ? expectedEntries : Math.min(expectedEntries, maxBlockSizeInBytes / expectedBytesPerEntry),
-                expectedBytesPerEntry);
+                expectedBytes);
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockRetainedSizeBreakdown.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockRetainedSizeBreakdown.java
@@ -119,7 +119,7 @@ public class TestBlockRetainedSizeBreakdown
     @Test
     public void testVariableWidthBlock()
     {
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, 4);
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES, 4 * EXPECTED_ENTRIES);
         writeEntries(EXPECTED_ENTRIES, blockBuilder, VARCHAR);
         checkRetainedSize(blockBuilder.build(), false);
     }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockBuilder.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockBuilder.java
@@ -13,16 +13,23 @@
  */
 package com.facebook.presto.spi.block;
 
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.ceil;
+import static org.openjdk.jol.info.ClassLayout.parseClass;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestVariableWidthBlockBuilder
 {
+    private static final int BLOCK_BUILDER_INSTANCE_SIZE = parseClass(VariableWidthBlockBuilder.class).instanceSize();
+    private static final int SLICE_INSTANCE_SIZE = parseClass(DynamicSliceOutput.class).instanceSize() + parseClass(Slice.class).instanceSize();
     private static final int VARCHAR_VALUE_SIZE = 7;
     private static final int VARCHAR_ENTRY_SIZE = SIZE_OF_INT + VARCHAR_VALUE_SIZE;
     private static final int EXPECTED_ENTRY_COUNT = 3;
@@ -35,9 +42,29 @@ public class TestVariableWidthBlockBuilder
         testIsFull(new PageBuilderStatus(1024, VARCHAR_ENTRY_SIZE * EXPECTED_ENTRY_COUNT));
     }
 
+    @Test
+    public void testNewBlockBuilderLike()
+            throws Exception
+    {
+        int entries = 12345;
+        double resetSkew = 1.25;
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, entries, entries);
+        for (int i = 0; i < entries; i++) {
+            blockBuilder.writeByte(i);
+            blockBuilder.closeEntry();
+        }
+        blockBuilder = blockBuilder.newBlockBuilderLike(null);
+        // force to initialize capacity
+        blockBuilder.writeByte(1);
+
+        long actualArrayBytes = sizeOf(new int[(int) ceil(resetSkew * (entries + 1))]) + sizeOf(new boolean[(int) ceil(resetSkew * entries)]);
+        long actualSliceBytes = SLICE_INSTANCE_SIZE + sizeOf(new byte[(int) ceil(resetSkew * entries)]);
+        assertEquals(blockBuilder.getRetainedSizeInBytes(), BLOCK_BUILDER_INSTANCE_SIZE + actualSliceBytes + actualArrayBytes);
+    }
+
     private void testIsFull(PageBuilderStatus pageBuilderStatus)
     {
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(pageBuilderStatus.createBlockBuilderStatus(), 32, 32);
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(pageBuilderStatus.createBlockBuilderStatus(), 32, 1024);
         assertTrue(pageBuilderStatus.isEmpty());
         while (!pageBuilderStatus.isFull()) {
             VARCHAR.writeSlice(blockBuilder, Slices.allocate(VARCHAR_VALUE_SIZE));


### PR DESCRIPTION
newBlockBuilderLike() of VariableWidthBlockBuilder will set a minimal
entry count to be 64. If the block builder is going to add a single
entry only. The initial capacity can be 64 times of the entry size,
which leads to huge waste of memory. Pass in the expected bytes directly
instead of the average entry bytes.