### PR TITLE
Fix optimized parquet reader complex hive types processing

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/Field.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/Field.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.spi.type.Type;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class Field
+{
+    private final Type type;
+    private final int repetitionLevel;
+    private final int definitionLevel;
+    private final boolean required;
+
+    protected Field(Type type, int repetitionLevel, int definitionLevel, boolean required)
+    {
+        this.type = requireNonNull(type, "type is required");
+        this.repetitionLevel = repetitionLevel;
+        this.definitionLevel = definitionLevel;
+        this.required = required;
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public int getRepetitionLevel()
+    {
+        return repetitionLevel;
+    }
+
+    public int getDefinitionLevel()
+    {
+        return definitionLevel;
+    }
+
+    public boolean isRequired()
+    {
+        return required;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/GroupField.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/GroupField.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class GroupField
+        extends Field
+{
+    private final ImmutableList<Optional<Field>> children;
+
+    public GroupField(Type type, int repetitionLevel, int definitionLevel, boolean required, ImmutableList<Optional<Field>> children)
+    {
+        super(type, repetitionLevel, definitionLevel, required);
+        this.children = requireNonNull(children, "children is required");
+    }
+
+    public List<Optional<Field>> getChildren()
+    {
+        return children;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive.parquet;
 
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.parquet.reader.ParquetReader;
-import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
@@ -27,12 +26,11 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
-import parquet.column.ColumnDescriptor;
+import parquet.io.MessageColumnIO;
 import parquet.schema.MessageType;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -40,14 +38,11 @@ import java.util.Properties;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
-import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptor;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getFieldIndex;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetType;
-import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
-import static com.facebook.presto.spi.type.StandardTypes.MAP;
-import static com.facebook.presto.spi.type.StandardTypes.ROW;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
+import static parquet.io.ColumnIOConverter.constructField;
 
 public class ParquetPageSource
         implements ConnectorPageSource
@@ -55,12 +50,11 @@ public class ParquetPageSource
     private static final int MAX_VECTOR_LENGTH = 1024;
 
     private final ParquetReader parquetReader;
-    private final ParquetDataSource dataSource;
     private final MessageType fileSchema;
     // for debugging heap dump
-    private final MessageType requestedSchema;
     private final List<String> columnNames;
     private final List<Type> types;
+    private final List<Optional<Field>> fields;
 
     private final Block[] constantBlocks;
     private final int[] hiveColumnIndexes;
@@ -70,28 +64,21 @@ public class ParquetPageSource
     private long readTimeNanos;
     private final boolean useParquetColumnNames;
 
-    private final AggregatedMemoryContext systemMemoryContext;
-
     public ParquetPageSource(
             ParquetReader parquetReader,
-            ParquetDataSource dataSource,
             MessageType fileSchema,
-            MessageType requestedSchema,
+            MessageColumnIO messageColumnIO,
+            TypeManager typeManager,
             Properties splitSchema,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
-            TypeManager typeManager,
-            boolean useParquetColumnNames,
-            AggregatedMemoryContext systemMemoryContext)
+            boolean useParquetColumnNames)
     {
         requireNonNull(splitSchema, "splitSchema is null");
         requireNonNull(columns, "columns is null");
         requireNonNull(effectivePredicate, "effectivePredicate is null");
-
         this.parquetReader = requireNonNull(parquetReader, "parquetReader is null");
-        this.dataSource = requireNonNull(dataSource, "dataSource is null");
         this.fileSchema = requireNonNull(fileSchema, "fileSchema is null");
-        this.requestedSchema = requireNonNull(requestedSchema, "requestedSchema is null");
         this.useParquetColumnNames = useParquetColumnNames;
 
         int size = columns.size();
@@ -100,6 +87,7 @@ public class ParquetPageSource
 
         ImmutableList.Builder<String> namesBuilder = ImmutableList.builder();
         ImmutableList.Builder<Type> typesBuilder = ImmutableList.builder();
+        ImmutableList.Builder<Optional<Field>> fieldsBuilder = ImmutableList.builder();
         for (int columnIndex = 0; columnIndex < size; columnIndex++) {
             HiveColumnHandle column = columns.get(columnIndex);
             checkState(column.getColumnType() == REGULAR, "column type must be regular");
@@ -109,22 +97,26 @@ public class ParquetPageSource
 
             namesBuilder.add(name);
             typesBuilder.add(type);
-
             hiveColumnIndexes[columnIndex] = column.getHiveColumnIndex();
 
             if (getParquetType(column, fileSchema, useParquetColumnNames) == null) {
                 constantBlocks[columnIndex] = RunLengthEncodedBlock.create(type, null, MAX_VECTOR_LENGTH);
+                fieldsBuilder.add(Optional.empty());
+            }
+            else {
+                String columnName = useParquetColumnNames ? name : fileSchema.getFields().get(column.getHiveColumnIndex()).getName();
+                fieldsBuilder.add(constructField(type, messageColumnIO.getChild(columnName)));
             }
         }
         types = typesBuilder.build();
+        fields = fieldsBuilder.build();
         columnNames = namesBuilder.build();
-        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
     }
 
     @Override
     public long getCompletedBytes()
     {
-        return dataSource.getReadBytes();
+        return parquetReader.getDataSource().getReadBytes();
     }
 
     @Override
@@ -142,7 +134,7 @@ public class ParquetPageSource
     @Override
     public long getSystemMemoryUsage()
     {
-        return systemMemoryContext.getBytes();
+        return parquetReader.getSystemMemoryContext().getBytes();
     }
 
     @Override
@@ -168,6 +160,7 @@ public class ParquetPageSource
                 }
                 else {
                     Type type = types.get(fieldId);
+                    Optional<Field> field = fields.get(fieldId);
                     int fieldIndex;
                     if (useParquetColumnNames) {
                         fieldIndex = getFieldIndex(fileSchema, columnNames.get(fieldId));
@@ -175,32 +168,11 @@ public class ParquetPageSource
                     else {
                         fieldIndex = hiveColumnIndexes[fieldId];
                     }
-
-                    if (fieldIndex == -1) {
-                        blocks[fieldId] = RunLengthEncodedBlock.create(type, null, batchSize);
-                        continue;
-                    }
-
-                    String fieldName = fileSchema.getFields().get(fieldIndex).getName();
-                    List<String> path = new ArrayList<>();
-                    path.add(fieldName);
-                    if (ROW.equals(type.getTypeSignature().getBase())) {
-                        blocks[fieldId] = parquetReader.readStruct(type, path);
-                    }
-                    else if (MAP.equals(type.getTypeSignature().getBase())) {
-                        blocks[fieldId] = parquetReader.readMap(type, path);
-                    }
-                    else if (ARRAY.equals(type.getTypeSignature().getBase())) {
-                        blocks[fieldId] = parquetReader.readArray(type, path);
+                    if (fieldIndex != -1 && field.isPresent()) {
+                        blocks[fieldId] = new LazyBlock(batchSize, new ParquetBlockLoader(field.get()));
                     }
                     else {
-                        Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, path);
-                        if (descriptor.isPresent()) {
-                            blocks[fieldId] = new LazyBlock(batchSize, new ParquetBlockLoader(descriptor.get(), type));
-                        }
-                        else {
-                            blocks[fieldId] = RunLengthEncodedBlock.create(type, null, batchSize);
-                        }
+                        blocks[fieldId] = RunLengthEncodedBlock.create(type, null, batchSize);
                     }
                 }
             }
@@ -210,11 +182,7 @@ public class ParquetPageSource
             closeWithSuppression(e);
             throw e;
         }
-        catch (ParquetCorruptionException e) {
-            closeWithSuppression(e);
-            throw new PrestoException(HIVE_BAD_DATA, e);
-        }
-        catch (IOException | RuntimeException e) {
+        catch (RuntimeException e) {
             closeWithSuppression(e);
             throw new PrestoException(HIVE_CURSOR_ERROR, e);
         }
@@ -254,14 +222,12 @@ public class ParquetPageSource
             implements LazyBlockLoader<LazyBlock>
     {
         private final int expectedBatchId = batchId;
-        private final ColumnDescriptor columnDescriptor;
-        private final Type type;
+        private final Field field;
         private boolean loaded;
 
-        public ParquetBlockLoader(ColumnDescriptor columnDescriptor, Type type)
+        public ParquetBlockLoader(Field field)
         {
-            this.columnDescriptor = columnDescriptor;
-            this.type = requireNonNull(type, "type is null");
+            this.field = requireNonNull(field, "field is null");
         }
 
         @Override
@@ -274,7 +240,7 @@ public class ParquetPageSource
             checkState(batchId == expectedBatchId);
 
             try {
-                Block block = parquetReader.readPrimitive(columnDescriptor, type);
+                Block block = parquetReader.readBlock(field);
                 lazyBlock.setBlock(block);
             }
             catch (ParquetCorruptionException e) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/PrimitiveField.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/PrimitiveField.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.spi.type.Type;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrimitiveField
+        extends Field
+{
+    private final RichColumnDescriptor descriptor;
+    private final int id;
+
+    public PrimitiveField(Type type, int repetitionLevel, int definitionLevel, boolean required, RichColumnDescriptor descriptor, int id)
+    {
+        super(type, repetitionLevel, definitionLevel, required);
+        this.descriptor = requireNonNull(descriptor, "descriptor is required");
+        this.id = id;
+    }
+
+    public RichColumnDescriptor getDescriptor()
+    {
+        return descriptor;
+    }
+
+    public int getId()
+    {
+        return id;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/RichColumnDescriptor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/RichColumnDescriptor.java
@@ -16,24 +16,31 @@ package com.facebook.presto.hive.parquet;
 import parquet.column.ColumnDescriptor;
 import parquet.schema.PrimitiveType;
 
+import static parquet.schema.Type.Repetition.OPTIONAL;
+
 // extension of parquet's ColumnDescriptor. Exposes full Primitive type information
 public class RichColumnDescriptor
         extends ColumnDescriptor
 {
     private final PrimitiveType primitiveType;
+    private final boolean required;
 
     public RichColumnDescriptor(
-            String[] path,
-            PrimitiveType primitiveType,
-            int maxRep,
-            int maxDef)
+            ColumnDescriptor descriptor,
+            PrimitiveType primitiveType)
     {
-        super(path, primitiveType.getPrimitiveTypeName(), primitiveType.getTypeLength(), maxRep, maxDef);
+        super(descriptor.getPath(), primitiveType.getPrimitiveTypeName(), primitiveType.getTypeLength(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel());
         this.primitiveType = primitiveType;
+        this.required = primitiveType.getRepetition() != OPTIONAL;
     }
 
     public PrimitiveType getPrimitiveType()
     {
         return primitiveType;
+    }
+
+    public boolean isRequired()
+    {
+        return required;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ColumnChunk.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ColumnChunk.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.reader;
+
+import com.facebook.presto.spi.block.Block;
+
+import static java.util.Objects.requireNonNull;
+
+public class ColumnChunk
+{
+    private final Block block;
+    private final int[] definitionLevels;
+    private final int[] repetitionLevels;
+
+    public ColumnChunk(Block block, int[] definitionLevels, int[] repetitionLevels)
+    {
+        this.block = requireNonNull(block, "block is null");
+        this.definitionLevels = requireNonNull(definitionLevels, "definitionLevels is null");
+        this.repetitionLevels = requireNonNull(repetitionLevels, "repetitionLevels is null");
+    }
+
+    public Block getBlock()
+    {
+        return block;
+    }
+
+    public int[] getDefinitionLevels()
+    {
+        return definitionLevels;
+    }
+
+    public int[] getRepetitionLevels()
+    {
+        return repetitionLevels;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBinaryColumnReader.java
@@ -13,10 +13,10 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
-import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
 import static com.facebook.presto.spi.type.Chars.isCharType;
@@ -27,9 +27,9 @@ import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.wrappedBuffer;
 
 public class ParquetBinaryColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetBinaryColumnReader(ColumnDescriptor descriptor)
+    public ParquetBinaryColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -54,7 +54,7 @@ public class ParquetBinaryColumnReader
             }
             type.writeSlice(blockBuilder, value);
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBooleanColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetBooleanColumnReader.java
@@ -13,14 +13,14 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 public class ParquetBooleanColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetBooleanColumnReader(ColumnDescriptor descriptor)
+    public ParquetBooleanColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -31,7 +31,7 @@ public class ParquetBooleanColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeBoolean(blockBuilder, valuesReader.readBoolean());
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDecimalColumnReaderFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDecimalColumnReaderFactory.java
@@ -20,7 +20,7 @@ public final class ParquetDecimalColumnReaderFactory
 {
     private ParquetDecimalColumnReaderFactory() {}
 
-    public static ParquetColumnReader createReader(RichColumnDescriptor descriptor, int precision, int scale)
+    public static ParquetPrimitiveColumnReader createReader(RichColumnDescriptor descriptor, int precision, int scale)
     {
         DecimalType decimalType = DecimalType.createDecimalType(precision, scale);
         if (decimalType.isShort()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDoubleColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetDoubleColumnReader.java
@@ -13,14 +13,14 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 public class ParquetDoubleColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetDoubleColumnReader(ColumnDescriptor descriptor)
+    public ParquetDoubleColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -31,7 +31,7 @@ public class ParquetDoubleColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeDouble(blockBuilder, valuesReader.readDouble());
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
@@ -13,16 +13,16 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 import static java.lang.Float.floatToRawIntBits;
 
 public class ParquetFloatColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetFloatColumnReader(ColumnDescriptor descriptor)
+    public ParquetFloatColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -33,7 +33,7 @@ public class ParquetFloatColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, floatToRawIntBits(valuesReader.readFloat()));
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetIntColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetIntColumnReader.java
@@ -13,14 +13,14 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 public class ParquetIntColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetIntColumnReader(ColumnDescriptor descriptor)
+    public ParquetIntColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -31,7 +31,7 @@ public class ParquetIntColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, valuesReader.readInteger());
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetListColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetListColumnReader.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.reader;
+
+import com.facebook.presto.hive.parquet.Field;
+import com.facebook.presto.hive.parquet.ParquetTypeUtils;
+import it.unimi.dsi.fastutil.booleans.BooleanList;
+import it.unimi.dsi.fastutil.ints.IntList;
+
+public class ParquetListColumnReader
+{
+    private ParquetListColumnReader()
+    {
+    }
+
+    /**
+     * Each collection (Array or Map) has four variants of presence:
+     * 1) Collection is not defined, because one of it's optional parent fields is null
+     * 2) Collection is null
+     * 3) Collection is defined but empty
+     * 4) Collection is defined and not empty. In this case offset value is increased by the number of elements in that collection
+     */
+    public static void calculateCollectionOffsets(Field field, IntList offsets, BooleanList collectionIsNull, int[] definitionLevels, int[] repetitionLevels)
+    {
+        int maxDefinitionLevel = field.getDefinitionLevel();
+        int maxElementRepetitionLevel = field.getRepetitionLevel() + 1;
+        boolean required = field.isRequired();
+        int offset = 0;
+        offsets.add(offset);
+        for (int i = 0; i < definitionLevels.length; i = getNextCollectionStartIndex(repetitionLevels, maxElementRepetitionLevel, i)) {
+            if (ParquetTypeUtils.isValueNull(required, definitionLevels[i], maxDefinitionLevel)) {
+                // Collection is null
+                collectionIsNull.add(true);
+                offsets.add(offset);
+            }
+            else if (definitionLevels[i] == maxDefinitionLevel) {
+                // Collection is defined but empty
+                collectionIsNull.add(false);
+                offsets.add(offset);
+            }
+            else if (definitionLevels[i] > maxDefinitionLevel) {
+                // Collection is defined and not empty
+                collectionIsNull.add(false);
+                offset += getCollectionSize(repetitionLevels, maxElementRepetitionLevel, i + 1);
+                offsets.add(offset);
+            }
+        }
+    }
+
+    private static int getNextCollectionStartIndex(int[] repetitionLevels, int maxRepetitionLevel, int elementIndex)
+    {
+        do {
+            elementIndex++;
+        }
+        while (hasMoreElements(repetitionLevels, elementIndex) && !isCollectionBeginningMarker(repetitionLevels, maxRepetitionLevel, elementIndex));
+        return elementIndex;
+    }
+
+    /**
+     * This method is only called for non-empty collections
+     */
+    private static int getCollectionSize(int[] repetitionLevels, int maxRepetitionLevel, int nextIndex)
+    {
+        int size = 1;
+        while (hasMoreElements(repetitionLevels, nextIndex) && !isCollectionBeginningMarker(repetitionLevels, maxRepetitionLevel, nextIndex)) {
+            // Collection elements can not only be primitive, but also can have nested structure
+            // Counting only elements which belong to current collection, skipping inner elements of nested collections/structs
+            if (repetitionLevels[nextIndex] <= maxRepetitionLevel) {
+                size++;
+            }
+            nextIndex++;
+        }
+        return size;
+    }
+
+    private static boolean isCollectionBeginningMarker(int[] repetitionLevels, int maxRepetitionLevel, int nextIndex)
+    {
+        return repetitionLevels[nextIndex] < maxRepetitionLevel;
+    }
+
+    private static boolean hasMoreElements(int[] repetitionLevels, int nextIndex)
+    {
+        return nextIndex < repetitionLevels.length;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongColumnReader.java
@@ -13,14 +13,14 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 public class ParquetLongColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetLongColumnReader(ColumnDescriptor descriptor)
+    public ParquetLongColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -31,7 +31,7 @@ public class ParquetLongColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             type.writeLong(blockBuilder, valuesReader.readLong());
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetLongDecimalColumnReader.java
@@ -13,18 +13,18 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
 import java.math.BigInteger;
 
 public class ParquetLongDecimalColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    ParquetLongDecimalColumnReader(ColumnDescriptor descriptor)
+    ParquetLongDecimalColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -36,7 +36,7 @@ public class ParquetLongDecimalColumnReader
             Binary value = valuesReader.readBytes();
             type.writeSlice(blockBuilder, Decimals.encodeUnscaledValue(new BigInteger(value.getBytes())));
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetMetadataReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetMetadataReader.java
@@ -119,7 +119,9 @@ public final class ParquetMetadataReader
                                     || (filePath != null && filePath.equals(columnChunk.getFile_path())),
                             "all column chunks of the same row group must be in the same file");
                     ColumnMetaData metaData = columnChunk.meta_data;
-                    String[] path = metaData.path_in_schema.toArray(new String[metaData.path_in_schema.size()]);
+                    String[] path = metaData.path_in_schema.stream()
+                            .map(String::toLowerCase)
+                            .toArray(String[]::new);
                     ColumnPath columnPath = ColumnPath.get(path);
                     PrimitiveTypeName primitiveTypeName = messageType.getType(columnPath.toArray()).asPrimitiveType().getPrimitiveTypeName();
                     ColumnChunkMetaData column = ColumnChunkMetaData.get(
@@ -188,7 +190,7 @@ public final class ParquetMetadataReader
             if (element.isSetField_id()) {
                 typeBuilder.id(element.field_id);
             }
-            typeBuilder.named(element.name);
+            typeBuilder.named(element.name.toLowerCase());
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetShortDecimalColumnReader.java
@@ -13,18 +13,18 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 
 import static com.facebook.presto.hive.util.DecimalUtils.getShortDecimalValue;
 import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 
 public class ParquetShortDecimalColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    ParquetShortDecimalColumnReader(ColumnDescriptor descriptor)
+    ParquetShortDecimalColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -46,7 +46,7 @@ public class ParquetShortDecimalColumnReader
             }
             type.writeLong(blockBuilder, decimalValue);
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetStructColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetStructColumnReader.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.reader;
+
+import com.facebook.presto.hive.parquet.Field;
+import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
+import it.unimi.dsi.fastutil.booleans.BooleanList;
+
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.isValueNull;
+
+public class ParquetStructColumnReader
+{
+    private ParquetStructColumnReader()
+    {
+    }
+
+    /**
+     * Each struct has three variants of presence:
+     * 1) Struct is not defined, because one of it's optional parent fields is null
+     * 2) Struct is null
+     * 3) Struct is defined and not empty.
+     */
+    public static BooleanList calculateStructOffsets(
+            Field field,
+            int[] fieldDefinitionLevels,
+            int[] fieldRepetitionLevels)
+    {
+        int maxDefinitionLevel = field.getDefinitionLevel();
+        int maxRepetitionLevel = field.getRepetitionLevel();
+        BooleanList structIsNull = new BooleanArrayList();
+        boolean required = field.isRequired();
+        if (fieldDefinitionLevels == null) {
+            return structIsNull;
+        }
+        for (int i = 0; i < fieldDefinitionLevels.length; i++) {
+            if (fieldRepetitionLevels[i] <= maxRepetitionLevel) {
+                if (isValueNull(required, fieldDefinitionLevels[i], maxDefinitionLevel)) {
+                    // Struct is null
+                    structIsNull.add(true);
+                }
+                else if (fieldDefinitionLevels[i] >= maxDefinitionLevel) {
+                    // Struct is defined and not empty
+                    structIsNull.add(false);
+                }
+            }
+        }
+        return structIsNull;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetTimestampColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetTimestampColumnReader.java
@@ -13,17 +13,17 @@
  */
 package com.facebook.presto.hive.parquet.reader;
 
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.column.ColumnDescriptor;
 import parquet.io.api.Binary;
 
 import static com.facebook.presto.hive.parquet.ParquetTimestampUtils.getTimestampMillis;
 
 public class ParquetTimestampColumnReader
-        extends ParquetColumnReader
+        extends ParquetPrimitiveColumnReader
 {
-    public ParquetTimestampColumnReader(ColumnDescriptor descriptor)
+    public ParquetTimestampColumnReader(RichColumnDescriptor descriptor)
     {
         super(descriptor);
     }
@@ -35,7 +35,7 @@ public class ParquetTimestampColumnReader
             Binary binary = valuesReader.readBytes();
             type.writeLong(blockBuilder, getTimestampMillis(binary));
         }
-        else {
+        else if (isValueNull()) {
             blockBuilder.appendNull();
         }
     }

--- a/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
+++ b/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io;
+
+import com.facebook.presto.hive.parquet.Field;
+import com.facebook.presto.hive.parquet.GroupField;
+import com.facebook.presto.hive.parquet.PrimitiveField;
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.NamedTypeSignature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getArrayElementColumn;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getMapKeyValueColumn;
+import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
+import static com.facebook.presto.spi.type.StandardTypes.MAP;
+import static com.facebook.presto.spi.type.StandardTypes.ROW;
+import static parquet.schema.Type.Repetition.OPTIONAL;
+
+/**
+ * Placed in parquet.io package to have access to ColumnIO getRepetitionLevel() and getDefinitionLevel() methods.
+ */
+public class ColumnIOConverter
+{
+    private ColumnIOConverter()
+    {
+    }
+
+    public static Optional<Field> constructField(Type type, ColumnIO columnIO)
+    {
+        if (columnIO == null) {
+            return Optional.empty();
+        }
+        boolean required = columnIO.getType().getRepetition() != OPTIONAL;
+        int repetitionLevel = columnIO.getRepetitionLevel();
+        int definitionLevel = columnIO.getDefinitionLevel();
+        if (ROW.equals(type.getTypeSignature().getBase())) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            List<Type> parameters = type.getTypeParameters();
+            ImmutableList.Builder<Optional<Field>> fileldsBuilder = ImmutableList.builder();
+            List<TypeSignatureParameter> fields = type.getTypeSignature().getParameters();
+            boolean structHasParameters = false;
+            for (int i = 0; i < fields.size(); i++) {
+                NamedTypeSignature namedTypeSignature = fields.get(i).getNamedTypeSignature();
+                String name = namedTypeSignature.getName().get().toLowerCase(Locale.ENGLISH);
+                Optional<Field> field = constructField(parameters.get(i), groupColumnIO.getChild(name));
+                structHasParameters |= field.isPresent();
+                fileldsBuilder.add(field);
+            }
+            if (structHasParameters) {
+                return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, fileldsBuilder.build()));
+            }
+            return Optional.empty();
+        }
+        else if (MAP.equals(type.getTypeSignature().getBase())) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            MapType mapType = (MapType) type;
+            GroupColumnIO keyValueColumnIO = getMapKeyValueColumn(groupColumnIO);
+            if (keyValueColumnIO.getChildrenCount() < 2) {
+                return Optional.empty();
+            }
+            Optional<Field> keyField = constructField(mapType.getKeyType(), keyValueColumnIO.getChild(0));
+            Optional<Field> valueField = constructField(mapType.getValueType(), keyValueColumnIO.getChild(1));
+            return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(keyField, valueField)));
+        }
+        else if (ARRAY.equals(type.getTypeSignature().getBase())) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            List<Type> types = type.getTypeParameters();
+            if (groupColumnIO.getChildrenCount() == 0) {
+                return Optional.empty();
+            }
+            Optional<Field> field = constructField(types.get(0), getArrayElementColumn(groupColumnIO.getChild(0)));
+            return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(field)));
+        }
+        PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;
+        RichColumnDescriptor column = new RichColumnDescriptor(primitiveColumnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType());
+        return Optional.of(new PrimitiveField(type, repetitionLevel, definitionLevel, required, column, primitiveColumnIO.getId()));
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -13,10 +13,13 @@
  */
 package com.facebook.presto.hive.parquet;
 
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.SqlDate;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.spi.type.SqlVarbinary;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.ContiguousSet;
@@ -25,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Shorts;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveDecimalObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.joda.time.DateTimeZone;
@@ -40,16 +44,23 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.hive.parquet.ParquetTester.HIVE_STORAGE_TIME_ZONE;
+import static com.facebook.presto.hive.parquet.ParquetTester.insertNullEvery;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
@@ -58,17 +69,26 @@ import static com.facebook.presto.spi.type.Decimals.MAX_PRECISION;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.RowType.field;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.tests.StructuralTestUtil.mapType;
 import static com.google.common.base.Functions.compose;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.cycle;
 import static com.google.common.collect.Iterables.limit;
 import static com.google.common.collect.Iterables.transform;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardListObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardMapObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaBooleanObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteObjectInspector;
@@ -100,6 +120,613 @@ public abstract class AbstractTestParquetReader
     {
         assertEquals(DateTimeZone.getDefault(), HIVE_STORAGE_TIME_ZONE);
         setParquetLogging();
+    }
+
+    @Test
+    public void testArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> values = createTestArrays(limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER));
+    }
+
+    @Test
+    public void testEmptyArrays()
+            throws Exception
+    {
+        Iterable<List<Integer>> values = limit(cycle(singletonList(Collections.emptyList())), 30_000);
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER));
+    }
+
+    @Test
+    public void testNestedArrays()
+            throws Exception
+    {
+        int nestingLevel = ThreadLocalRandom.current().nextInt(1, 15);
+        ObjectInspector objectInspector = getStandardListObjectInspector(javaIntObjectInspector);
+        Type type = new ArrayType(INTEGER);
+        Iterable values = limit(cycle(asList(1, null, 3, null, 5, null, 7, null, null, null, 11, null, 13)), 3_210);
+        for (int i = 0; i < nestingLevel; i++) {
+            values = createNullableTestArrays(values);
+            objectInspector = getStandardListObjectInspector(objectInspector);
+            type = new ArrayType(type);
+        }
+        values = createTestArrays(values);
+        tester.testRoundTrip(objectInspector, values, values, type);
+    }
+
+    @Test
+    public void testSingleLevelSchemaNestedArrays()
+            throws Exception
+    {
+        int nestingLevel = ThreadLocalRandom.current().nextInt(1, 15);
+        ObjectInspector objectInspector = getStandardListObjectInspector(javaIntObjectInspector);
+        Type type = new ArrayType(INTEGER);
+        Iterable values = intsBetween(0, 31_234);
+        for (int i = 0; i < nestingLevel; i++) {
+            values = createTestArrays(values);
+            objectInspector = getStandardListObjectInspector(objectInspector);
+            type = new ArrayType(type);
+        }
+        values = createTestArrays(values);
+        tester.testSingleLevelArraySchemaRoundTrip(objectInspector, values, values, type);
+    }
+
+    @Test
+    public void testArrayOfStructs()
+            throws Exception
+    {
+        Iterable<List> structs = createNullableTestStructs(transform(intsBetween(0, 31_234), Object::toString), longsBetween(0, 31_234));
+        Iterable<List<List>> values = createTestArrays(structs);
+        List<String> structFieldNames = asList("stringField", "longField");
+        Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
+        tester.testRoundTrip(
+                getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, asList(javaStringObjectInspector, javaLongObjectInspector))),
+                values, values, new ArrayType(structType));
+    }
+
+    @Test
+    public void testCustomSchemaArrayOfStucts()
+            throws Exception
+    {
+        MessageType customSchemaArrayOfStucts = parseMessageType("message ParquetSchema { " +
+                "  optional group self (LIST) { " +
+                "    repeated group self_tuple { " +
+                "      optional int64 a; " +
+                "      optional boolean b; " +
+                "      required binary c (UTF8); " +
+                "    } " +
+                "  } " +
+                "}");
+        Iterable<Long> aValues = limit(cycle(asList(1L, null, 3L, 5L, null, null, null, 7L, 11L, null, 13L, 17L)), 30_000);
+        Iterable<Boolean> bValues = limit(cycle(asList(null, true, false, null, null, true, false)), 30_000);
+        Iterable<String> cValues = transform(intsBetween(0, 31_234), Object::toString);
+
+        Iterable<List> structs = createTestStructs(aValues, bValues, cValues);
+        Iterable<List<List>> values = createTestArrays(structs);
+        List<String> structFieldNames = asList("a", "b", "c");
+        Type structType = RowType.from(asList(field("a", BIGINT), field("b", BOOLEAN), field("c", VARCHAR)));
+        tester.testRoundTrip(
+                getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, asList(javaLongObjectInspector, javaBooleanObjectInspector, javaStringObjectInspector))),
+                values, values, new ArrayType(structType), Optional.of(customSchemaArrayOfStucts));
+    }
+
+    @Test
+    public void testSingleLevelSchemaArrayOfStucts()
+            throws Exception
+    {
+        Iterable<Long> aValues = limit(cycle(asList(1L, null, 3L, 5L, null, null, null, 7L, 11L, null, 13L, 17L)), 30_000);
+        Iterable<Boolean> bValues = limit(cycle(asList(null, true, false, null, null, true, false)), 30_000);
+        Iterable<String> cValues = transform(intsBetween(0, 31_234), Object::toString);
+
+        Iterable<List> structs = createTestStructs(aValues, bValues, cValues);
+        Iterable<List<List>> values = createTestArrays(structs);
+        List<String> structFieldNames = asList("a", "b", "c");
+        Type structType = RowType.from(asList(field("a", BIGINT), field("b", BOOLEAN), field("c", VARCHAR)));
+        ObjectInspector objectInspector = getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, asList(javaLongObjectInspector, javaBooleanObjectInspector, javaStringObjectInspector)));
+        tester.testSingleLevelArraySchemaRoundTrip(objectInspector, values, values, new ArrayType(structType));
+    }
+
+    @Test
+    public void testArrayOfArrayOfStructOfArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List> structs = createNullableTestStructs(stringArrayField, limit(cycle(asList(1, null, 3, 5, null, 7, 11, null, 17)), 31_234));
+        List<String> structFieldNames = asList("stringArrayField", "intField");
+        Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
+        Iterable<List<List>> arrays = createNullableTestArrays(structs);
+        Iterable<List<List<List>>> values = createTestArrays(arrays);
+        tester.testRoundTrip(
+                getStandardListObjectInspector(
+                        getStandardListObjectInspector(
+                                getStandardStructObjectInspector(
+                                        structFieldNames,
+                                        asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector)))),
+                values, values, new ArrayType(new ArrayType(structType)));
+    }
+
+    @Test
+    public void testSingleLevelSchemaArrayOfArrayOfStructOfArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List> structs = createTestStructs(stringArrayField, limit(cycle(asList(1, null, 3, 5, null, 7, 11, null, 17)), 31_234));
+        List<String> structFieldNames = asList("stringArrayField", "intField");
+        Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
+        Iterable<List<List>> arrays = createTestArrays(structs);
+        Iterable<List<List<List>>> values = createTestArrays(arrays);
+        tester.testSingleLevelArraySchemaRoundTrip(
+                getStandardListObjectInspector(
+                        getStandardListObjectInspector(
+                                getStandardStructObjectInspector(
+                                        structFieldNames,
+                                        asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector)))),
+                values, values, new ArrayType(new ArrayType(structType)));
+    }
+
+    @Test
+    public void testArrayOfStructOfArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List> structs = createNullableTestStructs(stringArrayField, limit(cycle(asList(1, 3, null, 5, 7, null, 11, 13, null, 17)), 31_234));
+        List<String> structFieldNames = asList("stringArrayField", "intField");
+        Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
+        Iterable<List<List>> values = createTestArrays(structs);
+        tester.testRoundTrip(
+                getStandardListObjectInspector(
+                        getStandardStructObjectInspector(
+                                structFieldNames,
+                                asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector))),
+                values, values, new ArrayType(structType));
+    }
+
+    @Test
+    public void testSingleLevelSchemaArrayOfStructOfArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List> structs = createTestStructs(stringArrayField, limit(cycle(asList(1, 3, null, 5, 7, null, 11, 13, null, 17)), 31_234));
+        List<String> structFieldNames = asList("stringArrayField", "intField");
+        Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
+        Iterable<List<List>> values = createTestArrays(structs);
+        tester.testSingleLevelArraySchemaRoundTrip(
+                getStandardListObjectInspector(
+                        getStandardStructObjectInspector(
+                                structFieldNames,
+                                asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector))),
+                values, values, new ArrayType(structType));
+    }
+
+    @Test
+    public void testMap()
+            throws Exception
+    {
+        Iterable<Map<String, Long>> values = createTestMaps(transform(intsBetween(0, 100_000), Object::toString), longsBetween(0, 10_000));
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector), values, values, mapType(VARCHAR, BIGINT));
+    }
+
+    @Test
+    public void testNestedMaps()
+            throws Exception
+    {
+        int nestingLevel = ThreadLocalRandom.current().nextInt(1, 15);
+        Iterable<Integer> keys = intsBetween(0, 3_210);
+        Iterable maps = limit(cycle(asList(null, "value2", "value3", null, null, "value6", "value7")), 3_210);
+        ObjectInspector objectInspector = getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector);
+        Type type = mapType(INTEGER, VARCHAR);
+        for (int i = 0; i < nestingLevel; i++) {
+            maps = createNullableTestMaps(keys, maps);
+            objectInspector = getStandardMapObjectInspector(javaIntObjectInspector, objectInspector);
+            type = mapType(INTEGER, type);
+        }
+        maps = createTestMaps(keys, maps);
+        tester.testRoundTrip(objectInspector, maps, maps, type);
+    }
+
+    @Test
+    public void testArrayOfMaps()
+            throws Exception
+    {
+        Iterable<Map<String, Long>> maps = createNullableTestMaps(transform(intsBetween(0, 10), Object::toString), longsBetween(0, 10));
+        List<List<Map<String, Long>>> values = createTestArrays(maps);
+        tester.testRoundTrip(getStandardListObjectInspector(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector)),
+                values, values, new ArrayType(mapType(VARCHAR, BIGINT)));
+    }
+
+    @Test
+    public void testSingleLevelSchemaArrayOfMaps()
+            throws Exception
+    {
+        Iterable<Map<String, Long>> maps = createTestMaps(transform(intsBetween(0, 10), Object::toString), longsBetween(0, 10));
+        List<List<Map<String, Long>>> values = createTestArrays(maps);
+        ObjectInspector objectInspector = getStandardListObjectInspector(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector));
+        tester.testSingleLevelArraySchemaRoundTrip(objectInspector, values, values, new ArrayType(mapType(VARCHAR, BIGINT)));
+    }
+
+    @Test
+    public void testArrayOfMapOfStruct()
+            throws Exception
+    {
+        Iterable<Integer> keys = intsBetween(0, 10_000);
+        Iterable<List> structs = createNullableTestStructs(transform(intsBetween(0, 10_000), Object::toString), longsBetween(0, 10_000));
+        List<String> structFieldNames = asList("stringField", "longField");
+        Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
+        Iterable<Map<Integer, List>> maps = createNullableTestMaps(keys, structs);
+        List<List<Map<Integer, List>>> values = createTestArrays(maps);
+        tester.testRoundTrip(getStandardListObjectInspector(
+                getStandardMapObjectInspector(
+                        javaIntObjectInspector,
+                        getStandardStructObjectInspector(structFieldNames, asList(javaStringObjectInspector, javaLongObjectInspector)))),
+                values, values, new ArrayType(mapType(INTEGER, structType)));
+    }
+
+    @Test
+    public void testSingleLevelArrayOfMapOfStruct()
+            throws Exception
+    {
+        Iterable<Integer> keys = intsBetween(0, 10_000);
+        Iterable<List> structs = createNullableTestStructs(transform(intsBetween(0, 10_000), Object::toString), longsBetween(0, 10_000));
+        List<String> structFieldNames = asList("stringField", "longField");
+        Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
+        Iterable<Map<Integer, List>> maps = createTestMaps(keys, structs);
+        List<List<Map<Integer, List>>> values = createTestArrays(maps);
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardListObjectInspector(
+                getStandardMapObjectInspector(
+                        javaIntObjectInspector,
+                        getStandardStructObjectInspector(structFieldNames, asList(javaStringObjectInspector, javaLongObjectInspector)))),
+                values, values, new ArrayType(mapType(INTEGER, structType)));
+    }
+
+    @Test
+    public void testArrayOfMapOfArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> arrays = createNullableTestArrays(limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 10_000));
+        Iterable<String> keys = transform(intsBetween(0, 10_000), Object::toString);
+        Iterable<Map<String, List<Integer>>> maps = createNullableTestMaps(keys, arrays);
+        List<List<Map<String, List<Integer>>>> values = createTestArrays(maps);
+        tester.testRoundTrip(getStandardListObjectInspector(
+                getStandardMapObjectInspector(
+                        javaStringObjectInspector,
+                        getStandardListObjectInspector(javaIntObjectInspector))),
+                values, values, new ArrayType(mapType(VARCHAR, new ArrayType(INTEGER))));
+    }
+
+    @Test
+    public void testSingleLevelArrayOfMapOfArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> arrays = createNullableTestArrays(intsBetween(0, 10_000));
+        Iterable<String> keys = transform(intsBetween(0, 10_000), Object::toString);
+        Iterable<Map<String, List<Integer>>> maps = createTestMaps(keys, arrays);
+        List<List<Map<String, List<Integer>>>> values = createTestArrays(maps);
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardListObjectInspector(
+                getStandardMapObjectInspector(
+                        javaStringObjectInspector,
+                        getStandardListObjectInspector(javaIntObjectInspector))),
+                values, values, new ArrayType(mapType(VARCHAR, new ArrayType(INTEGER))));
+    }
+
+    @Test
+    public void testMapOfArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> arrays = createNullableTestArrays(limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        Iterable<Integer> keys = intsBetween(0, 30_000);
+        Iterable<Map<Integer, List<Integer>>> values = createTestMaps(keys, arrays);
+        tester.testRoundTrip(getStandardMapObjectInspector(
+                javaIntObjectInspector,
+                getStandardListObjectInspector(javaIntObjectInspector)),
+                values, values, mapType(INTEGER, new ArrayType(INTEGER)));
+    }
+
+    @Test
+    public void testMapOfSingleLevelArray()
+            throws Exception
+    {
+        Iterable<List<Integer>> arrays = createNullableTestArrays(intsBetween(0, 30_000));
+        Iterable<Integer> keys = intsBetween(0, 30_000);
+        Iterable<Map<Integer, List<Integer>>> values = createTestMaps(keys, arrays);
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardMapObjectInspector(
+                javaIntObjectInspector,
+                getStandardListObjectInspector(javaIntObjectInspector)),
+                values, values, mapType(INTEGER, new ArrayType(INTEGER)));
+    }
+
+    @Test
+    public void testMapOfStruct()
+            throws Exception
+    {
+        Iterable<Long> keys = longsBetween(0, 30_000);
+        Iterable<List> structs = createNullableTestStructs(transform(intsBetween(0, 30_000), Object::toString), longsBetween(0, 30_000));
+        List<String> structFieldNames = asList("stringField", "longField");
+        Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
+        Iterable<Map<Long, List>> values = createTestMaps(keys, structs);
+        tester.testRoundTrip(getStandardMapObjectInspector(
+                javaLongObjectInspector,
+                getStandardStructObjectInspector(structFieldNames, asList(javaStringObjectInspector, javaLongObjectInspector))),
+                values, values, mapType(BIGINT, structType));
+    }
+
+    @Test
+    public void testMapWithNullValues()
+            throws Exception
+    {
+        Iterable<Integer> mapKeys = intsBetween(0, 31_234);
+        Iterable<String> mapValues = limit(cycle(asList(null, "value2", "value3", null, null, "value6", "value7")), 31_234);
+        Iterable<Map<Integer, String>> values = createTestMaps(mapKeys, mapValues);
+        tester.testRoundTrip(getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector), values, values, mapType(INTEGER, VARCHAR));
+    }
+
+    @Test
+    public void testStruct()
+            throws Exception
+    {
+        List<List> values = createTestStructs(transform(intsBetween(0, 31_234), Object::toString), longsBetween(0, 31_234));
+        List<String> structFieldNames = asList("stringField", "longField");
+        Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames, asList(javaStringObjectInspector, javaLongObjectInspector)), values, values, structType);
+    }
+
+    @Test
+    public void testNestedStructs()
+            throws Exception
+    {
+        int nestingLevel = ThreadLocalRandom.current().nextInt(1, 15);
+        Optional<List<String>> structFieldNames = Optional.of(singletonList("structField"));
+        Iterable<?> values = limit(cycle(asList(1, null, 3, null, 5, null, 7, null, null, null, 11, null, 13)), 3_210);
+        ObjectInspector objectInspector = getStandardStructObjectInspector(structFieldNames.get(), singletonList(javaIntObjectInspector));
+        Type type = RowType.from(singletonList(field("structField", INTEGER)));
+        for (int i = 0; i < nestingLevel; i++) {
+            values = createNullableTestStructs(values);
+            objectInspector = getStandardStructObjectInspector(structFieldNames.get(), singletonList(objectInspector));
+            type = RowType.from(singletonList(field("structField", type)));
+        }
+        values = createTestStructs(values);
+        tester.testRoundTrip(objectInspector, values, values, type);
+    }
+
+    @Test
+    public void testComplexNestedStructs()
+            throws Exception
+    {
+        final int n = 30;
+        Iterable<Integer> mapKeys = intsBetween(0, n);
+        Iterable<Integer> intPrimitives = limit(cycle(asList(1, null, 3, null, 5, null, 7, null, null, null, 11, null, 13)), n);
+        Iterable<String> stringPrimitives = limit(cycle(asList(null, "value2", "value3", null, null, "value6", "value7")), n);
+        Iterable<Double> doublePrimitives = limit(cycle(asList(1.1, null, 3.3, null, 5.5, null, 7.7, null, null, null, 11.11, null, 13.13)), n);
+        Iterable<Boolean> booleanPrimitives = limit(cycle(asList(null, true, false, null, null, true, false)), n);
+        Iterable<String> mapStringKeys = Stream.generate(() -> UUID.randomUUID().toString()).limit(n).collect(Collectors.toList());
+        Iterable<Map<Integer, String>> mapsIntString = createNullableTestMaps(mapKeys, stringPrimitives);
+        Iterable<List<String>> arraysString = createNullableTestArrays(stringPrimitives);
+        Iterable<Map<Integer, Double>> mapsIntDouble = createNullableTestMaps(mapKeys, doublePrimitives);
+        Iterable<List<Boolean>> arraysBoolean = createNullableTestArrays(booleanPrimitives);
+        Iterable<Map<String, String>> mapsStringString = createNullableTestMaps(mapStringKeys, stringPrimitives);
+
+        List<String> struct1FieldNames = asList("mapIntStringField", "stringArrayField", "intField");
+        Iterable<?> stucts1 = createNullableTestStructs(mapsIntString, arraysString, intPrimitives);
+        ObjectInspector struct1ObjectInspector = getStandardStructObjectInspector(struct1FieldNames,
+                asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        javaIntObjectInspector));
+        Type struct1Type = RowType.from(asList(
+                field("mapIntStringField", mapType(INTEGER, VARCHAR)),
+                field("stringArrayField", new ArrayType(VARCHAR)),
+                field("intField", INTEGER)));
+
+        List<String> struct2FieldNames = asList("mapIntStringField", "stringArrayField", "structField");
+        Iterable<?> structs2 = createNullableTestStructs(mapsIntString, arraysString, stucts1);
+        ObjectInspector struct2ObjectInspector = getStandardStructObjectInspector(struct2FieldNames,
+                asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        struct1ObjectInspector));
+        Type struct2Type = RowType.from(asList(
+                field("mapIntStringField", mapType(INTEGER, VARCHAR)),
+                field("stringArrayField", new ArrayType(VARCHAR)),
+                field("structField", struct1Type)));
+
+        List<String> struct3FieldNames = asList("mapIntDoubleField", "booleanArrayField", "booleanField");
+        Iterable<?> structs3 = createNullableTestStructs(mapsIntDouble, arraysBoolean, booleanPrimitives);
+        ObjectInspector struct3ObjectInspector = getStandardStructObjectInspector(struct3FieldNames,
+                asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaDoubleObjectInspector),
+                        getStandardListObjectInspector(javaBooleanObjectInspector),
+                        javaBooleanObjectInspector));
+        Type struct3Type = RowType.from(asList(
+                field("mapIntDoubleField", mapType(INTEGER, DOUBLE)),
+                field("booleanArrayField", new ArrayType(BOOLEAN)),
+                field("booleanField", BOOLEAN)));
+
+        List<String> struct4FieldNames = asList("mapIntDoubleField", "booleanArrayField", "structField");
+        Iterable<?> stucts4 = createNullableTestStructs(mapsIntDouble, arraysBoolean, structs3);
+        ObjectInspector struct4ObjectInspector = getStandardStructObjectInspector(struct4FieldNames,
+                asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaDoubleObjectInspector),
+                        getStandardListObjectInspector(javaBooleanObjectInspector),
+                        struct3ObjectInspector));
+        Type struct4Type = RowType.from(asList(
+                field("mapIntDoubleField", mapType(INTEGER, DOUBLE)),
+                field("booleanArrayField", new ArrayType(BOOLEAN)),
+                field("structField", struct3Type)));
+
+        List<String> structFieldNames = asList("structField1", "structField2", "structField3", "structField4", "mapIntDoubleField", "booleanArrayField", "mapStringStringField");
+        List<ObjectInspector> objectInspectors =
+                asList(
+                        struct1ObjectInspector,
+                        struct2ObjectInspector,
+                        struct3ObjectInspector,
+                        struct4ObjectInspector,
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaDoubleObjectInspector),
+                        getStandardListObjectInspector(javaBooleanObjectInspector),
+                        getStandardMapObjectInspector(javaStringObjectInspector, javaStringObjectInspector));
+        List<Type> types = ImmutableList.of(struct1Type, struct2Type, struct3Type, struct4Type, mapType(INTEGER, DOUBLE), new ArrayType(BOOLEAN), mapType(VARCHAR, VARCHAR));
+
+        Iterable<?>[] values = new Iterable<?>[] {stucts1, structs2, structs3, stucts4, mapsIntDouble, arraysBoolean, mapsStringString};
+        tester.assertRoundTrip(objectInspectors, values, values, structFieldNames, types, Optional.empty());
+    }
+
+    @Test
+    public void testStructOfMaps()
+            throws Exception
+    {
+        Iterable<Integer> mapKeys = Stream.generate(() -> ThreadLocalRandom.current().nextInt(10_000)).limit(10_000).collect(Collectors.toList());
+        Iterable<Integer> intPrimitives = limit(cycle(asList(1, null, 3, null, 5, null, 7, null, null, null, 11, null, 13)), 10_000);
+        Iterable<String> stringPrimitives = limit(cycle(asList(null, "value2", "value3", null, null, "value6", "value7")), 10_000);
+        Iterable<Map<Integer, String>> maps = createNullableTestMaps(mapKeys, stringPrimitives);
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(stringPrimitives);
+        List<List> values = createTestStructs(maps, stringArrayField, intPrimitives);
+        List<String> structFieldNames = asList("mapIntStringField", "stringArrayField", "intField");
+
+        Type structType = RowType.from(asList(field("mapIntStringField", mapType(INTEGER, VARCHAR)), field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                asList(
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        javaIntObjectInspector)),
+                values, values, structType);
+    }
+
+    @Test
+    public void testStructOfNullableMapBetweenNonNullFields()
+            throws Exception
+    {
+        Iterable<Integer> intPrimitives = intsBetween(0, 10_000);
+        Iterable<String> stringPrimitives = limit(cycle(asList(null, "value2", "value3", null, null, "value6", "value7")), 10_000);
+        Iterable<Map<Integer, String>> maps = createNullableTestMaps(intPrimitives, stringPrimitives);
+        List<List> values = createTestStructs(intPrimitives, maps, intPrimitives);
+        List<String> structFieldNames = asList("intField1", "mapIntStringField", "intField2");
+
+        Type structType = RowType.from(asList(field("intField1", INTEGER), field("mapIntStringField", mapType(INTEGER, VARCHAR)), field("intField2", INTEGER)));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                asList(
+                        javaIntObjectInspector,
+                        getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
+                        javaIntObjectInspector)),
+                values, values, structType);
+    }
+
+    @Test
+    public void testStructOfNullableArrayBetweenNonNullFields()
+            throws Exception
+    {
+        Iterable<Integer> intPrimitives = intsBetween(0, 10_000);
+        Iterable<String> stringPrimitives = limit(cycle(asList(null, "value2", "value3", null, null, "value6", "value7")), 10_000);
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(stringPrimitives);
+        List<List> values = createTestStructs(intPrimitives, stringArrayField, intPrimitives);
+        List<String> structFieldNames = asList("intField1", "arrayStringField", "intField2");
+
+        Type structType = RowType.from(asList(field("intField1", INTEGER), field("arrayStringField", new ArrayType(VARCHAR)), field("intField2", INTEGER)));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                asList(
+                        javaIntObjectInspector,
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        javaIntObjectInspector)),
+                values, values, structType);
+    }
+
+    @Test
+    public void testStructOfArrayAndPrimitive()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        List<List> values = createTestStructs(stringArrayField, limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234));
+        List<String> structFieldNames = asList("stringArrayField", "intField");
+
+        Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector)), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfSingleLevelArrayAndPrimitive()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        List<List> values = createTestStructs(stringArrayField, limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234));
+        List<String> structFieldNames = asList("stringArrayField", "intField");
+
+        Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                asList(getStandardListObjectInspector(javaStringObjectInspector), javaIntObjectInspector)), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfPrimitiveAndArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<Integer> intField = limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234);
+        List<List> values = createTestStructs(intField, stringArrayField);
+        List<String> structFieldNames = asList("intField", "stringArrayField");
+
+        Type structType = RowType.from(asList(field("intField", INTEGER), field("stringArrayField", new ArrayType(VARCHAR))));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                asList(javaIntObjectInspector, getStandardListObjectInspector(javaStringObjectInspector))), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfPrimitiveAndSingleLevelArray()
+            throws Exception
+    {
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<Integer> intField = limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234);
+        List<List> values = createTestStructs(intField, stringArrayField);
+        List<String> structFieldNames = asList("intField", "stringArrayField");
+
+        Type structType = RowType.from(asList(field("intField", INTEGER), field("stringArrayField", new ArrayType(VARCHAR))));
+        tester.testSingleLevelArraySchemaRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                asList(javaIntObjectInspector, getStandardListObjectInspector(javaStringObjectInspector))), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfTwoArrays()
+            throws Exception
+    {
+        Iterable<List<Integer>> intArrayField = createNullableTestArrays(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 30_000), Object::toString));
+        List<List> values = createTestStructs(stringArrayField, intArrayField);
+        List<String> structFieldNames = asList("stringArrayField", "intArrayField");
+
+        Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intArrayField", new ArrayType(INTEGER))));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                asList(getStandardListObjectInspector(javaStringObjectInspector), getStandardListObjectInspector(javaIntObjectInspector))), values, values, structType);
+    }
+
+    @Test
+    public void testStructOfTwoNestedArrays()
+            throws Exception
+    {
+        Iterable<List<List<Integer>>> intArrayField = createNullableTestArrays(createNullableTestArrays(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)));
+        Iterable<List<List<String>>> stringArrayField = createNullableTestArrays(createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString)));
+        List<List> values = createTestStructs(stringArrayField, intArrayField);
+        List<String> structFieldNames = asList("stringArrayField", "intArrayField");
+        Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(new ArrayType(VARCHAR))), field("intArrayField", new ArrayType(new ArrayType(INTEGER)))));
+        tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames,
+                asList(
+                        getStandardListObjectInspector(getStandardListObjectInspector(javaStringObjectInspector)),
+                        getStandardListObjectInspector(getStandardListObjectInspector(javaIntObjectInspector)))),
+                values, values, structType);
+    }
+
+    @Test
+    public void testStructOfTwoNestedSingleLevelSchemaArrays()
+            throws Exception
+    {
+        Iterable<List<List<Integer>>> intArrayField = createNullableTestArrays(createTestArrays(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)));
+        Iterable<List<List<String>>> stringArrayField = createNullableTestArrays(createTestArrays(transform(intsBetween(0, 31_234), Object::toString)));
+        List<List> values = createTestStructs(stringArrayField, intArrayField);
+        List<String> structFieldNames = asList("stringArrayField", "intArrayField");
+
+        Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(new ArrayType(VARCHAR))), field("intArrayField", new ArrayType(new ArrayType(INTEGER)))));
+        ObjectInspector objectInspector = getStandardStructObjectInspector(structFieldNames,
+                asList(
+                        getStandardListObjectInspector(getStandardListObjectInspector(javaStringObjectInspector)),
+                        getStandardListObjectInspector(getStandardListObjectInspector(javaIntObjectInspector))));
+        tester.testSingleLevelArraySchemaRoundTrip(objectInspector, values, values, structType);
     }
 
     @Test
