### PR TITLE
Support for detailed error messages on presto-client side (+CLI support) (v2)

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
@@ -66,6 +66,9 @@ public class BenchmarkDriverOptions
     @Option(name = "--debug", title = "debug", description = "Enable debug information (default: false)")
     public boolean debug;
 
+    @Option(name = "--quiet", title = "quiet", description = "Enable quiet mode (less verbose error messages) (default: false)")
+    public boolean quiet;
+
     @Option(name = "--session", title = "session", description = "Session property (property can be used multiple times; format is key=value)")
     public final List<ClientSessionProperty> sessionProperties = new ArrayList<>();
 
@@ -99,6 +102,7 @@ public class BenchmarkDriverOptions
                 ImmutableMap.of(),
                 null,
                 debug,
+                quiet,
                 clientRequestTimeout);
     }
 

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -24,6 +24,11 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-parser</artifactId>
         </dependency>
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -98,6 +98,9 @@ public class ClientOptions
     @Option(name = "--debug", title = "debug", description = "Enable debug information")
     public boolean debug;
 
+    @Option(name = {"--quiet", "-q"}, title = "quiet", description = "Enable quiet mode (less verbose error messages)")
+    public boolean quiet;
+
     @Option(name = "--log-levels-file", title = "log levels file", description = "Configure log levels for debugging using this file")
     public String logLevelsFile;
 
@@ -145,6 +148,7 @@ public class ClientOptions
                 emptyMap(),
                 null,
                 debug,
+                quiet,
                 clientRequestTimeout);
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
 
 import static com.facebook.presto.cli.Completion.commandCompleter;
 import static com.facebook.presto.cli.Completion.lowerCaseCommandCompleter;
-import static com.facebook.presto.cli.ErrorMessages.createErrorMessage;
+import static com.facebook.presto.cli.ErrorMessages.createExceptionMessage;
 import static com.facebook.presto.cli.Help.getHelpText;
 import static com.facebook.presto.cli.QueryPreprocessor.preprocessQuery;
 import static com.facebook.presto.client.ClientSession.stripTransactionId;
@@ -335,7 +335,7 @@ public class Console
             queryRunner.setSession(session);
         }
         catch (RuntimeException e) {
-            System.err.println(createErrorMessage(e, queryRunner.getSession()));
+            System.err.println(createExceptionMessage(e, queryRunner.getSession()));
         }
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -47,6 +47,7 @@ import java.util.regex.Pattern;
 
 import static com.facebook.presto.cli.Completion.commandCompleter;
 import static com.facebook.presto.cli.Completion.lowerCaseCommandCompleter;
+import static com.facebook.presto.cli.ErrorMessages.createErrorMessage;
 import static com.facebook.presto.cli.Help.getHelpText;
 import static com.facebook.presto.cli.QueryPreprocessor.preprocessQuery;
 import static com.facebook.presto.client.ClientSession.stripTransactionId;
