### PR TITLE
Fix handling of empty files in Hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -507,6 +507,7 @@ public class BackgroundHiveSplitLoader
         }
 
         if (blockLocations.length == 0) {
+            // TODO empty file should produce empty split rather than no split. Empty file is ignorable only in certain file formats.
             return Optional.empty();
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -506,6 +506,10 @@ public class BackgroundHiveSplitLoader
             return Optional.empty();
         }
 
+        if (blockLocations.length == 0) {
+            return Optional.empty();
+        }
+
         boolean forceLocalScheduling = HiveSessionProperties.isForceLocalScheduling(session);
 
         ImmutableList.Builder<InternalHiveBlock> blockBuilder = ImmutableList.builder();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -163,6 +163,20 @@ public class TestBackgroundHiveSplitLoader
         assertEquals(paths.get(0), RETURNED_PATH.toString());
     }
 
+    @Test
+    public void testEmptySplit()
+            throws Exception
+    {
+        BackgroundHiveSplitLoader backgroundHiveSplitLoader = backgroundHiveSplitLoader(
+                ImmutableList.of(emptySplit(RETURNED_PATH)),
+                TupleDomain.none());
+
+        HiveSplitSource hiveSplitSource = hiveSplitSource(backgroundHiveSplitLoader, TupleDomain.none());
+        backgroundHiveSplitLoader.start(hiveSplitSource);
+
+        assertEquals(drain(hiveSplitSource).size(), 0);
+    }
+
     private List<String> drain(HiveSplitSource source)
             throws Exception
     {
@@ -282,6 +296,23 @@ public class TestBackgroundHiveSplitLoader
                 null,
                 path,
                 new BlockLocation[] {new BlockLocation()});
+    }
+
+    private static LocatedFileStatus emptySplit(Path path)
+    {
+        return new LocatedFileStatus(
+                0L,
+                false,
+                0,
+                0L,
+                0L,
+                0L,
+                null,
+                null,
+                null,
+                null,
+                path,
+                new BlockLocation[] {});
     }
 
     private static class TestingDirectoryLister

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -62,7 +62,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.testng.Assert.assertEquals;
 
-public class TestBackgroundSplitLoader
+public class TestBackgroundHiveSplitLoader
 {
     private static final int BUCKET_COUNT = 2;
 


### PR DESCRIPTION
This fixes product tests running Hive queries on tables with empty data files -- empty table can have no files and this worked, but also it can have one or more empty files and such case didn't work.

Related to #9232, fixes #9311

cc @haozhun 

