### PR TITLE
Add flattened query plan to QueryCompletedEvent

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -102,6 +102,15 @@ public class QueryMonitor
 
     public void queryCreatedEvent(QueryInfo queryInfo)
     {
+        Optional<String> plan = Optional.empty();
+        try {
+            if (queryInfo.getPlan().isPresent()) {
+                plan = Optional.of(objectMapper.writeValueAsString(queryInfo.getPlan().get()));
+            }
+        }
+        catch (JsonProcessingException ignored) {
+        }
+
         eventListenerManager.queryCreated(
                 new QueryCreatedEvent(
                         queryInfo.getQueryStats().getCreateTime().toDate().toInstant(),
@@ -125,6 +134,7 @@ public class QueryMonitor
                                 queryInfo.getQuery(),
                                 queryInfo.getState().toString(),
                                 queryInfo.getSelf(),
+                                plan,
                                 Optional.empty())));
     }
 
@@ -181,6 +191,11 @@ public class QueryMonitor
                 operatorSummaries.add(objectMapper.writeValueAsString(summary));
             }
 
+            Optional<String> plan = Optional.empty();
+            if (queryInfo.getPlan().isPresent()) {
+                plan = Optional.of(objectMapper.writeValueAsString(queryInfo.getPlan().get()));
+            }
+
             eventListenerManager.queryCompleted(
                     new QueryCompletedEvent(
                             new QueryMetadata(
@@ -189,6 +204,7 @@ public class QueryMonitor
                                     queryInfo.getQuery(),
                                     queryInfo.getState().toString(),
                                     queryInfo.getSelf(),
+                                    plan,
                                     queryInfo.getOutputStage().flatMap(stage -> stageInfoCodec.toJsonWithLengthLimit(stage, toIntExact(config.getMaxOutputStageJsonSize().toBytes())))),
                             new QueryStatistics(
                                     ofMillis(queryStats.getTotalCpuTime().toMillis()),

--- a/presto-main/src/main/java/com/facebook/presto/execution/PlanFlattener.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PlanFlattener.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.QueryExplainer;
+import com.facebook.presto.sql.planner.PartitioningHandle;
+import com.facebook.presto.sql.planner.PartitioningScheme;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.SimplePlanVisitor;
+import com.facebook.presto.sql.planner.SubPlan;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class PlanFlattener
+{
+    private final QueryExplainer explainer;
+    private final FlatteningVisitor visitor;
+
+    @Inject
+    public PlanFlattener(QueryExplainer explainer, ObjectMapper objectMapper)
+    {
+        this.explainer = requireNonNull(explainer, "explainer is null");
+        this.visitor = new FlatteningVisitor(requireNonNull(objectMapper, "objectMapper is null"));
+    }
+
+    public FlattenedPlan flatten(SubPlan rootStage, Session session)
+    {
+        return new FlattenedPlan(rootStage.getAllFragments().stream()
+                .map(fragment -> FlattenedPlanFragment.fromPlanFragment(fragment, explainer, session, visitor))
+                .collect(Collectors.toList()));
+    }
+
+    public static class FlattenedPlan
+    {
+        private final List<FlattenedPlanFragment> fragments;
+
+        private FlattenedPlan(List<FlattenedPlanFragment> fragments)
+        {
+            this.fragments = ImmutableList.copyOf(requireNonNull(fragments, "fragments is null"));
+        }
+
+        @JsonProperty
+        public List<FlattenedPlanFragment> getFragments()
+        {
+            return fragments;
+        }
+    }
+
+    public static class FlattenedPlanFragment
+    {
+        private final String textPlan;
+        private final List<FlattenedNode> nodes;
+        private final PlanFragment fragment;
+
+        public static FlattenedPlanFragment fromPlanFragment(PlanFragment fragment, QueryExplainer explainer, Session session, FlatteningVisitor visitor)
+        {
+            ImmutableList.Builder<FlattenedNode> nodes = ImmutableList.builder();
+            fragment.getRoot().accept(visitor, nodes);
+            return new FlattenedPlanFragment(explainer.getPlan(fragment, session), fragment, nodes.build());
+        }
+
+        private FlattenedPlanFragment(String textPlan, PlanFragment fragment, List<FlattenedNode> nodes)
+        {
+            this.textPlan = requireNonNull(textPlan, "textPlan is null");
+            this.fragment = requireNonNull(fragment, "fragment is null");
+            this.nodes = ImmutableList.copyOf(requireNonNull(nodes, "nodes is null"));
+        }
+
+        @JsonProperty
+        public PlanFragmentId getId()
+        {
+            return fragment.getId();
+        }
+
+        @JsonProperty
+        public String getTextPlan()
+        {
+            return textPlan;
+        }
+
+        @JsonProperty
+        public PlanNode getTree()
+        {
+            return fragment.getRoot();
+        }
+
+        @JsonProperty
+        public List<FlattenedNode> getNodes()
+        {
+            return nodes;
+        }
+
+        @JsonProperty
+        public Map<Symbol, Type> getSymbols()
+        {
+            return fragment.getSymbols();
+        }
+
+        @JsonProperty
+        public PartitioningHandle getPartitioning()
+        {
+            return fragment.getPartitioning();
+        }
+
+        @JsonProperty
+        public List<PlanNodeId> getPartitionedSources()
+        {
+            return fragment.getPartitionedSources();
+        }
+
+        @JsonProperty
+        public List<Type> getTypes()
+        {
+            return fragment.getTypes();
+        }
+
+        @JsonProperty
+        public Set<PlanNode> getPartitionedSourceNodes()
+        {
+            return fragment.getPartitionedSourceNodes();
+        }
+
+        @JsonProperty
+        public List<RemoteSourceNode> getRemoteSourceNodes()
+        {
+            return fragment.getRemoteSourceNodes();
+        }
+
+        @JsonProperty
+        public PartitioningScheme getPartitioningScheme()
+        {
+            return fragment.getPartitioningScheme();
+        }
+    }
+
+    public static class FlattenedNode
+    {
+        private final String node;
+
+        public FlattenedNode(String node)
+        {
+            this.node = requireNonNull(node, "node is null");
+        }
+
+        @JsonValue
+        @JsonRawValue
+        public String getNode()
+        {
+            return node;
+        }
+    }
+
+    private static class FlatteningVisitor
+            extends SimplePlanVisitor<ImmutableList.Builder<FlattenedNode>>
+    {
+        private final ObjectMapper flatteningMapper;
+
+        public FlatteningVisitor(ObjectMapper originalMapper)
+        {
+            this.flatteningMapper = originalMapper.copy();
+
+            PlanNodeFlatteningSerializer flattener = new PlanNodeFlatteningSerializer(originalMapper.getSerializerProviderInstance());
+            flatteningMapper.registerModule(new SimpleModule().addSerializer(PlanNode.class, flattener));
+        }
+
+        @Override
+        protected Void visitPlan(PlanNode node, ImmutableList.Builder<FlattenedNode> context)
+        {
+            try {
+                context.add(new FlattenedNode(flatteningMapper.writeValueAsString(node)));
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException("Unable to flatten plan node", e);
+            }
+            return super.visitPlan(node, context);
+        }
+    }
+
+    /**
+     * The children of the given node should be serialized with only the properties of the PlanNode supertype.
+     * This is accomplished using different techniques to serialize the root (i.e. the node it's passed) and
+     * that node's children. For the root, it uses the subtype serializer (e.g. OutputNode), for children it uses
+     * the supertype serializer (i.e. the serializer for PlanNode).
+     */
+    private static class PlanNodeFlatteningSerializer
+            extends JsonSerializer<PlanNode>
+    {
+        private final SerializerProvider provider;
+        private final JsonSerializer<Object> superTypeSerializer;
+
+        private boolean rootLevel = true;
+
+        public PlanNodeFlatteningSerializer(SerializerProvider provider)
+        {
+            this.provider = provider;
+            try {
+                this.superTypeSerializer = provider.findTypedValueSerializer(PlanNode.class, false, null);
+            }
+            catch (JsonMappingException e) {
+                throw new RuntimeException("Unable to serialize plan node", e);
+            }
+        }
+
+        @Override
+        public void serialize(PlanNode value, JsonGenerator jgen, SerializerProvider provider)
+                throws IOException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void serializeWithType(PlanNode value, JsonGenerator gen, SerializerProvider serializers, TypeSerializer typeSer)
+                throws IOException
+        {
+            if (rootLevel) {
+                rootLevel = false;
+                try {
+                    JsonSerializer<Object> subTypeSerializer = provider.findTypedValueSerializer(value.getClass(), true, null);
+                    subTypeSerializer.serializeWithType(value, gen, serializers, typeSer);
+                }
+                finally {
+                    rootLevel = true;
+                }
+                return;
+            }
+
+            superTypeSerializer.serializeWithType(value, gen, serializers, typeSer);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.SessionRepresentation;
 import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.execution.PlanFlattener.FlattenedPlan;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.ErrorType;
 import com.facebook.presto.spi.QueryId;
@@ -64,6 +65,7 @@ public class QueryInfo
     private final ErrorCode errorCode;
     private final Set<Input> inputs;
     private final Optional<Output> output;
+    private final Optional<FlattenedPlan> plan;
     private final boolean completeInfo;
     private final Optional<String> resourceGroupName;
 
@@ -90,6 +92,7 @@ public class QueryInfo
             @JsonProperty("errorCode") ErrorCode errorCode,
             @JsonProperty("inputs") Set<Input> inputs,
             @JsonProperty("output") Optional<Output> output,
+            @JsonProperty("flattenedPlan") Optional<FlattenedPlan> plan,
             @JsonProperty("completeInfo") boolean completeInfo,
             @JsonProperty("resourceGroupName") Optional<String> resourceGroupName)
     {
@@ -108,6 +111,7 @@ public class QueryInfo
         requireNonNull(outputStage, "outputStage is null");
         requireNonNull(inputs, "inputs is null");
         requireNonNull(output, "output is null");
+        requireNonNull(plan, "plan is null");
         requireNonNull(resourceGroupName, "resourceGroupName is null");
 
         this.queryId = queryId;
@@ -132,6 +136,7 @@ public class QueryInfo
         this.errorCode = errorCode;
         this.inputs = ImmutableSet.copyOf(inputs);
         this.output = output;
+        this.plan = plan;
         this.completeInfo = completeInfo;
         this.resourceGroupName = resourceGroupName;
     }
@@ -276,6 +281,12 @@ public class QueryInfo
     public Optional<Output> getOutput()
     {
         return output;
+    }
+
+    @JsonProperty
+    public Optional<FlattenedPlan> getPlan()
+    {
+        return plan;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.execution.PlanFlattener.FlattenedPlan;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
@@ -129,6 +130,8 @@ public class QueryStateMachine
 
     private final AtomicReference<Set<Input>> inputs = new AtomicReference<>(ImmutableSet.of());
     private final AtomicReference<Optional<Output>> output = new AtomicReference<>(Optional.empty());
+    private final AtomicReference<Optional<FlattenedPlan>> flattenedPlan = new AtomicReference<>(Optional.empty());
+
     private final StateMachine<Optional<QueryInfo>> finalQueryInfo;
 
     private final AtomicReference<ResourceGroupId> resourceGroup = new AtomicReference<>();
@@ -440,6 +443,7 @@ public class QueryStateMachine
                 errorCode,
                 inputs.get(),
                 output.get(),
+                flattenedPlan.get(),
                 completeInfo,
                 getResourceGroup().map(ResourceGroupId::toString));
     }
@@ -470,6 +474,11 @@ public class QueryStateMachine
     {
         requireNonNull(output, "output is null");
         this.output.set(output);
+    }
+
+    public void setPlan(FlattenedPlan plan)
+    {
+        this.flattenedPlan.set(Optional.of(plan));
     }
 
     public Map<String, String> getSetSessionProperties()
@@ -787,6 +796,7 @@ public class QueryStateMachine
                 queryInfo.getErrorCode(),
                 queryInfo.getInputs(),
                 queryInfo.getOutput(),
+                queryInfo.getPlan(),
                 queryInfo.isCompleteInfo(),
                 queryInfo.getResourceGroupName());
         finalQueryInfo.compareAndSet(finalInfo, Optional.of(prunedQueryInfo));

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -131,6 +131,7 @@ public final class SqlQueryExecution
     private final FailureDetector failureDetector;
 
     private final QueryExplainer queryExplainer;
+    private final PlanFlattener planFlattener;
     private final CostCalculator costCalculator;
     private final AtomicReference<SqlQueryScheduler> queryScheduler = new AtomicReference<>();
     private final AtomicReference<Plan> queryPlan = new AtomicReference<>();
@@ -161,6 +162,7 @@ public final class SqlQueryExecution
             FailureDetector failureDetector,
             NodeTaskMap nodeTaskMap,
             QueryExplainer queryExplainer,
+            PlanFlattener planFlattener,
             ExecutionPolicy executionPolicy,
             List<Expression> parameters,
             SplitSchedulerStats schedulerStats)
@@ -181,6 +183,7 @@ public final class SqlQueryExecution
             this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
             this.executionPolicy = requireNonNull(executionPolicy, "executionPolicy is null");
             this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
+            this.planFlattener = requireNonNull(planFlattener, "planFlattener is null");
             this.parameters = requireNonNull(parameters);
             this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
 
@@ -372,13 +375,14 @@ public final class SqlQueryExecution
         stateMachine.setOutput(output);
 
         // fragment the plan
-        SubPlan subplan = PlanFragmenter.createSubPlans(stateMachine.getSession(), metadata, plan);
+        SubPlan fragmentedPlan = PlanFragmenter.createSubPlans(stateMachine.getSession(), metadata, plan);
+        stateMachine.setPlan(planFlattener.flatten(fragmentedPlan, stateMachine.getSession()));
 
         // record analysis time
         stateMachine.recordAnalysisTime(analysisStart);
 
         boolean explainAnalyze = analysis.getStatement() instanceof Explain && ((Explain) analysis.getStatement()).isAnalyze();
-        return new PlanRoot(subplan, !explainAnalyze, extractConnectors(analysis));
+        return new PlanRoot(fragmentedPlan, !explainAnalyze, extractConnectors(analysis));
     }
 
     private Set<ConnectorId> extractConnectors(Analysis analysis)
@@ -644,6 +648,7 @@ public final class SqlQueryExecution
         private final RemoteTaskFactory remoteTaskFactory;
         private final TransactionManager transactionManager;
         private final QueryExplainer queryExplainer;
+        private final PlanFlattener planFlattener;
         private final LocationFactory locationFactory;
         private final ExecutorService executor;
         private final FailureDetector failureDetector;
@@ -668,6 +673,7 @@ public final class SqlQueryExecution
                 FailureDetector failureDetector,
                 NodeTaskMap nodeTaskMap,
                 QueryExplainer queryExplainer,
+                PlanFlattener planFlattener,
                 Map<String, ExecutionPolicy> executionPolicies,
                 SplitSchedulerStats schedulerStats)
         {
@@ -689,6 +695,7 @@ public final class SqlQueryExecution
             this.failureDetector = requireNonNull(failureDetector, "failureDetector is null");
             this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
             this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
+            this.planFlattener = requireNonNull(planFlattener, "planFlattener is null");
 
             this.executionPolicies = requireNonNull(executionPolicies, "schedulerPolicies is null");
             this.costCalculator = requireNonNull(costCalculator, "cost calculator is null");
@@ -724,6 +731,7 @@ public final class SqlQueryExecution
                     failureDetector,
                     nodeTaskMap,
                     queryExplainer,
+                    planFlattener,
                     executionPolicy,
                     parameters,
                     schedulerStats);

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -28,6 +28,7 @@ import com.facebook.presto.execution.DropTableTask;
 import com.facebook.presto.execution.DropViewTask;
 import com.facebook.presto.execution.ForQueryExecution;
 import com.facebook.presto.execution.GrantTask;
