### PR TITLE
Add http-server log path to config file in RPM

### DIFF
--- a/presto-server-rpm/src/main/resources/dist/config/config.properties
+++ b/presto-server-rpm/src/main/resources/dist/config/config.properties
@@ -1,6 +1,7 @@
 #single node install config
 coordinator=true
 node-scheduler.include-coordinator=true
+http-server.log.path=/var/log/presto/http-request.log
 http-server.http.port=8080
 discovery-server.enabled=true
 discovery.uri=http://localhost:8080


### PR DESCRIPTION
Currently, all log files are placed in /var/log/presto except for http-server log.
To make all presto logs more manageable, all logs including http-server log place
in the same directory.