### PR TITLE
Use read-write lock in internal resource group

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -28,7 +28,6 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
 
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.Collection;
@@ -41,6 +40,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.SystemSessionProperties.getQueryPriority;
@@ -75,57 +75,36 @@ public class InternalResourceGroup
 {
     public static final int DEFAULT_WEIGHT = 1;
 
-    private final InternalResourceGroup root;
+    protected final ReentrantReadWriteLock lock;
     private final Optional<InternalResourceGroup> parent;
     private final ResourceGroupId id;
     private final BiConsumer<InternalResourceGroup, Boolean> jmxExportListener;
     private final Executor executor;
 
-    @GuardedBy("root")
     private final Map<String, InternalResourceGroup> subGroups = new HashMap<>();
     // Sub groups with queued queries, that have capacity to run them
     // That is, they must return true when internalStartNext() is called on them
-    @GuardedBy("root")
     private Queue<InternalResourceGroup> eligibleSubGroups = new FifoQueue<>();
     // Sub groups whose memory usage may be out of date. Most likely because they have a running query.
-    @GuardedBy("root")
     private final Set<InternalResourceGroup> dirtySubGroups = new HashSet<>();
-    @GuardedBy("root")
     private long softMemoryLimitBytes;
-    @GuardedBy("root")
     private int softConcurrencyLimit;
-    @GuardedBy("root")
     private int hardConcurrencyLimit;
-    @GuardedBy("root")
     private int maxQueuedQueries;
-    @GuardedBy("root")
     private long softCpuLimitMillis = Long.MAX_VALUE;
-    @GuardedBy("root")
     private long hardCpuLimitMillis = Long.MAX_VALUE;
-    @GuardedBy("root")
     private long cpuUsageMillis;
-    @GuardedBy("root")
     private long cpuQuotaGenerationMillisPerSecond = Long.MAX_VALUE;
-    @GuardedBy("root")
     private int descendantRunningQueries;
-    @GuardedBy("root")
     private int descendantQueuedQueries;
     // Memory usage is cached because it changes very rapidly while queries are running, and would be expensive to track continuously
-    @GuardedBy("root")
     private long cachedMemoryUsageBytes;
-    @GuardedBy("root")
     private int schedulingWeight = DEFAULT_WEIGHT;
-    @GuardedBy("root")
     private UpdateablePriorityQueue<QueryExecution> queuedQueries = new FifoQueue<>();
-    @GuardedBy("root")
     private final Set<QueryExecution> runningQueries = new HashSet<>();
-    @GuardedBy("root")
     private SchedulingPolicy schedulingPolicy = FAIR;
-    @GuardedBy("root")
     private boolean jmxExport;
-    @GuardedBy("root")
     private Duration queuedTimeLimit = new Duration(Long.MAX_VALUE, MILLISECONDS);
-    @GuardedBy("root")
     private Duration runningTimeLimit = new Duration(Long.MAX_VALUE, MILLISECONDS);
 
     protected InternalResourceGroup(Optional<InternalResourceGroup> parent, String name, BiConsumer<InternalResourceGroup, Boolean> jmxExportListener, Executor executor)
@@ -136,17 +115,18 @@ public class InternalResourceGroup
         requireNonNull(name, "name is null");
         if (parent.isPresent()) {
             id = new ResourceGroupId(parent.get().id, name);
-            root = parent.get().root;
+            lock = parent.get().lock;
         }
         else {
             id = new ResourceGroupId(name);
-            root = this;
+            lock = new ReentrantReadWriteLock();
         }
     }
 
     public ResourceGroupInfo getInfo()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             checkState(!subGroups.isEmpty() || (descendantRunningQueries == 0 && descendantQueuedQueries == 0), "Leaf resource group has descendant queries.");
 
             List<ResourceGroupInfo> infos = subGroups.values().stream()
@@ -168,11 +148,15 @@ public class InternalResourceGroup
                     queuedQueries.size() + descendantQueuedQueries,
                     infos);
         }
+        finally {
+            lock.readLock().unlock();
+        }
     }
 
     public ResourceGroupStateInfo getStateInfo()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return new ResourceGroupStateInfo(
                     id,
                     getState(),
@@ -201,11 +185,15 @@ public class InternalResourceGroup
                                     subGroup.queuedQueries.size() + subGroup.descendantQueuedQueries))
                             .collect(toImmutableList()));
         }
