### PR TITLE
Fix exception caused by coersion in plan printer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -1351,9 +1351,8 @@ public class PlanPrinter
             return "NULL";
         }
 
-        Signature coercion = functionRegistry.getCoercion(type, VARCHAR);
-
         try {
+            Signature coercion = functionRegistry.getCoercion(type, VARCHAR);
             Slice coerced = (Slice) new FunctionInvoker(functionRegistry).invoke(coercion, session.toConnectorSession(), value);
             return coerced.toStringUtf8();
         }


### PR DESCRIPTION
PlanPrinter can throw an exception when attempting to convert a constant to a String