### PR TITLE
Add reference counting for SliceBigArray

### DIFF
--- a/presto-array/src/main/java/com/facebook/presto/array/BlockBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/BlockBigArray.java
@@ -67,7 +67,7 @@ public final class BlockBigArray
                     sizeOfBlocks -= size;
                     return;
                 }
-                if (trackedObjects.decrementReference(object) == 0) {
+                if (trackedObjects.decrementAndGet(object) == 0) {
                     // decrement the size only when it is the last reference
                     sizeOfBlocks -= size;
                 }
@@ -80,7 +80,7 @@ public final class BlockBigArray
                     sizeOfBlocks += size;
                     return;
                 }
-                if (trackedObjects.incrementReference(object) == 1) {
+                if (trackedObjects.incrementAndGet(object) == 1) {
                     // increment the size only when it is the first reference
                     sizeOfBlocks += size;
                 }

--- a/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
@@ -34,7 +34,7 @@ public final class ReferenceCountMap
     /**
      * Increments the reference count of an object by 1 and returns the updated reference count
      */
-    public int incrementReference(Object key)
+    public int incrementAndGet(Object key)
     {
         return addTo(key, 1) + 1;
     }
@@ -42,7 +42,7 @@ public final class ReferenceCountMap
     /**
      * Decrements the reference count of an object by 1 and returns the updated reference count
      */
-    public int decrementReference(Object key)
+    public int decrementAndGet(Object key)
     {
         int previousCount = addTo(key, -1);
         if (previousCount == 1) {

--- a/presto-array/src/test/java/com/facebook/presto/array/TestBlockBigArray.java
+++ b/presto-array/src/test/java/com/facebook/presto/array/TestBlockBigArray.java
@@ -44,7 +44,7 @@ public class TestBlockBigArray
         }
 
         ReferenceCountMap referenceCountMap = new ReferenceCountMap();
-        referenceCountMap.incrementReference(block);
+        referenceCountMap.incrementAndGet(block);
         long expectedSize = ClassLayout.parseClass(BlockBigArray.class).instanceSize()
                 + referenceCountMap.sizeOf()
                 + (new ObjectBigArray()).sizeOf()

--- a/presto-array/src/test/java/com/facebook/presto/array/TestSliceBigArray.java
+++ b/presto-array/src/test/java/com/facebook/presto/array/TestSliceBigArray.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.array;
+
+import io.airlift.slice.Slice;
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static io.airlift.slice.SizeOf.sizeOf;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestSliceBigArray
+{
+    private static final long BIG_ARRAY_INSTANCE_SIZE = ClassLayout.parseClass(SliceBigArray.class).instanceSize() + new ReferenceCountMap().sizeOf() + new ObjectBigArray<Slice>().sizeOf();
+    private static final long SLICE_INSTANCE_SIZE = ClassLayout.parseClass(Slice.class).instanceSize();
+    private static final int CAPACITY = 32;
+    private final byte[] firstBytes = new byte[1234];
+    private final byte[] secondBytes = new byte[4567];
+    private SliceBigArray sliceBigArray;
+
+    @BeforeMethod
+    public void setup()
+    {
+        sliceBigArray = new SliceBigArray();
+        sliceBigArray.ensureCapacity(CAPACITY);
+    }
+
+    @Test
+    public void testSameSliceRetainedSize()
+    {
+        // same slice should be counted only once
+        Slice slice = wrappedBuffer(secondBytes, 201, 1501);
+        for (int i = 0; i < CAPACITY; i++) {
+            sliceBigArray.set(i, slice);
+            assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE + sizeOf(secondBytes) + SLICE_INSTANCE_SIZE);
+        }
+
+        // adding a new slice will increase the size
+        slice = wrappedBuffer(secondBytes, 201, 1501);
+        sliceBigArray.set(3, slice);
+        assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE + sizeOf(secondBytes) + SLICE_INSTANCE_SIZE * 2);
+    }
+
+    @Test
+    public void testNullSlicesRetainedSize()
+    {
+        // add null values
+        sliceBigArray.set(0, null);
+        assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE);
+
+        // replace null with a slice
+        sliceBigArray.set(0, wrappedBuffer(secondBytes, 201, 1501));
+        assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE + sizeOf(secondBytes) + SLICE_INSTANCE_SIZE);
+
+        // add another slice
+        sliceBigArray.set(1, wrappedBuffer(secondBytes, 201, 1501));
+        assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE + sizeOf(secondBytes) + SLICE_INSTANCE_SIZE * 2);
+
+        // replace slice with null
+        sliceBigArray.set(1, null);
+        assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE + sizeOf(secondBytes) + SLICE_INSTANCE_SIZE);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        // add two elements
+        sliceBigArray.set(0, wrappedBuffer(firstBytes, 0, 100));
+        sliceBigArray.set(1, wrappedBuffer(secondBytes, 0, 100));
+        assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE + sizeOf(firstBytes) + sizeOf(secondBytes) + SLICE_INSTANCE_SIZE * 2);
+
+        // add two more
+        sliceBigArray.set(2, wrappedBuffer(firstBytes, 100, 200));
+        sliceBigArray.set(3, wrappedBuffer(secondBytes, 20, 150));
+        assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE + sizeOf(firstBytes) + sizeOf(secondBytes) + SLICE_INSTANCE_SIZE * 4);
+
+        // replace with different slices but the same base
+        sliceBigArray.set(2, wrappedBuffer(firstBytes, 11, 1200));
+        sliceBigArray.set(3, wrappedBuffer(secondBytes, 201, 1501));
+        assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE + sizeOf(firstBytes) + sizeOf(secondBytes) + SLICE_INSTANCE_SIZE * 4);
+
+        // replace with a different slice with a different base
+        sliceBigArray.set(0, wrappedBuffer(secondBytes, 11, 1200));
+        sliceBigArray.set(2, wrappedBuffer(secondBytes, 201, 1501));
+        assertEquals(sliceBigArray.sizeOf(), BIG_ARRAY_INSTANCE_SIZE + sizeOf(secondBytes) + SLICE_INSTANCE_SIZE * 4);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
@@ -230,7 +230,7 @@ public class PageProcessor
             for (Block block : page.getBlocks()) {
                 if (!isUnloadedLazyBlock(block)) {
                     block.retainedBytesForEachPart((object, size) -> {
-                        if (referenceCountMap.incrementReference(object) == 1) {
+                        if (referenceCountMap.incrementAndGet(object) == 1) {
                             retainedSizeInBytes += size;
                         }
                     });
@@ -239,7 +239,7 @@ public class PageProcessor
             for (Block previouslyComputedResult : previouslyComputedResults) {
                 if (previouslyComputedResult != null) {
                     previouslyComputedResult.retainedBytesForEachPart((object, size) -> {
-                        if (referenceCountMap.incrementReference(object) == 1) {
+                        if (referenceCountMap.incrementAndGet(object) == 1) {
                             retainedSizeInBytes += size;
                         }
                     });


### PR DESCRIPTION
Add a map in SliceBigArray to track the underlying data of the slice it
sets. The map aims to avoid under or over counting the memory usage. In
production, we found the original approximation can be off by 2X.