### PR TITLE
Skip creation of TPCH tables for type mapping tests

### DIFF
--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
@@ -23,7 +23,6 @@ import com.facebook.presto.tests.datatype.DataTypeTest;
 import com.facebook.presto.tests.sql.JdbcSqlExecutor;
 import com.facebook.presto.tests.sql.PrestoSqlExecutor;
 import io.airlift.testing.mysql.TestingMySqlServer;
-import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -38,6 +37,7 @@ import static com.facebook.presto.tests.datatype.DataType.stringDataType;
 import static com.facebook.presto.tests.datatype.DataType.varcharDataType;
 import static com.google.common.base.Strings.repeat;
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 
 @Test
 public class TestMySqlTypeMapping
@@ -56,7 +56,7 @@ public class TestMySqlTypeMapping
     private TestMySqlTypeMapping(TestingMySqlServer mysqlServer)
             throws Exception
     {
-        super(() -> createMySqlQueryRunner(mysqlServer, TpchTable.getTables()));
+        super(() -> createMySqlQueryRunner(mysqlServer, emptyList()));
         this.mysqlServer = mysqlServer;
     }
 

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgresSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgresSqlTypeMapping.java
@@ -22,7 +22,6 @@ import com.facebook.presto.tests.datatype.DataTypeTest;
 import com.facebook.presto.tests.sql.JdbcSqlExecutor;
 import com.facebook.presto.tests.sql.PrestoSqlExecutor;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
-import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -34,6 +33,7 @@ import java.util.function.Function;
 import static com.facebook.presto.plugin.postgresql.PostgreSqlQueryRunner.createPostgreSqlQueryRunner;
 import static com.facebook.presto.tests.datatype.DataType.varcharDataType;
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 
 @Test
 public class TestPostgresSqlTypeMapping
@@ -50,7 +50,7 @@ public class TestPostgresSqlTypeMapping
     private TestPostgresSqlTypeMapping(TestingPostgreSqlServer postgreSqlServer)
             throws Exception
     {
-        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, TpchTable.getTables()));
+        super(() -> createPostgreSqlQueryRunner(postgreSqlServer, emptyList()));
         this.postgreSqlServer = postgreSqlServer;
     }
 


### PR DESCRIPTION
The tables are not used in these tests.