### PR TITLE
Remove maven-buildtime-extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -10,9 +10,4 @@
         <artifactId>takari-concurrent-localrepo</artifactId>
         <version>0.0.7</version>
     </extension>
-    <extension>
-        <groupId>co.leantechniques</groupId>
-        <artifactId>maven-buildtime-extension</artifactId>
-        <version>3.0.0</version>
-    </extension>
 </extensions>


### PR DESCRIPTION
For unknown reasons, this extension causes extra uploads and downloads
of maven-metadata.xml during deployments.