### PR TITLE
Use loginUser instead of currentUser

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/SimpleHadoopAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/SimpleHadoopAuthentication.java
@@ -25,7 +25,7 @@ public class SimpleHadoopAuthentication
     public UserGroupInformation getUserGroupInformation()
     {
         try {
-            return UserGroupInformation.getCurrentUser();
+            return UserGroupInformation.getLoginUser();
         }
         catch (IOException e) {
             throw Throwables.propagate(e);


### PR DESCRIPTION
We have seen the following error when doing "create table as" with simple impersonation in the presto-hive connector. It appears that there is two places hooked the `doAs`; the first one is in the `HivePageSink.doAppend` and the second one is in `RcFileFileWriterFactory.createFileWriter`.

+cc @dabaitu

Config:
```
hive.hdfs.authentication.type=NONE
hive.hdfs.impersonation.enabled=true
```
Full Stack Trace:
```
java.lang.RuntimeException: org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.authorize.AuthorizationException): User: pdutta is not allowed to impersonate pdutta
	at com.google.common.base.Throwables.propagate(Throwables.java:240)
	at com.facebook.presto.hive.RcFileFileWriterFactory.createFileWriter(RcFileFileWriterFactory.java:167)
	at com.facebook.presto.hive.HiveWriterFactory.createWriter(HiveWriterFactory.java:361)
	at com.facebook.presto.hive.HivePageSink.getWriterIndexes(HivePageSink.java:328)
	at com.facebook.presto.hive.HivePageSink.writePage(HivePageSink.java:262)
	at com.facebook.presto.hive.HivePageSink.doAppend(HivePageSink.java:257)
	at com.facebook.presto.hive.HivePageSink.lambda$appendPage$2(HivePageSink.java:243)
	at com.facebook.presto.hive.authentication.HdfsAuthentication.lambda$doAs$0(HdfsAuthentication.java:24)
	at com.facebook.presto.hive.authentication.UserGroupInformationUtils.lambda$executeActionInDoAs$0(UserGroupInformationUtils.java:29)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:360)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1678)
	at com.facebook.presto.hive.authentication.UserGroupInformationUtils.executeActionInDoAs(UserGroupInformationUtils.java:27)
	at com.facebook.presto.hive.authentication.ImpersonatingHdfsAuthentication.doAs(ImpersonatingHdfsAuthentication.java:39)
	at com.facebook.presto.hive.authentication.HdfsAuthentication.doAs(HdfsAuthentication.java:23)
	at com.facebook.presto.hive.HdfsEnvironment.doAs(HdfsEnvironment.java:81)
	at com.facebook.presto.hive.HivePageSink.appendPage(HivePageSink.java:243)
	at com.facebook.presto.spi.classloader.ClassLoaderSafeConnectorPageSink.appendPage(ClassLoaderSafeConnectorPageSink.java:49)
	at com.facebook.presto.operator.TableWriterOperator.addInput(TableWriterOperator.java:203)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:306)
	at com.facebook.presto.operator.Driver.lambda$processFor$6(Driver.java:234)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:538)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:229)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:623)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
	at com.facebook.presto.execution.executor.LegacyPrioritizedSplitRunner.process(LegacyPrioritizedSplitRunner.java:23)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:478)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.hadoop.ipc.RemoteException: User: pdutta is not allowed to impersonate pdutta
	at org.apache.hadoop.ipc.Client.call(Client.java:1475)
	at org.apache.hadoop.ipc.Client.call(Client.java:1412)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:229)
	at com.sun.proxy.$Proxy168.create(Unknown Source)
	at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.create(ClientNamenodeProtocolTranslatorPB.java:296)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:191)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102)
	at com.sun.proxy.$Proxy169.create(Unknown Source)
	at org.apache.hadoop.hdfs.DFSOutputStream.newStreamForCreate(DFSOutputStream.java:1648)
	at org.apache.hadoop.hdfs.DFSClient.create(DFSClient.java:1689)
	at org.apache.hadoop.hdfs.DFSClient.create(DFSClient.java:1624)
	at org.apache.hadoop.hdfs.DistributedFileSystem$7.doCall(DistributedFileSystem.java:448)
	at org.apache.hadoop.hdfs.DistributedFileSystem$7.doCall(DistributedFileSystem.java:444)
	at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
	at org.apache.hadoop.hdfs.DistributedFileSystem.create(DistributedFileSystem.java:459)
	at org.apache.hadoop.hdfs.DistributedFileSystem.create(DistributedFileSystem.java:387)
	at org.apache.hadoop.fs.FilterFileSystem.create(FilterFileSystem.java:179)
	at org.apache.hadoop.fs.viewfs.ChRootedFileSystem.create(ChRootedFileSystem.java:183)
	at org.apache.hadoop.fs.viewfs.ViewFileSystem.create(ViewFileSystem.java:301)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:911)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:892)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:789)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:778)
	at com.facebook.presto.hive.RcFileFileWriterFactory.createFileWriter(RcFileFileWriterFactory.java:130)
	... 28 more
```