### PR TITLE
Add current memory to QueryProgressStats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/QueryProgressStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryProgressStats.java
@@ -31,6 +31,7 @@ public class QueryProgressStats
     private final long cpuTimeMillis;
     private final long scheduledTimeMillis;
     private final long blockedTimeMillis;
+    private final long currentMemoryBytes;
     private final long peakMemoryBytes;
     private final long inputRows;
     private final long inputBytes;
@@ -45,6 +46,7 @@ public class QueryProgressStats
             @JsonProperty("cpuTimeMillis") long cpuTimeMillis,
             @JsonProperty("scheduledTimeMillis") long scheduledTimeMillis,
             @JsonProperty("blockedTimeMillis") long blockedTimeMillis,
+            @JsonProperty("currentMemoryBytes") long currentMemoryBytes,
             @JsonProperty("peakMemoryBytes") long peakMemoryBytes,
             @JsonProperty("inputRows") long inputRows,
             @JsonProperty("inputBytes") long inputBytes,
@@ -57,6 +59,7 @@ public class QueryProgressStats
         this.cpuTimeMillis = cpuTimeMillis;
         this.scheduledTimeMillis = scheduledTimeMillis;
         this.blockedTimeMillis = blockedTimeMillis;
+        this.currentMemoryBytes = currentMemoryBytes;
         this.peakMemoryBytes = peakMemoryBytes;
         this.inputRows = inputRows;
         this.inputBytes = inputBytes;
@@ -73,6 +76,7 @@ public class QueryProgressStats
                 queryStats.getTotalCpuTime().toMillis(),
                 queryStats.getTotalScheduledTime().toMillis(),
                 queryStats.getTotalBlockedTime().toMillis(),
+                queryStats.getTotalMemoryReservation().toBytes(),
                 queryStats.getPeakMemoryReservation().toBytes(),
                 queryStats.getRawInputPositions(),
                 queryStats.getRawInputDataSize().toBytes(),
@@ -114,6 +118,12 @@ public class QueryProgressStats
     public long getBlockedTimeMillis()
     {
         return blockedTimeMillis;
+    }
+
+    @JsonProperty
+    public long getCurrentMemoryBytes()
+    {
+        return currentMemoryBytes;
     }
 
     @JsonProperty

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryProgressStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryProgressStats.java
@@ -34,6 +34,7 @@ public class TestQueryProgressStats
                 22222,
                 3333,
                 444,
+                100000,
                 34230492,
                 1000,
                 100000,
@@ -50,6 +51,7 @@ public class TestQueryProgressStats
         assertEquals(actual.getCpuTimeMillis(), 22222);
         assertEquals(actual.getScheduledTimeMillis(), 3333);
         assertEquals(actual.getBlockedTimeMillis(), 444);
+        assertEquals(actual.getCurrentMemoryBytes(), 100000);
         assertEquals(actual.getPeakMemoryBytes(), 34230492);
         assertEquals(actual.getInputRows(), 1000);
         assertEquals(actual.getInputBytes(), 100000);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -213,6 +213,7 @@ public class TestQueryStateInfo
         assertEquals(progress.getCpuTimeMillis(), Duration.valueOf("24m").toMillis());
         assertEquals(progress.getScheduledTimeMillis(), Duration.valueOf("23m").toMillis());
         assertEquals(progress.getBlockedTimeMillis(), Duration.valueOf("26m").toMillis());
+        assertEquals(progress.getCurrentMemoryBytes(), DataSize.valueOf("21GB").toBytes());
         assertEquals(progress.getPeakMemoryBytes(), DataSize.valueOf("22GB").toBytes());
         assertEquals(progress.getInputRows(), 28);
         assertEquals(progress.getInputBytes(), DataSize.valueOf("27GB").toBytes());

--- a/presto-main/src/test/java/com/facebook/presto/server/TestResourceGroupStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestResourceGroupStateInfo.java
@@ -69,6 +69,7 @@ public class TestResourceGroupStateInfo
                                 1541,
                                 566038,
                                 1680000,
+                                0,
                                 24,
                                 124539,
                                 8283750,
@@ -120,6 +121,7 @@ public class TestResourceGroupStateInfo
         assertEquals(progressStats.getCpuTimeMillis(), 1541);
         assertEquals(progressStats.getScheduledTimeMillis(), 566038);
         assertEquals(progressStats.getBlockedTimeMillis(), 1680000);
+        assertEquals(progressStats.getCurrentMemoryBytes(), 0);
         assertEquals(progressStats.getPeakMemoryBytes(), 24);
         assertEquals(progressStats.getInputRows(), 124539);
         assertEquals(progressStats.getInputBytes(), 8283750);


### PR DESCRIPTION
totalMemoryReservation in QueryStats is an aggregate of memoryReservation from all tasks.