### PR TITLE
Add tpch.q17 test query to big_query tests group

### DIFF
--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q17.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q17.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch; tables: lineitem,part
+-- database: presto; groups: tpch, big_query; tables: lineitem,part
 SELECT sum(l_extendedprice) / 7.0 AS avg_yearly
 FROM
   lineitem,


### PR DESCRIPTION
Add tpch.q17 test query to big_query tests group

That query often causes JVM on travis to hit the travis memory limit.
Because of that this and all the subsequent tests are failing.