@@ -200,7 +827,6 @@ public abstract class AbstractTestParquetReader
     {
         for (int precision = MAX_PRECISION_INT64 + 1; precision < MAX_PRECISION; precision++) {
             int scale = ThreadLocalRandom.current().nextInt(precision);
-            MessageType parquetSchema = parseMessageType(format("message hive_decimal { optional FIXED_LEN_BYTE_ARRAY(16) test (DECIMAL(%d, %d)); }", precision, scale));
             ContiguousSet<BigInteger> values = bigIntegersBetween(BigDecimal.valueOf(Math.pow(10, precision - 1)).toBigInteger(), BigDecimal.valueOf(Math.pow(10, precision)).toBigInteger());
             ImmutableList.Builder<SqlDecimal> expectedValues = new ImmutableList.Builder<>();
             ImmutableList.Builder<HiveDecimal> writeValues = new ImmutableList.Builder<>();
@@ -211,9 +837,445 @@ public abstract class AbstractTestParquetReader
             tester.testRoundTrip(new JavaHiveDecimalObjectInspector(new DecimalTypeInfo(precision, scale)),
                     writeValues.build(),
                     expectedValues.build(),
-                    createDecimalType(precision, scale),
-                    Optional.of(parquetSchema));
+                    createDecimalType(precision, scale));
         }
