### PR TITLE
Update memory revocation handling in OperatorContext 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
@@ -41,7 +40,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
@@ -51,7 +49,7 @@ import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static java.lang.Boolean.TRUE;
 import static java.util.Objects.requireNonNull;
@@ -80,6 +78,8 @@ public class Driver
 
     @GuardedBy("exclusiveLock")
     private TaskSource currentTaskSource;
+
+    private AtomicReference<SettableFuture<?>> driverBlockedFuture = new AtomicReference<>();
 
     private enum State
     {
@@ -117,6 +117,10 @@ public class Driver
         this.deleteOperator = deleteOperator;
 
         currentTaskSource = sourceOperator.map(operator -> new TaskSource(operator.getSourceId(), ImmutableSet.of(), false)).orElse(null);
+        // initially the driverBlockedFuture is not blocked (it is completed)
+        SettableFuture<?> future = SettableFuture.create();
+        future.set(null);
+        driverBlockedFuture.set(future);
     }
 
     public DriverContext getDriverContext()
@@ -230,6 +234,12 @@ public class Driver
 
         requireNonNull(duration, "duration is null");
 
+        // if the driver is blocked we don't need to continue
+        SettableFuture<?> blockedFuture = driverBlockedFuture.get();
+        if (!blockedFuture.isDone()) {
+            return blockedFuture;
+        }
+
         long maxRuntime = duration.roundTo(TimeUnit.NANOSECONDS);
 
         Optional<ListenableFuture<?>> result = tryWithLock(100, TimeUnit.MILLISECONDS, () -> {
@@ -240,7 +250,7 @@ public class Driver
                 do {
                     ListenableFuture<?> future = processInternal();
                     if (!future.isDone()) {
-                        return wakeUpOnRevokeRequest(future);
+                        return updateDriverBlockedFuture(future);
                     }
                 }
                 while (System.nanoTime() - start < maxRuntime && !isFinishedInternal());
@@ -258,35 +268,27 @@ public class Driver
     {
         checkLockNotHeld("Can not process while holding the driver lock");
 
+        // if the driver is blocked we don't need to continue
+        SettableFuture<?> blockedFuture = driverBlockedFuture.get();
+        if (!blockedFuture.isDone()) {
+            return blockedFuture;
+        }
+
         Optional<ListenableFuture<?>> result = tryWithLock(100, TimeUnit.MILLISECONDS, () -> {
-            ListenableFuture<?> driverBlockedFuture = processInternal();
-            return wakeUpOnRevokeRequest(driverBlockedFuture);
+            ListenableFuture<?> future = processInternal();
+            return updateDriverBlockedFuture(future);
         });
         return result.orElse(NOT_BLOCKED);
     }
 
-    private ListenableFuture<?> wakeUpOnRevokeRequest(ListenableFuture<?> driverBlockedFuture)
+    private ListenableFuture<?> updateDriverBlockedFuture(ListenableFuture<?> sourceBlockedFuture)
     {
-        if (driverBlockedFuture.isDone()) {
-            // driver is not blocked; just return completed future
-            return driverBlockedFuture;
-        }
-
-        ImmutableList<SettableFuture<?>> revokingRequestedFutures = operators.stream()
-                .map(Operator::getOperatorContext)
-                .map(OperatorContext::getMemoryRevokingRequestedFuture)
-                .collect(toImmutableList());
-        Optional<SettableFuture<?>> doneRevokingRequestedFuture = revokingRequestedFutures.stream().filter(Future::isDone).findAny();
-        if (doneRevokingRequestedFuture.isPresent()) {
-            // revoking already requested for one of operators; return completed future
-            return doneRevokingRequestedFuture.get();
-        }
-
-        // unblock as soon as driver is unblocked or we get revoking request for any of operators
-        ImmutableList.Builder<ListenableFuture<?>> futures = ImmutableList.builder();
-        futures.add(driverBlockedFuture);
-        futures.addAll(revokingRequestedFutures);
-        return firstFinishedFuture(futures.build());
+        // driverBlockedFuture will be completed as soon as the sourceBlockedFuture is completed
+        // or any of the operators gets a memory revocation request
+        SettableFuture<?> newDriverBlockedFuture = SettableFuture.create();
+        driverBlockedFuture.set(newDriverBlockedFuture);
+        sourceBlockedFuture.addListener(() -> newDriverBlockedFuture.set(null), newDirectExecutorService());
+        return newDriverBlockedFuture;
     }
 
     @GuardedBy("exclusiveLock")
@@ -577,7 +579,7 @@ public class Driver
     private static ListenableFuture<?> firstFinishedFuture(List<ListenableFuture<?>> futures)
     {
         SettableFuture<?> result = SettableFuture.create();
-        ExecutorService executor = MoreExecutors.newDirectExecutorService();
+        ExecutorService executor = newDirectExecutorService();
 
         for (ListenableFuture<?> future : futures) {
             future.addListener(() -> result.set(null), executor);

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverFactory.java
@@ -92,7 +92,9 @@ public class DriverFactory
             Operator operator = operatorFactory.createOperator(driverContext);
             operators.add(operator);
         }
-        return new Driver(driverContext, operators.build());
+        Driver driver = new Driver(driverContext, operators.build());
+        driver.initialize();
+        return driver;
     }
 
     public synchronized void noMoreDrivers()

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -119,7 +119,9 @@ public class TestMemoryPools
             RevocableMemoryOperator revocableMemoryOperator = new RevocableMemoryOperator(revokableOperatorContext, reservedPerPage, numberOfPages);
             createOperator.set(revocableMemoryOperator);
 
-            return ImmutableList.of(new Driver(driverContext, revocableMemoryOperator, outputOperator));
+            Driver driver = new Driver(driverContext, revocableMemoryOperator, outputOperator);
+            driver.initialize();
+            return ImmutableList.of(driver);
         });
         return createOperator.get();
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -104,6 +104,7 @@ public class TestDriver
 
         Operator sink = createSinkOperator(source);
         Driver driver = new Driver(driverContext, source, sink);
