### PR TITLE
Fixing presto native parquet read path for parquet types with repetit…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1045,6 +1045,7 @@
                         </violationsFiles>
                         <exclusionPatterns>
                             <exclusionPattern>org/joda/time/.*</exclusionPattern>
+                            <exclusionPattern>com/google/common/base/Function</exclusionPattern>
                         </exclusionPatterns>
                     </configuration>
                 </plugin>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
@@ -37,7 +37,7 @@ public class ParquetBinaryColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, boolean isMapVal, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             Binary binary = valuesReader.readBytes();
@@ -57,7 +57,7 @@ public class ParquetBinaryColumnReader
             type.writeSlice(blockBuilder, value);
         }
         else {
-            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, isMapVal, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
@@ -19,6 +19,8 @@ import io.airlift.slice.Slice;
 import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
+import java.util.Optional;
+
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
@@ -35,7 +37,7 @@ public class ParquetBinaryColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             Binary binary = valuesReader.readBytes();
@@ -55,7 +57,7 @@ public class ParquetBinaryColumnReader
             type.writeSlice(blockBuilder, value);
         }
         else {
-            blockBuilder.appendNull();
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBooleanColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBooleanColumnReader.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import parquet.column.ColumnDescriptor;
 
+import java.util.Optional;
+
 public class ParquetBooleanColumnReader
         extends ParquetColumnReader
 {
@@ -26,13 +28,13 @@ public class ParquetBooleanColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeBoolean(blockBuilder, valuesReader.readBoolean());
         }
         else {
-            blockBuilder.appendNull();
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBooleanColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBooleanColumnReader.java
@@ -28,13 +28,13 @@ public class ParquetBooleanColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, boolean isMapVal, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeBoolean(blockBuilder, valuesReader.readBoolean());
         }
         else {
-            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, isMapVal, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetColumnReader.java
@@ -66,7 +66,7 @@ public abstract class ParquetColumnReader
     private int remainingValueCountInPage;
     private int readOffset;
 
-    protected abstract void readValue(BlockBuilder blockBuilder, Type type);
+    protected abstract void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum);
 
     protected abstract void skipValue();
 
@@ -147,7 +147,7 @@ public abstract class ParquetColumnReader
         return columnDescriptor;
     }
 
-    public Block readPrimitive(Type type, IntList positions)
+    public Block readPrimitive(Type type, IntList positions, Optional<boolean[]> isNullAtRowNum, boolean isMapKey)
             throws IOException
     {
         seek();
@@ -158,9 +158,9 @@ public abstract class ParquetColumnReader
                 readNextPage();
             }
             int numValues = Math.min(remainingValueCountInPage, nextBatchSize - valueCount);
-            readValues(blockBuilder, numValues, type, positions);
+            int valuesRead = readValues(blockBuilder, numValues, type, positions, isNullAtRowNum, isMapKey);
             valueCount += numValues;
-            updatePosition(numValues);
+            updatePosition(valuesRead);
         }
         checkArgument(valueCount == nextBatchSize, "valueCount %s not equals to batchSize %s", valueCount, nextBatchSize);
 
@@ -169,49 +169,63 @@ public abstract class ParquetColumnReader
         return blockBuilder.build();
     }
 
