### PR TITLE
Update minimums when scheduling splits to full nodes with TopologyAwareNodeSelector

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TopologyAwareNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TopologyAwareNodeSelector.java
@@ -239,6 +239,7 @@ public class TopologyAwareNodeSelector
             fullCandidatesConsidered++;
             int totalSplitCount = assignmentStats.getQueuedSplitCountForStage(node);
             if (totalSplitCount < min && totalSplitCount < maxPendingSplitsPerTask) {
+                min = totalSplitCount;
                 bestQueueNotFull = node;
             }
         }


### PR DESCRIPTION
The TopologyAwareNodeSelector does not correctly choose the candidate with the fewest queued splits because it never updates the minimum. This leads to an uneven distribution and hotspots, which we've observed increasing latency.

The SimpleNodeSelector appears to do the right thing.