+    }
+
+    @Test
+    public void testSchemaWithRepeatedOptionalRequiredFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group address_book {" +
+                "    required binary owner (UTF8);" +
+                "    optional group owner_phone_numbers (LIST) {" +
+                "      repeated group bag {" +
+                "        optional binary array_element (UTF8);" +
+                "      }" +
+                "    }" +
+                "    optional group contacts (LIST) {" +
+                "      repeated group bag {" +
+                "        optional group array_element {" +
+                "          required binary name (UTF8);" +
+                "          optional binary phone_number (UTF8);" +
+                "        }" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+
+        Iterable<String> owner = limit(cycle(asList("owner1", "owner2", "owner3")), 50_000);
+        Iterable<List<String>> ownerPhoneNumbers = limit(cycle(asList(null, asList("phoneNumber2", "phoneNumber3", null), asList(null, "phoneNumber6", "phoneNumber7"))), 50_000);
+        Iterable<String> name = asList("name1", "name2", "name3", "name4", "name5", "name6", "name7");
+        Iterable<String> phoneNumber = asList(null, "phoneNumber2", "phoneNumber3", null, null, "phoneNumber6", "phoneNumber7");
+        Iterable<List> contact = createNullableTestStructs(name, phoneNumber);
+        Iterable<List<List>> contacts = createNullableTestArrays(limit(cycle(contact), 50_000));
+        List<List> values = createTestStructs(owner, ownerPhoneNumbers, contacts);
+        List<String> addressBookFieldNames = asList("owner", "owner_phone_numbers", "contacts");
+        List<String> contactsFieldNames = asList("name", "phone_number");
+        Type contactsType = new ArrayType(RowType.from(asList(field("name", VARCHAR), field("phone_number", VARCHAR))));
+        Type addressBookType = RowType.from(asList(field("owner", VARCHAR), field("owner_phone_numbers", new ArrayType(VARCHAR)), field("contacts", contactsType)));
+        tester.testRoundTrip(getStandardStructObjectInspector(addressBookFieldNames,
+                asList(
+                        javaStringObjectInspector,
+                        getStandardListObjectInspector(javaStringObjectInspector),
+                        getStandardListObjectInspector(
+                                getStandardStructObjectInspector(contactsFieldNames, asList(javaStringObjectInspector, javaStringObjectInspector))))),
+                values, values, addressBookType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithOptionalOptionalRequiredFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    optional group b {" +
+                "      optional group c {" +
+                "        required binary d (UTF8);" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = RowType.from(singletonList(field("d", VARCHAR)));
+        Type bType = RowType.from(singletonList(field("c", cType)));
+        Type aType = RowType.from(singletonList(field("b", bType)));
+        Iterable<String> dValues = asList("d1", "d2", "d3", "d4", "d5", "d6", "d7");
+        Iterable<List> cValues = createNullableTestStructs(dValues);
+        Iterable<List> bValues = createNullableTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaStringObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithOptionalRequiredOptionalFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    optional group b {" +
+                "      required group c {" +
+                "        optional int32 d;" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = RowType.from(singletonList(field("d", INTEGER)));
+        Type bType = RowType.from(singletonList(field("c", cType)));
+        Type aType = RowType.from(singletonList(field("b", bType)));
+        Iterable<Integer> dValues = asList(111, null, 333, 444, null, 666, 777);
+        List<List> cValues = createTestStructs(dValues);
+        Iterable<List> bValues = createNullableTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaIntObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithRequiredRequiredOptionalFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    required group b {" +
+                "      required group c {" +
+                "        optional int32 d;" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = RowType.from(singletonList(field("d", INTEGER)));
+        Type bType = RowType.from(singletonList(field("c", cType)));
+        Type aType = RowType.from(singletonList(field("b", bType)));
+        Iterable<Integer> dValues = asList(111, null, 333, 444, null, 666, 777);
+        List<List> cValues = createTestStructs(dValues);
+        List<List> bValues = createTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaIntObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithRequiredOptionalOptionalFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    required group b {" +
+                "      optional group c {" +
+                "        optional int32 d;" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = RowType.from(singletonList(field("d", INTEGER)));
+        Type bType = RowType.from(singletonList(field("c", cType)));
+        Type aType = RowType.from(singletonList(field("b", bType)));
+        Iterable<Integer> dValues = asList(111, null, 333, 444, null, 666, 777);
+        Iterable<List> cValues = createNullableTestStructs(dValues);
+        List<List> bValues = createTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaIntObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithRequiredOptionalRequiredFields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    required group b {" +
+                "      optional group c {" +
+                "        required binary d (UTF8);" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+        Type cType = RowType.from(singletonList(field("d", VARCHAR)));
+        Type bType = RowType.from(singletonList(field("c", cType)));
+        Type aType = RowType.from(singletonList(field("b", bType)));
+        Iterable<String> dValues = asList("d1", "d2", "d3", "d4", "d5", "d6", "d7");
+        Iterable<List> cValues = createNullableTestStructs(dValues);
+        List<List> bValues = createTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaStringObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithRequiredStruct()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  required group a {" +
+                "    required group b {" +
+                "        required binary c (UTF8);" +
+                "        required int32 d;" +
+                "    }" +
+                "    required binary e (UTF8);" +
+                "  }" +
+                "} ");
+        Type bType = RowType.from(asList(field("c", VARCHAR), field("d", INTEGER)));
+        Type aType = RowType.from(asList(field("b", bType), field("e", VARCHAR)));
+        Iterable<String> cValues = limit(cycle(asList("c0", "c1", "c2", "c3", "c4", "c5", "c6", "c7")), 30000);
+        Iterable<Integer> dValues = intsBetween(0, 30000);
+        Iterable<String> eValues = limit(cycle(asList("e0", "e1", "e2", "e3", "e4", "e5", "e6", "e7")), 30000);
+        List<List> bValues = createTestStructs(cValues, dValues);
+        List<List> aValues = createTestStructs(bValues, eValues);
+        ObjectInspector bInspector = getStandardStructObjectInspector(asList("c", "d"), asList(javaStringObjectInspector, javaIntObjectInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(asList("b", "e"), asList(bInspector, javaStringObjectInspector));
+        tester.assertRoundTrip(singletonList(aInspector), new Iterable<?>[] {aValues}, new Iterable<?>[] {
+                aValues}, singletonList("a"), singletonList(aType), Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testSchemaWithRequiredOptionalRequired2Fields()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message hive_schema {" +
+                "  optional group a {" +
+                "    required group b {" +
+                "      optional group c {" +
+                "        required binary d (UTF8);" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "  optional group e {" +
+                "    required group f {" +
+                "      optional group g {" +
+                "        required binary h (UTF8);" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "} ");
+
+        Type cType = RowType.from(singletonList(field("d", VARCHAR)));
+        Type bType = RowType.from(singletonList(field("c", cType)));
+        Type aType = RowType.from(singletonList(field("b", bType)));
+        Iterable<String> dValues = asList("d1", "d2", "d3", "d4", "d5", "d6", "d7");
+        Iterable<List> cValues = createNullableTestStructs(dValues);
+        List<List> bValues = createTestStructs(cValues);
+        List<List> aValues = createTestStructs(bValues);
+
+        Type gType = RowType.from(singletonList(field("h", VARCHAR)));
+        Type fType = RowType.from(singletonList(field("g", gType)));
+        Type eType = RowType.from(singletonList(field("f", fType)));
+        Iterable<String> hValues = asList("h1", "h2", "h3", "h4", "h5", "h6", "h7");
+        Iterable<List> gValues = createNullableTestStructs(hValues);
+        List<List> fValues = createTestStructs(gValues);
+        List<List> eValues = createTestStructs(fValues);
+
+        ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaStringObjectInspector));
+        ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
+        ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
+        ObjectInspector gInspector = getStandardStructObjectInspector(singletonList("h"), singletonList(javaStringObjectInspector));
+        ObjectInspector fInspector = getStandardStructObjectInspector(singletonList("g"), singletonList(gInspector));
+        ObjectInspector eInspector = getStandardStructObjectInspector(singletonList("f"), singletonList(fInspector));
+        tester.testRoundTrip(asList(aInspector, eInspector),
+                new Iterable<?>[] {aValues, eValues}, new Iterable<?>[] {aValues, eValues},
+                asList("a", "e"), asList(aType, eType), Optional.of(parquetSchema));
+    }
+
+    @Test
+    public void testOldAvroArray()
+            throws Exception
+    {
+        MessageType parquetMrAvroSchema = parseMessageType("message avro_schema_old {" +
+                "  optional group my_list (LIST){" +
+                "        repeated int32 array;" +
+                "  }" +
+                "} ");
+        Iterable<List<Integer>> nonNullArrayElements = createTestArrays(intsBetween(0, 31_234));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), nonNullArrayElements, nonNullArrayElements, new ArrayType(INTEGER), Optional.of(parquetMrAvroSchema));
+    }
+
+    @Test
+    public void testNewAvroArray()
+            throws Exception
+    {
+        MessageType parquetMrAvroSchema = parseMessageType("message avro_schema_new { " +
+                "  optional group my_list (LIST) { " +
+                "    repeated group list { " +
+                "      optional int32 element; " +
+                "    } " +
+                "  } " +
+                "}");
+        Iterable<List<Integer>> values = createTestArrays(limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(parquetMrAvroSchema));
+    }
+
+    /**
+     * Test reading various arrays schemas compatible with spec
+     * https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
+     */
+    @Test
+    public void testArraySchemas()
+            throws Exception
+    {
+        MessageType parquetMrNullableSpecSchema = parseMessageType("message hive_schema {" +
+                "  optional group my_list (LIST){" +
+                "    repeated group list {" +
+                "        required int32 element;" +
+                "    }" +
+                "  }" +
+                "} ");
+        Iterable<List<Integer>> nonNullArrayElements = createTestArrays(intsBetween(0, 31_234));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), nonNullArrayElements, nonNullArrayElements, new ArrayType(INTEGER), Optional.of(parquetMrNullableSpecSchema));
+
+        MessageType parquetMrNonNullSpecSchema = parseMessageType("message hive_schema {" +
+                "  required group my_list (LIST){" +
+                "    repeated group list {" +
+                "        optional int32 element;" +
+                "    }" +
+                "  }" +
+                "} ");
+        Iterable<List<Integer>> values = createTestArrays(limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        tester.assertRoundTrip(singletonList(getStandardListObjectInspector(javaIntObjectInspector)), new Iterable<?>[] {values}, new Iterable<?>[] {
+                values}, singletonList("my_list"), singletonList(new ArrayType(INTEGER)), Optional.of(parquetMrNonNullSpecSchema));
+
+        MessageType sparkSchema = parseMessageType("message hive_schema {" +
+                "  optional group my_list (LIST){" +
+                "    repeated group list {" +
+                "        optional int32 element;" +
+                "    }" +
+                "  }" +
+                "} ");
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(sparkSchema));
+
+        MessageType hiveSchema = parseMessageType("message hive_schema {" +
+                "  optional group my_list (LIST){" +
+                "    repeated group bag {" +
+                "        optional int32 array_element;" +
+                "    }" +
+                "  }" +
+                "} ");
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(hiveSchema));
+
+        MessageType customNamingSchema = parseMessageType("message hive_schema {" +
+                "  optional group my_list (LIST){" +
+                "    repeated group bag {" +
+                "        optional int32 array;" +
+                "    }" +
+                "  }" +
+                "} ");
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(customNamingSchema));
+    }
+
+    /**
+     * Test reading various maps schemas compatible with spec
+     * https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps
+     */
+    @Test
+    public void testMapSchemas()
+            throws Exception
+    {
+        Iterable<Map<String, Integer>> values = createTestMaps(transform(intsBetween(0, 100_000), Object::toString), intsBetween(0, 10_000));
+        Iterable<Map<String, Integer>> nullableValues = createTestMaps(transform(intsBetween(0, 30_000), Object::toString), limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, mapType(VARCHAR, INTEGER));
+
+        // Map<String, Integer> (nullable map, non-null values)
+        MessageType map = parseMessageType("message hive_schema {" +
+                " optional group my_map (MAP) {" +
+                "     repeated group map { " +
+                "        required binary str (UTF8);   " +
+                "        required int32 num;  " +
+                "    }  " +
+                "  }" +
+                "}   ");
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, mapType(VARCHAR, INTEGER), Optional.of(map));
+
+        // Map<String, Integer> (nullable map, non-null values)
+        map = parseMessageType("message hive_schema {" +
+                " optional group my_map (MAP_KEY_VALUE) {" +
+                "     repeated group map { " +
+                "        required binary str (UTF8);   " +
+                "        required int32 num;  " +
+                "    }  " +
+                "  }" +
+                "}   ");
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, mapType(VARCHAR, INTEGER), Optional.of(map));
+
+        // Map<String, Integer> (non-null map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " required group my_map (MAP) { " +
+                "    repeated group map {  " +
+                "        required binary key (UTF8);      " +
+                "       optional int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {nullableValues},
+                new Iterable<?>[] {nullableValues}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+
+        // Map<String, Integer> (non-null map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " required group my_map (MAP_KEY_VALUE) { " +
+                "    repeated group map {  " +
+                "        required binary key (UTF8);      " +
+                "       optional int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {nullableValues},
+                new Iterable<?>[] {nullableValues}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+
+        // Map<String, Integer> (non-null map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " required group my_map (MAP) { " +
+                "    repeated group map {  " +
+                "        required binary key (UTF8);      " +
+                "       required int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {values},
+                new Iterable<?>[] {values}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+
+        // Map<String, Integer> (non-null map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " required group my_map (MAP_KEY_VALUE) { " +
+                "    repeated group map {  " +
+                "        required binary key (UTF8);      " +
+                "       required int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.assertRoundTrip(singletonList(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector)), new Iterable<?>[] {values},
+                new Iterable<?>[] {values}, singletonList("my_map"), singletonList(mapType(VARCHAR, INTEGER)), Optional.of(map));
+
+        // Map<String, Integer> (nullable map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " optional group my_map (MAP) { " +
+                "    repeated group map {  " +
+                "       required binary key (UTF8);      " +
+                "       optional int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), nullableValues, nullableValues, mapType(VARCHAR, INTEGER), Optional.of(map));
+
+        // Map<String, Integer> (nullable map, nullable values)
+        map = parseMessageType("message hive_schema {" +
+                " optional group my_map (MAP_KEY_VALUE) { " +
+                "    repeated group map {  " +
+                "       required binary key (UTF8);      " +
+                "       optional int32 value;   " +
+                "    }   " +
+                "  }" +
+                " }  ");
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), nullableValues, nullableValues, mapType(VARCHAR, INTEGER), Optional.of(map));
     }
 
     @Test
