### PR TITLE
Add environment support to db-backed resource manager

### DIFF
--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -53,6 +53,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.resourceGroups.db;
 
+import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.customizers.Mapper;
@@ -47,6 +48,7 @@ public interface ResourceGroupsDao
             "  queued_time_limit VARCHAR(128) NULL,\n" +
             "  running_time_limit VARCHAR(128) NULL,\n" +
             "  parent BIGINT NULL,\n" +
+            "  environment VARCHAR(128) NULL,\n" +
             "  PRIMARY KEY (resource_group_id),\n" +
             "  FOREIGN KEY (parent) REFERENCES resource_groups (resource_group_id)\n" +
             ")")
@@ -55,9 +57,10 @@ public interface ResourceGroupsDao
     @SqlQuery("SELECT resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, " +
             "  hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, " +
             "  hard_cpu_limit, queued_time_limit, running_time_limit, parent\n" +
-            "FROM resource_groups")
+            "FROM resource_groups\n" +
+            "WHERE environment = :environment\n")
     @Mapper(ResourceGroupSpecBuilder.Mapper.class)
-    List<ResourceGroupSpecBuilder> getResourceGroups();
+    List<ResourceGroupSpecBuilder> getResourceGroups(@Bind("environment") String environment);
 
     @SqlQuery("SELECT resource_group_id, user_regex, source_regex from selectors")
     @Mapper(SelectorRecord.Mapper.class)

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
@@ -29,8 +29,8 @@ public interface H2ResourceGroupsDao
     void updateResourceGroupsGlobalProperties(@Bind("name") String name);
 
     @SqlUpdate("INSERT INTO resource_groups\n" +
-            "(resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, hard_cpu_limit, queued_time_limit, running_time_limit, parent)\n" +
-            "VALUES (:resource_group_id, :name, :soft_memory_limit, :max_queued, :soft_concurrency_limit, :hard_concurrency_limit, :scheduling_policy, :scheduling_weight, :jmx_export, :soft_cpu_limit, :hard_cpu_limit, :queued_time_limit, :running_time_limit, :parent)")
+            "(resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, hard_cpu_limit, queued_time_limit, running_time_limit, parent, environment)\n" +
+            "VALUES (:resource_group_id, :name, :soft_memory_limit, :max_queued, :soft_concurrency_limit, :hard_concurrency_limit, :scheduling_policy, :scheduling_weight, :jmx_export, :soft_cpu_limit, :hard_cpu_limit, :queued_time_limit, :running_time_limit, :parent, :environment)")
     void insertResourceGroup(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("name") String name,
@@ -45,7 +45,8 @@ public interface H2ResourceGroupsDao
             @Bind("hard_cpu_limit") String hardCpuLimit,
             @Bind("queued_time_limit") String queuedTimeLimit,
             @Bind("running_time_limit") String runningTimeLimit,
-            @Bind("parent") Long parent);
+            @Bind("parent") Long parent,
+            @Bind("environment") String environment);
 
     @SqlUpdate("UPDATE resource_groups SET\n" +
             " resource_group_id = :resource_group_id\n" +
@@ -62,6 +63,7 @@ public interface H2ResourceGroupsDao
             ", queued_time_limit = :queued_time_limit\n" +
             ", running_time_limit = :running_time_limit\n" +
             ", parent = :parent\n" +
+            ", environment = :environment\n" +
             "WHERE resource_group_id = :resource_group_id")
     void updateResourceGroup(
             @Bind("resource_group_id") long resourceGroupId,
@@ -77,7 +79,8 @@ public interface H2ResourceGroupsDao
             @Bind("hard_cpu_limit") String hardCpuLimit,
             @Bind("queued_time_limit") String queuedTimeLimit,
             @Bind("running_time_limit") String runningTimeLimit,
-            @Bind("parent") Long parent);
+            @Bind("parent") Long parent,
+            @Bind("environment") String environment);
 
     @SqlUpdate("DELETE FROM resource_groups WHERE resource_group_id = :resource_group_id")
     void deleteResourceGroup(@Bind("resource_group_id") long resourceGroupId);

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
@@ -30,6 +30,8 @@ import static org.testng.Assert.assertTrue;
 
 public class TestResourceGroupsDao
 {
+    private static final String ENVIRONMENT = "test";
+
     static H2ResourceGroupsDao setup(String prefix)
     {
         DbResourceGroupConfig config = new DbResourceGroupConfig().setConfigDbUrl("jdbc:h2:mem:test_" + prefix + System.nanoTime());
@@ -49,9 +51,9 @@ public class TestResourceGroupsDao
 
     private static void testResourceGroupInsert(H2ResourceGroupsDao dao, Map<Long, ResourceGroupSpecBuilder> map)
     {
-        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null);
-        dao.insertResourceGroup(2, "bi", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L);
-        List<ResourceGroupSpecBuilder> records = dao.getResourceGroups();
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "bi", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        List<ResourceGroupSpecBuilder> records = dao.getResourceGroups(ENVIRONMENT);
         assertEquals(records.size(), 2);
         map.put(1L, new ResourceGroupSpecBuilder(1, new ResourceGroupNameTemplate("global"), "100%", 100, Optional.of(100), 100, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), null));
         map.put(2L, new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), "50%", 50, Optional.of(50), 50, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L)));
