### PR TITLE
Add weighted fair resource group scheduling policy

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/Queue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/Queue.java
@@ -13,11 +13,9 @@
  */
 package com.facebook.presto.execution.resourceGroups;
 
-interface UpdateablePriorityQueue<E>
-        extends Queue<E>
+interface Queue<E>
+        extends Iterable<E>
 {
-    boolean addOrUpdate(E element, long priority);
-
     boolean contains(E element);
 
     boolean remove(E element);

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/WeightedFairQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/WeightedFairQueue.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.resourceGroups;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+final class WeightedFairQueue<E>
+        implements Queue<E>
+{
+    private final Map<E, Node<E>> index = new LinkedHashMap<>();
+
+    public boolean addOrUpdate(E element, Usage usage)
+    {
+        Node<E> node = index.get(element);
+        if (node != null) {
+            node.update(usage);
+            return false;
+        }
+
+        node = new Node<>(element, usage);
+        index.put(element, node);
+        return true;
+    }
+
+    @Override
+    public E peek()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean contains(E element)
+    {
+        return index.containsKey(element);
+    }
+
+    @Override
+    public boolean remove(E element)
+    {
+        Node<E> node = index.remove(element);
+        return node != null;
+    }
+
+    @Override
+    public E poll()
+    {
+        Collection<Node<E>> candidates = index.values();
+        long totalShare = 0;
+        long totalUtilization = 1; // prevent / by zero
+
+        for (Node<E> candidate : candidates) {
+            totalShare += candidate.getShare();
+            totalUtilization += candidate.getUtilization();
+        }
+
+        List<Node<E>> winners = new ArrayList<>();
+        double winnerDelta = 1;
+
+        for (Node<E> candidate : candidates) {
+            double actualFraction = 1.0 * candidate.getUtilization() / totalUtilization;
+            double expectedFraction = 1.0 * candidate.getShare() / totalShare;
+            double delta = actualFraction / expectedFraction;
+
+            if (delta <= winnerDelta) {
+                if (delta < winnerDelta) {
+                    winnerDelta = delta;
+                    winners.clear();
+                }
+
+                // if multiple candidates have the same delta, picking deterministically could cause starvation
+                // we use a stochastic method (weighted by share) to pick amongst these candidates
+                winners.add(candidate);
+            }
+        }
+
+        E winner = pickWinner(winners);
+        index.remove(winner);
+        return winner;
+    }
+
+    private E pickWinner(List<Node<E>> winners)
+    {
+        if (winners.isEmpty()) {
+            return null;
+        }
+
+        if (winners.size() == 1) {
+            return winners.get(0).getValue();
+        }
+
+        long totalShares = winners.stream()
+                .mapToLong(Node::getShare)
+                .sum();
+
+        long winningTicket = ThreadLocalRandom.current().nextLong(0, totalShares);
+        long cumulativeShare = 0;
+        for (Node<E> winner : winners) {
+            if (cumulativeShare + winner.getShare() > winningTicket) {
+                return winner.getValue();
+            }
+            cumulativeShare += winner.getShare();
+        }
+
+        throw new IllegalStateException("A winner should already have been picked");
+    }
+
+    @Override
+    public int size()
+    {
+        return index.size();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return index.isEmpty();
+    }
+
+    @Override
+    public Iterator<E> iterator()
+    {
+        return index.keySet().iterator();
+    }
+
+    public static class Usage
+    {
+        // relative number that is used to determine fraction of resources a group should get
+        // for example, if there are two eligible groups with shares 1 and 2, the first group
+        // should get 1/(1+2) fraction of resources.
+        private int share;
+
+        // a number that represents the current utilization of resources by a group
+        private int utilization;
+
+        public Usage(int share, int utilization)
+        {
+            checkArgument(share > 0, "share must be positive");
+            checkArgument(utilization >= 0, "utilization must be zero or positive");
+
+            this.share = share;
+            this.utilization = utilization;
+        }
+
+        public int getShare()
+        {
+            return share;
+        }
+
+        public int getUtilization()
+        {
+            return utilization;
+        }
+    }
+
+    private static final class Node<E>
+    {
+        private E value;
+        private Usage usage;
+
+        private Node(E value, Usage usage)
+        {
+            this.value = requireNonNull(value, "value is null");
+            this.usage = requireNonNull(usage, "usage is null");
+        }
+
+        public E getValue()
+        {
+            return value;
+        }
+
+        public void update(Usage usage)
+        {
+            this.usage = requireNonNull(usage, "usage is null");
+        }
+
+        public int getShare()
+        {
+            return usage.getShare();
+        }
+
+        public int getUtilization()
+        {
+            return usage.getUtilization();
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestWeightedFairQueue.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestWeightedFairQueue.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.resourceGroups;
+
+import com.facebook.presto.execution.resourceGroups.WeightedFairQueue.Usage;
+import org.apache.commons.math3.distribution.BinomialDistribution;
+import org.testng.annotations.Test;
+
+import static io.airlift.testing.Assertions.assertBetweenInclusive;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestWeightedFairQueue
+{
+    @Test
+    public void testBasic()
+    {
+        WeightedFairQueue<String> queue = new WeightedFairQueue<>();
+        String item1 = "1";
+        String item2 = "2";
+        queue.addOrUpdate(item1, new Usage(1, 1));
+        queue.addOrUpdate(item2, new Usage(2, 1));
+
+        assertEquals(queue.size(), 2);
+        assertEquals(queue.poll(), item2);
+        assertTrue(queue.contains(item1));
+        assertEquals(queue.poll(), item1);
+        assertEquals(queue.size(), 0);
+        assertEquals(queue.poll(), null);
+        assertEquals(queue.poll(), null);
+        assertEquals(queue.size(), 0);
+    }
+
+    @Test
+    public void testUpdate()
+    {
+        WeightedFairQueue<String> queue = new WeightedFairQueue<>();
+        String item1 = "1";
+        String item2 = "2";
+        String item3 = "3";
+        queue.addOrUpdate(item1, new Usage(1, 1));
+        queue.addOrUpdate(item2, new Usage(2, 1));
+        queue.addOrUpdate(item3, new Usage(3, 1));
+
+        assertEquals(queue.poll(), item3);
+        queue.addOrUpdate(item1, new Usage(4, 1));
+        assertEquals(queue.poll(), item1);
+        assertEquals(queue.poll(), item2);
+        assertEquals(queue.size(), 0);
+    }
+
+    @Test
+    public void testMultipleWinners()
+    {
+        WeightedFairQueue<String> queue = new WeightedFairQueue<>();
+        String item1 = "1";
+        String item2 = "2";
+        queue.addOrUpdate(item1, new Usage(2, 0));
+        queue.addOrUpdate(item2, new Usage(1, 0));
+
+        int count1 = 0;
+        int count2 = 0;
+        for (int i = 0; i < 1000; i++) {
+            if (queue.poll().equals(item1)) {
+                queue.addOrUpdate(item1, new Usage(2, 0));
+                count1++;
+            }
+            else {
+                queue.addOrUpdate(item2, new Usage(1, 0));
+                count2++;
+            }
+        }
+
+        BinomialDistribution binomial = new BinomialDistribution(1000, 2.0 / 3.0);
+        int lowerBound = binomial.inverseCumulativeProbability(0.000001);
+        int upperBound = binomial.inverseCumulativeProbability(0.999999);
+
+        assertBetweenInclusive(count1, lowerBound, upperBound);
+        assertBetweenInclusive((1000 - count2), lowerBound, upperBound);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/SchedulingPolicy.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/SchedulingPolicy.java
@@ -17,5 +17,6 @@ public enum SchedulingPolicy
 {
     FAIR,
     WEIGHTED,
+    WEIGHTED_FAIR,
     QUERY_PRIORITY
 }


### PR DESCRIPTION
This policy allocates query slots amongst eligible resource groups in
realtime, weighted by shares. Of all competing groups, the group with
the lowest ratio of actual utilization (running queries/total queries)
to expected utilization (share/sum of shares of all eligible groups)
of the cluster will win the slot. If multiple groups have the same
ratio, a lottery is held where the number of tickets for each group is
proportional to the share.

Will add documentation if the approach/naming looks good.