### PR TITLE
Fix transaction support in client and CLI

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.facebook.presto.client.ClientSession.stripTransactionId;
 import static com.facebook.presto.client.OkHttpUtil.basicAuth;
 import static com.facebook.presto.client.OkHttpUtil.setupHttpProxy;
 import static com.facebook.presto.client.OkHttpUtil.setupKerberos;
@@ -94,12 +95,17 @@ public class QueryRunner
 
     public Query startQuery(String query)
     {
-        return new Query(startInternalQuery(query));
+        return new Query(startInternalQuery(session.get(), query));
     }
 
     public StatementClient startInternalQuery(String query)
     {
-        return new StatementClient(httpClient, session.get(), query);
+        return startInternalQuery(stripTransactionId(session.get()), query);
+    }
+
+    private StatementClient startInternalQuery(ClientSession session, String query)
+    {
+        return new StatementClient(httpClient, session, query);
     }
 
     @Override

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -338,7 +338,7 @@ public class StatementClient
         if (startedTransactionId != null) {
             this.startedtransactionId.set(startedTransactionId);
         }
-        if (headers.values(PRESTO_CLEAR_TRANSACTION_ID) != null) {
+        if (headers.get(PRESTO_CLEAR_TRANSACTION_ID) != null) {
             clearTransactionId.set(true);
         }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliProcess.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliProcess.java
@@ -19,14 +19,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static java.util.regex.Pattern.quote;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class PrestoCliProcess
         extends LocalCliProcess
 {
-    private static final String PRESTO_PROMPT = "presto>";
-    private static final Pattern PRESTO_PROMPT_PATTERN = Pattern.compile(quote(PRESTO_PROMPT));
+    private static final Pattern PRESTO_PROMPT_PATTERN = Pattern.compile("presto(:[a-z0-9_]+)?>");
 
     public PrestoCliProcess(Process process)
     {
@@ -45,6 +43,6 @@ public final class PrestoCliProcess
 
     public void waitForPrompt()
     {
-        assertThat(nextOutputToken()).isEqualTo(PRESTO_PROMPT);
+        assertThat(nextOutputToken()).matches(PRESTO_PROMPT_PATTERN);
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoCliTests.java
@@ -141,6 +141,62 @@ public class PrestoCliTests
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
     }
 
+    @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldHandleTransaction()
+            throws IOException, InterruptedException
+    {
+        launchPrestoCliWithServerArgument();
+        presto.waitForPrompt();
+
+        presto.getProcessInput().println("use hive.default;");
+        presto.readLinesUntilPrompt();
+
+        // start transaction and create table
+        presto.getProcessInput().println("start transaction;");
+        assertThat(presto.readLinesUntilPrompt()).contains("START TRANSACTION");
+
+        presto.getProcessInput().println("create table txn_test (x bigint);");
+        assertThat(presto.readLinesUntilPrompt()).contains("CREATE TABLE");
+
+        // cause an error that aborts the transaction
+        presto.getProcessInput().println("select foo;");
+        assertThat(presto.readLinesUntilPrompt()).extracting(PrestoCliTests::removePrefix)
+                .contains("line 1:8: Column 'foo' cannot be resolved");
+
+        // verify commands are rejected until rollback
+        presto.getProcessInput().println("select * from nation;");
+        assertThat(presto.readLinesUntilPrompt()).extracting(PrestoCliTests::removePrefix)
+                .contains("Current transaction is aborted, commands ignored until end of transaction block");
+
+        presto.getProcessInput().println("rollback;");
+        assertThat(presto.readLinesUntilPrompt()).contains("ROLLBACK");
+
+        // verify commands work after rollback
+        presto.getProcessInput().println("select * from nation;");
+        assertThat(trimLines(presto.readLinesUntilPrompt())).containsAll(nationTableInteractiveLines);
+
+        // verify table was not created
+        presto.getProcessInput().println("show tables;");
+        assertThat(trimLines(presto.readLinesUntilPrompt())).doesNotContain("txn_test");
+
+        // start transaction, create two tables and commit
+        presto.getProcessInput().println("start transaction;");
+        assertThat(presto.readLinesUntilPrompt()).contains("START TRANSACTION");
+
+        presto.getProcessInput().println("create table txn_test1 (x bigint);");
+        assertThat(presto.readLinesUntilPrompt()).contains("CREATE TABLE");
+
+        presto.getProcessInput().println("create table txn_test2 (x bigint);");
+        assertThat(presto.readLinesUntilPrompt()).contains("CREATE TABLE");
+
+        presto.getProcessInput().println("commit;");
+        assertThat(presto.readLinesUntilPrompt()).contains("COMMIT");
+
+        // verify tables were created
+        presto.getProcessInput().println("show tables;");
+        assertThat(trimLines(presto.readLinesUntilPrompt())).contains("txn_test1", "txn_test2");
+    }
+
     private void launchPrestoCliWithServerArgument(String... arguments)
             throws IOException, InterruptedException
     {
@@ -175,5 +231,11 @@ public class PrestoCliTests
 
         prestoClientOptions.add(arguments);
         launchPrestoCli(prestoClientOptions.build());
+    }
+
+    private static String removePrefix(String line)
+    {
+        int i = line.indexOf(':');
+        return (i >= 0) ? line.substring(i + 1).trim() : line;
     }
 }

--- a/presto-product-tests/src/main/resources/com/facebook/presto/tests/cli/interactive_query.results
+++ b/presto-product-tests/src/main/resources/com/facebook/presto/tests/cli/interactive_query.results
@@ -1,4 +1,3 @@
-select * from hive.default.nation;
 n_nationkey |     n_name     | n_regionkey |                                                     n_comment
 -------------+----------------+-------------+--------------------------------------------------------------------------------------------------------------------
 0 | ALGERIA        |           0 |  haggle. carefully final deposits detect slyly agai


### PR DESCRIPTION
The transaction was marked as cleared on the statement immediately
following the START TRANSACTION statement.