@@ -60,17 +62,17 @@ public class TestResourceGroupsDao
 
     private static void testResourceGroupUpdate(H2ResourceGroupsDao dao, Map<Long, ResourceGroupSpecBuilder> map)
     {
-        dao.updateResourceGroup(2, "bi", "40%", 40, 30, 30, null, null, true, null, null, null, null, 1L);
+        dao.updateResourceGroup(2, "bi", "40%", 40, 30, 30, null, null, true, null, null, null, null, 1L, ENVIRONMENT);
         ResourceGroupSpecBuilder updated = new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), "40%", 40, Optional.of(30), 30, Optional.empty(), Optional.empty(), Optional.of(true), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L));
         map.put(2L, updated);
-        compareResourceGroups(map, dao.getResourceGroups());
+        compareResourceGroups(map, dao.getResourceGroups(ENVIRONMENT));
     }
 
     private static void testResourceGroupDelete(H2ResourceGroupsDao dao, Map<Long, ResourceGroupSpecBuilder> map)
     {
         dao.deleteResourceGroup(2);
         map.remove(2L);
-        compareResourceGroups(map, dao.getResourceGroups());
+        compareResourceGroups(map, dao.getResourceGroups(ENVIRONMENT));
     }
 
     @Test
@@ -100,9 +102,9 @@ public class TestResourceGroupsDao
                         3L,
                         Optional.of(Pattern.compile("admin_user")),
                         Optional.of(Pattern.compile(".*"))));
-        dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, null, null);
-        dao.insertResourceGroup(2, "ping_query", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L);
-        dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L);
+        dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "ping_query", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertSelector(2, "ping_user", ".*");
         dao.insertSelector(3, "admin_user", ".*");
         List<SelectorRecord> records = dao.getSelectors();

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -96,20 +96,21 @@ public class DistributedQueryRunner
             int workersCount,
             Map<String, String> extraProperties,
             Map<String, String> coordinatorProperties,
-            SqlParserOptions parserOptions)
+            SqlParserOptions parserOptions,
+            String environment)
             throws Exception
     {
         requireNonNull(defaultSession, "defaultSession is null");
 
         try {
             long start = System.nanoTime();
-            discoveryServer = closer.register(new TestingDiscoveryServer(ENVIRONMENT));
+            discoveryServer = closer.register(new TestingDiscoveryServer(environment));
             log.info("Created TestingDiscoveryServer in %s", nanosSince(start).convertToMostSuccinctTimeUnit());
 
             ImmutableList.Builder<TestingPrestoServer> servers = ImmutableList.builder();
 
             for (int i = 1; i < workersCount; i++) {
-                TestingPrestoServer worker = closer.register(createTestingPrestoServer(discoveryServer.getBaseUrl(), false, extraProperties, parserOptions));
+                TestingPrestoServer worker = closer.register(createTestingPrestoServer(discoveryServer.getBaseUrl(), false, extraProperties, parserOptions, environment));
                 servers.add(worker);
             }
 
@@ -119,7 +120,7 @@ public class DistributedQueryRunner
                     .putAll(extraProperties)
                     .putAll(coordinatorProperties)
                     .build();
-            coordinator = closer.register(createTestingPrestoServer(discoveryServer.getBaseUrl(), true, extraCoordinatorProperties, parserOptions));
+            coordinator = closer.register(createTestingPrestoServer(discoveryServer.getBaseUrl(), true, extraCoordinatorProperties, parserOptions, environment));
             servers.add(coordinator);
 
             this.servers = servers.build();
@@ -161,7 +162,18 @@ public class DistributedQueryRunner
         }
     }
 
