### PR TITLE
Fix IllegalArgumentException: Input geometries must have same spatial reference

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
@@ -55,6 +55,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public final class GeoFunctions
 {
+    // EPSG:4326 spatial reference referring to the World Geodetic System (WGS) 1984
+    // This is the default spatial reference used by OGCGeometry.fromText method. We
+    // must use the same when creating geometries through other means (e.g. ST_Point(x, y))
+    // to avoid failures in verifySameSpatialReference.
+    private static final SpatialReference DEFAULT_SPATIAL_REFERENCE = SpatialReference.create(4326);
+
     private GeoFunctions() {}
 
     @Description("Returns a Geometry type LineString object from Well-Known Text representation (WKT)")
@@ -72,7 +78,7 @@ public final class GeoFunctions
     @SqlType(GEOMETRY_TYPE_NAME)
     public static Slice stPoint(@SqlType(StandardTypes.DOUBLE) double x, @SqlType(StandardTypes.DOUBLE) double y)
     {
-        OGCGeometry geometry = createFromEsriGeometry(new Point(x, y), null);
+        OGCGeometry geometry = createFromEsriGeometry(new Point(x, y), DEFAULT_SPATIAL_REFERENCE);
         return serialize(geometry);
     }
 

--- a/presto-geospatial/src/test/java/com/facebook/presto/geospatial/TestGeoQueries.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/geospatial/TestGeoQueries.java
@@ -267,6 +267,7 @@ public class TestGeoQueries
             throws Exception
     {
         assertFunction("ST_Distance(ST_Point(50, 100), ST_Point(150, 150))", DOUBLE, 111.80339887498948);
+        assertFunction("ST_Distance(ST_Point(50, 100), ST_GeometryFromText('POINT (150 150)'))", DOUBLE, 111.80339887498948);
         assertFunction("ST_Distance(ST_GeometryFromText('POINT (50 100)'), ST_GeometryFromText('POINT (150 150)'))", DOUBLE, 111.80339887498948);
         assertFunction("ST_Distance(ST_GeometryFromText('MULTIPOINT (50 100, 50 200)'), ST_GeometryFromText('Point (50 100)'))", DOUBLE, 0.0);
         assertFunction("ST_Distance(ST_GeometryFromText('LINESTRING (50 100, 50 200)'), ST_GeometryFromText('LINESTRING (10 10, 20 20)'))", DOUBLE, 85.44003745317531);


### PR DESCRIPTION
This PR fixes IllegalArgumentException when calling ST_Distance for a pair of points created using ST_GeometryFromText and ST_Point functions. For example,

ST_Distance(ST_Point(x1, y1), ST_GeometryFromText('POINT (x2 y2)')

Geometry objects created with ST_Point had null spatial reference, while objects created with ST_GeometryFromText had WGS84 spatial reference. ST_Distance function invoked for a point created with ST_Point and another point created with ST_GeometryFromText ran into spatial references 'null' and WGS84 and failed with IllegalArgumentException: Input geometries must have same spatial reference.

This PR changes ST_Point function to create Geometry object WGS84 spatial reference.