@@ -334,10 +335,7 @@ public class Console
             queryRunner.setSession(session);
         }
         catch (RuntimeException e) {
-            System.err.println("Error running command: " + e.getMessage());
-            if (queryRunner.getSession().isDebug()) {
-                e.printStackTrace();
-            }
+            System.err.println(createErrorMessage(e, queryRunner.getSession()));
         }
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.ErrorLocation;
+import com.facebook.presto.client.PrestoClientException;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementClient;
@@ -31,17 +32,21 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getCausalChain;
 import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 
 public class ErrorMessages
 {
     private static final String PRESTO_COORDINATOR_NOT_FOUND = "There was a problem with a response from Presto Coordinator.\n";
+    private static final String PRESTO_COORDINATOR_404 = "Presto HTTP interface returned 404 (file not found).\n";
 
     private enum Tip
     {
         VERIFY_PRESTO_RUNNING("Verify that Presto is running on %s."),
         DEFINE_SERVER_AS_CLI_PARAM("Use '--server' argument when starting Presto CLI to define server host and port."),
         CHECK_NETWORK("Check the network conditions between client and server."),
-        USE_DEBUG_MODE("Use '--debug' argument to get more technical details.");
+        USE_DEBUG_MODE("Use '--debug' argument to get more technical details."),
+        CHECK_OTHER_HTTP_SERVICE("Make sure that none other HTTP service is running on %s."),
+        CLIENT_IS_UP_TO_DATE_WITH_SERVER("Update CLI to match Presto server version.");
 
         private static final String TIPS_INTRO = "To solve this problem you may try to:\n";
 
@@ -107,12 +112,11 @@ public class ErrorMessages
     {
         StringBuilder builder = new StringBuilder();
 
-        if (getCausalChain(throwable).stream().anyMatch(x -> x instanceof EOFException || x instanceof ConnectException)) {
-            serverNotFoundErrorMessage(builder, session);
+        if (throwable instanceof PrestoClientException) {
+            createPrestoClientExceptionErrorMessage(builder, (PrestoClientException) throwable, session);
         }
         else {
-            // We have no clue about what went wrong, just display what we obtained.
-            builder.append("Error running command:\n" + throwable.getMessage() + "\n");
+            runtimeExceptionErrorMessage(builder, throwable, session);
         }
 
         if (session.isDebug()) {
@@ -120,6 +124,27 @@ public class ErrorMessages
         }
 
         return builder.toString();
+    }
+
+    private static void createPrestoClientExceptionErrorMessage(StringBuilder builder, PrestoClientException exception, ClientSession session)
+    {
+        if (exception.getResponse().getStatusCode() == HTTP_NOT_FOUND) {
+            serverFileNotFoundErrorMessage(builder, session);
+        }
+        else {
+            runtimeExceptionErrorMessage(builder, exception, session);
+        }
+    }
+
+    private static void runtimeExceptionErrorMessage(StringBuilder builder, Throwable throwable, ClientSession session)
+    {
+        if (getCausalChain(throwable).stream().anyMatch(x -> x instanceof EOFException || x instanceof ConnectException)) {
+            serverNotFoundErrorMessage(builder, session);
+        }
+        else {
+            // We have no clue about what went wrong, just display what we obtained.
+            builder.append("Error running command:\n" + throwable.getMessage() + "\n");
+        }
     }
 
     //region Messages for given problems
@@ -130,6 +155,21 @@ public class ErrorMessages
         tipsBuilder.addTip(Tip.VERIFY_PRESTO_RUNNING, session.getServer())
                 .addTip(Tip.DEFINE_SERVER_AS_CLI_PARAM)
                 .addTip(Tip.CHECK_NETWORK).build();
+        if (!session.isDebug()) {
+            tipsBuilder.addTip(Tip.USE_DEBUG_MODE);
+        }
+        builder.append(tipsBuilder.build());
+    }
+
+    private static void serverFileNotFoundErrorMessage(StringBuilder builder, ClientSession session)
+    {
+        builder.append(PRESTO_COORDINATOR_404);
+        Tip.Builder tipsBuilder = Tip.builder();
+        tipsBuilder.addTip(Tip.VERIFY_PRESTO_RUNNING, session.getServer())
+                .addTip(Tip.DEFINE_SERVER_AS_CLI_PARAM)
+                .addTip(Tip.CHECK_NETWORK)
+                .addTip(Tip.CHECK_OTHER_HTTP_SERVICE, session.getServer())
+                .addTip(Tip.CLIENT_IS_UP_TO_DATE_WITH_SERVER);
         if (!session.isDebug()) {
             tipsBuilder.addTip(Tip.USE_DEBUG_MODE);
         }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -251,6 +251,7 @@ public class ErrorMessages
         builder.append("========= TECHNICAL DETAILS END =========\n\n");
     }
 
+    //region Standard QueryError format
     private static void standardQueryErrorMessage(StringBuilder builder, StatementClient client)
     {
         QueryError error = extractQueryError(client);
@@ -294,7 +295,9 @@ public class ErrorMessages
             builder.append(padding + "^");
         }
     }
+    //endregion
 
+    //region Helpers
     private static QueryError extractQueryError(StatementClient client)
     {
         QueryResults results = client.finalResults();
@@ -302,4 +305,5 @@ public class ErrorMessages
         checkState(error != null);
         return error;
     }
+    //endregion
 }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -14,19 +14,111 @@
 package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
