### PR TITLE
Write ORC output streams based on the order of sizes

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -368,6 +368,11 @@ public class StripeReader
         }
     }
 
+    static boolean isIndexStream(Stream stream)
+    {
+        return stream.getStreamKind() == ROW_INDEX || stream.getStreamKind() == DICTIONARY_COUNT || stream.getStreamKind() == BLOOM_FILTER;
+    }
+
     private Map<Integer, List<HiveBloomFilter>> readBloomFilterIndexes(Map<StreamId, Stream> streams, Map<StreamId, OrcInputStream> streamsData)
             throws IOException
     {
@@ -442,11 +447,6 @@ public class StripeReader
             }
         }
         return statistics.build();
-    }
-
-    private static boolean isIndexStream(Stream stream)
-    {
-        return stream.getStreamKind() == ROW_INDEX || stream.getStreamKind() == DICTIONARY_COUNT || stream.getStreamKind() == BLOOM_FILTER;
     }
 
     private static boolean isDictionary(Stream stream, ColumnEncodingKind columnEncoding)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OutputDataStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OutputDataStream.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import com.facebook.presto.orc.metadata.Stream;
+import io.airlift.slice.SliceOutput;
+
+import javax.annotation.Nonnull;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public final class OutputDataStream
+        implements Comparable<OutputDataStream>
+{
+    private final Function<SliceOutput, Optional<Stream>> writer;
+    private final long sizeInBytes;
+
+    public OutputDataStream(Function<SliceOutput, Optional<Stream>> writer, long sizeInBytes)
+    {
+        this.writer = requireNonNull(writer, "writer is null");
+        this.sizeInBytes = sizeInBytes;
+    }
+
+    @Override
+    public int compareTo(@Nonnull OutputDataStream otherStream)
+    {
+        return Long.compare(sizeInBytes, otherStream.sizeInBytes);
+    }
+
+    public long getSizeInBytes()
+    {
+        return sizeInBytes;
+    }
+
+    public Optional<Stream> writeData(SliceOutput sliceOutput)
+    {
+        return writer.apply(sliceOutput);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -177,18 +177,6 @@ public class BooleanColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return dataStream.getBufferedBytes() + presentStream.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.BooleanStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.BooleanOutputStream;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
@@ -162,6 +163,17 @@ public class BooleanColumnWriter
         presentCheckpoint.ifPresent(booleanStreamCheckpoint -> positionList.addAll(booleanStreamCheckpoint.toPositionList(compressed)));
         positionList.addAll(dataCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<OutputDataStream> getOutputDataStreams()
+    {
+        checkState(closed);
+
+        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        return outputDataStreams.build();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.ByteOutputStream;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
@@ -161,6 +162,17 @@ public class ByteColumnWriter
         presentCheckpoint.ifPresent(booleanStreamCheckpoint -> positionList.addAll(booleanStreamCheckpoint.toPositionList(compressed)));
         positionList.addAll(dataCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<OutputDataStream> getOutputDataStreams()
+    {
+        checkState(closed);
+
+        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        return outputDataStreams.build();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -176,18 +176,6 @@ public class ByteColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return dataStream.getBufferedBytes() + presentStream.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
@@ -58,14 +58,6 @@ public interface ColumnWriter
      */
     List<OutputDataStream> getOutputDataStreams();
 
-    /**
-     * Write data streams to the output and return the streams in the
-     * order in which they were written.  The ordering is critical because
-     * the stream only contain a length with no offset.
-     */
-    List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException;
-
     long getBufferedBytes();
 
     long getRetainedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.spi.block.Block;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SliceOutput;
@@ -51,6 +52,11 @@ public interface ColumnWriter
      */
     List<Stream> writeIndexStreams(SliceOutput outputStream, MetadataWriter metadataWriter)
             throws IOException;
+
+    /**
+     * Get the data streams to be written.
+     */
+    List<OutputDataStream> getOutputDataStreams();
 
     /**
      * Write data streams to the output and return the streams in the

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
@@ -229,19 +229,6 @@ public class DecimalColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        scaleStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return dataStream.getBufferedBytes() + scaleStream.getBufferedBytes() + presentStream.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
@@ -28,6 +28,7 @@ import com.facebook.presto.orc.metadata.statistics.ShortDecimalStatisticsBuilder
 import com.facebook.presto.orc.stream.DecimalOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStreamV2;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.DecimalType;
@@ -213,6 +214,18 @@ public class DecimalColumnWriter
         positionList.addAll(dataCheckpoint.toPositionList(compressed));
         positionList.addAll(scaleCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<OutputDataStream> getOutputDataStreams()
+    {
+        checkState(closed);
+
+        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> scaleStream.writeDataStreams(column, sliceOutput), scaleStream.getBufferedBytes()));
+        return outputDataStreams.build();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -24,6 +24,7 @@ import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.DoubleStatisticsBuilder;
 import com.facebook.presto.orc.stream.DoubleOutputStream;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
@@ -163,6 +164,17 @@ public class DoubleColumnWriter
         presentCheckpoint.ifPresent(booleanStreamCheckpoint -> positionList.addAll(booleanStreamCheckpoint.toPositionList(compressed)));
         positionList.addAll(dataCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<OutputDataStream> getOutputDataStreams()
+    {
+        checkState(closed);
+
+        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        return outputDataStreams.build();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -178,18 +178,6 @@ public class DoubleColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return dataStream.getBufferedBytes() + presentStream.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -180,18 +180,6 @@ public class FloatColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return dataStream.getBufferedBytes() + presentStream.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -24,6 +24,7 @@ import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.DoubleStatisticsBuilder;
 import com.facebook.presto.orc.stream.FloatOutputStream;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
@@ -165,6 +166,17 @@ public class FloatColumnWriter
         presentCheckpoint.ifPresent(booleanStreamCheckpoint -> positionList.addAll(booleanStreamCheckpoint.toPositionList(compressed)));
         positionList.addAll(dataCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<OutputDataStream> getOutputDataStreams()
+    {
+        checkState(closed);
+
+        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        return outputDataStreams.build();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -217,19 +217,6 @@ public class ListColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        lengthStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStreams.addAll(elementWriter.writeDataStreams(outputStream));
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return lengthStream.getBufferedBytes() + presentStream.getBufferedBytes() + elementWriter.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.LongOutputStream;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.ColumnarArray;
@@ -201,6 +202,18 @@ public class ListColumnWriter
         presentCheckpoint.ifPresent(booleanStreamCheckpoint -> positionList.addAll(booleanStreamCheckpoint.toPositionList(compressed)));
         positionList.addAll(lengthCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<OutputDataStream> getOutputDataStreams()
+    {
+        checkState(closed);
+
+        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getBufferedBytes()));
+        outputDataStreams.addAll(elementWriter.getOutputDataStreams());
+        return outputDataStreams.build();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -26,6 +26,7 @@ import com.facebook.presto.orc.metadata.statistics.LongValueStatisticsBuilder;
 import com.facebook.presto.orc.stream.LongOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStreamDwrf;
 import com.facebook.presto.orc.stream.LongOutputStreamV2;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
@@ -176,6 +177,17 @@ public class LongColumnWriter
         presentCheckpoint.ifPresent(booleanStreamCheckpoint -> positionList.addAll(booleanStreamCheckpoint.toPositionList(compressed)));
         positionList.addAll(dataCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<OutputDataStream> getOutputDataStreams()
+    {
+        checkState(closed);
+
+        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        return outputDataStreams.build();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -191,18 +191,6 @@ public class LongColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return dataStream.getBufferedBytes() + presentStream.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -229,20 +229,6 @@ public class MapColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        lengthStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStreams.addAll(keyWriter.writeDataStreams(outputStream));
-        dataStreams.addAll(valueWriter.writeDataStreams(outputStream));
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return lengthStream.getBufferedBytes() + presentStream.getBufferedBytes() + keyWriter.getBufferedBytes() + valueWriter.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -29,6 +29,7 @@ import com.facebook.presto.orc.stream.ByteArrayOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStreamV1;
 import com.facebook.presto.orc.stream.LongOutputStreamV2;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.DictionaryBlock;
@@ -416,6 +417,24 @@ public class SliceDictionaryColumnWriter
         presentCheckpoint.ifPresent(booleanStreamCheckpoint -> positionList.addAll(booleanStreamCheckpoint.toPositionList(compressed)));
         positionList.addAll(dataCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<OutputDataStream> getOutputDataStreams()
+    {
+        checkState(closed);
+
+        if (directEncoded) {
+            return directColumnWriter.getOutputDataStreams();
+        }
+
+        // actually write data
+        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dictionaryLengthStream.writeDataStreams(column, sliceOutput), dictionaryLengthStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dictionaryDataStream.writeDataStreams(column, sliceOutput), dictionaryDataStream.getBufferedBytes()));
+        return outputDataStreams.build();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -438,26 +438,6 @@ public class SliceDictionaryColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        if (directEncoded) {
-            return directColumnWriter.writeDataStreams(outputStream);
-        }
-
-        // actually write data
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dictionaryLengthStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dictionaryDataStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         checkState(!closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -201,19 +201,6 @@ public class SliceDirectColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        lengthStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        dataStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return lengthStream.getBufferedBytes() + dataStream.getBufferedBytes() + presentStream.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -218,20 +218,6 @@ public class StructColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        for (ColumnWriter structField : structFields) {
-            dataStreams.addAll(structField.writeDataStreams(outputStream));
-        }
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         long bufferedBytes = presentStream.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -218,19 +218,6 @@ public class TimestampColumnWriter
     }
 
     @Override
-    public List<Stream> writeDataStreams(SliceOutput outputStream)
-            throws IOException
-    {
-        checkState(closed);
-
-        ImmutableList.Builder<Stream> dataStreams = ImmutableList.builder();
-        presentStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        secondsStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        nanosStream.writeDataStreams(column, outputStream).ifPresent(dataStreams::add);
-        return dataStreams.build();
-    }
-
-    @Override
     public long getBufferedBytes()
     {
         return secondsStream.getBufferedBytes() + nanosStream.getBufferedBytes() + presentStream.getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -25,6 +25,7 @@ import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.LongOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStreamV1;
 import com.facebook.presto.orc.stream.LongOutputStreamV2;
+import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
@@ -202,6 +203,18 @@ public class TimestampColumnWriter
         positionList.addAll(secondsCheckpoint.toPositionList(compressed));
         positionList.addAll(nanosCheckpoint.toPositionList(compressed));
         return positionList.build();
+    }
+
+    @Override
+    public List<OutputDataStream> getOutputDataStreams()
+    {
+        checkState(closed);
+
+        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> secondsStream.writeDataStreams(column, sliceOutput), secondsStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> nanosStream.writeDataStreams(column, sliceOutput), nanosStream.getBufferedBytes()));
+        return outputDataStreams.build();
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.memory.AggregatedMemoryContext;
+import com.facebook.presto.orc.metadata.Footer;
+import com.facebook.presto.orc.metadata.MetadataReader;
+import com.facebook.presto.orc.metadata.OrcMetadataReader;
+import com.facebook.presto.orc.metadata.Stream;
+import com.facebook.presto.orc.metadata.StripeFooter;
+import com.facebook.presto.orc.metadata.StripeInformation;
+import com.facebook.presto.orc.stream.OrcInputStream;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.OutputStreamSliceOutput;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
+import static com.facebook.presto.orc.OrcWriter.createOrcWriter;
+import static com.facebook.presto.orc.StripeReader.isIndexStream;
+import static com.facebook.presto.orc.TestingOrcPredicate.ORC_ROW_GROUP_SIZE;
+import static com.facebook.presto.orc.TestingOrcPredicate.ORC_STRIPE_SIZE;
+import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.toIntExact;
+import static org.testng.Assert.assertFalse;
+
+public class TestOrcWriter
+{
+    @Test
+    public void testWriteOutputStreamsInOrder()
+            throws IOException
+    {
+        TempFile tempFile = new TempFile();
+        OrcWriter writer = createOrcWriter(
+                new OutputStreamSliceOutput(new FileOutputStream(tempFile.getFile())),
+                    ImmutableList.of("test1", "test2", "test3", "test4", "test5"),
+                    ImmutableList.of(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR),
+                    NONE,
+                    new DataSize(32, MEGABYTE),
+                    ORC_STRIPE_SIZE,
+                    ORC_STRIPE_SIZE,
+                    ORC_ROW_GROUP_SIZE,
+                    new DataSize(32, MEGABYTE),
+                    ImmutableMap.of(),
+                    HIVE_STORAGE_TIME_ZONE,
+                    true);
+
+        // write down some data with unsorted streams
+        String[] data = new String[]{"a", "bbbbb", "ccc", "dd", "eeee"};
+        Block[] blocks = new Block[data.length];
+        int entries = 65536;
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), entries);
+        for (int i = 0; i < data.length; i++) {
+            byte[] bytes = data[i].getBytes();
+            for (int j = 0; j < entries; j++) {
+                // force to write different data
+                bytes[0] = (byte) ((bytes[0] + 1) % 128);
+                blockBuilder.writeBytes(Slices.wrappedBuffer(bytes, 0, bytes.length), 0, bytes.length);
+                blockBuilder.closeEntry();
+            }
+            blocks[i] = blockBuilder.build();
+            blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+        }
+
+        writer.write(new Page(blocks));
+        writer.close();
+
+        // read the footer and verify the streams are ordered by size
+        DataSize dataSize = new DataSize(1, MEGABYTE);
+        MetadataReader metadataReader = new OrcMetadataReader();
+        OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), dataSize, dataSize, dataSize, true);
+        Footer footer = new OrcReader(orcDataSource, metadataReader, dataSize, dataSize, dataSize).getFooter();
+
+        for (StripeInformation stripe : footer.getStripes()) {
+            // read the footer
+            byte[] tailBuffer = new byte[toIntExact(stripe.getFooterLength())];
+            orcDataSource.readFully(stripe.getOffset() + stripe.getIndexLength() + stripe.getDataLength(), tailBuffer);
+            try (InputStream inputStream = new OrcInputStream(orcDataSource.getId(), Slices.wrappedBuffer(tailBuffer).getInput(), Optional.empty(), new AggregatedMemoryContext())) {
+                StripeFooter stripeFooter = metadataReader.readStripeFooter(footer.getTypes(), inputStream);
+
+                int size = 0;
+                boolean dataStreamStarted = false;
+                for (Stream stream : stripeFooter.getStreams()) {
+                    if (isIndexStream(stream)) {
+                        assertFalse(dataStreamStarted);
+                        continue;
+                    }
+                    dataStreamStarted = true;
+                    // verify sizes in order
+                    assertGreaterThanOrEqual(stream.getLength(), size);
+                    size = stream.getLength();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Writing streams in the order of their sizes can be helpful to reduce the
number of IOs when reading them. It gathers all streams together so we
can use a single IO to fetch all small streams.