+import com.facebook.presto.execution.PlanFlattener;
 import com.facebook.presto.execution.PrepareTask;
 import com.facebook.presto.execution.QueryExecution;
 import com.facebook.presto.execution.QueryExecutionMBean;
@@ -187,8 +188,9 @@ public class CoordinatorModule
         // cluster statistics
         jaxrsBinder(binder).bind(ClusterStatsResource.class);
 
-        // query explainer
+        // explainers
         binder.bind(QueryExplainer.class).in(Scopes.SINGLETON);
+        binder.bind(PlanFlattener.class).in(Scopes.SINGLETON);
 
         // execution scheduler
         binder.bind(RemoteTaskFactory.class).to(HttpRemoteTaskFactory.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -21,6 +21,7 @@ import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.LogicalPlanner;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.PlanOptimizers;
@@ -104,6 +105,11 @@ public class QueryExplainer
                 return PlanPrinter.textDistributedPlan(subPlan, metadata, costCalculator, session);
         }
         throw new IllegalArgumentException("Unhandled plan type: " + planType);
+    }
+
+    public String getPlan(PlanFragment fragment, Session session)
+    {
+        return PlanPrinter.textPlanFragment(fragment, metadata, costCalculator, session);
     }
 
     private static <T extends Statement> String explainTask(Statement statement, DataDefinitionTask<T> task, List<Expression> parameters)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -235,6 +235,11 @@ public class PlanPrinter
         return builder.toString();
     }
 