@@ -236,7 +1298,7 @@ public abstract class AbstractTestParquetReader
                 AbstractTestParquetReader::shortToInt,
                 INTEGER);
 
-        tester.testRoundTrip(javaIntObjectInspector, writeValues, writeValues, INTEGER);
+        tester.testRoundTrip(javaIntObjectInspector, writeValues, INTEGER);
         tester.testRoundTrip(javaLongObjectInspector, transform(writeValues, AbstractTestParquetReader::intToLong), BIGINT);
         tester.testRoundTrip(javaTimestampObjectInspector,
                 transform(writeValues, AbstractTestParquetReader::intToTimestamp),
@@ -448,17 +1510,90 @@ public abstract class AbstractTestParquetReader
 
     private static ContiguousSet<Integer> intsBetween(int lowerInclusive, int upperExclusive)
     {
-        return ContiguousSet.create(Range.openClosed(lowerInclusive, upperExclusive), DiscreteDomain.integers());
+        return ContiguousSet.create(Range.closedOpen(lowerInclusive, upperExclusive), DiscreteDomain.integers());
     }
 
     private static ContiguousSet<Long> longsBetween(long lowerInclusive, long upperExclusive)
     {
-        return ContiguousSet.create(Range.openClosed(lowerInclusive, upperExclusive), DiscreteDomain.longs());
+        return ContiguousSet.create(Range.closedOpen(lowerInclusive, upperExclusive), DiscreteDomain.longs());
     }
 
     private static ContiguousSet<BigInteger> bigIntegersBetween(BigInteger lowerInclusive, BigInteger upperExclusive)
     {
-        return ContiguousSet.create(Range.openClosed(lowerInclusive, upperExclusive), DiscreteDomain.bigIntegers());
+        return ContiguousSet.create(Range.closedOpen(lowerInclusive, upperExclusive), DiscreteDomain.bigIntegers());
+    }
+
+    private <F> List<List> createTestStructs(Iterable<F> fieldValues)
+    {
+        checkArgument(fieldValues.iterator().hasNext(), "struct field values cannot be empty");
+        List<List> structs = new ArrayList<>();
+        for (F field : fieldValues) {
+            structs.add(singletonList(field));
+        }
+        return structs;
+    }
+
+    private List<List> createTestStructs(Iterable<?>... values)
+    {
+        List<List> structs = new ArrayList<>();
+        List<Iterator> iterators = Arrays.stream(values).map(Iterable::iterator).collect(Collectors.toList());
+        iterators.forEach(iter -> checkArgument(iter.hasNext(), "struct field values cannot be empty"));
+        while (iterators.stream().allMatch(Iterator::hasNext)) {
+            structs.add(iterators.stream().map(Iterator::next).collect(Collectors.toList()));
+        }
+        return structs;
+    }
+
+    private Iterable<List> createNullableTestStructs(Iterable<?>... values)
+    {
+        return insertNullEvery(ThreadLocalRandom.current().nextInt(2, 5), createTestStructs(values));
+    }
+
+    private <T> List<List<T>> createTestArrays(Iterable<T> values)
+    {
+        List<List<T>> arrays = new ArrayList<>();
+        Iterator<T> valuesIter = values.iterator();
+        List<T> array = new ArrayList<>();
+        while (valuesIter.hasNext()) {
+            if (ThreadLocalRandom.current().nextBoolean()) {
+                arrays.add(array);
+                array = new ArrayList<>();
+            }
+            if (ThreadLocalRandom.current().nextInt(10) == 0) {
+                arrays.add(Collections.emptyList());
+            }
+            array.add(valuesIter.next());
+        }
+        return arrays;
+    }
+
+    private <T> Iterable<List<T>> createNullableTestArrays(Iterable<T> values)
+    {
+        return insertNullEvery(ThreadLocalRandom.current().nextInt(2, 5), createTestArrays(values));
+    }
+
+    private <K, V> Iterable<Map<K, V>> createTestMaps(Iterable<K> keys, Iterable<V> values)
+    {
+        List<Map<K, V>> maps = new ArrayList<>();
+        Iterator<K> keysIterator = keys.iterator();
+        Iterator<V> valuesIterator = values.iterator();
+        Map<K, V> map = new HashMap<>();
+        while (keysIterator.hasNext() && valuesIterator.hasNext()) {
+            if (ThreadLocalRandom.current().nextInt(5) == 0) {
+                maps.add(map);
+                map = new HashMap<>();
+            }
+            if (ThreadLocalRandom.current().nextInt(10) == 0) {
+                maps.add(Collections.emptyMap());
+            }
+            map.put(keysIterator.next(), valuesIterator.next());
+        }
+        return maps;
+    }
+
+    private <K, V> Iterable<Map<K, V>> createNullableTestMaps(Iterable<K> keys, Iterable<V> values)
+    {
+        return insertNullEvery(ThreadLocalRandom.current().nextInt(2, 5), createTestMaps(keys, values));
     }
 
     private static Byte intToByte(Integer input)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.parquet.predicate;
 
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.ArrayType;
@@ -32,10 +33,13 @@ import parquet.schema.GroupType;
 import parquet.schema.MessageType;
 import parquet.schema.PrimitiveType;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptors;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.getParquetTupleDomain;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.isOnlyDictionaryEncodingPages;
 import static com.facebook.presto.spi.block.MethodHandleUtil.methodHandle;
@@ -92,7 +96,8 @@ public class TestParquetPredicateUtils
                 new GroupType(OPTIONAL, "my_array",
                         new GroupType(REPEATED, "bag", new PrimitiveType(OPTIONAL, INT32, "array_element"))));
 
