### PR TITLE
Make shard boundary configurable

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPageSinkProvider.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPageSinkProvider.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import io.airlift.units.DataSize;
+import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 
@@ -37,6 +38,7 @@ public class RaptorPageSinkProvider
     private final StorageManager storageManager;
     private final PageSorter pageSorter;
     private final DataSize maxBufferSize;
+    private final DateTimeZone shardSplitTimezone;
 
     @Inject
     public RaptorPageSinkProvider(StorageManager storageManager, PageSorter pageSorter, StorageManagerConfig config)
@@ -44,6 +46,7 @@ public class RaptorPageSinkProvider
         this.storageManager = requireNonNull(storageManager, "storageManager is null");
         this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
         this.maxBufferSize = config.getMaxBufferSize();
+        this.shardSplitTimezone = config.getShardSplitTimezone();
     }
 
     @Override
@@ -61,7 +64,8 @@ public class RaptorPageSinkProvider
                 handle.getBucketCount(),
                 toColumnIds(handle.getBucketColumnHandles()),
                 handle.getTemporalColumnHandle(),
-                maxBufferSize);
+                maxBufferSize,
+                shardSplitTimezone);
     }
 
     @Override
@@ -79,7 +83,8 @@ public class RaptorPageSinkProvider
                 handle.getBucketCount(),
                 toColumnIds(handle.getBucketColumnHandles()),
                 handle.getTemporalColumnHandle(),
-                maxBufferSize);
+                maxBufferSize,
+                shardSplitTimezone);
     }
 
     private static List<Long> toColumnIds(List<RaptorColumnHandle> columnHandles)

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
@@ -22,6 +22,7 @@ import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 import io.airlift.units.MinDuration;
+import org.joda.time.DateTimeZone;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -59,6 +60,7 @@ public class StorageManagerConfig
     private DataSize maxShardSize = new DataSize(256, MEGABYTE);
     private DataSize maxBufferSize = new DataSize(256, MEGABYTE);
     private int oneSplitPerBucketThreshold;
+    private DateTimeZone shardSplitTimezone = DateTimeZone.UTC;
 
     @NotNull
     public File getDataDirectory()
@@ -283,6 +285,20 @@ public class StorageManagerConfig
     public StorageManagerConfig setMaxShardSize(DataSize maxShardSize)
     {
         this.maxShardSize = maxShardSize;
+        return this;
+    }
+
+    @NotNull
+    public DateTimeZone getShardSplitTimezone()
+    {
+        return shardSplitTimezone;
+    }
+
+    @Config("storage.shard-split-timezone")
+    @ConfigDescription("Timezone to split shard on")
+    public StorageManagerConfig setShardSplitTimezone(String shardSplitTimezone)
+    {
+        this.shardSplitTimezone = DateTimeZone.forID(shardSplitTimezone);
         return this;
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/CompactionSetCreator.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/CompactionSetCreator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.raptor.storage.organization;
 import com.facebook.presto.raptor.metadata.Table;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
+import org.joda.time.DateTimeZone;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,20 +35,22 @@ public class CompactionSetCreator
 {
     private final DataSize maxShardSize;
     private final long maxShardRows;
+    private final DateTimeZone shardSplitTimeZone;
 
-    public CompactionSetCreator(DataSize maxShardSize, long maxShardRows)
+    public CompactionSetCreator(DataSize maxShardSize, long maxShardRows, DateTimeZone shardSplitTimeZone)
     {
         checkArgument(maxShardRows > 0, "maxShardRows must be > 0");
 
         this.maxShardSize = requireNonNull(maxShardSize, "maxShardSize is null");
         this.maxShardRows = maxShardRows;
+        this.shardSplitTimeZone = requireNonNull(shardSplitTimeZone, "shardSplitTimeZone is null");
     }
 
     // Expects a pre-filtered collection of shards.
     // All shards provided to this method will be considered for creating a compaction set.
     public Set<OrganizationSet> createCompactionSets(Table tableInfo, Collection<ShardIndexInfo> shards)
     {
-        Collection<Collection<ShardIndexInfo>> shardsByDaysBuckets = getShardsByDaysBuckets(tableInfo, shards);
+        Collection<Collection<ShardIndexInfo>> shardsByDaysBuckets = getShardsByDaysBuckets(tableInfo, shards, shardSplitTimeZone);
 
         ImmutableSet.Builder<OrganizationSet> compactionSets = ImmutableSet.builder();
         for (Collection<ShardIndexInfo> shardInfos : shardsByDaysBuckets) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardCompactionManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardCompactionManager.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Multimaps;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import org.joda.time.DateTimeZone;
 import org.skife.jdbi.v2.IDBI;
 
 import javax.annotation.PostConstruct;
@@ -88,7 +89,8 @@ public class ShardCompactionManager
                 config.getCompactionInterval(),
                 config.getMaxShardSize(),
                 config.getMaxShardRows(),
-                config.isCompactionEnabled());
+                config.isCompactionEnabled(),
+                config.getShardSplitTimezone());
     }
 
     public ShardCompactionManager(
@@ -99,7 +101,8 @@ public class ShardCompactionManager
             Duration compactionDiscoveryInterval,
             DataSize maxShardSize,
             long maxShardRows,
-            boolean compactionEnabled)
+            boolean compactionEnabled,
+            DateTimeZone shardSplitTimezone)
     {
         this.dbi = requireNonNull(dbi, "dbi is null");
         this.metadataDao = onDemandDao(dbi, MetadataDao.class);
@@ -116,7 +119,7 @@ public class ShardCompactionManager
         this.maxShardRows = maxShardRows;
 
         this.compactionEnabled = compactionEnabled;
-        this.compactionSetCreator = new CompactionSetCreator(maxShardSize, maxShardRows);
+        this.compactionSetCreator = new CompactionSetCreator(maxShardSize, maxShardRows, shardSplitTimezone);
     }
 
     @PostConstruct

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
@@ -63,7 +63,8 @@ public class TestStorageManagerConfig
                 .setMaxShardRows(1_000_000)
                 .setMaxShardSize(new DataSize(256, MEGABYTE))
                 .setMaxBufferSize(new DataSize(256, MEGABYTE))
