### PR TITLE
Make raptor day boundary timezone table property

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorInsertTableHandle.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorInsertTableHandle.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTimeZone;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +42,7 @@ public class RaptorInsertTableHandle
     private final OptionalInt bucketCount;
     private final List<RaptorColumnHandle> bucketColumnHandles;
     private final Optional<RaptorColumnHandle> temporalColumnHandle;
+    private final Optional<DateTimeZone> tableTimeZone;
 
     @JsonCreator
     public RaptorInsertTableHandle(
@@ -54,7 +56,8 @@ public class RaptorInsertTableHandle
             @JsonProperty("sortOrders") List<SortOrder> sortOrders,
             @JsonProperty("bucketCount") OptionalInt bucketCount,
             @JsonProperty("bucketColumnHandles") List<RaptorColumnHandle> bucketColumnHandles,
-            @JsonProperty("temporalColumnHandle") Optional<RaptorColumnHandle> temporalColumnHandle)
+            @JsonProperty("temporalColumnHandle") Optional<RaptorColumnHandle> temporalColumnHandle,
+            @JsonProperty("tableTimeZone") Optional<DateTimeZone> tableTimeZone)
     {
         checkArgument(tableId > 0, "tableId must be greater than zero");
 
@@ -70,6 +73,7 @@ public class RaptorInsertTableHandle
         this.bucketCount = requireNonNull(bucketCount, "bucketCount is null");
         this.bucketColumnHandles = ImmutableList.copyOf(requireNonNull(bucketColumnHandles, "bucketColumnHandles is null"));
         this.temporalColumnHandle = requireNonNull(temporalColumnHandle, "temporalColumnHandle is null");
+        this.tableTimeZone = requireNonNull(tableTimeZone, "tableTimeZone is null");
     }
 
     @JsonProperty
@@ -136,6 +140,12 @@ public class RaptorInsertTableHandle
     public Optional<RaptorColumnHandle> getTemporalColumnHandle()
     {
         return temporalColumnHandle;
+    }
+
+    @JsonProperty
+    public Optional<DateTimeZone> getTableTimeZone()
+    {
+        return tableTimeZone;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.raptor;
 import com.facebook.presto.raptor.metadata.Distribution;
 import com.facebook.presto.raptor.metadata.ForMetadata;
 import com.facebook.presto.raptor.metadata.TableColumn;
+import com.facebook.presto.raptor.storage.organization.ShardSplitterProvider;
 import com.facebook.presto.raptor.systemtables.ShardMetadataSystemTable;
 import com.facebook.presto.raptor.systemtables.TableMetadataSystemTable;
 import com.facebook.presto.raptor.systemtables.TableStatsSystemTable;
@@ -60,6 +61,7 @@ public class RaptorModule
         binder.bind(RaptorNodePartitioningProvider.class).in(Scopes.SINGLETON);
         binder.bind(RaptorSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(RaptorTableProperties.class).in(Scopes.SINGLETON);
+        binder.bind(ShardSplitterProvider.class).in(Scopes.SINGLETON);
 
         Multibinder<SystemTable> tableBinder = newSetBinder(binder, SystemTable.class);
         tableBinder.addBinding().to(ShardMetadataSystemTable.class).in(Scopes.SINGLETON);

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorOutputTableHandle.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorOutputTableHandle.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTimeZone;
 
 import java.util.List;
 import java.util.Optional;
@@ -45,6 +46,7 @@ public class RaptorOutputTableHandle
     private final OptionalInt bucketCount;
     private final List<RaptorColumnHandle> bucketColumnHandles;
     private final boolean organized;
+    private final Optional<DateTimeZone> tableTimeZone;
 
     @JsonCreator
     public RaptorOutputTableHandle(
@@ -60,7 +62,8 @@ public class RaptorOutputTableHandle
             @JsonProperty("distributionId") OptionalLong distributionId,
             @JsonProperty("bucketCount") OptionalInt bucketCount,
             @JsonProperty("organized") boolean organized,
-            @JsonProperty("bucketColumnHandles") List<RaptorColumnHandle> bucketColumnHandles)
+            @JsonProperty("bucketColumnHandles") List<RaptorColumnHandle> bucketColumnHandles,
+            @JsonProperty("tableTimeZone") Optional<DateTimeZone> tableTimeZone)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.transactionId = transactionId;
@@ -75,6 +78,7 @@ public class RaptorOutputTableHandle
         this.bucketCount = requireNonNull(bucketCount, "bucketCount is null");
         this.bucketColumnHandles = ImmutableList.copyOf(requireNonNull(bucketColumnHandles, "bucketColumnHandles is null"));
         this.organized = organized;
+        this.tableTimeZone = requireNonNull(tableTimeZone, "tableTimeZone is null");
     }
 
     @JsonProperty