-        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+        Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(descriptorsByPath, domain);
         assertTrue(tupleDomain.getDomains().get().isEmpty());
     }
 
@@ -109,7 +114,8 @@ public class TestParquetPredicateUtils
                         new GroupType(REPEATED, "bag",
                                 new GroupType(OPTIONAL, "array_element", new PrimitiveType(OPTIONAL, INT32, "a")))));
 
-        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+        Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(descriptorsByPath, domain);
         assertTrue(tupleDomain.getDomains().get().isEmpty());
     }
 
@@ -122,7 +128,8 @@ public class TestParquetPredicateUtils
 
         MessageType fileSchema = new MessageType("hive_schema", new PrimitiveType(OPTIONAL, INT64, "my_primitive"));
 
-        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+        Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(descriptorsByPath, domain);
 
         assertEquals(tupleDomain.getDomains().get().size(), 1);
         ColumnDescriptor descriptor = tupleDomain.getDomains().get().keySet().iterator().next();
@@ -145,8 +152,8 @@ public class TestParquetPredicateUtils
                 new GroupType(OPTIONAL, "my_struct",
                         new PrimitiveType(OPTIONAL, INT32, "a"),
                         new PrimitiveType(OPTIONAL, INT32, "b")));
-
-        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+        Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(descriptorsByPath, domain);
         assertTrue(tupleDomain.getDomains().get().isEmpty());
     }
 
