### PR TITLE
Add a priority column to the db resource group selectors

### DIFF
--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/StaticSelector.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/StaticSelector.java
@@ -16,6 +16,7 @@ package com.facebook.presto.resourceGroups;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupSelector;
 import com.facebook.presto.spi.resourceGroups.SelectionContext;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -69,5 +70,11 @@ public class StaticSelector
         }
 
         return Optional.of(group.expandTemplate(context));
+    }
+
+    @VisibleForTesting
+    public Optional<Pattern> getUserRegex()
+    {
+        return userRegex;
     }
 }

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManager.java
@@ -250,9 +250,8 @@ public class DbResourceGroupConfigurationManager
         // Specs are built from db records, validate and return manager spec
         List<ResourceGroupSpec> rootGroups = rootGroupIds.stream().map(resourceGroupSpecMap::get).collect(Collectors.toList());
 
-        List<SelectorSpec> selectors = dao.getSelectors()
+        List<SelectorSpec> selectors = dao.getSelectors(environment)
                 .stream()
-                .filter(selectorRecord -> resourceGroupIdTemplateMap.containsKey(selectorRecord.getResourceGroupId()))
                 .map(selectorRecord ->
                 new SelectorSpec(
                         selectorRecord.getUserRegex(),

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
@@ -62,10 +62,11 @@ public interface ResourceGroupsDao
     @Mapper(ResourceGroupSpecBuilder.Mapper.class)
     List<ResourceGroupSpecBuilder> getResourceGroups(@Bind("environment") String environment);
 
-    @SqlQuery("SELECT S.resource_group_id, S.user_regex, S.source_regex, S.client_tags\n" +
+    @SqlQuery("SELECT S.resource_group_id, S.user_regex, S.source_regex, S.client_tags, S.priority\n" +
             "FROM selectors S\n" +
             "JOIN resource_groups R ON (S.resource_group_id = R.resource_group_id)\n" +
-            "WHERE R.environment = :environment\n")
+            "WHERE R.environment = :environment\n" +
+            "ORDER by priority DESC")
     @Mapper(SelectorRecord.Mapper.class)
     List<SelectorRecord> getSelectors(@Bind("environment") String environment);
 
@@ -74,6 +75,7 @@ public interface ResourceGroupsDao
             "  user_regex VARCHAR(512),\n" +
             "  source_regex VARCHAR(512),\n" +
             "  client_tags VARCHAR(512),\n" +
+            "  priority BIGINT NOT NULL,\n" +
             "  FOREIGN KEY (resource_group_id) REFERENCES resource_groups (resource_group_id)\n" +
             ")")
     void createSelectorsTable();

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
@@ -62,9 +62,12 @@ public interface ResourceGroupsDao
     @Mapper(ResourceGroupSpecBuilder.Mapper.class)
     List<ResourceGroupSpecBuilder> getResourceGroups(@Bind("environment") String environment);
 
-    @SqlQuery("SELECT resource_group_id, user_regex, source_regex, client_tags from selectors")
+    @SqlQuery("SELECT S.resource_group_id, S.user_regex, S.source_regex, S.client_tags\n" +
+            "FROM selectors S\n" +
+            "JOIN resource_groups R ON (S.resource_group_id = R.resource_group_id)\n" +
+            "WHERE R.environment = :environment\n")
     @Mapper(SelectorRecord.Mapper.class)
-    List<SelectorRecord> getSelectors();
+    List<SelectorRecord> getSelectors(@Bind("environment") String environment);
 
     @SqlUpdate("CREATE TABLE IF NOT EXISTS selectors (\n" +
             "  resource_group_id BIGINT NOT NULL,\n" +

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/SelectorRecord.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/SelectorRecord.java
@@ -30,13 +30,15 @@ import static java.util.Objects.requireNonNull;
 public class SelectorRecord
 {
     private final long resourceGroupId;
+    private final long priority;
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> sourceRegex;
     private final Optional<List<String>> clientTags;
 
-    public SelectorRecord(long resourceGroupId, Optional<Pattern> userRegex, Optional<Pattern> sourceRegex, Optional<List<String>> clientTags)
+    public SelectorRecord(long resourceGroupId, Optional<Pattern> userRegex, Optional<Pattern> sourceRegex, Optional<List<String>> clientTags, long priority)
     {
         this.resourceGroupId = resourceGroupId;
+        this.priority = priority;
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.sourceRegex = requireNonNull(sourceRegex, "sourceRegex is null");
         this.clientTags = requireNonNull(clientTags, "clientTags is null").map(ImmutableList::copyOf);
@@ -45,6 +47,11 @@ public class SelectorRecord
     public long getResourceGroupId()
     {
         return resourceGroupId;
+    }
+
+    public long getPriority()
+    {
+        return priority;
     }
 
     public Optional<Pattern> getUserRegex()
@@ -75,7 +82,8 @@ public class SelectorRecord
                     resultSet.getLong("resource_group_id"),
                     Optional.ofNullable(resultSet.getString("user_regex")).map(Pattern::compile),
                     Optional.ofNullable(resultSet.getString("source_regex")).map(Pattern::compile),
-                    Optional.ofNullable(resultSet.getString("client_tags")).map(LIST_STRING_CODEC::fromJson));
+                    Optional.ofNullable(resultSet.getString("client_tags")).map(LIST_STRING_CODEC::fromJson),
+                    resultSet.getLong("priority"));
         }
     }
 }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
