### PR TITLE
Address intermittent failures of testQueryLoggingCount

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -968,7 +968,7 @@ public abstract class AbstractTestDistributedQueries
                 .build();
         // This is optimized using CAST(null AS interval day to second) which may be problematic to deserialize on worker
         assertQuery(session, "WITH t(a, b) AS (VALUES (1, INTERVAL '1' SECOND)) " +
-                "SELECT count(DISTINCT a), CAST(max(b) AS VARCHAR) FROM t",
+                        "SELECT count(DISTINCT a), CAST(max(b) AS VARCHAR) FROM t",
                 "VALUES (1, '0 00:00:01.000')");
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -26,12 +26,14 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
 import io.airlift.testing.Assertions;
 import io.airlift.units.Duration;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
@@ -62,6 +64,7 @@ import static java.lang.Thread.currentThread;
 import static java.util.Collections.nCopies;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -750,7 +753,11 @@ public abstract class AbstractTestDistributedQueries
                             ImmutableList.of()),
                     new Duration(1, MINUTES));
 
-            long beforeCompletedQueriesCount = queryManager.getStats().getCompletedQueries().getTotalCount();
+            // We cannot simply get the number of completed queries as soon as all the queries are completed, because this counter may not be up-to-date at that point.
+            // The completed queries counter is updated in a final query info listener, which is called eventually.
+            // Therefore, here we wait until the value of this counter gets stable.
+
+            long beforeCompletedQueriesCount = waitUntilStable(() -> queryManager.getStats().getCompletedQueries().getTotalCount(), new Duration(5, SECONDS));
             long beforeSubmittedQueriesCount = queryManager.getStats().getSubmittedQueries().getTotalCount();
             assertUpdate("CREATE TABLE test_query_logging_count AS SELECT 1 foo_1, 2 foo_2_4", 1);
             assertQuery("SELECT foo_1, foo_2_4 FROM test_query_logging_count", "SELECT 1, 2");
@@ -763,6 +770,21 @@ public abstract class AbstractTestDistributedQueries
                     new Duration(1, MINUTES));
             assertEquals(queryManager.getStats().getSubmittedQueries().getTotalCount() - beforeSubmittedQueriesCount, 4);
         });
+    }
+
+    private <T> T waitUntilStable(Supplier<T> computation, Duration timeout)
+    {
+        T lastValue = computation.get();
+        long start = System.nanoTime();
+        while (!currentThread().isInterrupted() && nanosSince(start).compareTo(timeout) < 0) {
+            sleepUninterruptibly(100, MILLISECONDS);
+            T currentValue = computation.get();
+            if (currentValue.equals(lastValue)) {
+                return currentValue;
+            }
+            lastValue = currentValue;
+        }
+        throw new UncheckedTimeoutException();
     }
 
     private static void assertUntilTimeout(Runnable assertion, Duration timeout)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -58,6 +58,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.airlift.units.Duration.nanosSince;
 import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
 import static java.util.Collections.nCopies;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -767,7 +768,7 @@ public abstract class AbstractTestDistributedQueries
     private static void assertUntilTimeout(Runnable assertion, Duration timeout)
     {
         long start = System.nanoTime();
-        while (!Thread.currentThread().isInterrupted()) {
+        while (!currentThread().isInterrupted()) {
             try {
                 assertion.run();
                 return;


### PR DESCRIPTION
The change addresses intermittent failures of AbstractTestDistributedQueries.testQueryLoggingCount.
The failure happened because of how `beforeCompletedQueriesCount` and
`beforeSubmittedQueriesCount` were determined at the beginning of tests.
Code assumed that it is safe to get those values as soon as all the
queries in queryManager are completed.

Yet it does not mean that stats counters were already updated, as those
two changes are not synchronized. See `SqlQueryManager.createQuery`:

Here is the code which updates stats counter for completed queries.
```
  QueryInfo info = queryExecution.getQueryInfo();
  stats.queryFinished(info);
  queryMonitor.queryCompletedEvent(info);
```

Yet according to `info.isFinalQueryInfo()` taken from
`queryManager.getAllQueryInfo()` the query is already completed.

fixes #8953