### PR TITLE
Use getTaskStatus instead of getTaskInfo.getTaskStatus

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
@@ -215,7 +215,7 @@ public class MemoryRevokingScheduler
     private long getMemoryAlreadyBeingRevoked(Collection<SqlTask> sqlTasks, MemoryPool memoryPool)
     {
         return sqlTasks.stream()
-                .filter(task -> task.getTaskInfo().getTaskStatus().getState() == TaskState.RUNNING)
+                .filter(task -> task.getTaskStatus().getState() == TaskState.RUNNING)
                 .filter(task -> task.getQueryContext().getMemoryPool() == memoryPool)
                 .mapToLong(task -> task.getQueryContext().accept(new TraversingQueryContextVisitor<Void, Long>()
                 {
@@ -242,7 +242,7 @@ public class MemoryRevokingScheduler
     {
         AtomicLong remainingBytesToRevokeAtomic = new AtomicLong(remainingBytesToRevoke);
         sqlTasks.stream()
-                .filter(task -> task.getTaskInfo().getTaskStatus().getState() == TaskState.RUNNING)
+                .filter(task -> task.getTaskStatus().getState() == TaskState.RUNNING)
                 .filter(task -> task.getQueryContext().getMemoryPool() == memoryPool)
                 .sorted(ORDER_BY_CREATE_TIME)
                 .forEach(task -> task.getQueryContext().accept(new VoidTraversingQueryContextVisitor<AtomicLong>()

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -295,11 +295,11 @@ public class SqlTask
         requireNonNull(callersCurrentState, "callersCurrentState is null");
 
         if (callersCurrentState.isDone()) {
-            return immediateFuture(getTaskInfo().getTaskStatus());
+            return immediateFuture(getTaskStatus());
         }
 
         ListenableFuture<TaskState> futureTaskState = taskStateMachine.getStateChange(callersCurrentState);
-        return Futures.transform(futureTaskState, input -> getTaskInfo().getTaskStatus());
+        return Futures.transform(futureTaskState, input -> getTaskStatus());
     }
 
     public ListenableFuture<TaskInfo> getTaskInfo(TaskState callersCurrentState)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -210,7 +210,7 @@ public class SqlTaskManager
     {
         boolean taskCanceled = false;
         for (SqlTask task : tasks.asMap().values()) {
-            if (task.getTaskInfo().getTaskStatus().getState().isDone()) {
+            if (task.getTaskStatus().getState().isDone()) {
                 continue;
             }
             task.failed(new PrestoException(SERVER_SHUTTING_DOWN, format("Server is shutting down. Task %s has been canceled", task.getTaskId())));
@@ -411,7 +411,7 @@ public class SqlTaskManager
         // already merged the final stats, we could miss the stats from this task
         // which would result in an under-count, but we will not get an over-count.
         tasks.asMap().values().stream()
-                .filter(task -> !task.getTaskInfo().getTaskStatus().getState().isDone())
+                .filter(task -> !task.getTaskStatus().getState().isDone())
                 .forEach(task -> tempIoStats.merge(task.getIoStats()));
 
         cachedStats.resetTo(tempIoStats);

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
@@ -187,7 +187,7 @@ public class TaskResource
         requireNonNull(taskId, "taskId is null");
 
         if (currentState == null || maxWait == null) {
-            TaskStatus taskStatus = taskManager.getTaskInfo(taskId).getTaskStatus();
+            TaskStatus taskStatus = taskManager.getTaskStatus(taskId);
             asyncResponse.resume(taskStatus);
             return;
         }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -622,7 +622,7 @@ public final class HttpRemoteTask
                     updateTaskInfo(result.getValue());
                 }
                 finally {
-                    if (!getTaskInfo().getTaskStatus().getState().isDone()) {
+                    if (!getTaskStatus().getState().isDone()) {
                         cleanUpLocally();
                     }
                 }


### PR DESCRIPTION
Calling getTaskInfo is more expensive than calling getTaskStatus because
more task info contains a lot more fields than task status. It is wasteful
to do so when only task status is needed.