@@ -86,13 +86,14 @@ public interface H2ResourceGroupsDao
     void deleteResourceGroup(@Bind("resource_group_id") long resourceGroupId);
 
     @SqlUpdate("INSERT INTO selectors\n" +
-            "(resource_group_id, user_regex, source_regex, client_tags)\n" +
-            "VALUES (:resource_group_id, :user_regex, :source_regex, :client_tags)")
+            "(resource_group_id, user_regex, source_regex, client_tags, priority)\n" +
+            "VALUES (:resource_group_id, :user_regex, :source_regex, :client_tags, :priority)")
     void insertSelector(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("user_regex") String userRegex,
             @Bind("source_regex") String sourceRegex,
-            @Bind("client_tags") String clientTags);
+            @Bind("client_tags") String clientTags,
+            @Bind("priority") long priority);
 
     @SqlUpdate("UPDATE selectors SET\n" +
             " resource_group_id = :resource_group_id\n" +

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.resourceGroups.db;
 
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroup;
 import com.facebook.presto.resourceGroups.ResourceGroupSpec;
+import com.facebook.presto.resourceGroups.StaticSelector;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupSelector;
 import com.facebook.presto.spi.resourceGroups.SchedulingPolicy;
@@ -25,9 +26,13 @@ import io.airlift.units.Duration;
 import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import static com.facebook.presto.execution.resourceGroups.InternalResourceGroup.DEFAULT_WEIGHT;
 import static com.facebook.presto.spi.resourceGroups.SchedulingPolicy.FAIR;
@@ -65,8 +70,8 @@ public class TestDbResourceGroupConfigurationManager
         // two resource groups are the same except the group for the prod environment has a larger softMemoryLimit
         dao.insertResourceGroup(1, "prod_global", "10MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1h", null, prodEnvironment);
         dao.insertResourceGroup(2, "dev_global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1h", null, devEnvironment);
-        dao.insertSelector(1, ".*prod_user.*", null, null);
-        dao.insertSelector(2, ".*dev_user.*", null, null);
+        dao.insertSelector(1, ".*prod_user.*", null, null, 1);
+        dao.insertSelector(2, ".*dev_user.*", null, null, 2);
 
         // check the prod configuration
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), prodEnvironment);
@@ -105,7 +110,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1h", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, "1h", "1h", 1L, ENVIRONMENT);
-        dao.insertSelector(2, null, null, null);
+        dao.insertSelector(2, null, null, null, 1);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         AtomicBoolean exported = new AtomicBoolean();
         InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
@@ -135,7 +140,7 @@ public class TestDbResourceGroupConfigurationManager
             assertTrue(ex.getCause() instanceof org.h2.jdbc.JdbcSQLException);
             assertTrue(ex.getCause().getMessage().startsWith("Unique index or primary key violation"));
         }
-        dao.insertSelector(1, null, null, null);
+        dao.insertSelector(1, null, null, null, 1);
         daoProvider = setup("test_dup_subs");
         dao = daoProvider.get();
         dao.createResourceGroupsGlobalPropertiesTable();
@@ -152,7 +157,7 @@ public class TestDbResourceGroupConfigurationManager
             assertTrue(ex.getCause().getMessage().startsWith("Unique index or primary key violation"));
         }
 
