### PR TITLE
Add eager compact option into PagesIndex

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -93,7 +93,7 @@ public class HashBuildAndJoinBenchmark
                 ImmutableList.of(),
                 1_500_000,
                 1,
-                new PagesIndex.TestingFactory(),
+                new PagesIndex.TestingFactory(false),
                 false,
                 SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
         driversBuilder.add(hashBuilder);

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -67,7 +67,7 @@ public class HashBuildBenchmark
                 ImmutableList.of(),
                 1_500_000,
                 1,
-                new PagesIndex.TestingFactory(),
+                new PagesIndex.TestingFactory(false),
                 false,
                 SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
         DriverFactory hashBuildDriverFactory = new DriverFactory(0, true, true, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -76,7 +76,7 @@ public class HashJoinBenchmark
                     ImmutableList.of(),
                     1_500_000,
                     1,
-                    new PagesIndex.TestingFactory(),
+                    new PagesIndex.TestingFactory(false),
                     false,
                     SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OrderByBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OrderByBenchmark.java
@@ -51,7 +51,7 @@ public class OrderByBenchmark
                 ROWS,
                 ImmutableList.of(0),
                 ImmutableList.of(ASC_NULLS_LAST),
-                new PagesIndex.TestingFactory());
+                new PagesIndex.TestingFactory(false));
 
         return ImmutableList.of(tableScanOperator, limitOperator, orderByOperator);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -57,6 +57,7 @@ public class FeaturesConfig
     private boolean legacyMapSubscript;
     private boolean optimizeMixedDistinctAggregations;
     private boolean forceSingleNodeOutput = true;
+    private boolean pagesIndexEagerCompactionEnabled;
 
     private boolean dictionaryAggregation;
     private boolean resourceGroups;
@@ -469,6 +470,18 @@ public class FeaturesConfig
     public FeaturesConfig setForceSingleNodeOutput(boolean value)
     {
         this.forceSingleNodeOutput = value;
+        return this;
+    }
+
+    public boolean isPagesIndexEagerCompactionEnabled()
+    {
+        return pagesIndexEagerCompactionEnabled;
+    }
+
+    @Config("pages-index.eager-compaction-enabled")
+    public FeaturesConfig setPagesIndexEagerCompactionEnabled(boolean pagesIndexEagerCompactionEnabled)
+    {
+        this.pagesIndexEagerCompactionEnabled = pagesIndexEagerCompactionEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -285,7 +285,7 @@ public class LocalQueryRunner
         this.sqlParser = new SqlParser();
         this.nodeManager = new InMemoryNodeManager();
         this.typeRegistry = new TypeRegistry();
-        this.pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory());
+        this.pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
         this.pageIndexerFactory = new GroupByHashPageIndexerFactory(new JoinCompiler());
         this.indexManager = new IndexManager();
         NodeScheduler nodeScheduler = new NodeScheduler(
@@ -639,7 +639,7 @@ public class LocalQueryRunner
                 singleStreamSpillerFactory,
                 partitioningSpillerFactory,
                 blockEncodingSerde,
-                new PagesIndex.TestingFactory(),
+                new PagesIndex.TestingFactory(false),
                 new JoinCompiler(),
                 new LookupJoinOperators(new JoinProbeCompiler()));
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
@@ -35,7 +35,7 @@ public class TestingConnectorContext
 {
     private final NodeManager nodeManager = new ConnectorAwareNodeManager(new InMemoryNodeManager(), "testenv", new ConnectorId("test"));
     private final TypeManager typeManager = new TypeRegistry();
-    private final PageSorter pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory());
+    private final PageSorter pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
     private final PageIndexerFactory pageIndexerFactory = new GroupByHashPageIndexerFactory(new JoinCompiler());
 
     public TestingConnectorContext()

--- a/presto-main/src/test/java/com/facebook/presto/BenchmarkPagesIndexPageSorter.java
+++ b/presto-main/src/test/java/com/facebook/presto/BenchmarkPagesIndexPageSorter.java
@@ -56,7 +56,7 @@ public class BenchmarkPagesIndexPageSorter
     @Benchmark
     public int runBenchmark(BenchmarkData data)
     {
-        PageSorter pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory());
+        PageSorter pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
         long[] addresses = pageSorter.sort(data.types, data.pages, data.sortChannels, nCopies(data.sortChannels.size(), ASC_NULLS_FIRST), 10_000);
         return addresses.length;
     }

--- a/presto-main/src/test/java/com/facebook/presto/TestPagesIndexPageSorter.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestPagesIndexPageSorter.java
@@ -36,7 +36,7 @@ import static org.testng.Assert.assertEquals;
 
 public class TestPagesIndexPageSorter
 {
-    private static final PagesIndexPageSorter sorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory());
+    private static final PagesIndexPageSorter sorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
 
     @Test
     public void testPageSorter()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -148,7 +148,7 @@ public final class TaskTestUtils
                     throw new UnsupportedOperationException();
                 },
                 new TestingBlockEncodingSerde(new TestingTypeManager()),
-                new PagesIndex.TestingFactory(),
+                new PagesIndex.TestingFactory(false),
                 new JoinCompiler(),
                 new LookupJoinOperators(new JoinProbeCompiler()));
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -296,7 +296,7 @@ public class BenchmarkHashBuildAndJoinOperators
                 ImmutableList.of(),
                 10_000,
                 1,
