### PR TITLE
Append timestamp to name of generated class

### DIFF
--- a/presto-bytecode/src/main/java/com/facebook/presto/bytecode/CompilerUtils.java
+++ b/presto-bytecode/src/main/java/com/facebook/presto/bytecode/CompilerUtils.java
@@ -32,11 +32,16 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandle;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static java.time.ZoneOffset.UTC;
 
 public final class CompilerUtils
 {
@@ -48,16 +53,24 @@ public final class CompilerUtils
     private static final boolean RUN_ASM_VERIFIER = false; // verifier doesn't work right now
     private static final AtomicReference<String> DUMP_CLASS_FILES_TO = new AtomicReference<>();
     private static final AtomicLong CLASS_ID = new AtomicLong();
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("YYYYMMdd_HHmmss");
 
     private CompilerUtils()
     {
     }
 
-    public static ParameterizedType makeClassName(String baseName)
+    public static ParameterizedType makeClassName(String baseName, Optional<String> suffix)
     {
-        String className = baseName + "_" + CLASS_ID.incrementAndGet();
+        String className = baseName
+                + "_" + suffix.orElseGet(() -> Instant.now().atZone(UTC).format(TIMESTAMP_FORMAT))
+                + "_" + CLASS_ID.incrementAndGet();
         String javaClassName = toJavaIdentifierString(className);
         return ParameterizedType.typeFromJavaClassName("com.facebook.presto.$gen." + javaClassName);
+    }
+
+    public static ParameterizedType makeClassName(String baseName)
+    {
+        return makeClassName(baseName, Optional.empty());
     }
 
     public static String toJavaIdentifierString(String className)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -216,9 +216,7 @@ public class PageFunctionCompiler
 
     private static ParameterizedType generateProjectionWorkClassName(Optional<String> classNameSuffix)
     {
-        StringBuilder className = new StringBuilder("PageProjectionWork");
-        classNameSuffix.ifPresent(suffix -> className.append("_").append(suffix.replace('.', '_')));
-        return makeClassName(className.toString());
+        return makeClassName("PageProjectionWork", classNameSuffix);
     }
 
     private ClassDefinition definePageProjectWorkClass(RowExpression projection, CallSiteBinder callSiteBinder, Optional<String> classNameSuffix)
@@ -429,9 +427,7 @@ public class PageFunctionCompiler
 
     private static ParameterizedType generateFilterClassName(Optional<String> classNameSuffix)
     {
-        StringBuilder className = new StringBuilder(PageFilter.class.getSimpleName());
-        classNameSuffix.ifPresent(suffix -> className.append("_").append(suffix.replace('.', '_')));
-        return makeClassName(className.toString());
+        return makeClassName(PageFilter.class.getSimpleName(), classNameSuffix);
     }
 
     private ClassDefinition defineFilterClass(RowExpression filter, InputChannels inputChannels, CallSiteBinder callSiteBinder, Optional<String> classNameSuffix)


### PR DESCRIPTION
Generated classes will be cached in the expression cache. Having a timestamp in the class name helps us know how long we have been using the cached class. This can help us better understand the jvm deopt bug which can be related to the age of the generated code.