-    private static TestingPrestoServer createTestingPrestoServer(URI discoveryUri, boolean coordinator, Map<String, String> extraProperties, SqlParserOptions parserOptions)
+    public DistributedQueryRunner(
+            Session defaultSession,
+            int workersCount,
+            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties,
+            SqlParserOptions parserOptions)
+            throws Exception
+    {
+        this(defaultSession, workersCount, extraProperties, coordinatorProperties, parserOptions, ENVIRONMENT);
+    }
+
+    private static TestingPrestoServer createTestingPrestoServer(URI discoveryUri, boolean coordinator, Map<String, String> extraProperties, SqlParserOptions parserOptions, String environment)
             throws Exception
     {
         long start = System.nanoTime();
@@ -180,7 +192,7 @@ public class DistributedQueryRunner
         HashMap<String, String> properties = new HashMap<>(propertiesBuilder.build());
         properties.putAll(extraProperties);
 
-        TestingPrestoServer server = new TestingPrestoServer(coordinator, properties, ENVIRONMENT, discoveryUri, parserOptions, ImmutableList.of());
+        TestingPrestoServer server = new TestingPrestoServer(coordinator, properties, environment, discoveryUri, parserOptions, ImmutableList.of());
 
         log.info("Created TestingPrestoServer in %s", nanosSince(start).convertToMostSuccinctTimeUnit());
 

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2ResourceGroupConfigurationManagerFactory.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2ResourceGroupConfigurationManagerFactory.java
@@ -23,6 +23,7 @@ import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.airlift.node.NodeModule;
 
 import java.util.Map;
 
@@ -51,6 +52,7 @@ public class H2ResourceGroupConfigurationManagerFactory
             Bootstrap app = new Bootstrap(
                     new JsonModule(),
                     new H2ResourceGroupsModule(),
+                    new NodeModule(),
                     binder -> binder.bind(ClusterMemoryPoolManager.class).toInstance(context.getMemoryPoolManager()));
 
             Injector injector = app

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
@@ -39,6 +39,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 class H2TestUtil
 {
     private static final String CONFIGURATION_MANAGER_TYPE = "h2";
+    public static final String TEST_ENVIRONMENT = "test_environment";
+    public static final String TEST_ENVIRONMENT_2 = "test_environment_2";
 
     private H2TestUtil() {}
 
@@ -110,20 +112,27 @@ class H2TestUtil
     public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao)
             throws Exception
     {
+        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT);
+    }
+
+    public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao, String environment)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner = new DistributedQueryRunner(
                 testSessionBuilder().setCatalog("tpch").setSchema("tiny").build(),
                 2,
                 ImmutableMap.of("experimental.resource-groups-enabled", "true"),
                 ImmutableMap.of(),
-                new SqlParserOptions());
+                new SqlParserOptions(),
+                environment);
         try {
             Plugin h2ResourceGroupManagerPlugin = new H2ResourceGroupManagerPlugin();
             queryRunner.installPlugin(h2ResourceGroupManagerPlugin);
             queryRunner.getCoordinator().getResourceGroupManager().get()
-                    .setConfigurationManager(CONFIGURATION_MANAGER_TYPE, ImmutableMap.of("resource-groups.config-db-url", dbConfigUrl));
+                    .setConfigurationManager(CONFIGURATION_MANAGER_TYPE, ImmutableMap.of("resource-groups.config-db-url", dbConfigUrl, "node.environment", environment));
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch");
-            setup(queryRunner, dao);
+            setup(queryRunner, dao, environment);
             return queryRunner;
         }
         catch (Exception e) {
@@ -140,20 +149,28 @@ class H2TestUtil
         return createQueryRunner(dbConfigUrl, dao);
     }
 
