### PR TITLE
Fix bound check for ArraySliceFunction

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySliceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySliceFunction.java
@@ -53,7 +53,7 @@ public final class ArraySliceFunction
 
         long toIndex = Math.min(fromIndex + length, size + 1);
 
-        if (fromIndex >= toIndex || fromIndex < 0 || toIndex < 0) {
+        if (fromIndex >= toIndex || fromIndex < 1) {
             return type.createBlockBuilder(new BlockBuilderStatus(), 0).build();
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -762,6 +762,8 @@ public class TestArrayOperators
         assertFunction("SLICE(ARRAY [1, 2, 3, 4], -3, 5)", new ArrayType(INTEGER), ImmutableList.of(2, 3, 4));
         assertFunction("SLICE(ARRAY [1, 2, 3, 4], 1, 0)", new ArrayType(INTEGER), ImmutableList.of());
         assertFunction("SLICE(ARRAY [1, 2, 3, 4], -2, 0)", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("SLICE(ARRAY [1, 2, 3, 4], -5, 5)", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("SLICE(ARRAY [1, 2, 3, 4], -6, 5)", new ArrayType(INTEGER), ImmutableList.of());
         assertFunction("SLICE(ARRAY [ARRAY [1], ARRAY [2, 3], ARRAY [4, 5, 6]], 1, 2)", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(ImmutableList.of(1), ImmutableList.of(2, 3)));
 
         assertInvalidFunction("SLICE(ARRAY [1, 2, 3, 4], 1, -1)", INVALID_FUNCTION_ARGUMENT);


### PR DESCRIPTION
There is a corner case that we can pass -1 to Block::getRegion when
fromIndex = -N, length = N, and array size is (N - 1) to array slice
function. Fix the bound check.