### PR TITLE
[WIP] Fix VARBINARY comparison in MaterializedRow.getFields()

### DIFF
--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
@@ -26,6 +26,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -237,7 +238,7 @@ public class TestBlackHoleSmoke
         assertEquals(row.getField(7), false);
         assertEquals(row.getField(8), new Date(0));
         assertEquals(row.getField(9), new Timestamp(0));
-        assertEquals(row.getField(10), "****************".getBytes());
+        assertEquals(row.getField(10), ByteBuffer.wrap("****************".getBytes()));
         assertEquals(row.getField(11), new BigDecimal("0.00"));
         assertEquals(row.getField(12), new BigDecimal("00000000000000000000.0000000000"));
         dropBlackholeAllTypesTable();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.HashMap;
@@ -188,7 +189,7 @@ public class TestHiveIntegrationSmokeTest
         assertEquals(results.getRowCount(), 1);
         MaterializedRow row = results.getMaterializedRows().get(0);
         assertEquals(row.getField(0), "foo");
-        assertEquals(row.getField(1), "bar".getBytes(UTF_8));
+        assertEquals(row.getField(1), ByteBuffer.wrap("bar".getBytes(UTF_8)));
         assertEquals(row.getField(2), 1L);
         assertEquals(row.getField(3), 2);
         assertEquals(row.getField(4), 3.14);

--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedRow.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedRow.java
@@ -117,9 +117,6 @@ public class MaterializedRow
             }
             return map;
         }
-        if (value instanceof ByteBuffer) {
-            return ((ByteBuffer) value).array();
-        }
 
         return value;
     }

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.Date;
 
@@ -79,7 +80,7 @@ public class TestMongoIntegrationSmokeTest
         assertEquals(results.getRowCount(), 1);
         MaterializedRow row = results.getMaterializedRows().get(0);
         assertEquals(row.getField(0), "foo");
-        assertEquals(row.getField(1), "bar".getBytes(UTF_8));
+        assertEquals(row.getField(1), ByteBuffer.wrap("bar".getBytes(UTF_8)));
         assertEquals(row.getField(2), 1L);
         assertEquals(row.getField(3), 3.14);
         assertEquals(row.getField(4), true);


### PR DESCRIPTION
This is a prerequisite for testing `varbinary` data types using
`DataTypeTest` framework. The `DataTypeTest.execute()` compares
`MaterializedRow.getFields()` with expected values, so this method must
return something that is `equals()`-comparable (e.g. `ByteBuffer` rather
than `byte[]`).

Related to #9413