### PR TITLE
FIX: timestamp column cannot insert into postgres table

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSink.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSink.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordSink;
+import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
@@ -129,6 +130,9 @@ public class JdbcRecordSink
                 long utcMillis = TimeUnit.DAYS.toMillis(value);
                 long localMillis = ISOChronology.getInstanceUTC().getZone().getMillisKeepLocal(DateTimeZone.getDefault(), utcMillis);
                 statement.setDate(next(), new Date(localMillis));
+            }
+            else if (TimestampType.TIMESTAMP.equals(columnTypes.get(field))) {
+                statement.setTimestamp(next(), new java.sql.Timestamp(value));
             }
             else {
                 statement.setLong(next(), value);


### PR DESCRIPTION
before this fix
error message
```
Query 20171020_134656_00012_bpf4r failed: Batch entry 0 INSERT INTO ... VALUES (212588,2623,0,0,'纯视频',290178,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,1505805534000) was aborted: ERROR: column "updatetime" is of type timestamp without time zone but expression is of type bigint
  Hint: You will need to rewrite or cast the expression.
  Position: 170  Call getNextException to see other errors in the batch
```
after this fix, the insert is success and result is correct.