+        finally {
+            lock.readLock().unlock();
+        }
     }
 
     private ResourceGroupState getState()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             if (canRunMore()) {
                 return CAN_RUN;
             }
@@ -216,11 +204,15 @@ public class InternalResourceGroup
                 return FULL;
             }
         }
+        finally {
+            lock.readLock().unlock();
+        }
     }
 
     private List<QueryStateInfo> getAggregatedRunningQueriesInfo()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             if (subGroups.isEmpty()) {
                 return runningQueries.stream()
                         .map(QueryExecution::getQueryInfo)
@@ -231,6 +223,9 @@ public class InternalResourceGroup
                     .map(InternalResourceGroup::getAggregatedRunningQueriesInfo)
                     .flatMap(List::stream)
                     .collect(toImmutableList());
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -243,23 +238,32 @@ public class InternalResourceGroup
     @Managed
     public int getRunningQueries()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return runningQueries.size() + descendantRunningQueries;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     @Managed
     public int getQueuedQueries()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return queuedQueries.size() + descendantQueuedQueries;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     @Managed
     public int getWaitingQueuedQueries()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             // For leaf group, when no queries can run, all queued queries are waiting for resources on this resource group.
             if (subGroups.isEmpty()) {
                 return queuedQueries.size();
@@ -275,40 +279,56 @@ public class InternalResourceGroup
 
             return waitingQueuedQueries;
         }
+        finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
     public DataSize getSoftMemoryLimit()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return new DataSize(softMemoryLimitBytes, BYTE);
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public void setSoftMemoryLimit(DataSize limit)
     {
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             boolean oldCanRun = canRunMore();
             this.softMemoryLimitBytes = limit.toBytes();
             if (canRunMore() != oldCanRun) {
                 updateEligiblility();
             }
         }
+        finally {
+            lock.writeLock().unlock();
+        }
     }
 
     @Override
     public Duration getSoftCpuLimit()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return new Duration(softCpuLimitMillis, MILLISECONDS);
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public void setSoftCpuLimit(Duration limit)
     {
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             if (limit.toMillis() > hardCpuLimitMillis) {
                 setHardCpuLimit(limit);
             }
@@ -318,20 +338,28 @@ public class InternalResourceGroup
                 updateEligiblility();
             }
         }
+        finally {
+            lock.writeLock().unlock();
+        }
     }
 
     @Override
     public Duration getHardCpuLimit()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return new Duration(hardCpuLimitMillis, MILLISECONDS);
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public void setHardCpuLimit(Duration limit)
     {
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             if (limit.toMillis() < softCpuLimitMillis) {
                 setSoftCpuLimit(limit);
             }
@@ -341,13 +369,20 @@ public class InternalResourceGroup
                 updateEligiblility();
             }
         }
+        finally {
+            lock.writeLock().unlock();
+        }
     }
 
     @Override
     public long getCpuQuotaGenerationMillisPerSecond()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return cpuQuotaGenerationMillisPerSecond;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -355,16 +390,24 @@ public class InternalResourceGroup
     public void setCpuQuotaGenerationMillisPerSecond(long rate)
     {
         checkArgument(rate > 0, "Cpu quota generation must be positive");
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             cpuQuotaGenerationMillisPerSecond = rate;
+        }
+        finally {
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public int getSoftConcurrencyLimit()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return softConcurrencyLimit;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -372,12 +415,16 @@ public class InternalResourceGroup
     public void setSoftConcurrencyLimit(int softConcurrencyLimit)
     {
         checkArgument(softConcurrencyLimit >= 0, "softConcurrencyLimit is negative");
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             boolean oldCanRun = canRunMore();
             this.softConcurrencyLimit = softConcurrencyLimit;
             if (canRunMore() != oldCanRun) {
                 updateEligiblility();
             }
+        }
+        finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -385,8 +432,12 @@ public class InternalResourceGroup
     @Override
     public int getHardConcurrencyLimit()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return hardConcurrencyLimit;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -395,12 +446,16 @@ public class InternalResourceGroup
     public void setHardConcurrencyLimit(int hardConcurrencyLimit)
     {
         checkArgument(hardConcurrencyLimit >= 0, "hardConcurrencyLimit is negative");
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             boolean oldCanRun = canRunMore();
             this.hardConcurrencyLimit = hardConcurrencyLimit;
             if (canRunMore() != oldCanRun) {
                 updateEligiblility();
             }
+        }
+        finally {
+            lock.writeLock().unlock();
         }
     }
 
