### PR TITLE
Fix dictionary offset in SliceDictionaryStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
@@ -204,7 +204,8 @@ public class SliceDictionaryStreamReader
         // the engine currently uses identity equality to test if dictionaries are the same
         if (currentDictionaryData != dictionaryData) {
             boolean[] isNullVector = new boolean[positionCount];
-            isNullVector[isNullVector.length - 1] = true;
+            isNullVector[positionCount - 1] = true;
+            dictionaryOffsets[positionCount] = dictionaryOffsets[positionCount - 1];
             dictionaryBlock = new VariableWidthBlock(positionCount, Slices.wrappedBuffer(dictionaryData), dictionaryOffsets, isNullVector);
             currentDictionaryData = dictionaryData;
         }


### PR DESCRIPTION
The last entry in dictionary block generated by
SliceDictionaryStreamReader is always null. The dictionary offset
of that entry should be set to the offset of the previous entry
(instead of 0). Otherwise we will try to allocate negative array size
when calling copyPositions that includes the last entry.