-        dao.insertSelector(2, null, null, null);
+        dao.insertSelector(2, null, null, null, 2);
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "No matching configuration found for: missing")
@@ -166,7 +171,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, null, null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
-        dao.insertSelector(2, null, null, null);
+        dao.insertSelector(2, null, null, null, 1);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         InternalResourceGroup missing = new InternalResourceGroup.RootInternalResourceGroup("missing", (group, export) -> {}, directExecutor());
         manager.configure(missing, new SelectionContext(true, "user", Optional.empty(), ImmutableSet.of(), 1, Optional.empty()));
@@ -183,7 +188,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createSelectorsTable();
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, null, null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, null, null, null);
+        dao.insertSelector(2, null, null, null, 1);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         manager.start();
@@ -221,7 +226,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createExactMatchSelectorsTable();
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, null, null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, null, null, null);
+        dao.insertSelector(2, null, null, null, 1);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         DbResourceGroupConfig config = new DbResourceGroupConfig();
         config.setExactMatchSelectorEnabled(true);
@@ -235,6 +240,49 @@ public class TestDbResourceGroupConfigurationManager
         manager.load();
         assertEquals(manager.getSelectors().size(), 1);
         assertFalse(manager.getSelectors().get(0) instanceof DbSourceExactMatchSelector);
+    }
+
+    @Test
+    public void testSelectorPriority()
+            throws Throwable
+    {
+        H2DaoProvider daoProvider = setup("selectors");
+        H2ResourceGroupsDao dao = daoProvider.get();
+        dao.createResourceGroupsTable();
+        dao.createSelectorsTable();
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
+
+        final int numberOfUsers = 100;
+        List<String> expectedUsers = new ArrayList<>();
+
+        int[] randomPriorities = ThreadLocalRandom.current()
+                .ints(0, 1000)
+                .distinct()
+                .limit(numberOfUsers)
+                .toArray();
+
+        // insert several selectors with unique random priority where userRegex is equal to the priority
+        for (int i = 0; i < numberOfUsers; i++) {
+            int priority = randomPriorities[i];
+            String user = String.valueOf(priority);
+            dao.insertSelector(1, user, ".*", null, priority);
+            expectedUsers.add(user);
+        }
+
+        DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager((poolId, listener) -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
+        manager.load();
+
+        List<ResourceGroupSelector> selectors = manager.getSelectors();
+        assertEquals(selectors.size(), expectedUsers.size());
+
+        // when we load the selectors we expect the selector list to be ordered by priority
+        expectedUsers.sort(Comparator.<String>comparingInt(Integer::parseInt).reversed());
+
+        for (int i = 0; i < numberOfUsers; i++) {
+            Optional<Pattern> user = ((StaticSelector) selectors.get(i)).getUserRegex();
+            assertTrue(user.isPresent());
+            assertEquals(user.get().pattern(), expectedUsers.get(i));
+        }
     }
 
     private static void assertEqualsResourceGroup(

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
@@ -103,18 +103,20 @@ public class TestResourceGroupsDao
                         2L,
                         Optional.of(Pattern.compile("ping_user")),
                         Optional.of(Pattern.compile(".*")),
-                        Optional.empty()));
+                        Optional.empty(),
+                        1L));
         map.put(3L,
                 new SelectorRecord(
                         3L,
                         Optional.of(Pattern.compile("admin_user")),
                         Optional.of(Pattern.compile(".*")),
-                        Optional.of(ImmutableList.of("tag1", "tag2"))));
+                        Optional.of(ImmutableList.of("tag1", "tag2")),
+                        2L));
         dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
         dao.insertResourceGroup(2, "ping_query", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, "ping_user", ".*", null);
-        dao.insertSelector(3, "admin_user", ".*", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
+        dao.insertSelector(2, "ping_user", ".*", null, 1);
+        dao.insertSelector(3, "admin_user", ".*", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), 2);
         List<SelectorRecord> records = dao.getSelectors(ENVIRONMENT);
         compareSelectors(map, records);
     }
@@ -126,14 +128,15 @@ public class TestResourceGroupsDao
                 2,
                 Optional.of(Pattern.compile("ping.*")),
                 Optional.of(Pattern.compile("ping_source")),