@@ -171,7 +178,8 @@ public class TestParquetPredicateUtils
                             new PrimitiveType(REQUIRED, INT32, "key"),
                             new PrimitiveType(OPTIONAL, INT32, "value"))));
 
-        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+        Map<List<String>, RichColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(descriptorsByPath, domain);
         assertTrue(tupleDomain.getDomains().get().isEmpty());
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/MapKeyValuesSchemaConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/MapKeyValuesSchemaConverter.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import parquet.schema.GroupType;
+import parquet.schema.MessageType;
+import parquet.schema.OriginalType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import parquet.schema.Type;
+import parquet.schema.Type.Repetition;
+import parquet.schema.Types;
+
+import java.util.List;
+
+import static parquet.schema.OriginalType.MAP_KEY_VALUE;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.convert.HiveSchemaConverter
+ * and modified to test maps where MAP_KEY_VALUE is incorrectly used in place of MAP
+ * Backward-compatibility rules described in spec https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps
+ */
+public class MapKeyValuesSchemaConverter
+{
+    private MapKeyValuesSchemaConverter()
+    {
+    }
+
+    public static MessageType convert(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        return new MessageType("hive_schema", convertTypes(columnNames, columnTypes));
+    }
+
+    private static Type[] convertTypes(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        if (columnNames.size() != columnTypes.size()) {
+            throw new IllegalStateException("Mismatched Hive columns and types. Hive columns names" +
+                    " found : " + columnNames + " . And Hive types found : " + columnTypes);
+        }
+        final Type[] types = new Type[columnNames.size()];
+        for (int i = 0; i < columnNames.size(); ++i) {
+            types[i] = convertType(columnNames.get(i), columnTypes.get(i));
+        }
+        return types;
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo)
+    {
+        return convertType(name, typeInfo, Repetition.OPTIONAL);
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo,
+            final Repetition repetition)
+    {
+        if (typeInfo.getCategory().equals(Category.PRIMITIVE)) {
+            if (typeInfo.equals(TypeInfoFactory.stringTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(OriginalType.UTF8)
+                        .named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.shortTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.byteTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT64, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT96, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
+                throw new UnsupportedOperationException("Void type not implemented");
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.CHAR_TYPE_NAME)) {
+                return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.VARCHAR_TYPE_NAME)) {
+                return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+            }
+            else if (typeInfo instanceof DecimalTypeInfo) {
+                DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
+                int prec = decimalTypeInfo.precision();
+                int scale = decimalTypeInfo.scale();
+                int bytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
+                return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).as(OriginalType.DATE).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
+                throw new UnsupportedOperationException("Unknown type not implemented");
+            }
+            else {
+                throw new IllegalArgumentException("Unknown type: " + typeInfo);
+            }
+        }
+        else if (typeInfo.getCategory().equals(Category.LIST)) {
+            return convertArrayType(name, (ListTypeInfo) typeInfo);
+        }
+        else if (typeInfo.getCategory().equals(Category.STRUCT)) {
+            return convertStructType(name, (StructTypeInfo) typeInfo);
+        }
+        else if (typeInfo.getCategory().equals(Category.MAP)) {
+            return convertMapType(name, (MapTypeInfo) typeInfo);
+        }
+        else if (typeInfo.getCategory().equals(Category.UNION)) {
+            throw new UnsupportedOperationException("Union type not implemented");
+        }
+        else {
+            throw new IllegalArgumentException("Unknown type: " + typeInfo);
+        }
+    }
+
+    // An optional group containing a repeated anonymous group "bag", containing
+    // 1 anonymous element "array_element"
+    private static GroupType convertArrayType(final String name, final ListTypeInfo typeInfo)
+    {
+        final TypeInfo subType = typeInfo.getListElementTypeInfo();
+        return listWrapper(name, OriginalType.LIST, new GroupType(Repetition.REPEATED,
+                ParquetHiveSerDe.ARRAY.toString(), convertType("array_element", subType)));
+    }
+
+    // An optional group containing multiple elements
+    private static GroupType convertStructType(final String name, final StructTypeInfo typeInfo)
+    {
+        final List<String> columnNames = typeInfo.getAllStructFieldNames();
+        final List<TypeInfo> columnTypes = typeInfo.getAllStructFieldTypeInfos();
+        return new GroupType(Repetition.OPTIONAL, name, convertTypes(columnNames, columnTypes));
+    }
+
+    // An optional group containing a repeated anonymous group "map", containing
+    // 2 elements: "key", "value"
+    private static GroupType convertMapType(final String name, final MapTypeInfo typeInfo)
+    {
+        final Type keyType = convertType(ParquetHiveSerDe.MAP_KEY.toString(),
+                typeInfo.getMapKeyTypeInfo(), Repetition.REQUIRED);
+        final Type valueType = convertType(ParquetHiveSerDe.MAP_VALUE.toString(),
+                typeInfo.getMapValueTypeInfo());
+        return mapType(Repetition.OPTIONAL, name, "map", keyType, valueType);
+    }
+
+    public static GroupType mapType(Repetition repetition, String alias, String mapAlias, Type keyType, Type valueType)
+    {
+        //support projection only on key of a map
+        if (valueType == null) {
+            return listWrapper(
+                    repetition,
+                    alias,
+                    MAP_KEY_VALUE,
+                    new GroupType(
+                            Repetition.REPEATED,
+                            mapAlias,
+                            keyType));
+        }
+        else {
+            if (!valueType.getName().equals("value")) {
+                throw new RuntimeException(valueType.getName() + " should be value");
+            }
+            return listWrapper(
+                    repetition,
+                    alias,
+                    MAP_KEY_VALUE,
+                    new GroupType(
+                            Repetition.REPEATED,
+                            mapAlias,
+                            keyType,
+                            valueType));
+        }
+    }
+
+    private static GroupType listWrapper(Repetition repetition, String alias, OriginalType originalType, Type nested)
+    {
+        if (!nested.isRepetition(Repetition.REPEATED)) {
+            throw new IllegalArgumentException("Nested type should be repeated: " + nested);
+        }
+        return new GroupType(repetition, alias, originalType, nested);
+    }
+
+    private static GroupType listWrapper(final String name, final OriginalType originalType,
+            final GroupType groupType)
+    {
+        return new GroupType(Repetition.OPTIONAL, name, originalType, groupType);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArrayMapKeyValuesSchemaConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArrayMapKeyValuesSchemaConverter.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import parquet.schema.GroupType;
+import parquet.schema.MessageType;
+import parquet.schema.OriginalType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import parquet.schema.Type;
+import parquet.schema.Type.Repetition;
+import parquet.schema.Types;
+
+import java.util.List;
+
+import static parquet.schema.OriginalType.MAP_KEY_VALUE;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.convert.HiveSchemaConverter
+ * and modified to test Array Schema without wrapping anonymous group "bag".
+ * Additionally, there is a schema modification in maps where MAP_KEY_VALUE is incorrectly used in place of MAP
+ * Backward-compatibility rules described in spec https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
+ */
+public class SingleLevelArrayMapKeyValuesSchemaConverter
+{
+    private SingleLevelArrayMapKeyValuesSchemaConverter()
+    {
+    }
+
+    public static MessageType convert(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        return new MessageType("hive_schema", convertTypes(columnNames, columnTypes));
+    }
+
+    private static Type[] convertTypes(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        if (columnNames.size() != columnTypes.size()) {
+            throw new IllegalStateException("Mismatched Hive columns and types. Hive columns names" +
+                    " found : " + columnNames + " . And Hive types found : " + columnTypes);
+        }
+        final Type[] types = new Type[columnNames.size()];
+        for (int i = 0; i < columnNames.size(); ++i) {
+            types[i] = convertType(columnNames.get(i), columnTypes.get(i));
+        }
+        return types;
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo)
+    {
+        return convertType(name, typeInfo, Repetition.OPTIONAL);
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo,
+            final Repetition repetition)
+    {
+        if (typeInfo.getCategory().equals(Category.PRIMITIVE)) {
+            if (typeInfo.equals(TypeInfoFactory.stringTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(OriginalType.UTF8)
+                        .named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.shortTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.byteTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT64, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT96, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
+                throw new UnsupportedOperationException("Void type not implemented");
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.CHAR_TYPE_NAME)) {
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.VARCHAR_TYPE_NAME)) {
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+            }
+            else if (typeInfo instanceof DecimalTypeInfo) {
+                DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
+                int prec = decimalTypeInfo.precision();
+                int scale = decimalTypeInfo.scale();
+                int bytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                }
+            }
+            else if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).as(OriginalType.DATE).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
+                throw new UnsupportedOperationException("Unknown type not implemented");
+            }
+            else {
+                throw new IllegalArgumentException("Unknown type: " + typeInfo);
+            }
+        }
+        else if (typeInfo.getCategory().equals(Category.LIST)) {
+            return convertArrayType(name, (ListTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.STRUCT)) {
+            return convertStructType(name, (StructTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.MAP)) {
+            return convertMapType(name, (MapTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.UNION)) {
+            throw new UnsupportedOperationException("Union type not implemented");
+        }
+        else {
+            throw new IllegalArgumentException("Unknown type: " + typeInfo);
+        }
+    }
+
+    // 1 anonymous element "array_element"
+    private static GroupType convertArrayType(final String name, final ListTypeInfo typeInfo, final Repetition repetition)
+    {
+        final TypeInfo subType = typeInfo.getListElementTypeInfo();
+        return listWrapper(name, OriginalType.LIST, convertType("array_element", subType, Repetition.REPEATED), repetition);
+    }
+
+    // An optional group containing multiple elements
+    private static GroupType convertStructType(final String name, final StructTypeInfo typeInfo, final Repetition repetition)
+    {
+        final List<String> columnNames = typeInfo.getAllStructFieldNames();
+        final List<TypeInfo> columnTypes = typeInfo.getAllStructFieldTypeInfos();
+        return new GroupType(repetition, name, convertTypes(columnNames, columnTypes));
+    }
+
+    // An optional group containing a repeated anonymous group "map", containing
+    // 2 elements: "key", "value"
+    private static GroupType convertMapType(final String name, final MapTypeInfo typeInfo, final Repetition repetition)
+    {
+        final Type keyType = convertType(ParquetHiveSerDe.MAP_KEY.toString(),
+                typeInfo.getMapKeyTypeInfo(), Repetition.REQUIRED);
+        final Type valueType = convertType(ParquetHiveSerDe.MAP_VALUE.toString(),
+                typeInfo.getMapValueTypeInfo());
+        return mapType(repetition, name, "map", keyType, valueType);
+    }
+
+    public static GroupType mapType(Repetition repetition, String alias, String mapAlias, Type keyType, Type valueType)
+    {
+        //support projection only on key of a map
+        if (valueType == null) {
+            return listWrapper(
+                    repetition,
+                    alias,
+                    MAP_KEY_VALUE,
+                    new GroupType(
+                            Repetition.REPEATED,
+                            mapAlias,
+                            keyType));
+        }
+        else {
+            if (!valueType.getName().equals("value")) {
+                throw new RuntimeException(valueType.getName() + " should be value");
+            }
+            return listWrapper(
+                    repetition,
+                    alias,
+                    MAP_KEY_VALUE,
+                    new GroupType(
+                            Repetition.REPEATED,
+                            mapAlias,
+                            keyType,
+                            valueType));
+        }
+    }
+
+    private static GroupType listWrapper(Repetition repetition, String alias, OriginalType originalType, Type nested)
+    {
+        if (!nested.isRepetition(Repetition.REPEATED)) {
+            throw new IllegalArgumentException("Nested type should be repeated: " + nested);
+        }
+        return new GroupType(repetition, alias, originalType, nested);
+    }
+
+    private static GroupType listWrapper(final String name, final OriginalType originalType,
+            final Type elementType, final Repetition repetition)
+    {
+        return new GroupType(repetition, name, originalType, elementType);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArraySchemaConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArraySchemaConverter.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import parquet.schema.ConversionPatterns;
+import parquet.schema.GroupType;
+import parquet.schema.MessageType;
+import parquet.schema.OriginalType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import parquet.schema.Type;
+import parquet.schema.Type.Repetition;
+import parquet.schema.Types;
+
+import java.util.List;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.convert.HiveSchemaConverter
+ * and modified to test Array Schema without wrapping anonymous group "bag".
+ * Backward-compatibility rules described in spec https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
+ */
+public class SingleLevelArraySchemaConverter
+{
+    private SingleLevelArraySchemaConverter()
+    {
+    }
+
+    public static MessageType convert(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        return new MessageType("hive_schema", convertTypes(columnNames, columnTypes));
+    }
+
+    private static Type[] convertTypes(final List<String> columnNames, final List<TypeInfo> columnTypes)
+    {
+        if (columnNames.size() != columnTypes.size()) {
+            throw new IllegalStateException("Mismatched Hive columns and types. Hive columns names" +
+                    " found : " + columnNames + " . And Hive types found : " + columnTypes);
+        }
+        final Type[] types = new Type[columnNames.size()];
+        for (int i = 0; i < columnNames.size(); ++i) {
+            types[i] = convertType(columnNames.get(i), columnTypes.get(i));
+        }
+        return types;
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo)
+    {
+        return convertType(name, typeInfo, Repetition.OPTIONAL);
+    }
+
+    private static Type convertType(final String name, final TypeInfo typeInfo,
+            final Repetition repetition)
+    {
+        if (typeInfo.getCategory().equals(Category.PRIMITIVE)) {
+            if (typeInfo.equals(TypeInfoFactory.stringTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).as(OriginalType.UTF8)
+                        .named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.intTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.shortTypeInfo) ||
+                    typeInfo.equals(TypeInfoFactory.byteTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.longTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT64, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.doubleTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.floatTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.booleanTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.binaryTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.BINARY, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.timestampTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT96, repetition).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.voidTypeInfo)) {
+                throw new UnsupportedOperationException("Void type not implemented");
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.CHAR_TYPE_NAME)) {
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+            }
+            else if (typeInfo.getTypeName().toLowerCase().startsWith(
+                    serdeConstants.VARCHAR_TYPE_NAME)) {
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.BINARY).as(OriginalType.UTF8).named(name);
+                }
+            }
+            else if (typeInfo instanceof DecimalTypeInfo) {
+                DecimalTypeInfo decimalTypeInfo = (DecimalTypeInfo) typeInfo;
+                int prec = decimalTypeInfo.precision();
+                int scale = decimalTypeInfo.scale();
+                int bytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
+                if (repetition == Repetition.OPTIONAL) {
+                    return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                }
+                else {
+                    return Types.repeated(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(bytes).as(OriginalType.DECIMAL).scale(scale).precision(prec).named(name);
+                }
+            }
+            else if (typeInfo.equals(TypeInfoFactory.dateTypeInfo)) {
+                return Types.primitive(PrimitiveTypeName.INT32, repetition).as(OriginalType.DATE).named(name);
+            }
+            else if (typeInfo.equals(TypeInfoFactory.unknownTypeInfo)) {
+                throw new UnsupportedOperationException("Unknown type not implemented");
+            }
+            else {
+                throw new IllegalArgumentException("Unknown type: " + typeInfo);
+            }
+        }
+        else if (typeInfo.getCategory().equals(Category.LIST)) {
+            return convertArrayType(name, (ListTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.STRUCT)) {
+            return convertStructType(name, (StructTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.MAP)) {
+            return convertMapType(name, (MapTypeInfo) typeInfo, repetition);
+        }
+        else if (typeInfo.getCategory().equals(Category.UNION)) {
+            throw new UnsupportedOperationException("Union type not implemented");
+        }
+        else {
+            throw new IllegalArgumentException("Unknown type: " + typeInfo);
+        }
+    }
+
+    // 1 anonymous element "array_element"
+    private static GroupType convertArrayType(final String name, final ListTypeInfo typeInfo, final Repetition repetition)
+    {
+        final TypeInfo subType = typeInfo.getListElementTypeInfo();
+        return listWrapper(name, OriginalType.LIST, convertType("array_element", subType, Repetition.REPEATED), repetition);
+    }
+
+    // An optional group containing multiple elements
+    private static GroupType convertStructType(final String name, final StructTypeInfo typeInfo, final Repetition repetition)
+    {
+        final List<String> columnNames = typeInfo.getAllStructFieldNames();
+        final List<TypeInfo> columnTypes = typeInfo.getAllStructFieldTypeInfos();
+        return new GroupType(repetition, name, convertTypes(columnNames, columnTypes));
+    }
+
+    // An optional group containing a repeated anonymous group "map", containing
+    // 2 elements: "key", "value"
+    private static GroupType convertMapType(final String name, final MapTypeInfo typeInfo, final Repetition repetition)
+    {
+        final Type keyType = convertType(ParquetHiveSerDe.MAP_KEY.toString(),
+                typeInfo.getMapKeyTypeInfo(), Repetition.REQUIRED);
+        final Type valueType = convertType(ParquetHiveSerDe.MAP_VALUE.toString(),
+                typeInfo.getMapValueTypeInfo());
+        return ConversionPatterns.mapType(repetition, name, keyType, valueType);
+    }
+
+    private static GroupType listWrapper(final String name, final OriginalType originalType,
+            final Type elementType, final Repetition repetition)
+    {
+        return new GroupType(repetition, name, originalType, elementType);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriteSupport.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriteSupport.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
+import org.apache.hadoop.hive.serde2.io.ParquetHiveRecord;
+import parquet.hadoop.api.WriteSupport;
+import parquet.io.api.RecordConsumer;
+import parquet.schema.MessageType;
+
+import java.util.HashMap;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport
+ * and extended to support empty arrays and maps (HIVE-13632).
+ */
+class TestDataWritableWriteSupport
+        extends WriteSupport<ParquetHiveRecord>
+{
+    private TestDataWritableWriter writer;
+    private MessageType schema;
+
+    @Override
+    public WriteContext init(final Configuration configuration)
+    {
+        schema = DataWritableWriteSupport.getSchema(configuration);
+        return new WriteContext(schema, new HashMap<>());
+    }
+
+    @Override
+    public void prepareForWrite(final RecordConsumer recordConsumer)
+    {
+        writer = new TestDataWritableWriter(recordConsumer, schema);
+    }
+
+    @Override
+    public void write(final ParquetHiveRecord record)
+    {
+        writer.write(record);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriter.java
@@ -1,0 +1,412 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet.write;
+
+import io.airlift.log.Logger;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTimeUtils;
+import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriter;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.serde2.io.ParquetHiveRecord;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ByteObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveCharObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveVarcharObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ShortObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import parquet.io.api.Binary;
+import parquet.io.api.RecordConsumer;
+import parquet.schema.GroupType;
+import parquet.schema.OriginalType;
+import parquet.schema.Type;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is copied from org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriter
+ * and extended to support empty arrays and maps (HIVE-13632).
+ * Additionally, there is a support for arrays without include an inner element layer and
+ * support for maps where  MAP_KEY_VALUE is incorrectly used in place of MAP
+ * for backward-compatibility rules testing (https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists)
+ */
+public class TestDataWritableWriter
+{
+    private static final Logger log = Logger.get(DataWritableWriter.class);
+    private final RecordConsumer recordConsumer;
+    private final GroupType schema;
+
+    public TestDataWritableWriter(final RecordConsumer recordConsumer, final GroupType schema)
+    {
+        this.recordConsumer = recordConsumer;
+        this.schema = schema;
+    }
+
+    /**
+     * It writes all record values to the Parquet RecordConsumer.
+     *
+     * @param record Contains the record that are going to be written.
+     */
+    public void write(final ParquetHiveRecord record)
+    {
+        if (record != null) {
+            recordConsumer.startMessage();
+            try {
+                writeGroupFields(record.getObject(), record.getObjectInspector(), schema);
+            }
+            catch (RuntimeException e) {
+                String errorMessage = "Parquet record is malformed: " + e.getMessage();
+                log.error(errorMessage, e);
+                throw new RuntimeException(errorMessage, e);
+            }
+            recordConsumer.endMessage();
+        }
+    }
+
+    /**
+     * It writes all the fields contained inside a group to the RecordConsumer.
+     *
+     * @param value The list of values contained in the group.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the group schema.
+     */
+    private void writeGroupFields(final Object value, final StructObjectInspector inspector, final GroupType type)
+    {
+        if (value != null) {
+            List<? extends StructField> fields = inspector.getAllStructFieldRefs();
+            List<Object> fieldValuesList = inspector.getStructFieldsDataAsList(value);
+
+            for (int i = 0; i < type.getFieldCount(); i++) {
+                Type fieldType = type.getType(i);
+                String fieldName = fieldType.getName();
+                Object fieldValue = fieldValuesList.get(i);
+
+                if (fieldValue != null) {
+                    ObjectInspector fieldInspector = fields.get(i).getFieldObjectInspector();
+                    recordConsumer.startField(fieldName, i);
+                    writeValue(fieldValue, fieldInspector, fieldType);
+                    recordConsumer.endField(fieldName, i);
+                }
+            }
+        }
+    }
+
+    /**
+     * It writes the field value to the Parquet RecordConsumer. It detects the field type, and calls
+     * the correct write function.
+     *
+     * @param value The writable object that contains the value.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the type schema.
+     */
+    private void writeValue(final Object value, final ObjectInspector inspector, final Type type)
+    {
+        if (type.isPrimitive()) {
+            checkInspectorCategory(inspector, ObjectInspector.Category.PRIMITIVE);
+            writePrimitive(value, (PrimitiveObjectInspector) inspector);
+        }
+        else {
+            GroupType groupType = type.asGroupType();
+            OriginalType originalType = type.getOriginalType();
+
+            if (originalType != null && originalType.equals(OriginalType.LIST)) {
+                checkInspectorCategory(inspector, ObjectInspector.Category.LIST);
+                writeArray(value, (ListObjectInspector) inspector, groupType);
+            }
+            else if (originalType != null && (originalType.equals(OriginalType.MAP) || originalType.equals(OriginalType.MAP_KEY_VALUE))) {
+                checkInspectorCategory(inspector, ObjectInspector.Category.MAP);
+                writeMap(value, (MapObjectInspector) inspector, groupType);
+            }
+            else {
+                checkInspectorCategory(inspector, ObjectInspector.Category.STRUCT);
+                writeGroup(value, (StructObjectInspector) inspector, groupType);
+            }
+        }
+    }
+
+    /**
+     * Checks that an inspector matches the category indicated as a parameter.
+     *
+     * @param inspector The object inspector to check
+     * @param category The category to match
+     * @throws IllegalArgumentException if inspector does not match the category
+     */
+    private void checkInspectorCategory(ObjectInspector inspector, ObjectInspector.Category category)
+    {
+        if (!inspector.getCategory().equals(category)) {
+            throw new IllegalArgumentException("Invalid data type: expected " + category
+                    + " type, but found: " + inspector.getCategory());
+        }
+    }
+
+    /**
+     * It writes a group type and all its values to the Parquet RecordConsumer.
+     * This is used only for optional and required groups.
+     *
+     * @param value Object that contains the group values.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the group schema.
+     */
+    private void writeGroup(final Object value, final StructObjectInspector inspector, final GroupType type)
+    {
+        recordConsumer.startGroup();
+        writeGroupFields(value, inspector, type);
+        recordConsumer.endGroup();
+    }
+
+    /**
+     * It writes a list type and its array elements to the Parquet RecordConsumer.
+     * This is called when the original type (LIST) is detected by writeValue()/
+     * This function assumes the following schema:
+     * optional group arrayCol (LIST) {
+     * repeated group array {
+     * optional TYPE array_element;
+     * }
+     * }
+     *
+     * @param value The object that contains the array values.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the group (LIST) schema.
+     */
+    private void writeArray(final Object value, final ListObjectInspector inspector, final GroupType type)
+    {
+        if (type.getType(0).isPrimitive()) {
+            writeSingleLevelArray(value, inspector, type);
+            return;
+        }
+        // Get the internal array structure
+        GroupType repeatedType = type.getType(0).asGroupType();
+        if (repeatedType.getOriginalType() != null || repeatedType.getFieldCount() > 1) {
+            writeSingleLevelArray(value, inspector, type);
+            return;
+        }
+        recordConsumer.startGroup();
+
+        List<?> arrayValues = inspector.getList(value);
+        if (!arrayValues.isEmpty()) {
+            recordConsumer.startField(repeatedType.getName(), 0);
+            ObjectInspector elementInspector = inspector.getListElementObjectInspector();
+
+            Type elementType = repeatedType.getType(0);
+            String elementName = elementType.getName();
+
+            for (Object element : arrayValues) {
+                recordConsumer.startGroup();
+                if (element != null) {
+                    recordConsumer.startField(elementName, 0);
+                    writeValue(element, elementInspector, elementType);
+                    recordConsumer.endField(elementName, 0);
+                }
+                recordConsumer.endGroup();
+            }
+
+            recordConsumer.endField(repeatedType.getName(), 0);
+        }
+        recordConsumer.endGroup();
+    }
+
+    private void writeSingleLevelArray(final Object value, final ListObjectInspector inspector, final GroupType type)
+    {
+        // Get the internal array structure
+        Type elementType = type.getType(0);
+
+        recordConsumer.startGroup();
+
+        List<?> arrayValues = inspector.getList(value);
+        if (!arrayValues.isEmpty()) {
+            recordConsumer.startField(elementType.getName(), 0);
+            ObjectInspector elementInspector = inspector.getListElementObjectInspector();
+
+            for (Object element : arrayValues) {
+                if (element == null) {
+                    throw new IllegalArgumentException("Array elements are requires in given schema definition");
+                }
+                writeValue(element, elementInspector, elementType);
+            }
+
+            recordConsumer.endField(elementType.getName(), 0);
+        }
+        recordConsumer.endGroup();
+    }
+
+    /**
+     * It writes a map type and its key-pair values to the Parquet RecordConsumer.
+     * This is called when the original type (MAP) is detected by writeValue().
+     * This function assumes the following schema:
+     * optional group mapCol (MAP) {
+     * repeated group map (MAP_KEY_VALUE) {
+     * required TYPE key;
+     * optional TYPE value;
+     * }
+     * }
+     *
+     * @param value The object that contains the map key-values.
+     * @param inspector The object inspector used to get the correct value type.
+     * @param type Type that contains information about the group (MAP) schema.
+     */
+    private void writeMap(final Object value, final MapObjectInspector inspector, final GroupType type)
+    {
+        // Get the internal map structure (MAP_KEY_VALUE)
+        GroupType repeatedType = type.getType(0).asGroupType();
+
+        recordConsumer.startGroup();
+        Map<?, ?> mapValues = inspector.getMap(value);
+        if (mapValues != null && mapValues.size() > 0) {
+            recordConsumer.startField(repeatedType.getName(), 0);
+
+            Type keyType = repeatedType.getType(0);
+            String keyName = keyType.getName();
+            ObjectInspector keyInspector = inspector.getMapKeyObjectInspector();
+
+            Type valuetype = repeatedType.getType(1);
+            String valueName = valuetype.getName();
+            ObjectInspector valueInspector = inspector.getMapValueObjectInspector();
+
+            for (Map.Entry<?, ?> keyValue : mapValues.entrySet()) {
+                recordConsumer.startGroup();
+                if (keyValue != null) {
+                    // write key element
+                    Object keyElement = keyValue.getKey();
+                    recordConsumer.startField(keyName, 0);
+                    writeValue(keyElement, keyInspector, keyType);
+                    recordConsumer.endField(keyName, 0);
+
+                    // write value element
+                    Object valueElement = keyValue.getValue();
+                    if (valueElement != null) {
+                        recordConsumer.startField(valueName, 1);
+                        writeValue(valueElement, valueInspector, valuetype);
+                        recordConsumer.endField(valueName, 1);
+                    }
+                }
+                recordConsumer.endGroup();
+            }
+
+            recordConsumer.endField(repeatedType.getName(), 0);
+        }
+        recordConsumer.endGroup();
+    }
+
+    /**
+     * It writes the primitive value to the Parquet RecordConsumer.
+     *
+     * @param value The object that contains the primitive value.
+     * @param inspector The object inspector used to get the correct value type.
+     */
+    private void writePrimitive(final Object value, final PrimitiveObjectInspector inspector)
+    {
+        if (value == null) {
+            return;
+        }
+
+        switch (inspector.getPrimitiveCategory()) {
+            case VOID:
+                return;
+            case DOUBLE:
+                recordConsumer.addDouble(((DoubleObjectInspector) inspector).get(value));
+                break;
+            case BOOLEAN:
+                recordConsumer.addBoolean(((BooleanObjectInspector) inspector).get(value));
+                break;
+            case FLOAT:
+                recordConsumer.addFloat(((FloatObjectInspector) inspector).get(value));
+                break;
+            case BYTE:
+                recordConsumer.addInteger(((ByteObjectInspector) inspector).get(value));
+                break;
+            case INT:
+                recordConsumer.addInteger(((IntObjectInspector) inspector).get(value));
+                break;
+            case LONG:
+                recordConsumer.addLong(((LongObjectInspector) inspector).get(value));
+                break;
+            case SHORT:
+                recordConsumer.addInteger(((ShortObjectInspector) inspector).get(value));
+                break;
+            case STRING:
+                String v = ((StringObjectInspector) inspector).getPrimitiveJavaObject(value);
+                recordConsumer.addBinary(Binary.fromString(v));
+                break;
+            case CHAR:
+                String vChar = ((HiveCharObjectInspector) inspector).getPrimitiveJavaObject(value).getStrippedValue();
+                recordConsumer.addBinary(Binary.fromString(vChar));
+                break;
+            case VARCHAR:
+                String vVarchar = ((HiveVarcharObjectInspector) inspector).getPrimitiveJavaObject(value).getValue();
+                recordConsumer.addBinary(Binary.fromString(vVarchar));
+                break;
+            case BINARY:
+                byte[] vBinary = ((BinaryObjectInspector) inspector).getPrimitiveJavaObject(value);
+                recordConsumer.addBinary(Binary.fromByteArray(vBinary));
+                break;
+            case TIMESTAMP:
+                Timestamp ts = ((TimestampObjectInspector) inspector).getPrimitiveJavaObject(value);
+                recordConsumer.addBinary(NanoTimeUtils.getNanoTime(ts, false).toBinary());
+                break;
+            case DECIMAL:
+                HiveDecimal vDecimal = ((HiveDecimal) inspector.getPrimitiveJavaObject(value));
+                DecimalTypeInfo decTypeInfo = (DecimalTypeInfo) inspector.getTypeInfo();
+                recordConsumer.addBinary(decimalToBinary(vDecimal, decTypeInfo));
+                break;
+            case DATE:
+                Date vDate = ((DateObjectInspector) inspector).getPrimitiveJavaObject(value);
+                recordConsumer.addInteger(DateWritable.dateToDays(vDate));
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported primitive data type: " + inspector.getPrimitiveCategory());
+        }
+    }
+
+    private Binary decimalToBinary(final HiveDecimal hiveDecimal, final DecimalTypeInfo decimalTypeInfo)
+    {
+        int prec = decimalTypeInfo.precision();
+        int scale = decimalTypeInfo.scale();
+        byte[] decimalBytes = hiveDecimal.setScale(scale).unscaledValue().toByteArray();
+
+        // Estimated number of bytes needed.
+        int precToBytes = ParquetHiveSerDe.PRECISION_TO_BYTE_COUNT[prec - 1];
+        if (precToBytes == decimalBytes.length) {
+            // No padding needed.
+            return Binary.fromByteArray(decimalBytes);
+        }
+
+        byte[] tgt = new byte[precToBytes];
+        if (hiveDecimal.signum() == -1) {
+            // For negative number, initializing bits to 1
+            for (int i = 0; i < precToBytes; i++) {
+                tgt[i] |= 0xFF;
+            }
+        }
+
+        System.arraycopy(decimalBytes, 0, tgt, precToBytes - decimalBytes.length, decimalBytes.length); // Padding leading zeroes/ones.
+        return Binary.fromByteArray(tgt);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestMapredParquetOutputFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestMapredParquetOutputFormat.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.hive.parquet;
+package com.facebook.presto.hive.parquet.write;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
@@ -20,6 +20,7 @@ import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.Progressable;
+import parquet.hadoop.ParquetOutputFormat;
 import parquet.schema.MessageType;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ public class TestMapredParquetOutputFormat
 
     public TestMapredParquetOutputFormat(Optional<MessageType> schema)
     {
+        super(new ParquetOutputFormat<>(new TestDataWritableWriteSupport()));
         this.schema = requireNonNull(schema, "schema is null");
     }
 


### PR DESCRIPTION
- Fix reading repeated fields, when parquet consists of multiple pages,
 so the beginning of the field can be on one page
 and it's ending on the next page.

- Support empty arrays read

- Determine null values of optional fields

- Add tests for hive complex types: arrays, maps and structs

- Rewrite tests to read parquets consising of multiple pages

- Add TestDataWritableWriter with patch for empty array and empty map
 because the bug https://issues.apache.org/jira/browse/HIVE-13632
 is already fixed in current hive version,
 so presto should be able to read empty arrays too