-                new PagesIndex.TestingFactory(),
+                new PagesIndex.TestingFactory(false),
                 false,
                 SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -1074,7 +1074,7 @@ public class TestHashJoinOperator
                 ImmutableList.of(),
                 100,
                 partitionCount,
-                new PagesIndex.TestingFactory(),
+                new PagesIndex.TestingFactory(false),
                 spillEnabled,
                 singleStreamSpillerFactory);
         PipelineContext buildPipeline = taskContext.addPipelineContext(1, true, true);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
@@ -88,7 +88,7 @@ public class TestOrderByOperator
                 10,
                 ImmutableList.of(0),
                 ImmutableList.of(ASC_NULLS_LAST),
-                new PagesIndex.TestingFactory());
+                new PagesIndex.TestingFactory(false));
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), DOUBLE)
                 .row(-0.1)
@@ -120,7 +120,7 @@ public class TestOrderByOperator
                 10,
                 ImmutableList.of(0, 1),
                 ImmutableList.of(ASC_NULLS_LAST, DESC_NULLS_LAST),
-                new PagesIndex.TestingFactory());
+                new PagesIndex.TestingFactory(false));
 
         MaterializedResult expected = MaterializedResult.resultBuilder(driverContext.getSession(), VARCHAR, BIGINT)
                 .row("a", 4L)
@@ -152,7 +152,7 @@ public class TestOrderByOperator
                 10,
                 ImmutableList.of(0),
                 ImmutableList.of(DESC_NULLS_LAST),
-                new PagesIndex.TestingFactory());
+                new PagesIndex.TestingFactory(false));
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT)
                 .row(4L)
@@ -188,7 +188,7 @@ public class TestOrderByOperator
                 10,
                 ImmutableList.of(0),
                 ImmutableList.of(ASC_NULLS_LAST),
-                new PagesIndex.TestingFactory());
+                new PagesIndex.TestingFactory(false));
 
         toPages(operatorFactory, driverContext, input);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
@@ -669,6 +669,6 @@ public class TestWindowOperator
                 sortOrder,
                 preSortedChannelPrefix,
                 10,
-                new PagesIndex.TestingFactory());
+                new PagesIndex.TestingFactory(false));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -65,7 +65,8 @@ public class TestFeaturesConfig
                 .setExchangeCompressionEnabled(false)
                 .setEnableIntermediateAggregations(false)
                 .setPushAggregationThroughJoin(true)
-                .setForceSingleNodeOutput(true));
+                .setForceSingleNodeOutput(true)
+                .setPagesIndexEagerCompactionEnabled(false));
     }
 
     @Test
@@ -104,6 +105,7 @@ public class TestFeaturesConfig
                 .put("exchange.compression-enabled", "true")
                 .put("optimizer.enable-intermediate-aggregations", "true")
                 .put("optimizer.force-single-node-output", "false")
+                .put("pages-index.eager-compaction-enabled", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -138,7 +140,8 @@ public class TestFeaturesConfig
                 .setLegacyOrderBy(true)
                 .setExchangeCompressionEnabled(true)
                 .setEnableIntermediateAggregations(true)
-                .setForceSingleNodeOutput(false);
+                .setForceSingleNodeOutput(false)
+                .setPagesIndexEagerCompactionEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -84,7 +84,7 @@ public class TestRaptorConnector
                 new RaptorMetadataFactory(connectorId, dbi, shardManager),
                 new RaptorSplitManager(connectorId, nodeSupplier, shardManager, false),
                 new RaptorPageSourceProvider(storageManager),
-                new RaptorPageSinkProvider(storageManager, new PagesIndexPageSorter(new PagesIndex.TestingFactory()), config),
+                new RaptorPageSinkProvider(storageManager, new PagesIndexPageSorter(new PagesIndex.TestingFactory(false)), config),
                 new RaptorNodePartitioningProvider(nodeSupplier),
                 new RaptorSessionProperties(config),
                 new RaptorTableProperties(typeRegistry),

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardCompactor.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardCompactor.java
@@ -71,7 +71,7 @@ import static java.util.stream.Collectors.toSet;
 public class TestShardCompactor
 {
     private static final int MAX_SHARD_ROWS = 1000;
-    private static final PagesIndexPageSorter PAGE_SORTER = new PagesIndexPageSorter(new PagesIndex.TestingFactory());
+    private static final PagesIndexPageSorter PAGE_SORTER = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
     private static final ReaderAttributes READER_ATTRIBUTES = new ReaderAttributes(new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
 
     private OrcStorageManager storageManager;


### PR DESCRIPTION
Currently PagesIndex compacts the blocks lazily. It is only compacted
when the HashBuilderOperator or OrderByOperator hold it cannot reserve
the memory required.

However, compacting blocks requires to copy them. Thus when the cluster
is running low on memory and multiple operators is requesting memory,
all these operators will start to compact the PagesIndex and put a huge
pressure on the memory, which frequently causes full GC.

Adding the eager compact option into PagesIndex allows PagesIndex to
compact Immediately whenever a new page is added.