+import com.facebook.presto.client.ErrorLocation;
+import com.facebook.presto.client.QueryError;
+import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.StatementClient;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import org.fusesource.jansi.Ansi;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 
 public class ErrorMessages
 {
     private ErrorMessages() {}
 
-    public static String createErrorMessage(Throwable throwable, ClientSession session)
+
+    public static String createQueryErrorMessage(StatementClient client, boolean useAnsiEscapeCodes)
     {
         StringBuilder builder = new StringBuilder();
-        builder.append("Error running command: " + throwable.getMessage());
-        if (session.isDebug()) {
-            builder.append(Throwables.getStackTraceAsString(throwable));
+        QueryError error = extractQueryError(client);
+
+        builder.append(String.format("Query %s failed: %s%n", client.finalResults().getId(), error.getMessage()));
+        if (client.isDebug() && (error.getFailureInfo() != null)) {
+            builder.append(Throwables.getStackTraceAsString(error.getFailureInfo().toException()));
         }
+        if (error.getErrorLocation() != null) {
+            errorLocationMessage(builder, client.getQuery(), error.getErrorLocation(), useAnsiEscapeCodes);
+        }
+
         return builder.toString();
+    }
+
+    public static String createExceptionMessage(Throwable throwable, ClientSession session)
+    {
+        StringBuilder builder = new StringBuilder();
+
+        // We have no clue about what went wrong, just display what we obtained.
+        builder.append("Error running command:\n" + throwable.getMessage() + "\n");
+
+        if (session.isDebug()) {
+            technicalDetailsRuntimeExceptionErrorMessage(builder, throwable, session);
+        }
+
+        return builder.toString();
+    }
+
+    private static void technicalDetailsRuntimeExceptionErrorMessage(StringBuilder builder, Throwable throwable, ClientSession session)
+    {
+        builder.append("\n=========   TECHNICAL DETAILS   =========\n");
+        builder.append("[ Error message ]\n");
+        builder.append(throwable.getMessage() + "\n\n");
+        builder.append("[ Session information ]\n");
+        builder.append(session + "\n\n");
+        builder.append("[ Stack trace ]\n");
+        builder.append(Throwables.getStackTraceAsString(throwable));
+        builder.append("========= TECHNICAL DETAILS END =========\n\n");
+    }
+
+    private static void errorLocationMessage(StringBuilder builder, String query, ErrorLocation location, boolean useAnsiEscapeCodes)
+    {
+        List<String> lines = ImmutableList.copyOf(Splitter.on('\n').split(query).iterator());
+
+        String errorLine = lines.get(location.getLineNumber() - 1);
+        String good = errorLine.substring(0, location.getColumnNumber() - 1);
+        String bad = errorLine.substring(location.getColumnNumber() - 1);
+
+        if ((location.getLineNumber() == lines.size()) && bad.trim().isEmpty()) {
+            bad = " <EOF>";
+        }
+
+        if (useAnsiEscapeCodes) {
+            Ansi ansi = Ansi.ansi();
+
+            ansi.fg(Ansi.Color.CYAN);
+            for (int i = 1; i < location.getLineNumber(); i++) {
+                ansi.a(lines.get(i - 1)).newline();
+            }
+            ansi.a(good);
+
+            ansi.fg(Ansi.Color.RED);
+            ansi.a(bad).newline();
+            for (int i = location.getLineNumber(); i < lines.size(); i++) {
+                ansi.a(lines.get(i)).newline();
+            }
+
+            ansi.reset();
+            builder.append(ansi);
+        }
+        else {
+            String prefix = format("LINE %s: ", location.getLineNumber());
+            String padding = Strings.repeat(" ", prefix.length() + (location.getColumnNumber() - 1));
+            builder.append(prefix + errorLine);
+            builder.append(padding + "^");
+        }
+    }
+
+    private static QueryError extractQueryError(StatementClient client)
+    {
+        QueryResults results = client.finalResults();
+        QueryError error = results.getError();
+        checkState(error != null);
+        return error;
     }
 }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -24,15 +24,68 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import org.fusesource.jansi.Ansi;
 
+import java.io.EOFException;
+import java.net.ConnectException;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.getCausalChain;
 import static java.lang.String.format;
 
 public class ErrorMessages
 {
-    private ErrorMessages() {}
+    private static final String PRESTO_COORDINATOR_NOT_FOUND = "There was a problem with a response from Presto Coordinator.\n";
 
+    private enum Tip
+    {
+        VERIFY_PRESTO_RUNNING("Verify that Presto is running on %s."),
+        DEFINE_SERVER_AS_CLI_PARAM("Use '--server' argument when starting Presto CLI to define server host and port."),
+        CHECK_NETWORK("Check the network conditions between client and server."),
+        USE_DEBUG_MODE("Use '--debug' argument to get more technical details.");
+
+        private static final String TIPS_INTRO = "To solve this problem you may try to:\n";
+
+        private final String message;
+
+        Tip(String message)
+        {
+            this.message = message;
+        }
+
+        @Override
+        public String toString()
+        {
+            return message;
+        }
+
+        public static Builder builder()
+        {
+            return new Builder();
+        }
+
+        private static class Builder
+        {
+            private StringBuilder builder = new StringBuilder();
+
+            public Builder()
+            {
+                builder.append(TIPS_INTRO);
+            }
+
+            public Builder addTip(Tip tip, Object... toFormat)
+            {
+                builder.append(format(" * " + tip.toString() + "\n", toFormat));
+                return this;
+            }
+
+            public String build()
+            {
+                return builder.toString();
+            }
+        }
+    }
+
+    private ErrorMessages() {}
 
     public static String createQueryErrorMessage(StatementClient client, boolean useAnsiEscapeCodes)
     {
@@ -54,8 +107,13 @@ public class ErrorMessages
     {
         StringBuilder builder = new StringBuilder();
 
-        // We have no clue about what went wrong, just display what we obtained.
-        builder.append("Error running command:\n" + throwable.getMessage() + "\n");
+        if (getCausalChain(throwable).stream().anyMatch(x -> x instanceof EOFException || x instanceof ConnectException)) {
+            serverNotFoundErrorMessage(builder, session);
+        }
+        else {
+            // We have no clue about what went wrong, just display what we obtained.
+            builder.append("Error running command:\n" + throwable.getMessage() + "\n");
+        }
 
         if (session.isDebug()) {
             technicalDetailsRuntimeExceptionErrorMessage(builder, throwable, session);
@@ -63,6 +121,21 @@ public class ErrorMessages
 
         return builder.toString();
     }
+
+    //region Messages for given problems
+    private static void serverNotFoundErrorMessage(StringBuilder builder, ClientSession session)
+    {
+        builder.append(PRESTO_COORDINATOR_NOT_FOUND);
+        Tip.Builder tipsBuilder = Tip.builder();
+        tipsBuilder.addTip(Tip.VERIFY_PRESTO_RUNNING, session.getServer())
+                .addTip(Tip.DEFINE_SERVER_AS_CLI_PARAM)
+                .addTip(Tip.CHECK_NETWORK).build();
+        if (!session.isDebug()) {
+            tipsBuilder.addTip(Tip.USE_DEBUG_MODE);
+        }
+        builder.append(tipsBuilder.build());
+    }
+    //endregion
 
     private static void technicalDetailsRuntimeExceptionErrorMessage(StringBuilder builder, Throwable throwable, ClientSession session)
     {

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -169,6 +169,10 @@ public class ErrorMessages
     private static void serverNotFoundErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_COORDINATOR_NOT_FOUND);
+        if (session.isQuiet()) {
+            return;
+        }
+
         Tip.Builder tipsBuilder = Tip.builder();
         tipsBuilder.addTip(Tip.VERIFY_PRESTO_RUNNING, session.getServer())
                 .addTip(Tip.DEFINE_SERVER_AS_CLI_PARAM)
@@ -182,6 +186,10 @@ public class ErrorMessages
     private static void serverStartingUpErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_STARTING_UP);
+        if (session.isQuiet()) {
+            return;
+        }
+
         Tip.Builder tipsBuilder = Tip.builder();
         tipsBuilder.addTip(Tip.WAIT_FOR_INITIALIZATION);
         if (!session.isDebug()) {
@@ -193,6 +201,10 @@ public class ErrorMessages
     private static void serverShuttingDownErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_SHUTTING_DOWN);
+        if (session.isQuiet()) {
+            return;
+        }
+
         Tip.Builder tipsBuilder = Tip.builder();
         tipsBuilder.addTip(Tip.WAIT_FOR_SERVER_RESTART)
                 .addTip(Tip.START_SERVER_AGAIN);
@@ -205,6 +217,10 @@ public class ErrorMessages
     private static void serverFileNotFoundErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_COORDINATOR_404);
+        if (session.isQuiet()) {
+            return;
+        }
+
         Tip.Builder tipsBuilder = Tip.builder();
         tipsBuilder.addTip(Tip.VERIFY_PRESTO_RUNNING, session.getServer())
                 .addTip(Tip.DEFINE_SERVER_AS_CLI_PARAM)

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -41,7 +41,7 @@ public class ErrorMessages
 
         builder.append(String.format("Query %s failed: %s%n", client.finalResults().getId(), error.getMessage()));
         if (client.isDebug() && (error.getFailureInfo() != null)) {
-            builder.append(Throwables.getStackTraceAsString(error.getFailureInfo().toException()));
+            technicalDetailsRuntimeExceptionErrorMessage(builder, error.getFailureInfo().toException(), client.getSession());
         }
         if (error.getErrorLocation() != null) {
             errorLocationMessage(builder, client.getQuery(), error.getErrorLocation(), useAnsiEscapeCodes);

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -105,6 +105,7 @@ public class ErrorMessages
         ClientSession session = client.getSession();
         QueryError error = extractQueryError(client);
 
+        // Try to recognize error and provide custom error message
         if (error.getErrorCode() == SERVER_STARTING_UP.toErrorCode().getCode()) {
             serverStartingUpErrorMessage(builder, session);
         }
@@ -112,9 +113,11 @@ public class ErrorMessages
             serverShuttingDownErrorMessage(builder, session);
         }
         else {
+            // Fallback to standard QueryError message
             standardQueryErrorMessage(builder, client);
         }
 
+        // Display common part of all QueryError (position, debug details)
         if (error.getErrorLocation() != null) {
             errorLocationMessage(builder, client.getQuery(), error.getErrorLocation(), useAnsiEscapeCodes);
         }
@@ -130,6 +133,7 @@ public class ErrorMessages
     {
         StringBuilder builder = new StringBuilder();
 
+        // Try to recognize exception type and provide custom error message
         if (throwable instanceof PrestoClientException) {
             createPrestoClientExceptionErrorMessage(builder, (PrestoClientException) throwable, session);
         }
@@ -137,6 +141,7 @@ public class ErrorMessages
             runtimeExceptionErrorMessage(builder, throwable, session);
         }
 
+        // Display common part of all Throwable error messages
         if (session.isDebug()) {
             technicalDetailsRuntimeExceptionErrorMessage(builder, throwable, session);
         }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import com.facebook.presto.client.ClientSession;
+import com.google.common.base.Throwables;
+
+public class ErrorMessages
+{
+    private ErrorMessages() {}
+
+    public static String createErrorMessage(Throwable throwable, ClientSession session)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Error running command: " + throwable.getMessage());
+        if (session.isDebug()) {
+            builder.append(Throwables.getStackTraceAsString(throwable));
+        }
+        return builder.toString();
+    }
+}

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ErrorMessages.java
@@ -29,6 +29,8 @@ import java.io.EOFException;
 import java.net.ConnectException;
 import java.util.List;
 
+import static com.facebook.presto.spi.StandardErrorCode.SERVER_SHUTTING_DOWN;
+import static com.facebook.presto.spi.StandardErrorCode.SERVER_STARTING_UP;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getCausalChain;
 import static java.lang.String.format;
@@ -38,6 +40,8 @@ public class ErrorMessages
 {
     private static final String PRESTO_COORDINATOR_NOT_FOUND = "There was a problem with a response from Presto Coordinator.\n";
     private static final String PRESTO_COORDINATOR_404 = "Presto HTTP interface returned 404 (file not found).\n";
+    private static final String PRESTO_STARTING_UP = "Presto is still starting up.\n";
+    private static final String PRESTO_SHUTTING_DOWN = "Presto is shutting down\n";
 
     private enum Tip
     {
@@ -45,6 +49,9 @@ public class ErrorMessages
         DEFINE_SERVER_AS_CLI_PARAM("Use '--server' argument when starting Presto CLI to define server host and port."),
         CHECK_NETWORK("Check the network conditions between client and server."),
         USE_DEBUG_MODE("Use '--debug' argument to get more technical details."),
+        WAIT_FOR_INITIALIZATION("Wait for server to complete initialization."),
+        WAIT_FOR_SERVER_RESTART("Wait for server to restart as it may have restart scheduled."),
+        START_SERVER_AGAIN("Start server again manually."),
         CHECK_OTHER_HTTP_SERVICE("Make sure that none other HTTP service is running on %s."),
         CLIENT_IS_UP_TO_DATE_WITH_SERVER("Update CLI to match Presto server version.");
 
@@ -95,14 +102,25 @@ public class ErrorMessages
     public static String createQueryErrorMessage(StatementClient client, boolean useAnsiEscapeCodes)
     {
         StringBuilder builder = new StringBuilder();
+        ClientSession session = client.getSession();
         QueryError error = extractQueryError(client);
 
-        builder.append(String.format("Query %s failed: %s%n", client.finalResults().getId(), error.getMessage()));
-        if (client.isDebug() && (error.getFailureInfo() != null)) {
-            technicalDetailsRuntimeExceptionErrorMessage(builder, error.getFailureInfo().toException(), client.getSession());
+        if (error.getErrorCode() == SERVER_STARTING_UP.toErrorCode().getCode()) {
+            serverStartingUpErrorMessage(builder, session);
         }
+        else if (error.getErrorCode() == SERVER_SHUTTING_DOWN.toErrorCode().getCode()) {
+            serverShuttingDownErrorMessage(builder, session);
+        }
+        else {
+            standardQueryErrorMessage(builder, client);
+        }
+
         if (error.getErrorLocation() != null) {
             errorLocationMessage(builder, client.getQuery(), error.getErrorLocation(), useAnsiEscapeCodes);
+        }
+
+        if (client.isDebug() && (error.getFailureInfo() != null)) {
+            technicalDetailsRuntimeExceptionErrorMessage(builder, error.getFailureInfo().toException(), session);
         }
 
         return builder.toString();
@@ -161,6 +179,29 @@ public class ErrorMessages
         builder.append(tipsBuilder.build());
     }
 
+    private static void serverStartingUpErrorMessage(StringBuilder builder, ClientSession session)
+    {
+        builder.append(PRESTO_STARTING_UP);
+        Tip.Builder tipsBuilder = Tip.builder();
+        tipsBuilder.addTip(Tip.WAIT_FOR_INITIALIZATION);
+        if (!session.isDebug()) {
+            tipsBuilder.addTip(Tip.USE_DEBUG_MODE);
+        }
+        builder.append(tipsBuilder.build());
+    }
+
+    private static void serverShuttingDownErrorMessage(StringBuilder builder, ClientSession session)
+    {
+        builder.append(PRESTO_SHUTTING_DOWN);
+        Tip.Builder tipsBuilder = Tip.builder();
+        tipsBuilder.addTip(Tip.WAIT_FOR_SERVER_RESTART)
+                .addTip(Tip.START_SERVER_AGAIN);
+        if (!session.isDebug()) {
+            tipsBuilder.addTip(Tip.USE_DEBUG_MODE);
+        }
+        builder.append(tipsBuilder.build());
+    }
+
     private static void serverFileNotFoundErrorMessage(StringBuilder builder, ClientSession session)
     {
         builder.append(PRESTO_COORDINATOR_404);
@@ -187,6 +228,12 @@ public class ErrorMessages
         builder.append("[ Stack trace ]\n");
         builder.append(Throwables.getStackTraceAsString(throwable));
         builder.append("========= TECHNICAL DETAILS END =========\n\n");
+    }
+
+    private static void standardQueryErrorMessage(StringBuilder builder, StatementClient client)
+    {
+        QueryError error = extractQueryError(client);
+        builder.append(String.format("Query %s failed: %s%n", client.finalResults().getId(), error.getMessage()));
     }
 
     private static void errorLocationMessage(StringBuilder builder, String query, ErrorLocation location, boolean useAnsiEscapeCodes)

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -15,17 +15,11 @@ package com.facebook.presto.cli;
 
 import com.facebook.presto.cli.ClientOptions.OutputFormat;
 import com.facebook.presto.client.Column;
-import com.facebook.presto.client.ErrorLocation;
-import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementClient;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.airlift.log.Logger;
-import org.fusesource.jansi.Ansi;
 import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
@@ -42,7 +36,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.facebook.presto.cli.ConsolePrinter.REAL_TERMINAL;
-import static com.google.common.base.Preconditions.checkState;
+import static com.facebook.presto.cli.ErrorMessages.createQueryErrorMessage;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -162,7 +156,7 @@ public class Query
             errorChannel.println("Query is gone (server restarted?)");
         }
         else if (client.isFailed()) {
-            renderFailure(errorChannel);
+            errorChannel.println(createQueryErrorMessage(client, REAL_TERMINAL));
         }
     }
 
@@ -291,60 +285,6 @@ public class Query
     public void close()
     {
         client.close();
-    }
-
-    public void renderFailure(PrintStream out)
-    {
-        QueryResults results = client.finalResults();
-        QueryError error = results.getError();
-        checkState(error != null);
-
-        out.printf("Query %s failed: %s%n", results.getId(), error.getMessage());
-        if (client.isDebug() && (error.getFailureInfo() != null)) {
-            error.getFailureInfo().toException().printStackTrace(out);
-        }
-        if (error.getErrorLocation() != null) {
-            renderErrorLocation(client.getQuery(), error.getErrorLocation(), out);
-        }
-        out.println();
-    }
-
-    private static void renderErrorLocation(String query, ErrorLocation location, PrintStream out)
-    {
-        List<String> lines = ImmutableList.copyOf(Splitter.on('\n').split(query).iterator());
-
-        String errorLine = lines.get(location.getLineNumber() - 1);
-        String good = errorLine.substring(0, location.getColumnNumber() - 1);
-        String bad = errorLine.substring(location.getColumnNumber() - 1);
-
-        if ((location.getLineNumber() == lines.size()) && bad.trim().isEmpty()) {
-            bad = " <EOF>";
-        }
-
-        if (REAL_TERMINAL) {
-            Ansi ansi = Ansi.ansi();
-
-            ansi.fg(Ansi.Color.CYAN);
-            for (int i = 1; i < location.getLineNumber(); i++) {
-                ansi.a(lines.get(i - 1)).newline();
-            }
-            ansi.a(good);
-
-            ansi.fg(Ansi.Color.RED);
-            ansi.a(bad).newline();
-            for (int i = location.getLineNumber(); i < lines.size(); i++) {
-                ansi.a(lines.get(i)).newline();
-            }
-
-            ansi.reset();
-            out.print(ansi);
-        }
-        else {
-            String prefix = format("LINE %s: ", location.getLineNumber());
-            String padding = Strings.repeat(" ", prefix.length() + (location.getColumnNumber() - 1));
-            out.println(prefix + errorLine);
-            out.println(padding + "^");
-        }
     }
 
     private static class ThreadInterruptor

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -42,6 +42,7 @@ public class ClientSession
     private final Map<String, String> preparedStatements;
     private final String transactionId;
     private final boolean debug;
+    private final boolean quiet;
     private final Duration clientRequestTimeout;
 
     public static ClientSession withCatalogAndSchema(ClientSession session, String catalog, String schema)
@@ -59,6 +60,7 @@ public class ClientSession
                 session.getPreparedStatements(),
                 session.getTransactionId(),
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -77,6 +79,7 @@ public class ClientSession
                 session.getPreparedStatements(),
                 session.getTransactionId(),
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -95,6 +98,7 @@ public class ClientSession
                 preparedStatements,
                 session.getTransactionId(),
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -113,6 +117,7 @@ public class ClientSession
                 session.getPreparedStatements(),
                 transactionId,
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -131,6 +136,7 @@ public class ClientSession
                 session.getPreparedStatements(),
                 null,
                 session.isDebug(),
+                session.isQuiet(),
                 session.getClientRequestTimeout());
     }
 