-                Optional.of(ImmutableList.of("tag1")));
+                Optional.of(ImmutableList.of("tag1")),
+                1L);
         map.put(2L, updated);
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
     }
 
     private static void testSelectorUpdateNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
-        SelectorRecord updated = new SelectorRecord(2, Optional.empty(), Optional.empty(), Optional.empty());
+        SelectorRecord updated = new SelectorRecord(2, Optional.empty(), Optional.empty(), Optional.empty(), 3L);
         map.put(2L, updated);
         dao.updateSelector(2, null, null, null, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1")));
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
@@ -141,7 +144,8 @@ public class TestResourceGroupsDao
                 2,
                 Optional.of(Pattern.compile("ping.*")),
                 Optional.of(Pattern.compile("ping_source")),
-                Optional.of(ImmutableList.of("tag1", "tag2")));
+                Optional.of(ImmutableList.of("tag1", "tag2")),
+                2L);
         map.put(2L, updated);
         dao.updateSelector(2, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null, null, null);
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
@@ -157,7 +161,7 @@ public class TestResourceGroupsDao
     private static void testSelectorDeleteNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
         dao.updateSelector(3, null, null, null, "admin_user", ".*", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
-        SelectorRecord nullRegexes = new SelectorRecord(3L, Optional.empty(), Optional.empty(), Optional.empty());
+        SelectorRecord nullRegexes = new SelectorRecord(3L, Optional.empty(), Optional.empty(), Optional.empty(), 2L);
         map.put(3L, nullRegexes);
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
         dao.deleteSelector(3, null, null, null);
@@ -171,12 +175,13 @@ public class TestResourceGroupsDao
             return;
         }
 
-        dao.insertSelector(3, "user1", "pipeline", null);
+        dao.insertSelector(3, "user1", "pipeline", null, 3L);
         map.put(3L, new SelectorRecord(
                 3L,
                 Optional.of(Pattern.compile("user1")),
                 Optional.of(Pattern.compile("pipeline")),
-                Optional.empty()));
+                Optional.empty(),
+                3L));
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
         dao.deleteSelectors(3L);
         map.remove(3L);

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
@@ -115,7 +115,7 @@ public class TestResourceGroupsDao
         dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertSelector(2, "ping_user", ".*", null);
         dao.insertSelector(3, "admin_user", ".*", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
-        List<SelectorRecord> records = dao.getSelectors();
+        List<SelectorRecord> records = dao.getSelectors(ENVIRONMENT);
         compareSelectors(map, records);
     }
 
@@ -128,7 +128,7 @@ public class TestResourceGroupsDao
                 Optional.of(Pattern.compile("ping_source")),
                 Optional.of(ImmutableList.of("tag1")));
         map.put(2L, updated);
-        compareSelectors(map, dao.getSelectors());
+        compareSelectors(map, dao.getSelectors(ENVIRONMENT));
     }
 
     private static void testSelectorUpdateNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
@@ -136,7 +136,7 @@ public class TestResourceGroupsDao
         SelectorRecord updated = new SelectorRecord(2, Optional.empty(), Optional.empty(), Optional.empty());
         map.put(2L, updated);
         dao.updateSelector(2, null, null, null, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1")));
-        compareSelectors(map, dao.getSelectors());
+        compareSelectors(map, dao.getSelectors(ENVIRONMENT));
         updated = new SelectorRecord(
                 2,
                 Optional.of(Pattern.compile("ping.*")),
@@ -144,14 +144,14 @@ public class TestResourceGroupsDao
                 Optional.of(ImmutableList.of("tag1", "tag2")));
         map.put(2L, updated);
         dao.updateSelector(2, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null, null, null);
-        compareSelectors(map, dao.getSelectors());
+        compareSelectors(map, dao.getSelectors(ENVIRONMENT));
     }
 
     private static void testSelectorDelete(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
         map.remove(2L);
         dao.deleteSelector(2, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
-        compareSelectors(map, dao.getSelectors());
+        compareSelectors(map, dao.getSelectors(ENVIRONMENT));
     }
 
     private static void testSelectorDeleteNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
@@ -159,10 +159,10 @@ public class TestResourceGroupsDao
         dao.updateSelector(3, null, null, null, "admin_user", ".*", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
         SelectorRecord nullRegexes = new SelectorRecord(3L, Optional.empty(), Optional.empty(), Optional.empty());
         map.put(3L, nullRegexes);
-        compareSelectors(map, dao.getSelectors());
+        compareSelectors(map, dao.getSelectors(ENVIRONMENT));
         dao.deleteSelector(3, null, null, null);
         map.remove(3L);
-        compareSelectors(map, dao.getSelectors());
+        compareSelectors(map, dao.getSelectors(ENVIRONMENT));
     }
 
     private static void testSelectorMultiDelete(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
@@ -177,10 +177,10 @@ public class TestResourceGroupsDao
                 Optional.of(Pattern.compile("user1")),
                 Optional.of(Pattern.compile("pipeline")),
                 Optional.empty()));
