### PR TITLE
Add page size stats to HivePageSink

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -94,6 +94,9 @@ public class HiveClientModule
         recordCursorProviderBinder.addBinding().to(ParquetRecordCursorProvider.class).in(Scopes.SINGLETON);
         recordCursorProviderBinder.addBinding().to(GenericHiveRecordCursorProvider.class).in(Scopes.SINGLETON);
 
+        binder.bind(HiveWriterStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(HiveWriterStats.class).as(generatedNameOf(HiveWriterStats.class, connectorId));
+
         newSetBinder(binder, EventClient.class).addBinding().to(HiveEventClient.class).in(Scopes.SINGLETON);
         binder.bind(HivePartitionManager.class).in(Scopes.SINGLETON);
         binder.bind(LocationService.class).to(HiveLocationService.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
@@ -55,6 +55,7 @@ public class HivePageSinkProvider
     private final NodeManager nodeManager;
     private final EventClient eventClient;
     private final HiveSessionProperties hiveSessionProperties;
+    private final HiveWriterStats hiveWriterStats;
 
     @Inject
     public HivePageSinkProvider(
@@ -68,7 +69,8 @@ public class HivePageSinkProvider
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
             NodeManager nodeManager,
             EventClient eventClient,
-            HiveSessionProperties hiveSessionProperties)
+            HiveSessionProperties hiveSessionProperties,
+            HiveWriterStats hiveWriterStats)
     {
         this.fileWriterFactories = ImmutableSet.copyOf(requireNonNull(fileWriterFactories, "fileWriterFactories is null"));
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
@@ -85,6 +87,7 @@ public class HivePageSinkProvider
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.eventClient = requireNonNull(eventClient, "eventClient is null");
         this.hiveSessionProperties = requireNonNull(hiveSessionProperties, "hiveSessionProperties is null");
+        this.hiveWriterStats = requireNonNull(hiveWriterStats, "stats is null");
     }
 
     @Override
@@ -124,7 +127,8 @@ public class HivePageSinkProvider
                 session,
                 nodeManager,
                 eventClient,
-                hiveSessionProperties);
+                hiveSessionProperties,
+                hiveWriterStats);
 
         return new HivePageSink(
                 writerFactory,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
@@ -30,10 +30,18 @@ public class HiveWriter
     private final String writePath;
     private final String targetPath;
     private final Consumer<HiveWriter> onCommit;
+    private final HiveWriterStats hiveWriterStats;
 
     private long rowCount = 0;
 
-    public HiveWriter(HiveFileWriter fileWriter, Optional<String> partitionName, boolean isNew, String fileName, String writePath, String targetPath, Consumer<HiveWriter> onCommit)
+    public HiveWriter(HiveFileWriter fileWriter,
+            Optional<String> partitionName,
+            boolean isNew,
+            String fileName,
+            String writePath,
+            String targetPath,
+            Consumer<HiveWriter> onCommit,
+            HiveWriterStats hiveWriterStats)
     {
         this.fileWriter = fileWriter;
         this.partitionName = partitionName;
@@ -42,6 +50,7 @@ public class HiveWriter
         this.writePath = writePath;
         this.targetPath = targetPath;
         this.onCommit = onCommit;
+        this.hiveWriterStats = hiveWriterStats;
     }
 
     public long getSystemMemoryUsage()
@@ -56,6 +65,8 @@ public class HiveWriter
 
     public void append(Page dataPage)
     {
+        // getRegionSizeInBytes for each row can be expensive; use getRetainedSizeInBytes for estimation
+        hiveWriterStats.addInputPageSizesInBytes(dataPage.getRetainedSizeInBytes());
         fileWriter.appendRows(dataPage);
         rowCount += dataPage.getPositionCount();
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -119,6 +119,8 @@ public class HiveWriterFactory
     private final EventClient eventClient;
     private final Map<String, String> sessionProperties;
 
+    private final HiveWriterStats hiveWriterStats;
+
     public HiveWriterFactory(
             Set<HiveFileWriterFactory> fileWriterFactories,
             String schemaName,
@@ -138,7 +140,8 @@ public class HiveWriterFactory
             ConnectorSession session,
             NodeManager nodeManager,
             EventClient eventClient,
-            HiveSessionProperties hiveSessionProperties)
+            HiveSessionProperties hiveSessionProperties,
+            HiveWriterStats hiveWriterStats)
     {
         this.fileWriterFactories = ImmutableSet.copyOf(requireNonNull(fileWriterFactories, "fileWriterFactories is null"));
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
@@ -216,6 +219,8 @@ public class HiveWriterFactory
         catch (IOException e) {
             throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed getting FileSystem: " + writePath, e);
         }
+
+        this.hiveWriterStats = requireNonNull(hiveWriterStats, "hiveWriterStats is null");
     }
 
     public HiveWriter createWriter(Page partitionColumns, int position, OptionalInt bucketNumber)
@@ -421,7 +426,7 @@ public class HiveWriterFactory
                     hiveWriter.getRowCount()));
         };
 
