### PR TITLE
Prune ORDER BY in aggregation when not necessary

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxBy.java
@@ -131,7 +131,7 @@ public abstract class AbstractMinMaxBy
                 stateFactory,
                 valueType);
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(getSignature().getName(), inputTypes, intermediateType, valueType, true, factory);
+        return new InternalAggregationFunction(getSignature().getName(), inputTypes, intermediateType, valueType, true, false, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type value, Type key)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxByNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxByNAggregationFunction.java
@@ -163,6 +163,6 @@ public abstract class AbstractMinMaxByNAggregationFunction
                 outputType);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(name, inputTypes, intermediateType, outputType, true, factory);
+        return new InternalAggregationFunction(name, inputTypes, intermediateType, outputType, true, false, factory);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
@@ -103,7 +103,7 @@ public abstract class AbstractMinMaxNAggregationFunction
                 outputType);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(getSignature().getName(), inputTypes, intermediateType, outputType, true, factory);
+        return new InternalAggregationFunction(getSignature().getName(), inputTypes, intermediateType, outputType, true, false, factory);
     }
 
     public static void input(BlockComparator comparator, Type type, MinMaxNState state, Block block, long n, int blockIndex)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
@@ -130,7 +130,7 @@ public class AggregationFromAnnotationsParser
     {
         AggregationFunction aggregationAnnotation = aggregationDefinition.getAnnotation(AggregationFunction.class);
         requireNonNull(aggregationAnnotation, "aggregationAnnotation is null");
-        return new AggregationHeader(aggregationAnnotation.value(), parseDescription(aggregationDefinition), aggregationAnnotation.decomposable());
+        return new AggregationHeader(aggregationAnnotation.value(), parseDescription(aggregationDefinition), aggregationAnnotation.decomposable(), aggregationAnnotation.isOrderSensitive());
     }
 
     private static List<AggregationHeader> parseHeaders(AnnotatedElement aggregationDefinition, AnnotatedElement toParse)
@@ -142,7 +142,8 @@ public class AggregationFromAnnotationsParser
                         new AggregationHeader(
                                 name,
                                 parseDescription(aggregationDefinition, toParse),
-                                aggregationAnnotation.decomposable()))
+                                aggregationAnnotation.decomposable(),
+                                aggregationAnnotation.isOrderSensitive()))
                 .collect(toImmutableList());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationHeader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationHeader.java
@@ -22,12 +22,14 @@ public class AggregationHeader
     private final String name;
     private final Optional<String> description;
     private final boolean decomposable;
+    private final boolean orderSensitive;
 
-    public AggregationHeader(String name, Optional<String> description, boolean decomposable)
+    public AggregationHeader(String name, Optional<String> description, boolean decomposable, boolean orderSensitive)
     {
         this.name = requireNonNull(name, "name cannot be null");
         this.description = requireNonNull(description, "description cannot be null");
         this.decomposable = decomposable;
+        this.orderSensitive = orderSensitive;
     }
 
     public String getName()
@@ -43,5 +45,10 @@ public class AggregationHeader
     public boolean isDecomposable()
     {
         return decomposable;
+    }
+
+    public boolean isOrderSensitive()
+    {
+        return orderSensitive;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
@@ -155,7 +155,7 @@ public class ArbitraryAggregationFunction
                 type);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, type, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, type, true, false, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type value)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArrayAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArrayAggregationFunction.java
@@ -106,7 +106,7 @@ public class ArrayAggregationFunction
                 outputType);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, true, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type value, boolean legacyArrayAgg)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ChecksumAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ChecksumAggregationFunction.java
@@ -94,7 +94,7 @@ public class ChecksumAggregationFunction
                 VARBINARY);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, BIGINT, VARBINARY, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, BIGINT, VARBINARY, true, false, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type type)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountColumn.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/CountColumn.java
@@ -95,7 +95,7 @@ public class CountColumn
                 BIGINT);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, BIGINT, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, BIGINT, true, false, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type type)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalAverageAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalAverageAggregation.java