-    private void readValues(BlockBuilder blockBuilder, int numValues, Type type, IntList positions)
+    private int readValues(BlockBuilder blockBuilder, int numValues, Type type, IntList positions, Optional<boolean[]> isNullAtRowNum, boolean isMapKey)
     {
-        definitionLevel = definitionReader.readLevel();
-        repetitionLevel = repetitionReader.readLevel();
-        int valueCount = 0;
+        int totalValsReadFromPage = 0;
         for (int i = 0; i < numValues; i++) {
+            int positionCount = blockBuilder.getPositionCount();
             do {
-                readValue(blockBuilder, type);
+                definitionLevel = definitionReader.readLevel();
+                repetitionLevel = repetitionReader.readLevel();
+                readValue(blockBuilder, type, isNullAtRowNum, isMapKey, positions.size());
+                int pCount = blockBuilder.getPositionCount();
                 try {
-                    valueCount++;
-                    repetitionLevel = repetitionReader.readLevel();
-                    if (repetitionLevel == 0) {
-                        positions.add(valueCount);
-                        valueCount = 0;
-                        if (i == numValues - 1) {
-                            return;
-                        }
+                    totalValsReadFromPage++;
+                    // If we have reached the end of the page then we should not peek the repetitionLevel but load the next page.
+                    // This is done to handle the case where the a repetitive structure with multiple columns(like map or row type)
+                    // has repetition that spans across page boundaries i.e. a map with n key-vals pairs where the data for
+                    // key-val 1 to m is on first page and m+1 to n is on second page.
+                    if (remainingValueCountInPage - totalValsReadFromPage == 0 && pageReader.hasMorePages()) {
+                        readNextPage();
+                        currentValueCount += totalValsReadFromPage;
+                        totalValsReadFromPage = 0;
                     }
-                    definitionLevel = definitionReader.readLevel();
+                    if (remainingValueCountInPage - totalValsReadFromPage == 0) {
+                        positions.add(pCount - positionCount);
+                        return totalValsReadFromPage;
+                    }
+                    repetitionLevel = repetitionReader.peekLevel();
+                    if (repetitionLevel == 0) {
+                        positions.add(pCount - positionCount);
+                    }
                 }
                 catch (IllegalArgumentException expected) {
                     // Reading past repetition stream, RunLengthBitPackingHybridDecoder throws IllegalArgumentException
-                    positions.add(valueCount);
-                    return;
+                    positions.add(pCount - positionCount);
+                    // It's unclear why would we ever read past the stream ideally we should not have to handle the exception.
+                    return totalValsReadFromPage;
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
             }
             while (repetitionLevel != 0);
         }
+        return totalValsReadFromPage;
     }
 
     private void skipValues(int offset)
     {
-        definitionLevel = definitionReader.readLevel();
-        repetitionLevel = repetitionReader.readLevel();
         for (int i = 0; i < offset; i++) {
             do {
+                definitionLevel = definitionReader.readLevel();
+                repetitionLevel = repetitionReader.readLevel();
                 skipValue();
                 try {
-                    repetitionLevel = repetitionReader.readLevel();
+                    repetitionLevel = repetitionReader.peekLevel();
                     if (i == offset - 1 && repetitionLevel == 0) {
                         return;
                     }
-                    definitionLevel = definitionReader.readLevel();
                 }
                 catch (IllegalArgumentException expected) {
                     // Reading past repetition stream, RunLengthBitPackingHybridDecoder throws IllegalArgumentException
@@ -248,7 +262,6 @@ public abstract class ParquetColumnReader
         page = pageReader.readPage();
         validateParquet(page != null, "Not enough values to read in column chunk");
         remainingValueCountInPage = page.getValueCount();
-
         if (page instanceof ParquetDataPageV1) {
             valuesReader = readPageV1((ParquetDataPageV1) page);
         }
@@ -320,6 +333,25 @@ public abstract class ParquetColumnReader
         }
         catch (IOException e) {
             throw new ParquetDecodingException("Error reading parquet page in column " + columnDescriptor, e);
+        }
+    }
+
+    protected void handleNull(BlockBuilder blockBuilder, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    {
+        // if isNullAtRowNum is already set to true for a position that indicates we are in call tree of a map'/s
+        // processing and the key is null. to keep the key and val length equal we make sure we do not append null
+        // for both the key and value. we only want to set the is NullAtRowNum to true if the key is null as null
+        // values for maps are not allowed.
+        if (isMapKey) {
+            isNullAtRowNum.map((arr) -> arr[mapRowNum] = true);
+        }
+        // if isNullAtRowNum is not present, that means this is not call tree of a map's value processing
+        // if it is present , then this is call tree of map's value and in that case we only append null
+        // if the key was not null.
+        else if (!isNullAtRowNum.isPresent() || !isNullAtRowNum.get()[mapRowNum]) {
+            // we only append null if either this is not a map value processing call tree
+            // or if in case this is a map value call tree, the key at this position is not set to null.
+            blockBuilder.appendNull();
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDoubleColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDoubleColumnReader.java
@@ -28,13 +28,13 @@ public class ParquetDoubleColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, boolean isMapVal, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeDouble(blockBuilder, valuesReader.readDouble());
         }
         else {
-            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, isMapVal, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDoubleColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDoubleColumnReader.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import parquet.column.ColumnDescriptor;
 
+import java.util.Optional;
+
 public class ParquetDoubleColumnReader
         extends ParquetColumnReader
 {
@@ -26,13 +28,13 @@ public class ParquetDoubleColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeDouble(blockBuilder, valuesReader.readDouble());
         }
         else {
-            blockBuilder.appendNull();
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
@@ -30,13 +30,13 @@ public class ParquetFloatColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, boolean isMapVal, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, floatToRawIntBits(valuesReader.readFloat()));
         }
         else {
-            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, isMapVal, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import parquet.column.ColumnDescriptor;
 
+import java.util.Optional;
+
 import static java.lang.Float.floatToRawIntBits;
 
 public class ParquetFloatColumnReader
@@ -28,13 +30,13 @@ public class ParquetFloatColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, floatToRawIntBits(valuesReader.readFloat()));
         }
         else {
-            blockBuilder.appendNull();
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetIntColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetIntColumnReader.java
@@ -28,13 +28,13 @@ public class ParquetIntColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, boolean isMapVal, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, valuesReader.readInteger());
         }
         else {
-            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, isMapVal, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetIntColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetIntColumnReader.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import parquet.column.ColumnDescriptor;
 
+import java.util.Optional;
+
 public class ParquetIntColumnReader
         extends ParquetColumnReader
 {
@@ -26,13 +28,13 @@ public class ParquetIntColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, valuesReader.readInteger());
         }
         else {
-            blockBuilder.appendNull();
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLevelNullReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLevelNullReader.java
@@ -21,4 +21,10 @@ public class ParquetLevelNullReader
     {
         return 0;
     }
+
+    @Override
+    public int peekLevel()
+    {
+        return 0;
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLevelRLEReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLevelRLEReader.java
@@ -23,6 +23,8 @@ public class ParquetLevelRLEReader
 {
     private final RunLengthBitPackingHybridDecoder delegate;
 
+    private Integer nextLevel;
+
     public ParquetLevelRLEReader(RunLengthBitPackingHybridDecoder delegate)
     {
         this.delegate = delegate;
@@ -31,11 +33,32 @@ public class ParquetLevelRLEReader
     @Override
     public int readLevel()
     {
+        if (nextLevel != null) {
+            int temp = nextLevel;
+            nextLevel = null;
+            return temp;
+        }
+
         try {
             return delegate.readInt();
         }
         catch (IOException e) {
             throw new ParquetDecodingException(e);
         }
+    }
+
+    @Override
+    public int peekLevel()
+    {
+        if (nextLevel == null) {
+            try {
+                nextLevel = delegate.readInt();
+            }
+            catch (IOException e) {
+                throw new ParquetDecodingException(e);
+            }
+        }
+
+        return nextLevel;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLevelReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLevelReader.java
@@ -16,4 +16,6 @@ package com.facebook.presto.hive.parquet.reader;
 public interface ParquetLevelReader
 {
     int readLevel();
+
+    int peekLevel();
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLevelValuesReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLevelValuesReader.java
@@ -20,6 +20,8 @@ public class ParquetLevelValuesReader
 {
     private final ValuesReader delegate;
 
+    private Integer nextLevel;
+
     public ParquetLevelValuesReader(ValuesReader delegate)
     {
         this.delegate = delegate;
@@ -28,6 +30,20 @@ public class ParquetLevelValuesReader
     @Override
     public int readLevel()
     {
+        if (nextLevel != null) {
+            int temp = nextLevel;
+            nextLevel = null;
+            return temp;
+        }
         return delegate.readInteger();
+    }
+
+    @Override
+    public int peekLevel()
+    {
+        if (nextLevel == null) {
+            nextLevel = delegate.readInteger();
+        }
+        return nextLevel;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongColumnReader.java
@@ -28,13 +28,13 @@ public class ParquetLongColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, boolean isMapVal, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, valuesReader.readLong());
         }
         else {
-            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, isMapVal, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongColumnReader.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import parquet.column.ColumnDescriptor;
 
+import java.util.Optional;
+
 public class ParquetLongColumnReader
         extends ParquetColumnReader
 {
@@ -26,13 +28,13 @@ public class ParquetLongColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, valuesReader.readLong());
         }
         else {
-            blockBuilder.appendNull();
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongDecimalColumnReader.java
@@ -20,6 +20,7 @@ import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
 import java.math.BigInteger;
+import java.util.Optional;
 
 public class ParquetLongDecimalColumnReader
         extends ParquetColumnReader
@@ -30,14 +31,14 @@ public class ParquetLongDecimalColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             Binary value = valuesReader.readBytes();
             type.writeSlice(blockBuilder, Decimals.encodeUnscaledValue(new BigInteger(value.getBytes())));
         }
         else {
-            blockBuilder.appendNull();
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongDecimalColumnReader.java
@@ -31,14 +31,14 @@ public class ParquetLongDecimalColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, boolean isMapVal, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             Binary value = valuesReader.readBytes();
             type.writeSlice(blockBuilder, Decimals.encodeUnscaledValue(new BigInteger(value.getBytes())));
         }
         else {
-            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, isMapVal, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetPageReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetPageReader.java
@@ -111,4 +111,9 @@ class ParquetPageReader
             throw new RuntimeException("Error reading dictionary page", e);
         }
     }
+
+    public boolean hasMorePages()
+    {
+        return !compressedPages.isEmpty();
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import parquet.column.ColumnDescriptor;
 
+import java.util.Optional;
+
 import static com.facebook.presto.hive.util.DecimalUtils.getShortDecimalValue;
 import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
@@ -30,7 +32,7 @@ public class ParquetShortDecimalColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             long decimalValue;
@@ -47,7 +49,7 @@ public class ParquetShortDecimalColumnReader
             type.writeLong(blockBuilder, decimalValue);
         }
         else {
-            blockBuilder.appendNull();
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
@@ -32,7 +32,7 @@ public class ParquetShortDecimalColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, boolean isMapVal, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             long decimalValue;
@@ -49,7 +49,7 @@ public class ParquetShortDecimalColumnReader
             type.writeLong(blockBuilder, decimalValue);
         }
         else {
-            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, isMapVal, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetTimestampColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetTimestampColumnReader.java
@@ -31,14 +31,14 @@ public class ParquetTimestampColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, boolean isMapVal, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             Binary binary = valuesReader.readBytes();
             type.writeLong(blockBuilder, getTimestampMillis(binary));
         }
         else {
-            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, isMapVal, mapRowNum);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetTimestampColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetTimestampColumnReader.java
@@ -18,6 +18,8 @@ import com.facebook.presto.spi.type.Type;
 import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
+import java.util.Optional;
+
 import static com.facebook.presto.hive.parquet.ParquetTimestampUtils.getTimestampMillis;
 
 public class ParquetTimestampColumnReader
@@ -29,14 +31,14 @@ public class ParquetTimestampColumnReader
     }
 
     @Override
-    protected void readValue(BlockBuilder blockBuilder, Type type)
+    protected void readValue(BlockBuilder blockBuilder, Type type, Optional<boolean[]> isNullAtRowNum, boolean isMapKey, int mapRowNum)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             Binary binary = valuesReader.readBytes();
             type.writeLong(blockBuilder, getTimestampMillis(binary));
         }
         else {
-            blockBuilder.appendNull();
+            handleNull(blockBuilder, isNullAtRowNum, isMapKey, mapRowNum);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -40,9 +40,7 @@ import org.apache.hadoop.hive.serde2.io.HiveVarcharWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveDecimalObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
-import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
 import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.io.Text;
@@ -440,12 +438,12 @@ public abstract class AbstractTestParquetReader
         };
 
         // test with no null items in any list
-        tester.testRoundTrip(arrInspector, listSequence(30_000, false), transform, arrayType, false);
+        tester.testRoundTrip(arrInspector, listSequence(30_000, false), transform, arrayType);
 
         // test with alternate null items in each list
-        tester.testRoundTrip(arrInspector, listSequence(30_000, true), transform, arrayType, false);
+        tester.testRoundTrip(arrInspector, listSequence(30_000, true), transform, arrayType);
 
-        // The following tests fail because the serde that is used to write records fail to handle null and empty lists correctly. even if we insert nulls without wrapping
+        // The following two tests fail because the serde that is used to write records fail to handle null and empty lists correctly. even if we insert nulls without wrapping
         // the writer writes it as [null] and not just null. we either need to upgrade our hive version or use static files generated using those versions to test for null case.
 
         // test with all null lists
@@ -479,7 +477,9 @@ public abstract class AbstractTestParquetReader
         rowTypeInfo.setAllStructFieldNames(Lists.newArrayList("field0", "field1"));
         ArrayWritableObjectInspector rowInspector = new ArrayWritableObjectInspector(rowTypeInfo);
 
-        tester.testRoundTrip(rowInspector, rowSequence(30_000, false), transform, rowType, false);
+        tester.testRoundTrip(rowInspector, rowSequence(30_000, false), transform, rowType);
+
+        tester.testRoundTrip(rowInspector, rowSequence(30_000, true), transform, rowType);
     }
 
     private static <T> Iterable<T> skipEvery(int n, Iterable<T> iterable)
@@ -592,7 +592,7 @@ public abstract class AbstractTestParquetReader
         return intsBetween(0, numberOfRows).stream().map((unused) -> generateRows(generateAlternateNullValues)).collect(Collectors.toList());
     }
 
-    private static final ArrayWritable generateRows(boolean generateAlternateNullItems)
+    private static final ArrayWritable generateRows(boolean generateNullValues)
     {
         final HiveVarcharWritable varcharWritable = new HiveVarcharWritable();
         varcharWritable.set("col-1");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -101,57 +101,36 @@ public class ParquetTester
     public void testRoundTrip(ObjectInspector columnObjectInspector, Iterable<?> writeValues, Type parameterType)
             throws Exception
     {
-        testRoundTrip(columnObjectInspector, writeValues, writeValues, parameterType, true);
+        testRoundTrip(columnObjectInspector, writeValues, writeValues, parameterType);
     }
 
     public <W, R> void testRoundTrip(ObjectInspector columnObjectInspector, Iterable<W> writeValues, Function<W, R> readTransform, Type parameterType)
             throws Exception
     {
-        testRoundTrip(columnObjectInspector, writeValues, transform(writeValues, readTransform), parameterType, true);
-    }
-
-    public <W, R> void testRoundTrip(ObjectInspector columnObjectInspector, Iterable<W> writeValues, Function<W, R> readTransform, Type parameterType, boolean testWithNulls)
-            throws Exception
-    {
-        testRoundTrip(columnObjectInspector, writeValues, transform(writeValues, readTransform), parameterType, testWithNulls);
+        testRoundTrip(columnObjectInspector, writeValues, transform(writeValues, readTransform), parameterType);
     }
 
     public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type)
             throws Exception
     {
-        testRoundTrip(objectInspector, writeValues, readValues, type, true);
-    }
-
-    public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, boolean testWithNulls)
-            throws Exception
-    {
         // just the values
-        testRoundTripType(objectInspector, writeValues, readValues, type, testWithNulls);
+        testRoundTripType(objectInspector, writeValues, readValues, type);
 
-        if (testWithNulls)
-        {
-            assertRoundTrip(objectInspector, transform(writeValues, constant(null)), transform(readValues, constant(null)), type);
-        }
+        // all nulls
+        assertRoundTrip(objectInspector, transform(writeValues, constant(null)), transform(readValues, constant(null)), type);
     }
 
     public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, Optional<MessageType> parquetSchema)
             throws Exception
     {
-        testRoundTrip(objectInspector,writeValues,readValues, type,parquetSchema, true);
-    }
-
-    public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, Optional<MessageType> parquetSchema, boolean testWithNulls)
-            throws Exception
-    {
         // just the values
-        testRoundTripType(objectInspector, writeValues, readValues, type, testWithNulls);
+        testRoundTripType(objectInspector, writeValues, readValues, type);
 
-        if (testWithNulls) {
-            assertRoundTrip(objectInspector, transform(writeValues, constant(null)), transform(readValues, constant(null)), type, parquetSchema);
-        }
+        // all nulls
+        assertRoundTrip(objectInspector, transform(writeValues, constant(null)), transform(readValues, constant(null)), type, parquetSchema);
     }
 
-    private void testRoundTripType(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, boolean testWithNulls)
+    private void testRoundTripType(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type)
             throws Exception
     {
         // forward order
@@ -160,13 +139,11 @@ public class ParquetTester
         // reverse order
         assertRoundTrip(objectInspector, reverse(writeValues), reverse(readValues), type);
 
-        if (testWithNulls) {
-            // forward order with nulls
-            assertRoundTrip(objectInspector, insertNullEvery(5, writeValues), insertNullEvery(5, readValues), type);
+        // forward order with nulls
+        assertRoundTrip(objectInspector, insertNullEvery(5, writeValues), insertNullEvery(5, readValues), type);
 
-            // reverse order with nulls
-            assertRoundTrip(objectInspector, insertNullEvery(5, reverse(writeValues)), insertNullEvery(5, reverse(readValues)), type);
-        }
+        // reverse order with nulls
+        assertRoundTrip(objectInspector, insertNullEvery(5, reverse(writeValues)), insertNullEvery(5, reverse(readValues)), type);
     }
 
     public void assertRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, Optional<MessageType> parquetSchema)
@@ -227,11 +204,14 @@ public class ParquetTester
             Block block;
             if (type instanceof MapType) {
                 block = parquetReader.readMap(type, Lists.newArrayList("test"));
-            } else if (type instanceof ArrayType) {
+            }
+            else if (type instanceof ArrayType) {
                 block = parquetReader.readArray(type, Lists.newArrayList("test"));
-            } else if (type instanceof RowType) {
+            }
+            else if (type instanceof RowType) {
                 block = parquetReader.readStruct(type, Lists.newArrayList("test"));
-            } else {
+            }
+            else {
                 ColumnDescriptor columnDescriptor = fileSchema.getColumns().get(0);
                 block = parquetReader.readPrimitive(columnDescriptor, type);
             }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -195,7 +195,7 @@ public abstract class AbstractRowBlock
     private void checkReadablePosition(int position)
     {
         if (position < 0 || position >= getPositionCount()) {
-            throw new IllegalArgumentException("position is not valid");
+            throw new IllegalArgumentException(position + " position is not valid, max position = " + getPositionCount());
         }
     }
 }


### PR DESCRIPTION
…ion level != 0, i.e. map, arrays, structs

The issue turned out to be more involved than what I originally thought. Parquet native read path essentially failed to read any type with repetition level !=0 correctly, which is basically all non primitive types. I added a test for maptypes as that was the original issue but I plan to add couple more test cases, specifically for array type and row type to ensure future releases can identify these issues early on. Let me know if you would rather have those tests as part of this PR as oppose to in a  separate PR. 