@@ -147,6 +153,7 @@ public class ClientSession
             Map<String, String> preparedStatements,
             String transactionId,
             boolean debug,
+            boolean quiet,
             Duration clientRequestTimeout)
     {
         this.server = requireNonNull(server, "server is null");
@@ -159,6 +166,7 @@ public class ClientSession
         this.timeZone = TimeZoneKey.getTimeZoneKey(timeZoneId);
         this.transactionId = transactionId;
         this.debug = debug;
+        this.quiet = quiet;
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
         this.preparedStatements = ImmutableMap.copyOf(requireNonNull(preparedStatements, "preparedStatements is null"));
         this.clientRequestTimeout = clientRequestTimeout;
@@ -233,6 +241,11 @@ public class ClientSession
         return debug;
     }
 
+    public boolean isQuiet()
+    {
+        return quiet;
+    }
+
     public Duration getClientRequestTimeout()
     {
         return clientRequestTimeout;
@@ -252,6 +265,7 @@ public class ClientSession
                 .add("properties", properties)
                 .add("transactionId", transactionId)
                 .add("debug", debug)
+                .add("quiet", quiet)
                 .toString();
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoClientException.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoClientException.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import okhttp3.Request;
+
+import static java.lang.String.format;
+
+public class PrestoClientException
+        extends RuntimeException
+{
+    private final String task;
+    private final Request request;
+    private final JsonResponse<QueryResults> response;
+
+    public PrestoClientException(String task, Request request, JsonResponse<QueryResults> response)
+    {
+        super(getDefaultMessage(task, request, response));
+        this.task = task;
+        this.request = request;
+        this.response = response;
+    }
+
+    private static String getDefaultMessage(String task, Request request, JsonResponse<QueryResults> response)
+    {
+        StringBuilder message = new StringBuilder();
+        message.append(format("Error %s at %s returned HTTP response code %s.\n", task, request.url(), response.getStatusCode()));
+        message.append(format("Response info:\n%s\n", response));
+        message.append(format("Response body:\n%s\n", response.getResponseBody()));
+        if (response.hasValue()) {
+            message.append(format("Response status:\n%s\n", response.getStatusMessage()));
+        }
+        return message.toString();
+    }
+
+    public String getTask()
+    {
+        return task;
+    }
+
+    public Request getRequest()
+    {
+        return request;
+    }
+
+    public JsonResponse<QueryResults> getResponse()
+    {
+        return response;
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -374,9 +374,7 @@ public class StatementClient
                                 .map(message -> ": " + message)
                                 .orElse(""));
             }
-            return new RuntimeException(
-                    format("Error %s at %s returned an invalid response: %s [Error: %s]", task, request.url(), response, response.getResponseBody()),
-                    response.getException());
+            return new PrestoClientException(task, request, response);
         }
         return new RuntimeException(format("Error %s at %s returned HTTP %s", task, request.url(), response.getStatusCode()));
     }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -638,6 +638,7 @@ public class PrestoConnection
                 ImmutableMap.copyOf(preparedStatements),
                 transactionId.get(),
                 false,
