### PR TITLE
Avoid unnecessary shuffle before table write

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -552,7 +552,7 @@ public class AddExchanges
                 partitioningScheme = Optional.of(new PartitioningScheme(Partitioning.create(FIXED_ARBITRARY_DISTRIBUTION, ImmutableList.of()), source.getNode().getOutputSymbols()));
             }
 
-            if (partitioningScheme.isPresent()) {
+            if (partitioningScheme.isPresent() && !source.getProperties().isNodePartitionedOn(partitioningScheme.get().getPartitioning(), false)) {
                 source = withDerivedProperties(
                         partitionedExchange(
                                 idAllocator.getNextId(),


### PR DESCRIPTION

If the output if already partitioned as expected, there is no need for
a shuffle before table write.