@@ -408,8 +463,12 @@ public class InternalResourceGroup
     @Override
     public int getMaxQueuedQueries()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return maxQueuedQueries;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -418,16 +477,24 @@ public class InternalResourceGroup
     public void setMaxQueuedQueries(int maxQueuedQueries)
     {
         checkArgument(maxQueuedQueries >= 0, "maxQueuedQueries is negative");
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             this.maxQueuedQueries = maxQueuedQueries;
+        }
+        finally {
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public int getSchedulingWeight()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return schedulingWeight;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -435,26 +502,35 @@ public class InternalResourceGroup
     public void setSchedulingWeight(int weight)
     {
         checkArgument(weight > 0, "weight must be positive");
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             this.schedulingWeight = weight;
             if (parent.isPresent() && parent.get().schedulingPolicy == WEIGHTED && parent.get().eligibleSubGroups.contains(this)) {
                 parent.get().addOrUpdateSubGroup(this);
             }
+        }
+        finally {
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public SchedulingPolicy getSchedulingPolicy()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return schedulingPolicy;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public void setSchedulingPolicy(SchedulingPolicy policy)
     {
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             if (policy == schedulingPolicy) {
                 return;
             }
@@ -502,21 +578,32 @@ public class InternalResourceGroup
             queuedQueries = queryQueue;
             schedulingPolicy = policy;
         }
+        finally {
+            lock.writeLock().unlock();
+        }
     }
 
     @Override
     public boolean getJmxExport()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return jmxExport;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public void setJmxExport(boolean export)
     {
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             jmxExport = export;
+        }
+        finally {
+            lock.writeLock().unlock();
         }
         jmxExportListener.accept(this, export);
     }
