### PR TITLE
Fix NPE when calling ST_Distance for ST_Point(x, y) geometries

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
@@ -37,6 +37,7 @@ import io.airlift.slice.Slices;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.esri.core.geometry.ogc.OGCGeometry.createFromEsriGeometry;
@@ -549,7 +550,7 @@ public final class GeoFunctions
 
     private static void verifySameSpatialReference(OGCGeometry leftGeometry, OGCGeometry rightGeometry)
     {
-        checkArgument(leftGeometry.getEsriSpatialReference().equals(rightGeometry.getEsriSpatialReference()), "Input Geometries Spatial Reference do not match");
+        checkArgument(Objects.equals(leftGeometry.getEsriSpatialReference(), rightGeometry.getEsriSpatialReference()), "Input geometries must have same spatial reference");
     }
 
     // Points centroid is arithmetic mean of the input points

--- a/presto-geospatial/src/test/java/com/facebook/presto/geospatial/TestGeoQueries.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/geospatial/TestGeoQueries.java
@@ -266,6 +266,7 @@ public class TestGeoQueries
     public void testSTDistance()
             throws Exception
     {
+        assertFunction("ST_Distance(ST_Point(50, 100), ST_Point(150, 150))", DOUBLE, 111.80339887498948);
         assertFunction("ST_Distance(ST_GeometryFromText('POINT (50 100)'), ST_GeometryFromText('POINT (150 150)'))", DOUBLE, 111.80339887498948);
         assertFunction("ST_Distance(ST_GeometryFromText('MULTIPOINT (50 100, 50 200)'), ST_GeometryFromText('Point (50 100)'))", DOUBLE, 0.0);
         assertFunction("ST_Distance(ST_GeometryFromText('LINESTRING (50 100, 50 200)'), ST_GeometryFromText('LINESTRING (10 10, 20 20)'))", DOUBLE, 85.44003745317531);


### PR DESCRIPTION
Before this change, ST_Distance(ST_Point(62.82, 44.4024), ST_Point(63.3333, 44.6833)) resulted in a NullPointerException. ST_Point creates a Geometry object with null spatial reference. ST_Distance (and other functions) use left.equals(right) to verify that spatial references of the input geometries match and fail with NPE if spatial reference on the left is null. This PR changes the check to use null-safe Object.equals(left, right).