### PR TITLE
[for Travis, ignore]

### DIFF
--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -6,6 +6,8 @@ services:
     volumes:
       - ../..:/docker/volumes/conf
       - ../../target:/docker/volumes/logs
+    environment:
+      - MALLOC_ARENA_MAX=1
 
   hadoop-master:
     extends:


### PR DESCRIPTION
Following advice
https://devcenter.heroku.com/articles/testing-cedar-14-memory-use, set
MALLOC_ARENA_MAX to a small number. The aim of this setting is to reduce
native memory fragmentation as managed by glibc and thus reduce JVM
memory footprint (with same heap size). Native memory fragmentation is
there for performance reasons, so we're trading off small potential
performance drop (estimated as few percent, see the link) for increased
product tests stability on Travis.

Hopefully fixes #9295.

This is version of #9310, with smaller setting.