+        driver.initialize();
 
         assertSame(driver.getDriverContext(), driverContext);
 
@@ -126,6 +127,7 @@ public class TestDriver
 
         PageConsumerOperator sink = createSinkOperator(source);
         Driver driver = new Driver(driverContext, source, sink);
+        driver.initialize();
 
         assertSame(driver.getDriverContext(), driverContext);
 
@@ -163,6 +165,7 @@ public class TestDriver
 
         PageConsumerOperator sink = createSinkOperator(source);
         Driver driver = new Driver(driverContext, source, sink);
+        driver.initialize();
 
         assertSame(driver.getDriverContext(), driverContext);
 
@@ -186,6 +189,7 @@ public class TestDriver
     {
         BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, new PlanNodeId("test"), "source"), false);
         final Driver driver = new Driver(driverContext, brokenOperator, createSinkOperator(brokenOperator));
+        driver.initialize();
 
         assertSame(driver.getDriverContext(), driverContext);
 
@@ -219,6 +223,7 @@ public class TestDriver
     {
         BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, new PlanNodeId("test"), "source"), true);
         final Driver driver = new Driver(driverContext, brokenOperator, createSinkOperator(brokenOperator));
+        driver.initialize();
 
         assertSame(driver.getDriverContext(), driverContext);
 
@@ -267,6 +272,7 @@ public class TestDriver
 
         BrokenOperator brokenOperator = new BrokenOperator(driverContext.addOperatorContext(0, new PlanNodeId("test"), "source"));
         final Driver driver = new Driver(driverContext, source, brokenOperator);
+        driver.initialize();
 
         // block thread in operator processing
         Future<Boolean> driverProcessFor = executor.submit(new Callable<Boolean>()

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -430,6 +430,7 @@ public class TestHashJoinOperator
                     valuesOperatorFactory.createOperator(joinDriverContext),
                     joinOperator,
                     pageBufferOperatorFactory.createOperator(joinDriverContext));
+            joinDriver.initialize();
 
             while (!called.get()) { // process first row of first page of LookupJoinOperator
                 processRow(joinDriver, taskStateMachine);
@@ -1074,6 +1075,7 @@ public class TestHashJoinOperator
         Driver sourceDriver = new Driver(collectDriverContext,
                 valuesOperatorFactory.createOperator(collectDriverContext),
                 sinkOperatorFactory.createOperator(collectDriverContext));
+        sourceDriver.initialize();
         valuesOperatorFactory.noMoreOperators();
         sinkOperatorFactory.noMoreOperators();
 
@@ -1112,6 +1114,7 @@ public class TestHashJoinOperator
                     buildDriverContext,
                     sourceOperatorFactory.createOperator(buildDriverContext),
                     buildOperator);