-                .setOneSplitPerBucketThreshold(0));
+                .setOneSplitPerBucketThreshold(0)
+                .setShardSplitTimezone("UTC"));
     }
 
     @Test
@@ -90,6 +91,7 @@ public class TestStorageManagerConfig
                 .put("storage.max-shard-size", "10MB")
                 .put("storage.max-buffer-size", "512MB")
                 .put("storage.one-split-per-bucket-threshold", "4")
+                .put("storage.shard-split-timezone", "America/Los_Angeles")
                 .build();
 
         StorageManagerConfig expected = new StorageManagerConfig()
@@ -112,7 +114,8 @@ public class TestStorageManagerConfig
                 .setMaxShardRows(10_000)
                 .setMaxShardSize(new DataSize(10, MEGABYTE))
                 .setMaxBufferSize(new DataSize(512, MEGABYTE))
-                .setOneSplitPerBucketThreshold(4);
+                .setOneSplitPerBucketThreshold(4)
+                .setShardSplitTimezone("America/Los_Angeles");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestCompactionSetCreator.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestCompactionSetCreator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
 import java.time.Duration;
@@ -44,7 +45,7 @@ public class TestCompactionSetCreator
     private static final Table bucketedTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.of(3), OptionalLong.empty(), false);
     private static final Table bucketedTemporalTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.of(3), OptionalLong.of(1), false);
 
-    private final CompactionSetCreator compactionSetCreator = new CompactionSetCreator(MAX_SHARD_SIZE, MAX_SHARD_ROWS);
+    private final CompactionSetCreator compactionSetCreator = new CompactionSetCreator(MAX_SHARD_SIZE, MAX_SHARD_ROWS, DateTimeZone.UTC);
 
     @Test
     public void testNonTemporalOrganizationSetSimple()

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizationManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizationManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
+import org.joda.time.DateTimeZone;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.IDBI;
@@ -136,7 +137,7 @@ public class TestShardOrganizationManager
                 shardWithSortRange(1, ShardRange.of(new Tuple(types, 6L, "hello", day, timestamp), new Tuple(types, 9L, "hello", day, timestamp))),
                 shardWithSortRange(1, ShardRange.of(new Tuple(types, 1L, "hello", day, timestamp), new Tuple(types, 5L, "hello", day, timestamp))));
 
-        Set<OrganizationSet> actual = createOrganizationSets(tableInfo, shards);
+        Set<OrganizationSet> actual = createOrganizationSets(tableInfo, shards, DateTimeZone.UTC);
 
         assertEquals(actual.size(), 1);
         // Shards 0, 1 and 2 are overlapping, so we should get an organization set with these shards
@@ -161,7 +162,7 @@ public class TestShardOrganizationManager
                 shardWithTemporalRange(1, ShardRange.of(new Tuple(types, 6L), new Tuple(types, 9L)), ShardRange.of(new Tuple(temporalType, day1), new Tuple(temporalType, day2))),
                 shardWithTemporalRange(1, ShardRange.of(new Tuple(types, 4L), new Tuple(types, 8L)), ShardRange.of(new Tuple(temporalType, day4), new Tuple(temporalType, day5))));
 
-        Set<OrganizationSet> organizationSets = createOrganizationSets(temporalTableInfo, shards);
+        Set<OrganizationSet> organizationSets = createOrganizationSets(temporalTableInfo, shards, DateTimeZone.UTC);
         Set<Set<UUID>> actual = organizationSets.stream()
                 .map(OrganizationSet::getShards)
                 .collect(toSet());
@@ -197,6 +198,6 @@ public class TestShardOrganizationManager
 
     private ShardOrganizationManager createShardOrganizationManager(long intervalMillis)
     {
-        return new ShardOrganizationManager(dbi, "node1", createShardManager(dbi), createShardOrganizer(), true, new Duration(intervalMillis, MILLISECONDS));
+        return new ShardOrganizationManager(dbi, "node1", createShardManager(dbi), createShardOrganizer(), true, new Duration(intervalMillis, MILLISECONDS), DateTimeZone.UTC);
     }
 }


### PR DESCRIPTION
Shard is currently splitted by its bucket id and date (assuming UTC
timezone). Making time zone configuration allows us to adjust the
shard boundary to data ingestion/retention timezone thus reduce
shard compaction operations.