-        return new HiveWriter(hiveFileWriter, partitionName, isNew, fileNameWithExtension, write.toString(), target.toString(), onCommit);
+        return new HiveWriter(hiveFileWriter, partitionName, isNew, fileNameWithExtension, write.toString(), target.toString(), onCommit, hiveWriterStats);
     }
 
     private void validateSchema(Optional<String> partitionName, Properties schema)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterStats.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterStats.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import io.airlift.stats.DistributionStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+public class HiveWriterStats
+{
+    private final DistributionStat inputPageSizeInBytes = new DistributionStat();
+
+    @Managed
+    @Nested
+    public DistributionStat getInputPageSizeInBytes()
+    {
+        return inputPageSizeInBytes;
+    }
+
+    public void addInputPageSizesInBytes(long bytes)
+    {
+        inputPageSizeInBytes.add(bytes);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -562,7 +562,8 @@ public abstract class AbstractTestHiveClient
                 partitionUpdateCodec,
                 new TestingNodeManager("fake-environment"),
                 new HiveEventClient(),
-                new HiveSessionProperties(hiveClientConfig));
+                new HiveSessionProperties(hiveClientConfig),
+                new HiveWriterStats());
         pageSourceProvider = new HivePageSourceProvider(hiveClientConfig, hdfsEnvironment, getDefaultHiveRecordCursorProvider(hiveClientConfig), getDefaultHiveDataStreamFactories(hiveClientConfig), TYPE_MANAGER);
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -218,7 +218,8 @@ public abstract class AbstractTestHiveClientS3
                 partitionUpdateCodec,
                 new TestingNodeManager("fake-environment"),
                 new HiveEventClient(),
-                new HiveSessionProperties(config));
+                new HiveSessionProperties(config),
+                new HiveWriterStats());
         pageSourceProvider = new HivePageSourceProvider(config, hdfsEnvironment, getDefaultHiveRecordCursorProvider(config), getDefaultHiveDataStreamFactories(config), TYPE_MANAGER);
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -125,7 +125,8 @@ public class TestHivePageSink
     private static long writeTestFile(HiveClientConfig config, ExtendedHiveMetastore metastore, String outputPath)
     {
         HiveTransactionHandle transaction = new HiveTransactionHandle();
-        ConnectorPageSink pageSink = createPageSink(transaction, config, metastore, new Path("file:///" + outputPath));
+        HiveWriterStats stats = new HiveWriterStats();
+        ConnectorPageSink pageSink = createPageSink(transaction, config, metastore, new Path("file:///" + outputPath), stats);
         List<LineItemColumn> columns = getTestColumns();
         List<Type> columnTypes = columns.stream()
                 .map(LineItemColumn::getType)
@@ -187,6 +188,7 @@ public class TestHivePageSink
         MaterializedResult expectedResults = toMaterializedResult(getSession(config), columnTypes, ImmutableList.of(page));
         MaterializedResult results = toMaterializedResult(getSession(config), columnTypes, pages);
         assertEquals(results, expectedResults);
+        assertEquals(stats.getInputPageSizeInBytes().getAllTime().getMax(), page.getRetainedSizeInBytes());
         return length;
     }
 
@@ -212,7 +214,7 @@ public class TestHivePageSink
         return provider.createPageSource(transaction, getSession(config), split, ImmutableList.copyOf(getColumnHandles()));
     }
 
-    private static ConnectorPageSink createPageSink(HiveTransactionHandle transaction, HiveClientConfig config, ExtendedHiveMetastore metastore, Path outputPath)
+    private static ConnectorPageSink createPageSink(HiveTransactionHandle transaction, HiveClientConfig config, ExtendedHiveMetastore metastore, Path outputPath, HiveWriterStats stats)
     {
         LocationHandle locationHandle = new LocationHandle(outputPath, Optional.of(outputPath), false);
         HiveOutputTableHandle handle = new HiveOutputTableHandle(
@@ -242,7 +244,8 @@ public class TestHivePageSink
                 partitionUpdateCodec,
                 new TestingNodeManager("fake-environment"),
                 new HiveEventClient(),
-                new HiveSessionProperties(config));
+                new HiveSessionProperties(config),
+                stats);
         return provider.createPageSink(transaction, getSession(config), handle);
     }
 


### PR DESCRIPTION
We found in production users may flush a single cell with a size of 1GB.
This can cause Hive writers to a huge amount of memory. Add stats to
monitor the distribution of pages flushed.