### PR TITLE
Fix #9164, error when drop column from hive table

### DIFF
--- a/presto-docs/src/main/sphinx/sql/alter-schema.rst
+++ b/presto-docs/src/main/sphinx/sql/alter-schema.rst
@@ -19,7 +19,7 @@ Examples
 
 Rename schema ``web`` to ``traffic``::
 
-    ALTER TABLE web RENAME TO traffic
+    ALTER SCHEMA web RENAME TO traffic
 
 See Also
 --------

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/BridgingHiveMetastore.java
@@ -210,12 +210,9 @@ public class BridgingHiveMetastore
     {
         verifyCanDropColumn(this, databaseName, tableName, columnName);
         org.apache.hadoop.hive.metastore.api.Table table = delegate.getTable(databaseName, tableName)
-                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
-        for (FieldSchema fieldSchema : table.getSd().getCols()) {
-            if (fieldSchema.getName().equals(columnName)) {
-                table.getSd().getCols().remove(fieldSchema);
-            }
-        }
+                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)))
+                .deepCopy();
+        table.getSd().getCols().removeIf(fieldSchema -> fieldSchema.getName().equals(columnName));
         alterTable(databaseName, tableName, table);
     }
 


### PR DESCRIPTION
I was able to reproduce #9164, then applied changes suggested by @electrum which resolve the issue. I opted to use `removeIf` which calls `iterator()` and `Iterator.remove()` under the hood: https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html#removeIf-java.util.function.Predicate-

I see other methods in `BridgingHiveMetastore` (eg: `renameColumn`) that retrieve an object and modify it without making a copy first. Should we address those? I can append commits to this PR.