@@ -153,6 +157,12 @@ public class RaptorOutputTableHandle
     public boolean isOrganized()
     {
         return organized;
+    }
+
+    @JsonProperty
+    public Optional<DateTimeZone> getTableTimeZone()
+    {
+        return tableTimeZone;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPageSinkProvider.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPageSinkProvider.java
@@ -15,6 +15,7 @@ package com.facebook.presto.raptor;
 
 import com.facebook.presto.raptor.storage.StorageManager;
 import com.facebook.presto.raptor.storage.StorageManagerConfig;
+import com.facebook.presto.raptor.storage.organization.ShardSplitterProvider;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
@@ -37,11 +38,13 @@ public class RaptorPageSinkProvider
     private final StorageManager storageManager;
     private final PageSorter pageSorter;
     private final DataSize maxBufferSize;
+    private final ShardSplitterProvider shardSplitterProvider;
 
     @Inject
-    public RaptorPageSinkProvider(StorageManager storageManager, PageSorter pageSorter, StorageManagerConfig config)
+    public RaptorPageSinkProvider(StorageManager storageManager, ShardSplitterProvider shardSplitterProvider, PageSorter pageSorter, StorageManagerConfig config)
     {
         this.storageManager = requireNonNull(storageManager, "storageManager is null");
+        this.shardSplitterProvider = requireNonNull(shardSplitterProvider, "shardSplitterProvider is null");
         this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
         this.maxBufferSize = config.getMaxBufferSize();
     }
@@ -53,12 +56,12 @@ public class RaptorPageSinkProvider
         return new RaptorPageSink(
                 pageSorter,
                 storageManager,
+                shardSplitterProvider.forTable(handle),
                 handle.getTransactionId(),
                 toColumnIds(handle.getColumnHandles()),
                 handle.getColumnTypes(),
                 toColumnIds(handle.getSortColumnHandles()),
                 handle.getSortOrders(),
-                handle.getBucketCount(),
                 toColumnIds(handle.getBucketColumnHandles()),
                 handle.getTemporalColumnHandle(),
                 maxBufferSize);
@@ -71,12 +74,12 @@ public class RaptorPageSinkProvider
         return new RaptorPageSink(
                 pageSorter,
                 storageManager,
+                shardSplitterProvider.forTable(handle),
                 handle.getTransactionId(),
                 toColumnIds(handle.getColumnHandles()),
                 handle.getColumnTypes(),
                 toColumnIds(handle.getSortColumnHandles()),
                 handle.getSortOrders(),
-                handle.getBucketCount(),
                 toColumnIds(handle.getBucketColumnHandles()),
                 handle.getTemporalColumnHandle(),
                 maxBufferSize);

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableProperties.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableProperties.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 
@@ -39,6 +40,7 @@ public class RaptorTableProperties
     public static final String BUCKETED_ON_PROPERTY = "bucketed_on";
     public static final String DISTRIBUTION_NAME_PROPERTY = "distribution_name";
     public static final String ORGANIZED_PROPERTY = "organized";
+    public static final String SHARD_DAY_BOUNDARY_TIME_ZONE = "shard_day_boundary_time_zone";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -68,6 +70,10 @@ public class RaptorTableProperties
                 .add(booleanSessionProperty(
                         ORGANIZED_PROPERTY,
                         "Keep the table organized using the sort order",
+                        null,
+                        false))
+                .add(timezoneSessionProperty(SHARD_DAY_BOUNDARY_TIME_ZONE,
+                        "Day boundary time zone to split shards",
                         null,
                         false))
                 .build();
@@ -110,6 +116,11 @@ public class RaptorTableProperties
         return (value == null) ? false : value;
     }
 
