### PR TITLE
Update FutureStateChange to reduce listener cancellation overhead

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/FutureStateChange.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FutureStateChange.java
@@ -14,15 +14,18 @@
 package com.facebook.presto.execution;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
@@ -32,11 +35,11 @@ public class FutureStateChange<T>
 {
     // Use a separate future for each listener so canceled listeners can be removed
     @GuardedBy("listeners")
-    private final Set<SettableFuture<T>> listeners = new HashSet<>();
+    private final Set<StateTrackingFuture<T>> listeners = new HashSet<>();
 
     public ListenableFuture<T> createNewListener()
     {
-        SettableFuture<T> listener = SettableFuture.create();
+        StateTrackingFuture<T> listener = StateTrackingFuture.create();
         synchronized (listeners) {
             listeners.add(listener);
         }
@@ -66,14 +69,54 @@ public class FutureStateChange<T>
     private void fireStateChange(T newState, Executor executor)
     {
         requireNonNull(executor, "executor is null");
-        Set<SettableFuture<T>> futures;
+        Set<StateTrackingFuture<T>> futures;
         synchronized (listeners) {
             futures = ImmutableSet.copyOf(listeners);
             listeners.clear();
         }
 
-        for (SettableFuture<T> future : futures) {
+        for (StateTrackingFuture<T> future : futures) {
             executor.execute(() -> future.set(newState));
+        }
+    }
+
+    /**
+     * Future cancellation can be expensive, because when a future is canceled
+     * a CancellationException is created and thrown under the hood. To get rid
+     * of the cancellation overhead this future implementation just cancels the
+     * future with the same exception instance.
+     */
+    private static final class StateTrackingFuture<V>
+            extends AbstractFuture<V>
+    {
+        private static final CancellationException EXCEPTION = new CancellationException("Future is canceled");
+        private AtomicBoolean canceled = new AtomicBoolean();
+
+        public static <V> StateTrackingFuture<V> create()
+        {
+            return new StateTrackingFuture<V>();
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning)
+        {
+            if (canceled.compareAndSet(false, true)) {
+                setException(EXCEPTION);
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        protected boolean set(@Nullable V value)
+        {
+            return super.set(value);
+        }
+
+        @Override
+        public boolean isCancelled()
+        {
+            return canceled.get();
         }
     }
 }


### PR DESCRIPTION
Cancelling a SettableFuture can be expensive as a CancellationException is
created and thrown under the hood. I have seen in prod that up to 5% of the
CPU cycles can be spent on the cancellation code path on the coordinator.

Here's the relevant hot code path:

```
"Query-20171108_224523_67496_bfyte-975035" #975035 prio=5 os_prio=0 tid=0x00007f1b34055230 nid=0xf078b runnable [0x00007f145c9e3000]
   java.lang.Thread.State: RUNNABLE
        at java.lang.Throwable.fillInStackTrace(Native Method)
        at java.lang.Throwable.fillInStackTrace(Throwable.java:783)
        - locked <0x00007f476a09e208> (a java.util.concurrent.CancellationException)
        at java.lang.Throwable.<init>(Throwable.java:265)
        at java.lang.Exception.<init>(Exception.java:66)
        at java.lang.RuntimeException.<init>(RuntimeException.java:62)
        at java.lang.IllegalStateException.<init>(IllegalStateException.java:55)
        at java.util.concurrent.CancellationException.<init>(CancellationException.java:61)
        at com.google.common.util.concurrent.AbstractFuture.cancellationExceptionWithCause(AbstractFuture.java:1114)
        at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:500)
        at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:461)
        at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:78)
        at com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:142)
        at com.google.common.util.concurrent.Futures.getDone(Futures.java:1174)
        at com.google.common.util.concurrent.Futures$4.run(Futures.java:1124)
        at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
        at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:902)
        at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:813)
        at com.google.common.util.concurrent.AbstractFuture.cancel(AbstractFuture.java:553)
        at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.cancel(AbstractFuture.java:106)
        at com.facebook.presto.execution.scheduler.NodeScheduler.lambda$getFirstCompleteAndCancelOthers$6(NodeScheduler.java:338)
        at com.facebook.presto.execution.scheduler.NodeScheduler$$Lambda$2338/484526032.run(Unknown Source)
        at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
        at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:902)
        at com.google.common.util.concurrent.AbstractFuture.addListener(AbstractFuture.java:636)
        at com.facebook.presto.execution.scheduler.NodeScheduler.getFirstCompleteAndCancelOthers(NodeScheduler.java:335)
        at com.facebook.presto.execution.scheduler.NodeScheduler.toWhenHasSplitQueueSpaceFuture(NodeScheduler.java:328)
        at com.facebook.presto.execution.scheduler.TopologyAwareNodeSelector.computeAssignments(TopologyAwareNodeSelector.java:197)
        at com.facebook.presto.execution.scheduler.DynamicSplitPlacementPolicy.computeAssignments(DynamicSplitPlacementPolicy.java:41)
        at com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.schedule(SourcePartitionedScheduler.java:124)
        - locked <0x00007f2096002d40> (a com.facebook.presto.execution.scheduler.SourcePartitionedScheduler)
        at com.facebook.presto.execution.scheduler.SqlQueryScheduler.schedule(SqlQueryScheduler.java:396)
        at com.facebook.presto.execution.scheduler.SqlQueryScheduler$$Lambda$1521/309878269.run(Unknown Source)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```