@@ -127,7 +127,7 @@ public class DecimalAverageAggregation
 
         Type intermediateType = stateSerializer.getSerializedType();
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, type, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, type, true, false, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type type)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalSumAggregation.java
@@ -116,7 +116,7 @@ public class DecimalSumAggregation
 
         Type intermediateType = stateSerializer.getSerializedType();
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, false, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type type)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Histogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Histogram.java
@@ -103,7 +103,7 @@ public class Histogram
                 outputType);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, false, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type keyType)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/InternalAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/InternalAggregationFunction.java
@@ -32,9 +32,10 @@ public final class InternalAggregationFunction
     private final Type intermediateType;
     private final Type finalType;
     private final boolean decomposable;
+    private final boolean orderSensitive;
     private final AccumulatorFactoryBinder factory;
 
-    public InternalAggregationFunction(String name, List<Type> parameterTypes, Type intermediateType, Type finalType, boolean decomposable, AccumulatorFactoryBinder factory)
+    public InternalAggregationFunction(String name, List<Type> parameterTypes, Type intermediateType, Type finalType, boolean decomposable, boolean orderSensitive, AccumulatorFactoryBinder factory)
     {
         this.name = requireNonNull(name, "name is null");
         checkArgument(!name.isEmpty(), "name is empty");
@@ -42,6 +43,7 @@ public final class InternalAggregationFunction
         this.intermediateType = requireNonNull(intermediateType, "intermediateType is null");
         this.finalType = requireNonNull(finalType, "finalType is null");
         this.decomposable = decomposable;
+        this.orderSensitive = orderSensitive;
         this.factory = requireNonNull(factory, "factory is null");
     }
 
@@ -71,6 +73,14 @@ public final class InternalAggregationFunction
     public boolean isDecomposable()
     {
         return decomposable;
+    }
+
+    /**
+     * Indicates that the aggregation is sensitive to input order
+     */
+    public boolean isOrderSensitive()
+    {
+        return orderSensitive;
     }
 
     public AccumulatorFactory bind(List<Integer> inputChannels, Optional<Integer> maskChannel)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
@@ -98,7 +98,7 @@ public class MapAggregationFunction
                 outputType);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, true, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type keyType, Type valueType)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionAggregation.java
@@ -92,7 +92,7 @@ public class MapUnionAggregation
                 outputType);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, false, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type inputType)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultimapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MultimapAggregationFunction.java
@@ -98,7 +98,7 @@ public class MultimapAggregationFunction
                 outputType);
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
-        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, factory);
+        return new InternalAggregationFunction(NAME, inputTypes, intermediateType, outputType, true, false, factory);
     }
 
     private static List<ParameterMetadata> createInputParameterMetadata(Type keyType, Type valueType)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
@@ -111,6 +111,7 @@ public class ParametricAggregation
                 stateSerializer.getSerializedType(),
                 outputType,
                 details.isDecomposable(),
+                details.isOrderSensitive(),
                 new LazyAccumulatorFactoryBinder(metadata, classLoader));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -46,6 +46,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneIndexSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinChildrenColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneJoinColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneMarkDistinctColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PruneOrderByInAggregation;
 import com.facebook.presto.sql.planner.iterative.rule.PruneOutputColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneProjectColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneSemiJoinColumns;
@@ -215,7 +216,8 @@ public class PlanOptimizers
                                         new ImplementFilteredAggregations(),
                                         new ImplementBernoulliSampleAsFilter(),
                                         new MergeLimitWithDistinct(),
