### PR TITLE
Changed range request for S3 to use single argument form of withRange

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -902,7 +902,7 @@ public class PrestoS3FileSystem
                         .onRetry(STATS::newGetObjectRetry)
                         .run("getS3Object", () -> {
                             try {
-                                GetObjectRequest request = new GetObjectRequest(host, keyFromPath(path)).withRange(start, Long.MAX_VALUE);
+                                GetObjectRequest request = new GetObjectRequest(host, keyFromPath(path)).withRange(start);
                                 return s3.getObject(request).getObjectContent();
                             }
                             catch (RuntimeException e) {


### PR DESCRIPTION
We use an S3 compatible storage system internally that didn't like Long.MAX_VALUE as the second part of a range request for retrieving objects. Change to the single argument form form of withRange in the amazon s3 api causes a '*' to be sent, instead of using Long.MAX_VALUE as the end value. This fixes our issues internally, it also means that the http requests will be 'slightly' smaller, and seems like the correct version of the method to use for reading objects.