### PR TITLE
Disallow window functions in HAVING clause

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.analyzer;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.tree.ExistsPredicate;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
@@ -42,6 +43,7 @@ public class ExpressionAnalysis
     private final Set<NodeRef<QuantifiedComparisonExpression>> quantifiedComparisons;
     // For lambda argument references, maps each QualifiedNameReference to the referenced LambdaArgumentDeclaration
     private final Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences;
+    private final Set<NodeRef<FunctionCall>> windowFunctions;
 
     public ExpressionAnalysis(
             Map<NodeRef<Expression>, Type> expressionTypes,
@@ -52,7 +54,8 @@ public class ExpressionAnalysis
             Map<NodeRef<Expression>, FieldId> columnReferences,
             Set<NodeRef<Expression>> typeOnlyCoercions,
             Set<NodeRef<QuantifiedComparisonExpression>> quantifiedComparisons,
-            Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences)
+            Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences,
+            Set<NodeRef<FunctionCall>> windowFunctions)
     {
         this.expressionTypes = ImmutableMap.copyOf(requireNonNull(expressionTypes, "expressionTypes is null"));
         this.expressionCoercions = ImmutableMap.copyOf(requireNonNull(expressionCoercions, "expressionCoercions is null"));
@@ -63,6 +66,7 @@ public class ExpressionAnalysis
         this.existsSubqueries = ImmutableSet.copyOf(requireNonNull(existsSubqueries, "existsSubqueries is null"));
         this.quantifiedComparisons = ImmutableSet.copyOf(requireNonNull(quantifiedComparisons, "quantifiedComparisons is null"));
         this.lambdaArgumentReferences = ImmutableMap.copyOf(requireNonNull(lambdaArgumentReferences, "lambdaArgumentReferences is null"));
+        this.windowFunctions = ImmutableSet.copyOf(requireNonNull(windowFunctions, "windowFunctions is null"));
     }
 
     public Type getType(Expression expression)
@@ -108,5 +112,10 @@ public class ExpressionAnalysis
     public Set<NodeRef<QuantifiedComparisonExpression>> getQuantifiedComparisons()
     {
         return quantifiedComparisons;
+    }
+
+    public Set<NodeRef<FunctionCall>> getWindowFunctions()
+    {
+        return windowFunctions;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -175,6 +175,7 @@ public class ExpressionAnalyzer
     private final Set<NodeRef<QuantifiedComparisonExpression>> quantifiedComparisons = new LinkedHashSet<>();
     // For lambda argument references, maps each QualifiedNameReference to the referenced LambdaArgumentDeclaration
     private final Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences = new LinkedHashMap<>();
+    private final Set<NodeRef<FunctionCall>> windowFunctions = new LinkedHashSet<>();
 
     private final Session session;
     private final List<Expression> parameters;
@@ -276,6 +277,11 @@ public class ExpressionAnalyzer
     public Set<NodeRef<QuantifiedComparisonExpression>> getQuantifiedComparisons()
     {
         return unmodifiableSet(quantifiedComparisons);
+    }
+
+    public Set<NodeRef<FunctionCall>> getWindowFunctions()
+    {
+        return unmodifiableSet(windowFunctions);
     }
 
     private class Visitor
@@ -772,6 +778,8 @@ public class ExpressionAnalyzer
                         }
                     }
                 }
+
+                windowFunctions.add(NodeRef.of(node));
             }
 
             if (node.getFilter().isPresent()) {
@@ -1485,7 +1493,8 @@ public class ExpressionAnalyzer
                 analyzer.getColumnReferences(),
                 analyzer.getTypeOnlyCoercions(),
                 analyzer.getQuantifiedComparisons(),
-                analyzer.getLambdaArgumentReferences());
+                analyzer.getLambdaArgumentReferences(),
+                analyzer.getWindowFunctions());
     }
 
     public static ExpressionAnalysis analyzeExpression(
@@ -1520,7 +1529,8 @@ public class ExpressionAnalyzer
                 analyzer.getColumnReferences(),
                 analyzer.getTypeOnlyCoercions(),
                 analyzer.getQuantifiedComparisons(),
-                analyzer.getLambdaArgumentReferences());
+                analyzer.getLambdaArgumentReferences(),
+                analyzer.getWindowFunctions());
     }
 
     public static ExpressionAnalyzer create(

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1360,6 +1360,13 @@ class StatementAnalyzer
                 Expression predicate = node.getHaving().get();
 
                 ExpressionAnalysis expressionAnalysis = analyzeExpression(predicate, scope);
+
+                expressionAnalysis.getWindowFunctions().stream()
+                        .findFirst()
+                        .ifPresent(function -> {
+                            throw new SemanticException(NESTED_WINDOW, function.getNode(), "HAVING clause cannot contain window functions");
+                        });
+
                 analysis.recordSubqueries(node, expressionAnalysis);
 
                 Type predicateType = expressionAnalysis.getType(predicate);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -355,6 +355,7 @@ public class TestAnalyzer
         assertFails(CANNOT_HAVE_AGGREGATIONS_WINDOWS_OR_GROUPING, "SELECT * FROM t1 WHERE foo() over () > 1");
         assertFails(CANNOT_HAVE_AGGREGATIONS_WINDOWS_OR_GROUPING, "SELECT * FROM t1 GROUP BY rank() over ()");
         assertFails(CANNOT_HAVE_AGGREGATIONS_WINDOWS_OR_GROUPING, "SELECT * FROM t1 JOIN t2 ON sum(t1.a) over () = t2.a");
+        assertFails(NESTED_WINDOW, "SELECT 1 FROM (VALUES 1) HAVING count(*) OVER () > 1");
     }
 
     @Test


### PR DESCRIPTION
Semantically, window functions are evaluated on the result of the
aggregation table expression, so it's non-sensical for the HAVING
clause to contain them.

Fixes #3979