### PR TITLE
Add new locations for query output during scheduling

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -30,7 +30,6 @@ import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.Duration;
 
 import javax.annotation.Nullable;
@@ -42,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import static com.facebook.presto.spi.resourceGroups.QueryType.DATA_DEFINITION;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -141,9 +141,9 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
-    public ListenableFuture<QueryOutputInfo> getOutputInfo()
+    public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
     {
-        return SettableFuture.create();
+        // DDL does not have an output
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -23,13 +23,13 @@ import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.Duration;
 
 import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -114,9 +114,9 @@ public class FailedQueryExecution
     }
 
     @Override
-    public ListenableFuture<QueryOutputInfo> getOutputInfo()
+    public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
     {
-        return SettableFuture.create();
+        // no-op
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -22,12 +22,13 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 public interface QueryManager
 {
     List<QueryInfo> getAllQueryInfo();
 
-    ListenableFuture<QueryOutputInfo> getOutputInfo(QueryId queryId);
+    void addOutputInfoListener(QueryId queryId, Consumer<QueryOutputInfo> listener);
 
     ListenableFuture<QueryState> getStateChange(QueryId queryId, QueryState currentState);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.execution.PlanFlattener.FlattenedPlan;
+import com.facebook.presto.execution.QueryExecution.QueryOutputInfo;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
@@ -26,6 +27,7 @@ import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.transaction.TransactionId;
@@ -42,10 +44,13 @@ import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +60,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.FINISHED;
@@ -70,6 +76,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.StandardErrorCode.USER_CANCELED;
 import static com.facebook.presto.util.Failures.toFailure;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.airlift.units.Duration.succinctNanos;
 import static java.util.Objects.requireNonNull;
@@ -92,6 +99,7 @@ public class QueryStateMachine
     private final TransactionManager transactionManager;
     private final Ticker ticker;
     private final Metadata metadata;
+    private final QueryOutputManager outputManager;
 
     private final AtomicReference<VersionedMemoryPoolId> memoryPool = new AtomicReference<>(new VersionedMemoryPoolId(GENERAL_POOL, 0));
 
@@ -129,8 +137,6 @@ public class QueryStateMachine
 
     private final AtomicReference<ExecutionFailureInfo> failureCause = new AtomicReference<>();
 
-    private final AtomicReference<List<String>> outputFieldNames = new AtomicReference<>(ImmutableList.of());
-
     private final AtomicReference<Set<Input>> inputs = new AtomicReference<>(ImmutableSet.of());
     private final AtomicReference<Optional<Output>> output = new AtomicReference<>(Optional.empty());
     private final AtomicReference<Optional<FlattenedPlan>> flattenedPlan = new AtomicReference<>(Optional.empty());
@@ -153,6 +159,7 @@ public class QueryStateMachine
 
         this.queryState = new StateMachine<>("query " + query, executor, QUEUED, TERMINAL_QUERY_STATES);
         this.finalQueryInfo = new StateMachine<>("finalQueryInfo-" + queryId, executor, Optional.empty());
+        this.outputManager = new QueryOutputManager(executor);
     }
 
     /**
@@ -431,7 +438,7 @@ public class QueryStateMachine
                 memoryPool.get().getId(),
                 isScheduled,
                 self,
-                outputFieldNames.get(),
+                outputManager.getQueryOutputInfo().map(QueryOutputInfo::getColumnNames).orElse(ImmutableList.of()),
                 query,
                 queryStats,
                 Optional.ofNullable(setCatalog.get()),
@@ -463,10 +470,19 @@ public class QueryStateMachine
         this.memoryPool.set(requireNonNull(memoryPool, "memoryPool is null"));
     }
 
-    public void setOutputFieldNames(List<String> outputFieldNames)
+    public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
     {
-        requireNonNull(outputFieldNames, "outputFieldNames is null");
-        this.outputFieldNames.set(ImmutableList.copyOf(outputFieldNames));
+        outputManager.addOutputInfoListener(listener);
+    }
+
+    public void setColumns(List<String> columnNames, List<Type> columnTypes)
+    {
+        outputManager.setColumns(columnNames, columnTypes);
+    }
+
+    public void updateOutputLocations(Set<URI> newExchangeLocations, boolean noMoreExchangeLocations)
+    {
+        outputManager.updateOutputLocations(newExchangeLocations, noMoreExchangeLocations);
     }
 
     public void setInputs(List<Input> inputs)
@@ -867,5 +883,93 @@ public class QueryStateMachine
     private Duration nanosSince(long start)
     {
         return succinctNanos(tickerNanos() - start);
+    }
+
+    public static class QueryOutputManager
+    {
+        private final Executor executor;
+
+        @GuardedBy("this")
+        private final List<Consumer<QueryOutputInfo>> outputInfoListeners = new ArrayList<>();
+
+        @GuardedBy("this")
+        private List<String> columnNames;
+        @GuardedBy("this")
+        private List<Type> columnTypes;
+        @GuardedBy("this")
+        private final Set<URI> exchangeLocations = new LinkedHashSet<>();
+        @GuardedBy("this")
+        private boolean noMoreExchangeLocations;
+
+        public QueryOutputManager(Executor executor)
+        {
+            this.executor = requireNonNull(executor, "executor is null");
+        }
+
+        public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
+        {
+            requireNonNull(listener, "listener is null");
+
+            Optional<QueryOutputInfo> queryOutputInfo;
+            synchronized (this) {
+                outputInfoListeners.add(listener);
+                queryOutputInfo = getQueryOutputInfo();
+            }
+            queryOutputInfo.ifPresent(info -> executor.execute(() -> listener.accept(info)));
+        }
+
+        public void setColumns(List<String> columnNames, List<Type> columnTypes)
+        {
+            requireNonNull(columnNames, "columnNames is null");
+            requireNonNull(columnTypes, "columnTypes is null");
+            checkArgument(columnNames.size() == columnTypes.size(), "columnNames and columnTypes must be the same size");
+
+            Optional<QueryOutputInfo> queryOutputInfo;
+            List<Consumer<QueryOutputInfo>> outputInfoListeners;
+            synchronized (this) {
+                checkState(this.columnNames == null && this.columnTypes == null, "output fields already set");
+                this.columnNames = ImmutableList.copyOf(columnNames);
+                this.columnTypes = ImmutableList.copyOf(columnTypes);
+
+                queryOutputInfo = getQueryOutputInfo();
+                outputInfoListeners = ImmutableList.copyOf(this.outputInfoListeners);
+            }
+            queryOutputInfo.ifPresent(info -> fireStateChanged(info, outputInfoListeners));
+        }
+
+        public void updateOutputLocations(Set<URI> newExchangeLocations, boolean noMoreExchangeLocations)
+        {
+            requireNonNull(newExchangeLocations, "newExchangeLocations is null");
+
+            Optional<QueryOutputInfo> queryOutputInfo;
+            List<Consumer<QueryOutputInfo>> outputInfoListeners;
+            synchronized (this) {
+                if (this.noMoreExchangeLocations) {
+                    checkArgument(this.exchangeLocations.containsAll(newExchangeLocations), "New locations added after no more locations set");
+                    return;
+                }
+
+                this.exchangeLocations.addAll(newExchangeLocations);
+                this.noMoreExchangeLocations = noMoreExchangeLocations;
+                queryOutputInfo = getQueryOutputInfo();
+                outputInfoListeners = ImmutableList.copyOf(this.outputInfoListeners);
+            }
+            queryOutputInfo.ifPresent(info -> fireStateChanged(info, outputInfoListeners));
+        }
+
+        private synchronized Optional<QueryOutputInfo> getQueryOutputInfo()
+        {
+            if (columnNames == null || columnTypes == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new QueryOutputInfo(columnNames, columnTypes, exchangeLocations, noMoreExchangeLocations));
+        }
+
+        private void fireStateChanged(QueryOutputInfo queryOutputInfo, List<Consumer<QueryOutputInfo>> outputInfoListeners)
+        {
+            for (Consumer<QueryOutputInfo> outputInfoListener : outputInfoListeners) {
+                executor.execute(() -> outputInfoListener.accept(queryOutputInfo));
+            }
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -68,6 +68,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import static com.facebook.presto.execution.ParameterExtractor.getParameterCount;
 import static com.facebook.presto.execution.QueryState.RUNNING;
@@ -274,16 +275,17 @@ public class SqlQueryManager
     }
 
     @Override
-    public ListenableFuture<QueryOutputInfo> getOutputInfo(QueryId queryId)
+    public void addOutputInfoListener(QueryId queryId, Consumer<QueryOutputInfo> listener)
     {
         requireNonNull(queryId, "queryId is null");
+        requireNonNull(listener, "listener is null");
 
         QueryExecution query = queries.get(queryId);
         if (query == null) {
-            return immediateFailedFuture(new NoSuchElementException());
+            throw new NoSuchElementException();
         }
 
-        return query.getOutputInfo();
+        query.addOutputInfoListener(listener);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
@@ -34,6 +33,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static com.facebook.presto.SystemSessionProperties.QUERY_PRIORITY;
 import static com.facebook.presto.execution.QueryState.FAILED;
@@ -185,9 +185,9 @@ public class MockQueryExecution
     }
 
     @Override
-    public ListenableFuture<QueryOutputInfo> getOutputInfo()
+    public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
     {
-        return SettableFuture.create();
+        // no-op
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -24,6 +24,7 @@ import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
+import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
@@ -52,6 +53,7 @@ import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.execution.QueryState.STARTING;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.USER_CANCELED;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.transaction.TransactionManager.createTestTransactionManager;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -71,6 +73,7 @@ public class TestQueryStateMachine
     private static final List<Input> INPUTS = ImmutableList.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("a", "varchar"))));
     private static final Optional<Output> OUTPUT = Optional.empty();
     private static final List<String> OUTPUT_FIELD_NAMES = ImmutableList.of("a", "b", "c");
+    private static final List<Type> OUTPUT_FIELD_TYPES = ImmutableList.of(BIGINT, BIGINT, BIGINT);
     private static final String UPDATE_TYPE = "update type";
     private static final VersionedMemoryPoolId MEMORY_POOL = new VersionedMemoryPoolId(new MemoryPoolId("pool"), 42);
     private static final Map<String, String> SET_SESSION_PROPERTIES = ImmutableMap.<String, String>builder()
@@ -409,7 +412,7 @@ public class TestQueryStateMachine
         QueryStateMachine stateMachine = QueryStateMachine.beginWithTicker(QUERY_ID, QUERY, TEST_SESSION, LOCATION, false, transactionManager, accessControl, executor, ticker, metadata);
         stateMachine.setInputs(INPUTS);
         stateMachine.setOutput(OUTPUT);
-        stateMachine.setOutputFieldNames(OUTPUT_FIELD_NAMES);
+        stateMachine.setColumns(OUTPUT_FIELD_NAMES, OUTPUT_FIELD_TYPES);
         stateMachine.setUpdateType(UPDATE_TYPE);
         stateMachine.setMemoryPool(MEMORY_POOL);
         for (Entry<String, String> entry : SET_SESSION_PROPERTIES.entrySet()) {


### PR DESCRIPTION
Simple single stage queries will add locations throughout execution,
so waiting until query finishs scheduling may deadlock the query.