+            driver.initialize();
             buildDrivers.add(driver);
             buildOperators.add(buildOperator);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
@@ -96,6 +96,7 @@ public class TestHashSemiJoinOperator
         Operator setBuilderOperator = setBuilderOperatorFactory.createOperator(driverContext);
 
         Driver driver = new Driver(driverContext, buildOperator, setBuilderOperator);
+        driver.initialize();
         while (!driver.isFinished()) {
             driver.process();
         }
@@ -152,6 +153,7 @@ public class TestHashSemiJoinOperator
         Operator setBuilderOperator = setBuilderOperatorFactory.createOperator(driverContext);
 
         Driver driver = new Driver(driverContext, buildOperator, setBuilderOperator);
+        driver.initialize();
         while (!driver.isFinished()) {
             driver.process();
         }
@@ -199,6 +201,7 @@ public class TestHashSemiJoinOperator
         Operator setBuilderOperator = setBuilderOperatorFactory.createOperator(driverContext);
 
         Driver driver = new Driver(driverContext, buildOperator, setBuilderOperator);
+        driver.initialize();
         while (!driver.isFinished()) {
             driver.process();
         }
@@ -250,6 +253,7 @@ public class TestHashSemiJoinOperator
         Operator setBuilderOperator = setBuilderOperatorFactory.createOperator(driverContext);
 
         Driver driver = new Driver(driverContext, buildOperator, setBuilderOperator);
+        driver.initialize();
         while (!driver.isFinished()) {
             driver.process();
         }
@@ -299,6 +303,7 @@ public class TestHashSemiJoinOperator
         Operator setBuilderOperator = setBuilderOperatorFactory.createOperator(driverContext);
 
         Driver driver = new Driver(driverContext, buildOperator, setBuilderOperator);
+        driver.initialize();
         while (!driver.isFinished()) {
             driver.process();
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopJoinOperator.java
@@ -499,6 +499,7 @@ public class TestNestedLoopJoinOperator
         Driver driver = new Driver(driverContext,
                 valuesOperatorFactory.createOperator(driverContext),
                 nestedLoopBuildOperatorFactory.createOperator(driverContext));
+        driver.initialize();
 
         valuesOperatorFactory.noMoreOperators();
         nestedLoopBuildOperatorFactory.noMoreOperators();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorMemoryRevocation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorMemoryRevocation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestOperatorMemoryRevocation
+{
+    @Test
+    public void testOperatorMemoryRevocation()
+    {
+        AtomicInteger counter = new AtomicInteger();
+        OperatorContext operatorContext = TestingOperatorContext.create();
+        operatorContext.reserveRevocableMemory(1000);
+        operatorContext.setMemoryRevocationRequestListener(() -> counter.incrementAndGet());
+        operatorContext.requestMemoryRevoking();
+        assertTrue(operatorContext.isMemoryRevokingRequested());
+        assertEquals(counter.get(), 1);
+
+        // calling resetMemoryRevokingRequested() should clear the memory revoking requested flag
+        operatorContext.resetMemoryRevokingRequested();
+        assertFalse(operatorContext.isMemoryRevokingRequested());
+
+        operatorContext.requestMemoryRevoking();
+        assertEquals(counter.get(), 2);
+        assertTrue(operatorContext.isMemoryRevokingRequested());
+    }
+
+    @Test
+    public void testRevocationAlreadyRequested()
+    {
+        AtomicInteger counter = new AtomicInteger();
+        OperatorContext operatorContext = TestingOperatorContext.create();
+        operatorContext.reserveRevocableMemory(1000);
+
+        // when memory revocation is already requested setting a listener should immediately execute it
+        operatorContext.requestMemoryRevoking();
+        operatorContext.setMemoryRevocationRequestListener(() -> counter.incrementAndGet());
+        assertTrue(operatorContext.isMemoryRevokingRequested());
+        assertEquals(counter.get(), 1);
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "listener already set")
+    public void testSingleListenerEnforcement()
+    {
+        OperatorContext operatorContext = TestingOperatorContext.create();
+        operatorContext.setMemoryRevocationRequestListener(() -> {});
+        operatorContext.setMemoryRevocationRequestListener(() -> {});
+    }
+}


### PR DESCRIPTION
The new wrapper class is used to guarantee that only a single listener is added
to the wrapped future. Previously, the driver was adding a large number of
listeners to this future causing GC issues.