### PR TITLE
Change LOWEST_MAX_STANDARD_ERROR for approx_distinct function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -165,7 +165,7 @@ Approximate Aggregate Functions
     is the standard deviation of the (approximately normal) error distribution
     over all possible sets. It does not guarantee an upper bound on the error
     for any specific input set. The current implementation of this function
-    requires that ``e`` be in the range: [0.01150, 0.26000].
+    requires that ``e`` be in the range: [0.0040625, 0.26000].
 
 .. function:: approx_percentile(x, percentage) -> [same as x]
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregations.java
@@ -35,7 +35,7 @@ import static com.facebook.presto.util.Failures.checkCondition;
 public final class ApproximateCountDistinctAggregations
 {
     private static final double DEFAULT_STANDARD_ERROR = 0.023;
-    private static final double LOWEST_MAX_STANDARD_ERROR = 0.01150;
+    private static final double LOWEST_MAX_STANDARD_ERROR = 0.0040625;
     private static final double HIGHEST_MAX_STANDARD_ERROR = 0.26000;
 
     private ApproximateCountDistinctAggregations() {}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctAggregations.java
@@ -38,6 +38,15 @@ public class TestApproximateCountDistinctAggregations
         assertEquals(standardErrorToBuckets(0.0162), 8192);
         assertEquals(standardErrorToBuckets(0.0116), 8192);
         assertEquals(standardErrorToBuckets(0.0115), 8192);
+        assertEquals(standardErrorToBuckets(0.0114), 16384);
+        assertEquals(standardErrorToBuckets(0.008126), 16384);
+        assertEquals(standardErrorToBuckets(0.008125), 16384);
+        assertEquals(standardErrorToBuckets(0.008124), 32768);
+        assertEquals(standardErrorToBuckets(0.00576), 32768);
+        assertEquals(standardErrorToBuckets(0.00575), 32768);
+        assertEquals(standardErrorToBuckets(0.00574), 65536);
+        assertEquals(standardErrorToBuckets(0.0040626), 65536);
+        assertEquals(standardErrorToBuckets(0.0040625), 65536);
     }
 
     @Test
@@ -46,7 +55,7 @@ public class TestApproximateCountDistinctAggregations
     {
         try {
             // Lower bound
-            standardErrorToBuckets(0.01149);
+            standardErrorToBuckets(0.0040624);
             fail();
         }
         catch (PrestoException e) {


### PR DESCRIPTION
Maximum number of buckets in HyperLogLog changed from 8192 to 65536,
so now we could support lower max standard errors.