+    public static DateTimeZone getShardDayBoundaryTimeZone(Map<String, Object> tableProperties)
+    {
+        return (DateTimeZone) tableProperties.get(SHARD_DAY_BOUNDARY_TIME_ZONE);
+    }
+
     public static PropertyMetadata<String> lowerCaseStringSessionProperty(String name, String description)
     {
         return new PropertyMetadata<>(
@@ -142,5 +153,18 @@ public class RaptorTableProperties
     private static List<String> stringList(Object value)
     {
         return (value == null) ? ImmutableList.of() : ((List<String>) value);
+    }
+
+    private static PropertyMetadata<DateTimeZone> timezoneSessionProperty(String name, String description, DateTimeZone defaultTimeZone, boolean hidden)
+    {
+        return new PropertyMetadata<>(
+                name,
+                description,
+                createUnboundedVarcharType(),
+                DateTimeZone.class,
+                defaultTimeZone,
+                hidden,
+                value -> DateTimeZone.forID((String) value),
+                DateTimeZone::toString);
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
@@ -27,7 +27,7 @@ import java.util.Set;
 public interface MetadataDao
 {
     String TABLE_INFORMATION_SELECT = "" +
-            "SELECT t.table_id, t.distribution_id, d.distribution_name, d.bucket_count, t.temporal_column_id, t.organization_enabled\n" +
+            "SELECT t.table_id, t.distribution_id, d.distribution_name, d.bucket_count, t.temporal_column_id, t.organization_enabled, t.table_time_zone\n" +
             "FROM tables t\n" +
             "LEFT JOIN distributions d ON (t.distribution_id = d.distribution_id)\n";
 
@@ -118,7 +118,7 @@ public interface MetadataDao
             "  shard_count, row_count, compressed_size, uncompressed_size)\n" +
             "VALUES (\n" +
             "  :schemaName, :tableName, :compactionEnabled, :organizationEnabled, :distributionId,\n" +
-            "  :createTime, :createTime, 0,\n" +
+            "  :createTime, :createTime,  0,\n" +
             "  0, 0, 0, 0)\n")
     @GetGeneratedKeys
     long insertTable(
@@ -219,6 +219,16 @@ public interface MetadataDao
     void updateTemporalColumnId(
             @Bind("tableId") long tableId,
             @Bind("columnId") long columnId);
+
+    @SqlQuery("SELECT table_time_zone\n" +
+            "FROM tables\n" +
+            "WHERE table_id = :tableId\n")
+    String getTableTimeZone(@Bind("tableId") long tableId);
+
+    @SqlUpdate("UPDATE tables SET\n" +
+            "table_time_zone = :tableTimeZone\n" +
+            "WHERE table_id = :tableId")
+    void updateTableTimeZone(@Bind("tableId") long tableId, @Bind("tableTimeZone") String timeZone);
 
     @SqlQuery("SELECT compaction_enabled AND maintenance_blocked IS NULL\n" +
             "FROM tables\n" +

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDao.java
@@ -42,6 +42,7 @@ public interface SchemaDao
             "  compressed_size BIGINT NOT NULL,\n" +
             "  uncompressed_size BIGINT NOT NULL,\n" +
             "  maintenance_blocked DATETIME,\n" +
+            "  table_time_zone VARCHAR(255) NULL,\n" +
             "  UNIQUE (schema_name, table_name),\n" +
             "  UNIQUE (distribution_id, table_id),\n" +
             "  UNIQUE (maintenance_blocked, table_id),\n" +

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/Table.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/Table.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.raptor.metadata;
 
+import org.joda.time.DateTimeZone;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
@@ -34,6 +35,7 @@ public final class Table
     private final Optional<String> distributionName;
     private final OptionalInt bucketCount;
     private final OptionalLong temporalColumnId;
+    private final Optional<DateTimeZone> tableTimeZone;
     private final boolean organized;
 
     public Table(
@@ -42,6 +44,7 @@ public final class Table
             Optional<String> distributionName,
             OptionalInt bucketCount,
             OptionalLong temporalColumnId,
+            Optional<DateTimeZone> tableTimeZone,
             boolean organized)
     {
         this.tableId = tableId;
@@ -49,6 +52,7 @@ public final class Table
         this.distributionName = requireNonNull(distributionName, "distributionName is null");
         this.bucketCount = requireNonNull(bucketCount, "bucketCount is null");
         this.temporalColumnId = requireNonNull(temporalColumnId, "temporalColumnId is null");
+        this.tableTimeZone = requireNonNull(tableTimeZone, "tableTimeZone is null");
         this.organized = organized;
     }
 
@@ -77,6 +81,11 @@ public final class Table
         return temporalColumnId;
     }
 
+    public Optional<DateTimeZone> getTableTimeZone()
+    {
+        return tableTimeZone;
+    }
+
     public boolean isOrganized()
     {
         return organized;
@@ -90,6 +99,7 @@ public final class Table
                 .add("distributionId", distributionId.isPresent() ? distributionId.getAsLong() : null)
                 .add("bucketCount", bucketCount.isPresent() ? bucketCount.getAsInt() : null)
                 .add("temporalColumnId", temporalColumnId.isPresent() ? temporalColumnId.getAsLong() : null)
+                .add("tableTiemZone", tableTimeZone.isPresent() ? tableTimeZone.get().toString() : null)
                 .add("organized", organized)
                 .omitNullValues()
                 .toString();
@@ -108,6 +118,7 @@ public final class Table
                     Optional.ofNullable(r.getString("distribution_name")),
                     getOptionalInt(r, "bucket_count"),
                     getOptionalLong(r, "temporal_column_id"),
+                    Optional.ofNullable(r.getString("table_time_zone")).map(DateTimeZone::forID),
                     r.getBoolean("organization_enabled"));
         }
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
@@ -22,6 +22,7 @@ import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 import io.airlift.units.MinDuration;
+import org.joda.time.DateTimeZone;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -58,6 +59,7 @@ public class StorageManagerConfig
     private long maxShardRows = 1_000_000;
     private DataSize maxShardSize = new DataSize(256, MEGABYTE);
     private DataSize maxBufferSize = new DataSize(256, MEGABYTE);
+    private DateTimeZone shardDayBoundaryTimeZone = DateTimeZone.UTC;
     private int oneSplitPerBucketThreshold;
 
     @NotNull
@@ -284,6 +286,20 @@ public class StorageManagerConfig
     {
         this.maxShardSize = maxShardSize;
         return this;
+    }
+
+    @Config("storage.shard-day-boundary-time-zone")
+    @ConfigDescription("Time zone to determine the day boundary used to split shards")
+    public StorageManagerConfig setShardDayBoundaryTimeZone(String dayBoundaryTimeZone)
+    {
+        this.shardDayBoundaryTimeZone = DateTimeZone.forID(dayBoundaryTimeZone);
+        return this;
+    }
+
+    @NotNull
+    public DateTimeZone getShardDayBoundaryTimeZone()
+    {
+        return shardDayBoundaryTimeZone;
     }
 
     @MinDataSize("1MB")

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardCompactionManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardCompactionManager.java
@@ -69,6 +69,7 @@ public class ShardCompactionManager
     private final MetadataDao metadataDao;
     private final ShardOrganizer organizer;
     private final ShardManager shardManager;
+    private final ShardSplitterProvider shardSplitterProvider;
     private final String currentNodeIdentifier;
     private final CompactionSetCreator compactionSetCreator;
 
@@ -79,12 +80,13 @@ public class ShardCompactionManager
     private final IDBI dbi;
 
     @Inject
-    public ShardCompactionManager(@ForMetadata IDBI dbi, NodeManager nodeManager, ShardManager shardManager, ShardOrganizer organizer, StorageManagerConfig config)
+    public ShardCompactionManager(@ForMetadata IDBI dbi, NodeManager nodeManager, ShardManager shardManager, ShardOrganizer organizer, ShardSplitterProvider shardSplitterProvider, StorageManagerConfig config)
     {
         this(dbi,
                 nodeManager.getCurrentNode().getNodeIdentifier(),
                 shardManager,
                 organizer,
+                shardSplitterProvider,
                 config.getCompactionInterval(),
                 config.getMaxShardSize(),
                 config.getMaxShardRows(),
@@ -96,6 +98,7 @@ public class ShardCompactionManager
             String currentNodeIdentifier,
             ShardManager shardManager,
             ShardOrganizer organizer,
+            ShardSplitterProvider shardSplitterProvider,
             Duration compactionDiscoveryInterval,
             DataSize maxShardSize,
             long maxShardRows,
@@ -107,6 +110,7 @@ public class ShardCompactionManager
         this.currentNodeIdentifier = requireNonNull(currentNodeIdentifier, "currentNodeIdentifier is null");
         this.shardManager = requireNonNull(shardManager, "shardManager is null");
         this.organizer = requireNonNull(organizer, "organizer is null");
+        this.shardSplitterProvider = requireNonNull(shardSplitterProvider, "shardSplitterProvider is null");
         this.compactionDiscoveryInterval = requireNonNull(compactionDiscoveryInterval, "compactionDiscoveryInterval is null");
 
         checkArgument(maxShardSize.toBytes() > 0, "maxShardSize must be > 0");
@@ -116,7 +120,7 @@ public class ShardCompactionManager
         this.maxShardRows = maxShardRows;
 
         this.compactionEnabled = compactionEnabled;
-        this.compactionSetCreator = new CompactionSetCreator(maxShardSize, maxShardRows);
+        this.compactionSetCreator = new CompactionSetCreator(shardSplitterProvider, maxShardSize, maxShardRows);
     }
 
     @PostConstruct

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardSplitter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardSplitter.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.storage.organization;
+
+import com.facebook.presto.raptor.RaptorBucketFunction;
+import com.facebook.presto.spi.BucketFunction;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimaps;
+import org.joda.time.DateTimeZone;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class ShardSplitter
+{
+    final OptionalInt bucketCount;
+    final OptionalLong temporalColumnId;
+    final Optional<Type> temporalColumnType;
+    final Optional<DateTimeZone> shardDayBoundaryTimeZone;
+
+    public ShardSplitter(OptionalInt bucketCount, OptionalLong temporalColumnId, Optional<Type> temporalColumnType, Optional<DateTimeZone> shardDayBoundaryTimeZone)
+    {
+        this.bucketCount = requireNonNull(bucketCount, "bucketCount is null");
+        this.temporalColumnId = requireNonNull(temporalColumnId, "temporalColumnId is null");
+        this.temporalColumnType = requireNonNull(temporalColumnType, "temperalColumnType is null");
+        this.shardDayBoundaryTimeZone = requireNonNull(shardDayBoundaryTimeZone, "shardDayBoundaryTimeZone is null");
+    }
+
+    public boolean shouldSplit()
+    {
+        return (bucketCount.isPresent() || temporalColumnId.isPresent());
+    }
+
+    public interface TemporalFunction
+    {
+        int getDay(Block block, int position);
+    }
+
+    public Optional<TemporalFunction> createTemporalFunction()
+    {
+        if (!temporalColumnType.isPresent()) {
+            return Optional.empty();
+        }
+        verify(shardDayBoundaryTimeZone.isPresent());
+
+        if (temporalColumnType.equals(DATE)) {
+            return Optional.of((temporalBlock, position) -> toIntExact(DATE.getLong(temporalBlock, position)));
+        }
+
+        if (temporalColumnType.equals(TIMESTAMP)) {
+            return Optional.of((temporalBlock, position) -> toIntExact(MILLISECONDS.toDays(shardDayBoundaryTimeZone.get().convertUTCToLocal(temporalBlock.getLong(position, 0)))));
+        }
+
+        throw new IllegalArgumentException("Wrong type for temporal column: " + temporalColumnType);
+    }
+
+    public Optional<BucketFunction> createBucketFunction(List<Type> types)
+    {
+        return bucketCount.isPresent() ? Optional.of(new RaptorBucketFunction(bucketCount.getAsInt(), types)) : Optional.empty();
+    }
+
+    public Collection<Collection<ShardIndexInfo>> getShardsByDaysBuckets(Collection<ShardIndexInfo> shards)
+    {
+        // Neither bucketed nor temporal, no partitioning required
+        if (!bucketCount.isPresent() && !temporalColumnId.isPresent()) {
+            return ImmutableList.of(shards);
+        }
+
+        // if only bucketed, partition by bucket number
+        if (bucketCount.isPresent() && !temporalColumnId.isPresent()) {
+            return Multimaps.index(shards, shard -> shard.getBucketNumber().getAsInt()).asMap().values();
+        }
+
+        // if temporal, partition into days first
+        ImmutableMultimap.Builder<Long, ShardIndexInfo> shardsByDaysBuilder = ImmutableMultimap.builder();
+        shards.stream()
+                .filter(shard -> shard.getTemporalRange().isPresent())
+                .forEach(shard -> {
+                    long day = determineDay(shard.getTemporalRange().get());
+                    shardsByDaysBuilder.put(day, shard);
+                });
+
+        Collection<Collection<ShardIndexInfo>> byDays = shardsByDaysBuilder.build().asMap().values();
+
+        // if table is bucketed further partition by bucket number
+        if (!bucketCount.isPresent()) {
+            return byDays;
+        }
+
+        ImmutableList.Builder<Collection<ShardIndexInfo>> sets = ImmutableList.builder();
+        for (Collection<ShardIndexInfo> s : byDays) {
+            sets.addAll(Multimaps.index(s, ShardIndexInfo::getBucketNumber).asMap().values());
+        }
+        return sets.build();
+    }
+
+    private long determineDay(ShardRange temporalRange)
+    {
+        Tuple min = temporalRange.getMinTuple();
+        Tuple max = temporalRange.getMaxTuple();
+
+        verify(temporalColumnType.isPresent());
+        verify(getOnlyElement(min.getTypes()).equals(temporalColumnType.get()));
+        verify(min.getTypes().equals(max.getTypes()));
+        Type type = getOnlyElement(min.getTypes());
+        verify(type.equals(DATE) || type.equals(TimestampType.TIMESTAMP));
+
+        if (type.equals(DATE)) {
+            return ((Integer) getOnlyElement(min.getValues())).longValue();
+        }
+
+        Long minValue = shardDayBoundaryTimeZone.get().convertUTCToLocal((Long) getOnlyElement(min.getValues()));
+        Long maxValue = shardDayBoundaryTimeZone.get().convertUTCToLocal((Long) getOnlyElement(max.getValues()));
+        return determineDay(minValue, maxValue);
+    }
+
+    private long determineDay(long rangeStart, long rangeEnd)
+    {
+        long startDay = Duration.ofMillis(rangeStart).toDays();
+        long endDay = Duration.ofMillis(rangeEnd).toDays();
+        if (startDay == endDay) {
+            return startDay;
+        }
+
+        if ((endDay - startDay) > 1) {
+            // range spans multiple days, return the first full day
+            return startDay + 1;
+        }
+
+        // range spans two days, return the day that has the larger time range
+        long millisInStartDay = Duration.ofDays(endDay).toMillis() - rangeStart;
+        long millisInEndDay = rangeEnd - Duration.ofDays(endDay).toMillis();
+        return (millisInStartDay >= millisInEndDay) ? startDay : endDay;
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardSplitterProvider.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardSplitterProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.storage.organization;
+
+import com.facebook.presto.raptor.RaptorColumnHandle;
+import com.facebook.presto.raptor.RaptorInsertTableHandle;
+import com.facebook.presto.raptor.RaptorOutputTableHandle;
+import com.facebook.presto.raptor.metadata.ForMetadata;
+import com.facebook.presto.raptor.metadata.MetadataDao;
+import com.facebook.presto.raptor.metadata.Table;
+import com.facebook.presto.raptor.metadata.TableColumn;
+import com.facebook.presto.raptor.storage.StorageManagerConfig;
+import com.facebook.presto.spi.type.Type;
+import com.google.inject.Inject;
+import org.joda.time.DateTimeZone;
+import org.skife.jdbi.v2.IDBI;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static com.facebook.presto.raptor.util.DatabaseUtil.onDemandDao;
+import static java.util.Objects.requireNonNull;
+
+public class ShardSplitterProvider
+{
+    final DateTimeZone defaultTimeZone;
+    final TemporalColumnMetaFunction temporalColumnMetaFunction;
+
+    @Inject
+    public ShardSplitterProvider(@ForMetadata IDBI dbi, StorageManagerConfig config)
+    {
+        this(createColumnTypeFromMetaData(onDemandDao(dbi, MetadataDao.class)), config.getShardDayBoundaryTimeZone());
+    }
+
+    public ShardSplitterProvider(TemporalColumnMetaFunction temporalColumnMetaFunction, DateTimeZone defaultTimeZone)
+    {
+        this.temporalColumnMetaFunction = requireNonNull(temporalColumnMetaFunction, "temporalColumnMetaFunction is null");
+        this.defaultTimeZone = requireNonNull(defaultTimeZone, "defaultTimeZone is null");
+    }
+
+    public ShardSplitter forTable(RaptorInsertTableHandle tableHandle)
+    {
+        return new ShardSplitter(tableHandle.getBucketCount(),
+                tableHandle.getTemporalColumnHandle().map(RaptorColumnHandle::getColumnId).map(OptionalLong::of).orElse(OptionalLong.empty()),
+                tableHandle.getTemporalColumnHandle().map(RaptorColumnHandle::getColumnType),
+                tableHandle.getTemporalColumnHandle().isPresent() ? Optional.of(tableHandle.getTableTimeZone().orElse(defaultTimeZone)) : Optional.empty());
+    }
+
+    public ShardSplitter forTable(RaptorOutputTableHandle tableHandle)
+    {
+        return new ShardSplitter(tableHandle.getBucketCount(),
+                tableHandle.getTemporalColumnHandle().map(RaptorColumnHandle::getColumnId).map(OptionalLong::of).orElse(OptionalLong.empty()),
+                tableHandle.getTemporalColumnHandle().map(RaptorColumnHandle::getColumnType),
+                tableHandle.getTemporalColumnHandle().isPresent() ? Optional.of(tableHandle.getTableTimeZone().orElse(defaultTimeZone)) : Optional.empty());
+    }
+
+    public ShardSplitter forTable(Table tableInfo)
+    {
+        Optional<Type> temporalType = Optional.empty();
+        if (tableInfo.getTemporalColumnId().isPresent()) {
+            temporalType = temporalColumnMetaFunction.get(tableInfo.getTableId(), tableInfo.getTemporalColumnId().getAsLong());
+        }
+
+        return new ShardSplitter(tableInfo.getBucketCount(),
+                tableInfo.getTemporalColumnId(),
+                temporalType,
+                tableInfo.getTemporalColumnId().isPresent() ? Optional.of(tableInfo.getTableTimeZone().orElse(defaultTimeZone)) : Optional.empty());
+    }
+
+    public interface TemporalColumnMetaFunction
+    {
+        Optional<Type> get(long tableId, long columnId);
+    }
+
+    private static TemporalColumnMetaFunction createColumnTypeFromMetaData(MetadataDao dao)
+    {
+        return (tableId, columnId) -> Optional.ofNullable(dao.getTableColumn(tableId, columnId)).map(TableColumn::getDataType);
+    }
+}

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -20,6 +20,7 @@ import com.facebook.presto.raptor.metadata.ShardManager;
 import com.facebook.presto.raptor.metadata.TableColumn;
 import com.facebook.presto.raptor.storage.StorageManager;
 import com.facebook.presto.raptor.storage.StorageManagerConfig;
+import com.facebook.presto.raptor.storage.organization.ShardSplitterProvider;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
@@ -84,7 +85,7 @@ public class TestRaptorConnector
                 new RaptorMetadataFactory(connectorId, dbi, shardManager),
                 new RaptorSplitManager(connectorId, nodeSupplier, shardManager, false),
                 new RaptorPageSourceProvider(storageManager),
-                new RaptorPageSinkProvider(storageManager, new PagesIndexPageSorter(new PagesIndex.TestingFactory(false)), config),
+                new RaptorPageSinkProvider(storageManager, new ShardSplitterProvider(dbi, config), new PagesIndexPageSorter(new PagesIndex.TestingFactory(false)), config),
                 new RaptorNodePartitioningProvider(nodeSupplier),
                 new RaptorSessionProperties(config),
                 new RaptorTableProperties(typeRegistry),
@@ -171,8 +172,8 @@ public class TestRaptorConnector
     {
         ConnectorTransactionHandle transaction = connector.beginTransaction(READ_COMMITTED, false);
         connector.getMetadata(transaction).createTable(SESSION, new ConnectorTableMetadata(
-                new SchemaTableName("test", name),
-                ImmutableList.of(new ColumnMetadata("id", BIGINT))),
+                        new SchemaTableName("test", name),
+                        ImmutableList.of(new ColumnMetadata("id", BIGINT))),
                 false);
         connector.commit(transaction);
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestMetadataDao.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestMetadataDao.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.raptor.metadata;
 
+import org.joda.time.DateTimeZone;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.IDBI;
@@ -69,6 +70,17 @@ public class TestMetadataDao
         long tableId2 = dao.insertTable("schema1", "table2", true, false, null, 0);
         Long columnId2 = dao.getTemporalColumnId(tableId2);
         assertNull(columnId2);
+    }
+
+    @Test
+    public void testTableTimeZone()
+    {
+        Long columnId = 1L;
+        long tableId = dao.insertTable("schema1", "table1", true, false, null, 0);
+        dao.insertColumn(tableId, columnId, "col1", 1, "bigint", null, null);
+        dao.updateTemporalColumnId(tableId, columnId);
+        dao.updateTableTimeZone(tableId, "America/LosAngles");
+        DateTimeZone dateTimeZone = DateTimeZone.forID(dao.getTableTimeZone(tableId));
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
@@ -63,7 +63,8 @@ public class TestStorageManagerConfig
                 .setMaxShardRows(1_000_000)
                 .setMaxShardSize(new DataSize(256, MEGABYTE))
                 .setMaxBufferSize(new DataSize(256, MEGABYTE))
-                .setOneSplitPerBucketThreshold(0));
+                .setOneSplitPerBucketThreshold(0)
+                .setShardDayBoundaryTimeZone("UTC"));
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizationManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizationManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
+import org.joda.time.DateTimeZone;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.IDBI;
@@ -56,8 +57,8 @@ public class TestShardOrganizationManager
     private MetadataDao metadataDao;
     private ShardOrganizerDao organizerDao;
 
-    private static final Table tableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.empty(), true);
-    private static final Table temporalTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.of(1), true);
+    private static final Table tableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.empty(), Optional.empty(), true);
+    private static final Table temporalTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.of(1), Optional.of(DateTimeZone.UTC), true);
 
     private static final List<Type> types = ImmutableList.of(BIGINT, VARCHAR, DATE, TIMESTAMP);
 


### PR DESCRIPTION
Shard is currently splitted by its bucket id and date (assuming UTC
timezone). Making time zone configuration allows us to adjust the
shard boundary to data ingestion/retention timezone thus reduce
shard compaction operations.

This is similar to PR #9378 but we are making this configuration per
table (or fall back to system level time zone if not specified for the table).
Also, per suggestion of @AlekseiS , moved all shard split related logic to a 
separate class. 