### PR TITLE
Fix jvm crash during tests

### DIFF
--- a/presto-product-tests/conf/presto/etc/jvm.config
+++ b/presto-product-tests/conf/presto/etc/jvm.config
@@ -15,5 +15,5 @@
 -XX:ReservedCodeCacheSize=150M
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
--Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
+#-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
 -XX:ErrorFile=/docker/volumes/logs/product-tests-presto-jvm-error-file.log

--- a/presto-product-tests/conf/presto/etc/jvm.config
+++ b/presto-product-tests/conf/presto/etc/jvm.config
@@ -10,7 +10,6 @@
 -XX:+UseG1GC
 -XX:+UseGCOverheadLimit
 -XX:+ExplicitGCInvokesConcurrent
--XX:+CMSClassUnloadingEnabled
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M

--- a/presto-product-tests/conf/presto/etc/jvm.config
+++ b/presto-product-tests/conf/presto/etc/jvm.config
@@ -11,7 +11,6 @@
 -XX:+UseGCOverheadLimit
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+CMSClassUnloadingEnabled
--XX:+AggressiveOpts
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M

--- a/presto-product-tests/conf/presto/etc/jvm.config
+++ b/presto-product-tests/conf/presto/etc/jvm.config
@@ -15,6 +15,5 @@
 -XX:ReservedCodeCacheSize=150M
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
--Xdebug 
 -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
 -XX:ErrorFile=/docker/volumes/logs/product-tests-presto-jvm-error-file.log


### PR DESCRIPTION
those two were seen to cause intermittent jvm crashes like below, during TPCDS product tests

```
2017-12-02 16:58:00 INFO: [1 of 10] sql_tests.testcases.tpcds.q80 (Groups: tpcds)
presto-master_1       | #
presto-master_1       | # A fatal error has been detected by the Java Runtime Environment:
presto-master_1       | #
presto-master_1       | #  SIGSEGV (0xb) at pc=0x00007f39eda79241, pid=6, tid=0x00007f39dd2f8700
presto-master_1       | #
presto-master_1       | # JRE version: Java(TM) SE Runtime Environment (8.0_152-b16) (build 1.8.0_152-b16)
presto-master_1       | # Java VM: Java HotSpot(TM) 64-Bit Server VM (25.152-b16 mixed mode linux-amd64 compressed oops)
presto-master_1       | # Problematic frame:
presto-master_1       | # V  [libjvm.so+0x692241]  KlassToOopClosure::do_klass(Klass*)+0x11
presto-master_1       | #
presto-master_1       | # Core dump written. Default location: /var/presto/core or core.6
presto-master_1       | #
presto-master_1       | # An error report file with more information is saved as:
presto-master_1       | # /docker/volumes/logs/product-tests-presto-jvm-error-file.log
presto-master_1       | #
```