-    private static void setup(DistributedQueryRunner queryRunner, H2ResourceGroupsDao dao)
+    private static void setup(DistributedQueryRunner queryRunner, H2ResourceGroupsDao dao, String environment)
             throws InterruptedException
     {
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
-        dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, null, null);
-        dao.insertResourceGroup(2, "bi-${USER}", "1MB", 3, 2, 2, null, null, null, null, null, null, null, 1L);
-        dao.insertResourceGroup(3, "user-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, 1L);
-        dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, 3L);
-        dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, null, 3L);
+        dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(2, "bi-${USER}", "1MB", 3, 2, 2, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(3, "user-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
         dao.insertSelector(2, "user.*", "test");
         dao.insertSelector(4, "user.*", "(?i).*adhoc.*");
         dao.insertSelector(5, "user.*", "(?i).*dashboard.*");
+        dao.insertSelector(6, ".*", ".*");
+
+        int expectedSelectors = 3;
+        if (environment.equals(TEST_ENVIRONMENT_2)) {
+            expectedSelectors = 1;
+        }
+
         // Selectors are loaded last
-        while (getSelectors(queryRunner).size() != 3) {
+        while (getSelectors(queryRunner).size() != expectedSelectors) {
             MILLISECONDS.sleep(500);
         }
     }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestEnvironments.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestEnvironments.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.resourceGroups.db;
+
+import com.facebook.presto.resourceGroups.db.H2ResourceGroupsDao;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.execution.QueryState.FAILED;
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.createQuery;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.waitForQueryState;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.TEST_ENVIRONMENT;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.TEST_ENVIRONMENT_2;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.adhocSession;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.createQueryRunner;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDao;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDbConfigUrl;
+
+public class TestEnvironments
+{
+    private static final String LONG_LASTING_QUERY = "SELECT COUNT(*) FROM lineitem";
+    private DistributedQueryRunner runner;
+
+    @BeforeGroups(value = TEST_ENVIRONMENT)
+    public void setUpRunnerForEnvironment1()
+            throws Exception
+    {
+        String dbConfigUrl = getDbConfigUrl();
+        H2ResourceGroupsDao dao = getDao(dbConfigUrl);
+        runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT);
+    }
+
+    @BeforeGroups(value = TEST_ENVIRONMENT_2)
+    public void setUpRunnerForEnvironment2()
+            throws Exception
+    {
+        String dbConfigUrl = getDbConfigUrl();
+        H2ResourceGroupsDao dao = getDao(dbConfigUrl);
+        runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT_2);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void shutdown()
+    {
+        runner.close();
+    }
+
+    @Test(timeOut = 60_000, groups = TEST_ENVIRONMENT)
+    public void testEnvironment1()
+            throws Exception
+    {
+        QueryId firstQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
+        waitForQueryState(runner, firstQuery, RUNNING);
+        QueryId secondQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
+        waitForQueryState(runner, secondQuery, RUNNING);
+    }
+
+    @Test(timeOut = 60_000, groups = TEST_ENVIRONMENT_2)
+    public void testEnvironment2()
+            throws Exception
+    {
+        QueryId firstQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
+        waitForQueryState(runner, firstQuery, RUNNING);
+        QueryId secondQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
+        // there is no queueing in TEST_ENVIRONMENT_2, so the second query should fail right away
+        waitForQueryState(runner, secondQuery, FAILED);
+    }
+}


### PR DESCRIPTION
With the current db-backed resource manager to support multiple clusters
we need to have multiple databases (one database per cluster). With this change
the schema of the db-backed resource manager will support multiple clusters with
the new environment column. The db-backed resource manager will load the right
configuration based on the configured environment.