### PR TITLE
Add query type to DbSourceExactMatchSelector

### DIFF
--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbSourceExactMatchSelector.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbSourceExactMatchSelector.java
@@ -48,7 +48,7 @@ public class DbSourceExactMatchSelector
             return Optional.empty();
         }
         try {
-            String resourceGroupId = dao.getExactMatchResourceGroup(environment, context.getSource().get());
+            String resourceGroupId = dao.getExactMatchResourceGroup(environment, context.getSource().get(), context.getQueryType().orElse(null));
 
             Long start = daoOfflineStart.get();
             if (start != null && daoOfflineStart.compareAndSet(start, null)) {

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
@@ -84,6 +84,7 @@ public interface ResourceGroupsDao
     @SqlUpdate("CREATE TABLE IF NOT EXISTS exact_match_source_selectors(\n" +
             "  environment VARCHAR(128) NOT NULL,\n" +
             "  source VARCHAR(512) NOT NULL,\n" +
+            "  query_type VARCHAR(512),\n" +
             "  update_time DATETIME NOT NULL,\n" +
             "  resource_group_id VARCHAR(256) NOT NULL,\n" +
             "  PRIMARY KEY (environment, source) \n" +
@@ -93,8 +94,10 @@ public interface ResourceGroupsDao
     @SqlQuery("SELECT resource_group_id\n" +
             "FROM exact_match_source_selectors\n" +
             "WHERE environment = :environment\n" +
-            "  AND source = :source")
+            "  AND source = :source\n" +
+            "  AND (query_type IS NULL OR query_type = :query_type)")
     String getExactMatchResourceGroup(
             @Bind("environment") String environment,
-            @Bind("source") String source);
+            @Bind("source") String source,
+            @Bind("query_type") String queryType);
 }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
@@ -127,7 +127,11 @@ public interface H2ResourceGroupsDao
     @SqlUpdate("DELETE FROM selectors WHERE resource_group_id = :resource_group_id")
     void deleteSelectors(@Bind("resource_group_id") long resourceGroup);
 
-    @SqlUpdate("INSERT INTO exact_match_source_selectors (environment, source, update_time, resource_group_id)\n" +
-            "VALUES (:environment, :source, now(), :resourceGroupId)\n")
-    void insertExactMatchSelector(@Bind("environment") String environment, @Bind("source") String source, @Bind("resourceGroupId") String resourceGroupId);
+    @SqlUpdate("INSERT INTO exact_match_source_selectors (environment, source, query_type, update_time, resource_group_id)\n" +
+            "VALUES (:environment, :source, :query_type, now(), :resourceGroupId)\n")
+    void insertExactMatchSelector(
+            @Bind("environment") String environment,
+            @Bind("source") String source,
+            @Bind("query_type") String queryType,
+            @Bind("resourceGroupId") String resourceGroupId);
 }


### PR DESCRIPTION
Metadata queries are categorized in the same way as other queries.
This can cause long queueing times for metadata queries if
the main insert/select query with the same source is categorized as
a high memory query.