### PR TITLE
Wait until hive can be queried in product tests

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -25,7 +25,9 @@ function hadoop_master_container(){
 }
 
 function check_hadoop() {
-  docker exec $(hadoop_master_container) supervisorctl status hive-server2 | grep -i running
+  HADOOP_MASTER_CONTAINER=$(hadoop_master_container)
+  docker exec ${HADOOP_MASTER_CONTAINER} su hive -c 'hive -e "CREATE TABLE IF NOT EXISTS check_hadoop (a INT);"'
+  docker exec ${HADOOP_MASTER_CONTAINER} su hive -c 'hive -e "INSERT INTO check_hadoop VALUES (1);"' 
 }
 
 function stop_unnecessary_hadoop_services() {


### PR DESCRIPTION
Wait until hive can be queried in product tests

Waiting for hive process is not enough, it could be possible that
metastore or hadoop services are still not yet ready to be used.
Such situation may cause some intermittent failures, hard to debug.
