### PR TITLE
Increase test timeout in TestPrestoDriver jdbc test

### DIFF
--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -1506,7 +1506,7 @@ public class TestPrestoDriver
         }
     }
 
-    @Test(timeOut = 4000)
+    @Test(timeOut = 10000)
     public void testQueryTimeout()
             throws Exception
     {


### PR DESCRIPTION
This particular test takes 2 seconds on an idle mac. The original 4 second
is too close, especially on a shared server.