### PR TITLE
Add support for enforcing query max execution time limits

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -48,6 +48,7 @@ public final class SystemSessionProperties
     public static final String TASK_CONCURRENCY = "task_concurrency";
     public static final String TASK_SHARE_INDEX_LOADING = "task_share_index_loading";
     public static final String QUERY_MAX_MEMORY = "query_max_memory";
+    public static final String QUERY_MAX_EXECUTION_TIME = "query_max_execution_time";
     public static final String QUERY_MAX_RUN_TIME = "query_max_run_time";
     public static final String RESOURCE_OVERCOMMIT = "resource_overcommit";
     public static final String QUERY_MAX_CPU_TIME = "query_max_cpu_time";
@@ -175,6 +176,15 @@ public final class SystemSessionProperties
                         VARCHAR,
                         Duration.class,
                         queryManagerConfig.getQueryMaxRunTime(),
+                        false,
+                        value -> Duration.valueOf((String) value),
+                        Duration::toString),
+                new PropertyMetadata<>(
+                        QUERY_MAX_EXECUTION_TIME,
+                        "Maximum execution time of a query",
+                        VARCHAR,
+                        Duration.class,
+                        queryManagerConfig.getQueryMaxExecutionTime(),
                         false,
                         value -> Duration.valueOf((String) value),
                         Duration::toString),
@@ -405,6 +415,11 @@ public final class SystemSessionProperties
     public static Duration getQueryMaxRunTime(Session session)
     {
         return session.getSystemProperty(QUERY_MAX_RUN_TIME, Duration.class);
+    }
+
+    public static Duration getQueryMaxExecutionTime(Session session)
+    {
+        return session.getSystemProperty(QUERY_MAX_EXECUTION_TIME, Duration.class);
     }
 
     public static boolean resourceOvercommit(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -172,7 +172,7 @@ public final class SystemSessionProperties
                         false),
                 new PropertyMetadata<>(
                         QUERY_MAX_RUN_TIME,
-                        "Maximum run time of a query",
+                        "Maximum run time of a query (includes the queueing time)",
                         VARCHAR,
                         Duration.class,
                         queryManagerConfig.getQueryMaxRunTime(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -54,6 +54,7 @@ public class QueryManagerConfig
 
     private String queryExecutionPolicy = "all-at-once";
     private Duration queryMaxRunTime = new Duration(100, TimeUnit.DAYS);
+    private Duration queryMaxExecutionTime = new Duration(100, TimeUnit.DAYS);
     private Duration queryMaxCpuTime = new Duration(1_000_000_000, TimeUnit.DAYS);
 
     private int initializationRequiredWorkers = 1;
@@ -248,6 +249,19 @@ public class QueryManagerConfig
     public QueryManagerConfig setQueryMaxRunTime(Duration queryMaxRunTime)
     {
         this.queryMaxRunTime = queryMaxRunTime;
+        return this;
+    }
+
+    @NotNull
+    public Duration getQueryMaxExecutionTime()
+    {
+        return queryMaxExecutionTime;
+    }
+
+    @Config("query.max-execution-time")
+    public QueryManagerConfig setQueryMaxExecutionTime(Duration queryMaxExecutionTime)
+    {
+        this.queryMaxExecutionTime = queryMaxExecutionTime;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -43,6 +43,7 @@ public class TestQueryManagerConfig
                 .setRemoteTaskMaxCallbackThreads(1000)
                 .setQueryExecutionPolicy("all-at-once")
                 .setQueryMaxRunTime(new Duration(100, TimeUnit.DAYS))
+                .setQueryMaxExecutionTime(new Duration(100, TimeUnit.DAYS))
                 .setQueryMaxCpuTime(new Duration(1_000_000_000, TimeUnit.DAYS))
                 .setInitializationRequiredWorkers(1)
                 .setInitializationTimeout(new Duration(5, TimeUnit.MINUTES)));
@@ -68,6 +69,7 @@ public class TestQueryManagerConfig
                 .put("query.remote-task.max-callback-threads", "10")
                 .put("query.execution-policy", "phased")
                 .put("query.max-run-time", "2h")
+                .put("query.max-execution-time", "3h")
                 .put("query.max-cpu-time", "2d")
                 .put("query-manager.initialization-required-workers", "200")
                 .put("query-manager.initialization-timeout", "1m")
@@ -90,6 +92,7 @@ public class TestQueryManagerConfig
                 .setRemoteTaskMaxCallbackThreads(10)
                 .setQueryExecutionPolicy("phased")
                 .setQueryMaxRunTime(new Duration(2, TimeUnit.HOURS))
+                .setQueryMaxExecutionTime(new Duration(3, TimeUnit.HOURS))
                 .setQueryMaxCpuTime(new Duration(2, TimeUnit.DAYS))
                 .setInitializationRequiredWorkers(200)
                 .setInitializationTimeout(new Duration(1, TimeUnit.MINUTES));

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution.resourceGroups.db;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
 import com.facebook.presto.resourceGroups.db.DbResourceGroupConfigurationManager;
@@ -27,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_EXECUTION_TIME;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
@@ -42,7 +44,10 @@ import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getSele
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.rejectingSession;
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.waitForCompleteQueryCount;
 import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.waitForRunningQueryCount;
+import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
 import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.testing.Assertions.assertContains;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 
@@ -217,5 +222,40 @@ public class TestQueues
         QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
         waitForQueryState(queryRunner, secondDashboardQuery, FAILED);
+    }
+
+    @Test(timeOut = 60_000)
+    public void testQueryExecutionTimeLimit()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("sf100000")
+                .setSource("dashboard")
+                .setSystemProperty(QUERY_MAX_EXECUTION_TIME, "1ms")
+                .build();
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+        QueryId firstQuery = createQuery(queryRunner, session, LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstQuery, FAILED);
+        assertEquals(queryManager.getQueryInfo(firstQuery).getErrorCode(), EXCEEDED_TIME_LIMIT.toErrorCode());
+        assertContains(queryManager.getQueryInfo(firstQuery).getFailureInfo().getMessage(), "Query exceeded the maximum execution time limit of 1.00ms");
+        // set max running queries to 0 for the dashboard resource group so that new queries get queued immediately
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 0, null, null, null, null, null, null, null, 3L);
+        dbConfigurationManager.load();
+        QueryId secondQuery = createQuery(queryRunner, session, LONG_LASTING_QUERY);
+        //this query should immediately get queued
+        waitForQueryState(queryRunner, secondQuery, QUEUED);
+        // after a 5s wait this query should still be QUEUED, not FAILED as the max execution time should be enforced after the query starts running
+        Thread.sleep(5_000);
+        assertEquals(queryManager.getQueryInfo(secondQuery).getState(), QUEUED);
+        // reconfigure the resource group to run the second query
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, null, null, null, null, null, null, null, 3L);
+        dbConfigurationManager.load();
+        // cancel the first one and let the second one start
+        queryManager.cancelQuery(firstQuery);
+        // wait until the second one is FAILED
+        waitForQueryState(queryRunner, secondQuery, FAILED);
     }
 }


### PR DESCRIPTION
A new pair of configuration and session properties are added for specifying
a query max execution time limit (query.max-execution-time/query_max_execution_time).

(we have a query max runtime limit, which is enforced starting from the query creation time, please see discussion [here](#8794)).