+    public static String textPlanFragment(PlanFragment fragment, Metadata metadata, CostCalculator costCalculator, Session session)
+    {
+        return formatFragment(metadata, costCalculator, session, fragment, Optional.empty(), Optional.empty(), false);
+    }
+
     private static String formatFragment(Metadata metadata, CostCalculator costCalculator, Session session, PlanFragment fragment, Optional<StageInfo> stageInfo, Optional<Map<PlanNodeId, PlanNodeStats>> planNodeStats, boolean verbose)
     {
         StringBuilder builder = new StringBuilder();

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -160,6 +160,7 @@ public class MockQueryExecution
                 null,
                 ImmutableSet.of(),
                 Optional.empty(),
+                Optional.empty(),
                 state.isDone(),
                 Optional.empty());
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -98,6 +98,7 @@ public class TestBasicQueryInfo
                         StandardErrorCode.ABANDONED_QUERY.toErrorCode(),
                         ImmutableSet.of(),
                         Optional.empty(),
+                        Optional.empty(),
                         false,
                         Optional.empty()));
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -278,6 +278,7 @@ public class TestQueryStateInfo
                 null,
                 ImmutableSet.of(),
                 Optional.empty(),
+                Optional.empty(),
                 false,
                 Optional.empty());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
@@ -30,6 +30,8 @@ public class QueryMetadata
 
     private final URI uri;
 
+    private final Optional<String> plan;
+
     private final Optional<String> payload;
 
     public QueryMetadata(
@@ -38,6 +40,7 @@ public class QueryMetadata
             String query,
             String queryState,
             URI uri,
+            Optional<String> plan,
             Optional<String> payload)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
@@ -45,6 +48,7 @@ public class QueryMetadata
         this.query = requireNonNull(query, "query is null");
         this.queryState = requireNonNull(queryState, "queryState is null");
         this.uri = requireNonNull(uri, "uri is null");
+        this.plan = requireNonNull(plan, "plan is null");
         this.payload = requireNonNull(payload, "payload is null");
     }
 
@@ -76,6 +80,12 @@ public class QueryMetadata
     public URI getUri()
     {
         return uri;
+    }
+
+    @JsonProperty
+    public Optional<String> getPlan()
+    {
+        return plan;
     }
 
     @JsonProperty


### PR DESCRIPTION
Flattened plans contain textual representations of every fragment, the
plan tree, and a flattened list of nodes. The flattened list is
constructed using a visitor with a custom serializer which produces
only ids and types for children. This format was selected to simplify
post-hoc plan analysis.

Closes #9016