+                false,
                 new Duration(2, MINUTES));
 
         return queryExecutor.startQuery(session, sql);

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -46,6 +46,7 @@ function check_presto() {
   run_in_application_runner_container \
     java -jar "/docker/volumes/presto-cli/presto-cli-executable.jar" \
     ${CLI_ARGUMENTS} \
+    --quiet \
     --execute "SHOW CATALOGS" | grep -i hive
 }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -77,7 +77,7 @@ public abstract class AbstractTestingPrestoClient<T>
     {
         ResultsSession<T> resultsSession = getResultSession(session);
 
-        ClientSession clientSession = toClientSession(session, prestoServer.getBaseUrl(), true, new Duration(2, TimeUnit.MINUTES));
+        ClientSession clientSession = toClientSession(session, prestoServer.getBaseUrl(), true, false, new Duration(2, TimeUnit.MINUTES));
 
         try (StatementClient client = new StatementClient(httpClient, clientSession, sql)) {
             while (client.isValid()) {
@@ -113,7 +113,7 @@ public abstract class AbstractTestingPrestoClient<T>
         }
     }
 
-    private static ClientSession toClientSession(Session session, URI server, boolean debug, Duration clientRequestTimeout)
+    private static ClientSession toClientSession(Session session, URI server, boolean debug, boolean quiet, Duration clientRequestTimeout)
     {
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         properties.putAll(session.getSystemProperties());
@@ -136,6 +136,7 @@ public abstract class AbstractTestingPrestoClient<T>
                 session.getPreparedStatements(),
                 session.getTransactionId().map(Object::toString).orElse(null),
                 debug,
+                quiet,
                 clientRequestTimeout);
     }
 


### PR DESCRIPTION
This change tries to make message of some known problems more informative for presto users.
The message does not cover all possibilities, however it covers our best known scenario for that exception, so it would be nice to have that tips at this point.
Also technical details are hidden and will require `--debug` to be shown. Note that stacktrace was visible only with `--debug` even before this change.

Superesedes: https://github.com/prestodb/presto/pull/5445