### PR TITLE
Support CAST to INTERVAL type

### DIFF
--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -357,7 +357,7 @@ type
     | MAP '<' type ',' type '>'
     | ROW '(' identifier type (',' identifier type)* ')'
     | baseType ('(' typeParameter (',' typeParameter)* ')')?
-    | intervalType
+    | INTERVAL from=intervalField TO to=intervalField
     ;
 
 typeParameter
@@ -369,10 +369,6 @@ baseType
     | TIMESTAMP_WITH_TIME_ZONE
     | DOUBLE_PRECISION
     | identifier
-    ;
-
-intervalType
-    : INTERVAL from=intervalField TO to=intervalField
     ;
 
 whenClause

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -357,6 +357,7 @@ type
     | MAP '<' type ',' type '>'
     | ROW '(' identifier type (',' identifier type)* ')'
     | baseType ('(' typeParameter (',' typeParameter)* ')')?
+    | intervalType
     ;
 
 typeParameter
@@ -368,6 +369,10 @@ baseType
     | TIMESTAMP_WITH_TIME_ZONE
     | DOUBLE_PRECISION
     | identifier
+    ;
+
+intervalType
+    : INTERVAL from=intervalField TO to=intervalField
     ;
 
 whenClause

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -2020,6 +2020,11 @@ class AstBuilder
             return "ROW" + builder.toString();
         }
 
+        if (type.intervalType() != null) {
+            return "INTERVAL " + getIntervalFieldType((Token) type.intervalType().from.getChild(0).getPayload()) +
+                    " TO " + getIntervalFieldType((Token) type.intervalType().to.getChild(0).getPayload());
+        }
+
         throw new IllegalArgumentException("Unsupported type specification: " + type.getText());
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -2020,9 +2020,9 @@ class AstBuilder
             return "ROW" + builder.toString();
         }
 
-        if (type.intervalType() != null) {
-            return "INTERVAL " + getIntervalFieldType((Token) type.intervalType().from.getChild(0).getPayload()) +
-                    " TO " + getIntervalFieldType((Token) type.intervalType().to.getChild(0).getPayload());
+        if (type.INTERVAL() != null) {
+            return "INTERVAL " + getIntervalFieldType((Token) type.from.getChild(0).getPayload()) +
+                    " TO " + getIntervalFieldType((Token) type.to.getChild(0).getPayload());
         }
 
         throw new IllegalArgumentException("Unsupported type specification: " + type.getText());

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -368,6 +368,8 @@ public class TestSqlParser
         assertCast("ROW(x BIGINT, y DOUBLE)", "ROW(x bigint,y double)");
         assertCast("ROW(x BIGINT, y DOUBLE, z ROW(m array<bigint>,n map<double,timestamp>))", "ROW(x BIGINT,y DOUBLE,z ROW(m array(bigint),n map(double,timestamp)))");
         assertCast("array<ROW(x BIGINT, y TIMESTAMP)>", "ARRAY(ROW(x BIGINT,y TIMESTAMP))");
+
+        assertCast("interval year to month", "INTERVAL YEAR TO MONTH");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -959,4 +959,16 @@ public abstract class AbstractTestDistributedQueries
 
         assertUpdate("DROP TABLE test_written_stats");
     }
+
+    @Test
+    public void testComplexCast()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(SystemSessionProperties.OPTIMIZE_DISTINCT_AGGREGATIONS, "true")
+                .build();
+        // This is optimized using CAST(null AS interval day to second) which may be problematic to deserialize on worker
+        assertQuery(session, "WITH t(a, b) AS (VALUES (1, INTERVAL '1' SECOND)) " +
+                "SELECT count(DISTINCT a), CAST(max(b) AS VARCHAR) FROM t",
+                "VALUES (1, '0 00:00:01.000')");
+    }
 }


### PR DESCRIPTION
This is required indirectly to support optimized aggregations on
INTERVAL types too.

Fixes #9338, #9336