### PR TITLE
Fix race condition in SpillAwareLookupSourceProvider.close

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -432,7 +432,14 @@ public final class PartitionedLookupSourceFactory
         @Override
         public void close()
         {
-            LookupSource lookupSource = suppliedLookupSources.remove(this);
+            LookupSource lookupSource;
+            lock.readLock().lock();
+            try {
+                lookupSource = suppliedLookupSources.remove(this);
+            }
+            finally {
+                lock.readLock().unlock();
+            }
             if (lookupSource != null) {
                 lookupSource.close();
             }


### PR DESCRIPTION
When `SpillAwareLookupSourceProvider.close` runs concurrently with
`PartitionedLookupSourceFactory.closeCachedLookupSources`,
`LookupSource.close` can be invoked twice concurrenctly on single
`LookupSource` instance.  This is a bug, since `LookupSource` doesn't
need to be thread-safe.

Thanks to @haozhun for finding this and forcing me to rethink concurrency in PLSF