### PR TITLE
Use fresh Future to remove unwanted deep list of listeners

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -426,6 +426,12 @@ public class OperatorContext
 
     public synchronized SettableFuture<?> getMemoryRevokingRequestedFuture()
     {
+        boolean alreadyRequested = isMemoryRevokingRequested();
+        if (!alreadyRequested && revocableMemoryReservation == 0) {
+            // use fresh Future to remove unwanted listener
+            memoryRevokingRequestedFuture = SettableFuture.create();
+        }
+
         return memoryRevokingRequestedFuture;
     }
 


### PR DESCRIPTION
I found excessively nested future listeners on `OperatorContext.memoryRevokingRequestedFuture`

![screen shot 2017-11-22 at 5 01 24 pm](https://user-images.githubusercontent.com/725129/33135818-dd29f874-cfe6-11e7-91da-98691e5979e8.png)

It's not a big deal for a short living Operator or NOT_BLOCKED Operator. But for a long living blocking operators, it seems to create deeply nested future listeners. 

Unless an Operator is involved in revoking memories, we could ignore previous listeners on the future.