@@ -524,39 +611,56 @@ public class InternalResourceGroup
     @Override
     public Duration getQueuedTimeLimit()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return queuedTimeLimit;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public void setQueuedTimeLimit(Duration queuedTimeLimit)
     {
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             this.queuedTimeLimit = queuedTimeLimit;
+        }
+        finally {
+            lock.writeLock().unlock();
         }
     }
 
     @Override
     public Duration getRunningTimeLimit()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return runningTimeLimit;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     @Override
     public void setRunningTimeLimit(Duration runningTimeLimit)
     {
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             this.runningTimeLimit = runningTimeLimit;
+        }
+        finally {
+            lock.writeLock().unlock();
         }
     }
 
     public InternalResourceGroup getOrCreateSubGroup(String name)
     {
         requireNonNull(name, "name is null");
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             checkArgument(runningQueries.isEmpty() && queuedQueries.isEmpty(), "Cannot add sub group to %s while queries are running", id);
             if (subGroups.containsKey(name)) {
                 return subGroups.get(name);
@@ -569,11 +673,15 @@ public class InternalResourceGroup
             subGroups.put(name, subGroup);
             return subGroup;
         }
+        finally {
+            lock.writeLock().unlock();
+        }
     }
 
     public void run(QueryExecution query)
     {
-        synchronized (root) {
+        lock.writeLock().lock();
+        try {
             checkState(subGroups.isEmpty(), "Cannot add queries to %s. It is not a leaf group.", id);
             // Check all ancestors for capacity
             query.setResourceGroup(id);
@@ -600,127 +708,127 @@ public class InternalResourceGroup
             }
             query.addStateChangeListener(state -> {
                 if (state.isDone()) {
-                    queryFinished(query);
+                    lock.writeLock().lock();
+                    try {
+                        queryFinished(query);
+                    }
+                    finally {
+                        lock.writeLock().unlock();
+                    }
                 }
             });
             if (query.getState().isDone()) {
                 queryFinished(query);
             }
         }
+        finally {
+            lock.writeLock().unlock();
+        }
     }
 
     private void enqueueQuery(QueryExecution query)
     {
-        checkState(Thread.holdsLock(root), "Must hold lock to enqueue a query");
-        synchronized (root) {
-            queuedQueries.addOrUpdate(query, getQueryPriority(query.getSession()));
-            InternalResourceGroup group = this;
-            while (group.parent.isPresent()) {
-                group.parent.get().descendantQueuedQueries++;
-                group = group.parent.get();
-            }
-            updateEligiblility();
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock to enqueue a query");
+        queuedQueries.addOrUpdate(query, getQueryPriority(query.getSession()));
+        InternalResourceGroup group = this;
+        while (group.parent.isPresent()) {
+            group.parent.get().descendantQueuedQueries++;
+            group = group.parent.get();
         }
+        updateEligiblility();
     }
 
     // This method must be called whenever the group's eligibility to run more queries may have changed.
     private void updateEligiblility()
     {
-        checkState(Thread.holdsLock(root), "Must hold lock to update eligibility");
-        synchronized (root) {
-            if (!parent.isPresent()) {
-                return;
-            }
-            if (isEligibleToStartNext()) {
-                parent.get().addOrUpdateSubGroup(this);
-            }
-            else {
-                parent.get().eligibleSubGroups.remove(this);
-            }
-            parent.get().updateEligiblility();
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock to update eligibility");
+        if (!parent.isPresent()) {
+            return;
         }
+        if (isEligibleToStartNext()) {
+            parent.get().addOrUpdateSubGroup(this);
+        }
+        else {
+            parent.get().eligibleSubGroups.remove(this);
+        }
+        parent.get().updateEligiblility();
     }
 
     private void startInBackground(QueryExecution query)
     {
-        checkState(Thread.holdsLock(root), "Must hold lock to start a query");
-        synchronized (root) {
-            runningQueries.add(query);
-            InternalResourceGroup group = this;
-            while (group.parent.isPresent()) {
-                group.parent.get().descendantRunningQueries++;
-                group.parent.get().dirtySubGroups.add(group);
-                group = group.parent.get();
-            }
-            updateEligiblility();
-            executor.execute(query::start);
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock to start a query");
+        runningQueries.add(query);
+        InternalResourceGroup group = this;
+        while (group.parent.isPresent()) {
+            group.parent.get().descendantRunningQueries++;
+            group.parent.get().dirtySubGroups.add(group);
+            group = group.parent.get();
         }
+        updateEligiblility();
+        executor.execute(query::start);
     }
 
     private void queryFinished(QueryExecution query)
     {
-        synchronized (root) {
-            if (!runningQueries.contains(query) && !queuedQueries.contains(query)) {
-                // Query has already been cleaned up
-                return;
-            }
-            // Only count the CPU time if the query succeeded, or the failure was the fault of the user
-            if (query.getState() == QueryState.FINISHED || query.getQueryInfo().getErrorType() == USER_ERROR) {
-                InternalResourceGroup group = this;
-                while (group != null) {
-                    try {
-                        group.cpuUsageMillis = Math.addExact(group.cpuUsageMillis, query.getTotalCpuTime().toMillis());
-                    }
-                    catch (ArithmeticException e) {
-                        group.cpuUsageMillis = Long.MAX_VALUE;
-                    }
-                    group = group.parent.orElse(null);
-                }
-            }
-            if (runningQueries.contains(query)) {
-                runningQueries.remove(query);
-                InternalResourceGroup group = this;
-                while (group.parent.isPresent()) {
-                    group.parent.get().descendantRunningQueries--;
-                    group = group.parent.get();
-                }
-            }
-            else {
-                queuedQueries.remove(query);
-                InternalResourceGroup group = this;
-                while (group.parent.isPresent()) {
-                    group.parent.get().descendantQueuedQueries--;
-                    group = group.parent.get();
-                }
-            }
-            updateEligiblility();
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock");
+        if (!runningQueries.contains(query) && !queuedQueries.contains(query)) {
+            // Query has already been cleaned up
+            return;
         }
+        // Only count the CPU time if the query succeeded, or the failure was the fault of the user
+        if (query.getState() == QueryState.FINISHED || query.getQueryInfo().getErrorType() == USER_ERROR) {
+            InternalResourceGroup group = this;
+            while (group != null) {
+                try {
+                    group.cpuUsageMillis = Math.addExact(group.cpuUsageMillis, query.getTotalCpuTime().toMillis());
+                }
+                catch (ArithmeticException e) {
+                    group.cpuUsageMillis = Long.MAX_VALUE;
+                }
+                group = group.parent.orElse(null);
+            }
+        }
+        if (runningQueries.contains(query)) {
+            runningQueries.remove(query);
+            InternalResourceGroup group = this;
+            while (group.parent.isPresent()) {
+                group.parent.get().descendantRunningQueries--;
+                group = group.parent.get();
+            }
+        }
+        else {
+            queuedQueries.remove(query);
+            InternalResourceGroup group = this;
+            while (group.parent.isPresent()) {
+                group.parent.get().descendantQueuedQueries--;
+                group = group.parent.get();
+            }
+        }
+        updateEligiblility();
     }
 
     // Memory usage stats are expensive to maintain, so this method must be called periodically to update them
     protected void internalRefreshStats()
     {
-        checkState(Thread.holdsLock(root), "Must hold lock to refresh stats");
-        synchronized (root) {
-            if (subGroups.isEmpty()) {
-                cachedMemoryUsageBytes = 0;
-                for (QueryExecution query : runningQueries) {
-                    cachedMemoryUsageBytes += query.getTotalMemoryReservation();
-                }
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock to refresh stats");
+        if (subGroups.isEmpty()) {
+            cachedMemoryUsageBytes = 0;
+            for (QueryExecution query : runningQueries) {
+                cachedMemoryUsageBytes += query.getTotalMemoryReservation();
             }
-            else {
-                for (Iterator<InternalResourceGroup> iterator = dirtySubGroups.iterator(); iterator.hasNext(); ) {
-                    InternalResourceGroup subGroup = iterator.next();
-                    long oldMemoryUsageBytes = subGroup.cachedMemoryUsageBytes;
-                    cachedMemoryUsageBytes -= oldMemoryUsageBytes;
-                    subGroup.internalRefreshStats();
-                    cachedMemoryUsageBytes += subGroup.cachedMemoryUsageBytes;
-                    if (!subGroup.isDirty()) {
-                        iterator.remove();
-                    }
-                    if (oldMemoryUsageBytes != subGroup.cachedMemoryUsageBytes) {
-                        subGroup.updateEligiblility();
-                    }
+        }
+        else {
+            for (Iterator<InternalResourceGroup> iterator = dirtySubGroups.iterator(); iterator.hasNext(); ) {
+                InternalResourceGroup subGroup = iterator.next();
+                long oldMemoryUsageBytes = subGroup.cachedMemoryUsageBytes;
+                cachedMemoryUsageBytes -= oldMemoryUsageBytes;
+                subGroup.internalRefreshStats();
+                cachedMemoryUsageBytes += subGroup.cachedMemoryUsageBytes;
+                if (!subGroup.isDirty()) {
+                    iterator.remove();
+                }
+                if (oldMemoryUsageBytes != subGroup.cachedMemoryUsageBytes) {
+                    subGroup.updateEligiblility();
                 }
             }
         }
@@ -728,81 +836,76 @@ public class InternalResourceGroup
 
     protected void internalGenerateCpuQuota(long elapsedSeconds)
     {
-        checkState(Thread.holdsLock(root), "Must hold lock to generate cpu quota");
-        synchronized (root) {
-            long newQuota;
-            try {
-                newQuota = Math.multiplyExact(elapsedSeconds, cpuQuotaGenerationMillisPerSecond);
-            }
-            catch (ArithmeticException e) {
-                newQuota = Long.MAX_VALUE;
-            }
-            try {
-                cpuUsageMillis = Math.subtractExact(cpuUsageMillis, newQuota);
-            }
-            catch (ArithmeticException e) {
-                cpuUsageMillis = 0;
-            }
-            cpuUsageMillis = Math.max(0, cpuUsageMillis);
-            for (InternalResourceGroup group : subGroups.values()) {
-                group.internalGenerateCpuQuota(elapsedSeconds);
-            }
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock to generate cpu quota");
+        long newQuota;
+        try {
+            newQuota = Math.multiplyExact(elapsedSeconds, cpuQuotaGenerationMillisPerSecond);
+        }
+        catch (ArithmeticException e) {
+            newQuota = Long.MAX_VALUE;
+        }
+        try {
+            cpuUsageMillis = Math.subtractExact(cpuUsageMillis, newQuota);
+        }
+        catch (ArithmeticException e) {
+            cpuUsageMillis = 0;
+        }
+        cpuUsageMillis = Math.max(0, cpuUsageMillis);
+        for (InternalResourceGroup group : subGroups.values()) {
+            group.internalGenerateCpuQuota(elapsedSeconds);
         }
     }
 
     protected boolean internalStartNext()
     {
-        checkState(Thread.holdsLock(root), "Must hold lock to find next query");
-        synchronized (root) {
-            if (!canRunMore()) {
-                return false;
-            }
-            QueryExecution query = queuedQueries.poll();
-            if (query != null) {
-                startInBackground(query);
-                return true;
-            }
-
-            // Remove even if the sub group still has queued queries, so that it goes to the back of the queue
-            InternalResourceGroup subGroup = eligibleSubGroups.poll();
-            if (subGroup == null) {
-                return false;
-            }
-            boolean started = subGroup.internalStartNext();
-            checkState(started, "Eligible sub group had no queries to run");
-            descendantQueuedQueries--;
-            // Don't call updateEligibility here, as we're in a recursive call, and don't want to repeatedly update our ancestors.
-            if (subGroup.isEligibleToStartNext()) {
-                addOrUpdateSubGroup(subGroup);
-            }
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock to find next query");
+        if (!canRunMore()) {
+            return false;
+        }
+        QueryExecution query = queuedQueries.poll();
+        if (query != null) {
+            startInBackground(query);
             return true;
         }
+
+        // Remove even if the sub group still has queued queries, so that it goes to the back of the queue
+        InternalResourceGroup subGroup = eligibleSubGroups.poll();
+        if (subGroup == null) {
+            return false;
+        }
+        boolean started = subGroup.internalStartNext();
+        checkState(started, "Eligible sub group had no queries to run");
+        descendantQueuedQueries--;
+        // Don't call updateEligibility here, as we're in a recursive call, and don't want to repeatedly update our ancestors.
+        if (subGroup.isEligibleToStartNext()) {
+            addOrUpdateSubGroup(subGroup);
+        }
+        return true;
     }
 
     protected void enforceTimeLimits()
     {
-        checkState(Thread.holdsLock(root), "Must hold lock to enforce time limits");
-        synchronized (root) {
-            for (InternalResourceGroup group : subGroups.values()) {
-                group.enforceTimeLimits();
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock to enforce time limits");
+        for (InternalResourceGroup group : subGroups.values()) {
+            group.enforceTimeLimits();
+        }
+        for (QueryExecution query : runningQueries) {
+            Duration runningTime = query.getQueryInfo().getQueryStats().getExecutionTime();
+            if (runningQueries.contains(query) && runningTime != null && runningTime.compareTo(runningTimeLimit) > 0) {
+                query.fail(new PrestoException(EXCEEDED_TIME_LIMIT, "query exceeded resource group runtime limit"));
             }
-            for (QueryExecution query : runningQueries) {
-                Duration runningTime = query.getQueryInfo().getQueryStats().getExecutionTime();
-                if (runningQueries.contains(query) && runningTime != null && runningTime.compareTo(runningTimeLimit) > 0) {
-                    query.fail(new PrestoException(EXCEEDED_TIME_LIMIT, "query exceeded resource group runtime limit"));
-                }
-            }
-            for (QueryExecution query : queuedQueries) {
-                Duration elapsedTime = query.getQueryInfo().getQueryStats().getElapsedTime();
-                if (queuedQueries.contains(query) && elapsedTime != null && elapsedTime.compareTo(queuedTimeLimit) > 0) {
-                    query.fail(new PrestoException(EXCEEDED_TIME_LIMIT, "query exceeded resource group queued time limit"));
-                }
+        }
+        for (QueryExecution query : queuedQueries) {
+            Duration elapsedTime = query.getQueryInfo().getQueryStats().getElapsedTime();
+            if (queuedQueries.contains(query) && elapsedTime != null && elapsedTime.compareTo(queuedTimeLimit) > 0) {
+                query.fail(new PrestoException(EXCEEDED_TIME_LIMIT, "query exceeded resource group queued time limit"));
             }
         }
     }
 
     private void addOrUpdateSubGroup(InternalResourceGroup group)
     {
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock");
         if (schedulingPolicy == WEIGHTED_FAIR) {
             ((WeightedFairQueue<InternalResourceGroup>) eligibleSubGroups).addOrUpdate(group, new Usage(group.getSchedulingWeight(), group.getRunningQueries()));
         }
@@ -823,6 +926,7 @@ public class InternalResourceGroup
 
     private long computeSchedulingWeight()
     {
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock");
         if (runningQueries.size() + descendantRunningQueries >= softConcurrencyLimit) {
             return schedulingWeight;
         }
@@ -832,47 +936,44 @@ public class InternalResourceGroup
 
     private boolean isDirty()
     {
-        checkState(Thread.holdsLock(root), "Must hold lock");
-        synchronized (root) {
-            return runningQueries.size() + descendantRunningQueries > 0;
-        }
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock");
+        return runningQueries.size() + descendantRunningQueries > 0;
     }
 
     private boolean isEligibleToStartNext()
     {
-        checkState(Thread.holdsLock(root), "Must hold lock");
-        synchronized (root) {
-            if (!canRunMore()) {
-                return false;
-            }
-            return !queuedQueries.isEmpty() || !eligibleSubGroups.isEmpty();
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock");
+        if (!canRunMore()) {
+            return false;
         }
+        return !queuedQueries.isEmpty() || !eligibleSubGroups.isEmpty();
     }
 
     private int getHighestQueryPriority()
     {
-        checkState(Thread.holdsLock(root), "Must hold lock");
-        synchronized (root) {
-            checkState(queuedQueries instanceof IndexedPriorityQueue, "Queued queries not ordered");
-            if (queuedQueries.isEmpty()) {
-                return 0;
-            }
-            return getQueryPriority(queuedQueries.peek().getSession());
+        checkState(lock.isWriteLockedByCurrentThread(), "Must hold write lock");
+        checkState(queuedQueries instanceof IndexedPriorityQueue, "Queued queries not ordered");
+        if (queuedQueries.isEmpty()) {
+            return 0;
         }
+        return getQueryPriority(queuedQueries.peek().getSession());
     }
 
     private boolean canQueueMore()
     {
-        checkState(Thread.holdsLock(root), "Must hold lock");
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return descendantQueuedQueries + queuedQueries.size() < maxQueuedQueries;
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
     private boolean canRunMore()
     {
-        checkState(Thread.holdsLock(root), "Must hold lock");
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             if (cpuUsageMillis >= hardCpuLimitMillis) {
                 return false;
             }
@@ -891,12 +992,19 @@ public class InternalResourceGroup
             return runningQueries.size() + descendantRunningQueries < hardConcurrencyLimit &&
                     cachedMemoryUsageBytes <= softMemoryLimitBytes;
         }
+        finally {
+            lock.readLock().unlock();
+        }
     }
 
     public Collection<InternalResourceGroup> subGroups()
     {
-        synchronized (root) {
+        lock.readLock().lock();
+        try {
             return subGroups.values();
+        }
+        finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -936,19 +1044,31 @@ public class InternalResourceGroup
             super(Optional.empty(), name, jmxExportListener, executor);
         }
 
-        public synchronized void processQueuedQueries()
+        public void processQueuedQueries()
         {
-            internalRefreshStats();
-            enforceTimeLimits();
-            while (internalStartNext()) {
-                // start all the queries we can
+            lock.writeLock().lock();
+            try {
+                internalRefreshStats();
+                enforceTimeLimits();
+                while (internalStartNext()) {
+                    // start all the queries we can
+                }
+            }
+            finally {
+                lock.writeLock().unlock();
             }
         }
 
-        public synchronized void generateCpuQuota(long elapsedSeconds)
+        public void generateCpuQuota(long elapsedSeconds)
         {
-            if (elapsedSeconds > 0) {
-                internalGenerateCpuQuota(elapsedSeconds);
+            lock.writeLock().lock();
+            try {
+                if (elapsedSeconds > 0) {
+                    internalGenerateCpuQuota(elapsedSeconds);
+                }
+            }
+            finally {
+                lock.writeLock().unlock();
             }
         }
     }


### PR DESCRIPTION
InternalResourceGroup has long lock contention so that some public
getters need to wait for hundreds of milliseconds to get a simple value.
Reduce the lock contention by splitting the lock into a read-write one.