### PR TITLE
[WIP]  Verify online partition before drop it

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -76,7 +76,6 @@ import static java.util.stream.Collectors.toList;
 
 public class HivePartitionManager
 {
-    public static final String PRESTO_OFFLINE = "presto_offline";
     private static final String PARTITION_VALUE_WILDCARD = "";
 
     private final DateTimeZone timeZone;


### PR DESCRIPTION
Resolves https://github.com/prestodb/presto/issues/9371

Ideally, we want to verify *all* the partitions are online before dropping a table. However, will this be too expensive?  As also mentioned in https://issues.apache.org/jira/browse/HIVE-11145:

> This is an expensive feature as when a table is dropped every partition must be fetched and checked to make sure it can be dropped.

Prevent dropping offline partition:

```
presto:di> delete from test_wxie_part where ds = '2017-10-01';

Query 20171118_044423_00002_2kn2r, FAILED, 1 node
Splits: 1 total, 0 done (0.00%)
0:01 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20171118_044423_00002_2kn2r failed: Table 'di.test_wxie_part' partition 'ds=2017-10-01' is offline

presto:di>
presto:di>
presto:di> delete from test_wxie_part;

Query 20171118_044432_00003_2kn2r, FAILED, 1 node
Splits: 1 total, 0 done (0.00%)
0:01 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20171118_044432_00003_2kn2r failed: Table 'di.test_wxie_part' partition 'ds=2017-10-01' is offline
```