-                                        new PruneCountAggregationOverScalar()))
+                                        new PruneCountAggregationOverScalar(),
+                                        new PruneOrderByInAggregation(metadata.getFunctionRegistry())))
                                 .build()),
                 simplifyOptimizer,
                 new UnaliasSymbolReferences(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
+import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
+import static java.util.Objects.requireNonNull;
+
+public class PruneOrderByInAggregation
+        implements Rule<AggregationNode>
+{
+    private static final Pattern<AggregationNode> PATTERN = aggregation();
+    private final FunctionRegistry functionRegistry;
+
+    public PruneOrderByInAggregation(FunctionRegistry functionRegistry)
+    {
+        this.functionRegistry = requireNonNull(functionRegistry, "functionRegistry is null");
+    }
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(AggregationNode node, Captures captures, Context context)
+    {
+        if (node.getAggregations().values().stream().allMatch(aggregation -> aggregation.getOrderBy().isEmpty())) {
+            return Result.empty();
+        }
+
+        boolean anyRewritten = false;
+        ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
+        for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
+            Aggregation aggregation = entry.getValue();
+            if (aggregation.getOrderBy().isEmpty()) {
+                aggregations.put(entry);
+            }
+            // getAggregateFunctionImplementation can be expensive, so check it last.
+            else if (functionRegistry.getAggregateFunctionImplementation(aggregation.getSignature()).isOrderSensitive()) {
+                aggregations.put(entry);
+            }
+            else {
+                anyRewritten = true;
+                aggregations.put(entry.getKey(), new Aggregation(aggregation.getCall(), aggregation.getSignature(), aggregation.getMask(), ImmutableList.of(), ImmutableList.of()));
+            }
+        }
+
+        if (!anyRewritten) {
+            return Result.empty();
+        }
+        return Result.ofPlanNode(new AggregationNode(node.getId(), node.getSource(), aggregations.build(), node.getGroupingSets(), node.getStep(), node.getHashSymbol(), node.getGroupIdSymbol()));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -180,6 +180,22 @@ public final class PlanMatchPattern
         return result;
     }
 
+    public static PlanMatchPattern aggregationWithOrderBy(
+            List<List<String>> groupingSets,
+            Map<Optional<String>, ExpectedValueProvider<FunctionCall>> aggregations,
+            Map<Symbol, Symbol> masks,
+            Optional<Symbol> groupId,
+            Map<String, List<String>> orderBys,
+            Map<String, List<SortOrder>> orderings,
+            Step step,
+            PlanMatchPattern source)
+    {
+        PlanMatchPattern result = node(AggregationNode.class, source).with(new AggregationMatcher(groupingSets, masks, groupId, Optional.of(orderBys), Optional.of(orderings), step));
+        aggregations.entrySet().forEach(
+                aggregation -> result.withAlias(aggregation.getKey(), new AggregationFunctionMatcher(aggregation.getValue())));
+        return result;
+    }
+
     public static PlanMatchPattern aggregation(
             List<List<String>> groupingSets,
             Map<Optional<String>, ExpectedValueProvider<FunctionCall>> aggregations,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneOrderByInAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneOrderByInAggregation.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_FIRST;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregationWithOrderBy;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
+
+public class TestPruneOrderByInAggregation
+        extends BaseRuleTest
+{
+    private static final FunctionRegistry functionRegistry = MetadataManager.createTestMetadataManager().getFunctionRegistry();
+
+    @Test
+    public void testBasics()
+    {
+        tester().assertThat(new PruneOrderByInAggregation(functionRegistry))
+                .on(this::buildAggregation)
+                .matches(
+                        aggregationWithOrderBy(
+                                ImmutableList.of(ImmutableList.of("key")),
+                                ImmutableMap.of(
+                                        Optional.of("avg"),
+                                        functionCall("avg", ImmutableList.of("input")),
+                                        Optional.of("array_agg"),
+                                        functionCall("array_agg", ImmutableList.of("input"))),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                ImmutableMap.of("avg", ImmutableList.of(), "array_agg", ImmutableList.of("input")),
+                                ImmutableMap.of("avg", ImmutableList.of(), "array_agg", ImmutableList.of(ASC_NULLS_FIRST)),
+                                SINGLE,
+                                values("input", "key", "keyHash", "mask")));
+    }
+
+    private AggregationNode buildAggregation(PlanBuilder planBuilder)
+    {
+        Symbol avg = planBuilder.symbol("avg");
+        Symbol arrayAgg = planBuilder.symbol("array_agg");
+        Symbol input = planBuilder.symbol("input");
+        Symbol key = planBuilder.symbol("key");
+        Symbol keyHash = planBuilder.symbol("keyHash");
+        Symbol mask = planBuilder.symbol("mask");
+        List<Symbol> sourceSymbols = ImmutableList.of(input, key, keyHash, mask);
+        return planBuilder.aggregation(aggregationBuilder -> aggregationBuilder
+                .addGroupingSet(key)
+                .addAggregation(avg, planBuilder.expression("avg(input)"), ImmutableList.of(BIGINT), mask, ImmutableList.of(input), ImmutableList.of(ASC_NULLS_FIRST))
+                .addAggregation(arrayAgg, planBuilder.expression("array_agg(input)"), ImmutableList.of(BIGINT), mask, ImmutableList.of(input), ImmutableList.of(ASC_NULLS_FIRST))
+                .hashSymbol(keyHash)
+                .source(planBuilder.values(sourceSymbols, ImmutableList.of())));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -202,20 +202,25 @@ public class PlanBuilder
 
         public AggregationBuilder addAggregation(Symbol output, Expression expression, List<Type> inputTypes)
         {
-            return addAggregation(output, expression, inputTypes, Optional.empty());
+            return addAggregation(output, expression, inputTypes, Optional.empty(), ImmutableList.of(), ImmutableList.of());
         }
 
         public AggregationBuilder addAggregation(Symbol output, Expression expression, List<Type> inputTypes, Symbol mask)
         {
-            return addAggregation(output, expression, inputTypes, Optional.of(mask));
+            return addAggregation(output, expression, inputTypes, Optional.of(mask), ImmutableList.of(), ImmutableList.of());
         }
 
-        private AggregationBuilder addAggregation(Symbol output, Expression expression, List<Type> inputTypes, Optional<Symbol> mask)
+        public AggregationBuilder addAggregation(Symbol output, Expression expression, List<Type> inputTypes, Symbol mask, List<Symbol> orderBy, List<SortOrder> ordering)
+        {
+            return addAggregation(output, expression, inputTypes, Optional.of(mask), orderBy, ordering);
+        }
+
+        private AggregationBuilder addAggregation(Symbol output, Expression expression, List<Type> inputTypes, Optional<Symbol> mask, List<Symbol> orderBy, List<SortOrder> ordering)
         {
             checkArgument(expression instanceof FunctionCall);
             FunctionCall aggregation = (FunctionCall) expression;
             Signature signature = metadata.getFunctionRegistry().resolveFunction(aggregation.getName(), TypeSignatureProvider.fromTypes(inputTypes));
-            return addAggregation(output, new Aggregation(aggregation, signature, mask, ImmutableList.of(), ImmutableList.of()));
+            return addAggregation(output, new Aggregation(aggregation, signature, mask, orderBy, ordering));
         }
 
         public AggregationBuilder addAggregation(Symbol output, Aggregation aggregation)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunction.java
@@ -28,5 +28,7 @@ public @interface AggregationFunction
 
     boolean decomposable() default true;
 
+    boolean isOrderSensitive() default false;
+
     String[] alias() default {};
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -9144,6 +9144,9 @@ public abstract class AbstractTestQueries
     public void testAggregationWithOrderBy()
     {
         assertQuery(
+                "SELECT sum(x ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
+                "VALUES (8)");
+        assertQuery(
                 "SELECT array_agg(x ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
                 "VALUES ((4, 1, 3))");
 


### PR DESCRIPTION
`ORDER BY` will be removed from aggregation functions except in `array_agg`, `map_agg`, `min`, `max`, `min_by`, `max_by`.

I'm not sure whether we should keep them in `map_agg` and `min/max` functions. The result could be different given different input order in these functions. People complain about not having a stable min/max. This could achieve that, but it's quite expensive.