-        compareSelectors(map, dao.getSelectors());
+        compareSelectors(map, dao.getSelectors(ENVIRONMENT));
         dao.deleteSelectors(3L);
         map.remove(3L);
-        compareSelectors(map, dao.getSelectors());
+        compareSelectors(map, dao.getSelectors(ENVIRONMENT));
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
@@ -163,12 +163,12 @@ class H2TestUtil
         dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
-        dao.insertSelector(2, "user.*", "test", null);
-        dao.insertSelector(4, "user.*", "(?i).*adhoc.*", null);
-        dao.insertSelector(5, "user.*", "(?i).*dashboard.*", null);
-        dao.insertSelector(4, "user.*", null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
-        dao.insertSelector(2, "user.*", null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1")));
-        dao.insertSelector(6, ".*", ".*", null);
+        dao.insertSelector(2, "user.*", "test", null, 10_000);
+        dao.insertSelector(4, "user.*", "(?i).*adhoc.*", null, 1_000);
+        dao.insertSelector(5, "user.*", "(?i).*dashboard.*", null, 100);
+        dao.insertSelector(4, "user.*", null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1", "tag2")), 10);
+        dao.insertSelector(2, "user.*", null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1")), 1);
+        dao.insertSelector(6, ".*", ".*", null, 6);
 
         int expectedSelectors = 5;
         if (environment.equals(TEST_ENVIRONMENT_2)) {

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueues.java
@@ -197,7 +197,7 @@ public class TestQueues
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
         assertEquals(queryManager.getQueryInfo(queryId).getErrorCode(), QUERY_REJECTED.toErrorCode());
         int selectorCount = getSelectors(queryRunner).size();
-        dao.insertSelector(4, "user.*", "(?i).*reject.*", null);
+        dao.insertSelector(4, "user.*", "(?i).*reject.*", null, 100_000);
         dbConfigurationManager.load();
         assertEquals(getSelectors(queryRunner).size(), selectorCount + 1);
         // Verify the query can be submitted
@@ -208,6 +208,38 @@ public class TestQueues
         // Verify the query cannot be submitted
         queryId = createQuery(queryRunner, rejectingSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, queryId, FAILED);
+    }
+
+    @Test(timeOut = 60_000)
+    public void testSelectorPriority()
+            throws Exception
+    {
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+
+        QueryId firstQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstQuery, RUNNING);
+
+        Optional<String> resourceGroup = queryManager.getQueryInfo(firstQuery).getResourceGroupName();
+        assertTrue(resourceGroup.isPresent());
+        assertEquals(resourceGroup.get(), "global.user-user.dashboard-user");
+
+        // create a new resource group that rejects all queries submitted to it
+        dao.insertResourceGroup(8, "reject-all-queries", "1MB", 0, 0, 0, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+
+        // add a new selector that has a higher priority than the existing dashboard selector and that routes queries to the "reject-all-queries" resource group
+        dao.insertSelector(8, "user.*", "(?i).*dashboard.*", null, 200);
+
+        // reload the configuration
+        dbConfigurationManager.load();
+
+        QueryId secondQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, secondQuery, FAILED);
+
+        resourceGroup = queryManager.getQueryInfo(secondQuery).getResourceGroupName();
+        assertTrue(resourceGroup.isPresent());
+        assertEquals(resourceGroup.get(), "global.user-user.reject-all-queries");
     }
 
     @Test(timeOut = 60_000)


### PR DESCRIPTION
When using the json resource group configuration the selectors list
has a well-defined order (the order in which selectors are defined
in the config file). The order in which selector rules are checked
matters if we want a selection rule to have a higher priority than
the other rules. This change adds support for defining an order
among selectors for the db-based resource groups.