### PR TITLE
[WIP] Remove redundant offset parameter in primitive type getter

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTileType.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/geospatial/BingTileType.java
@@ -42,6 +42,6 @@ public class BingTileType
             return null;
         }
 
-        return BingTile.decode(block.getLong(0, 0));
+        return BingTile.decode(block.getLong(0));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
@@ -323,7 +323,7 @@ public class HivePageSink
 
             OptionalInt bucketNumber = OptionalInt.empty();
             if (bucketBlock != null) {
-                bucketNumber = OptionalInt.of(bucketBlock.getInt(position, 0));
+                bucketNumber = OptionalInt.of(bucketBlock.getInt(position));
             }
             HiveWriter writer = writerFactory.createWriter(partitionColumns, position, bucketNumber);
             writers.set(writerIndex, writer);

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -76,27 +76,27 @@ public class GroupByIdBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
-        return block.getByte(position, offset);
+        return block.getByte(position);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
-        return block.getShort(position, offset);
+        return block.getShort(position);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
-        return block.getInt(position, offset);
+        return block.getInt(position);
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
-        return block.getLong(position, offset);
+        return block.getLong(position);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -410,7 +410,7 @@ public class MultiChannelGroupByHash
 
     private long getRawHash(int sliceIndex, int position)
     {
-        return channelBuilders.get(precomputedHashChannel.getAsInt()).get(sliceIndex).getLong(position, 0);
+        return channelBuilders.get(precomputedHashChannel.getAsInt()).get(sliceIndex).getLong(position);
     }
 
     private boolean positionEqualsCurrentRow(long address, int hashPosition, int position, Page page, byte rawHash, int[] hashChannels)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ListLiteralCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ListLiteralCast.java
@@ -37,7 +37,7 @@ public class ListLiteralCast
     {
         ImmutableList.Builder<Integer> listBuilder = ImmutableList.builder();
         for (int i = 0; i < array.getPositionCount(); i++) {
-            listBuilder.add(array.getInt(i, 0));
+            listBuilder.add(array.getInt(i));
         }
 
         return listBuilder.build();

--- a/presto-main/src/main/java/com/facebook/presto/type/ColorType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ColorType.java
@@ -49,7 +49,7 @@ public class ColorType
             return null;
         }
 
-        int color = block.getInt(position, 0);
+        int color = block.getInt(position);
         if (color < 0) {
             return ColorFunctions.SystemColor.valueOf(-(color + 1)).getName();
         }

--- a/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeType.java
@@ -36,7 +36,7 @@ public final class IntervalDayTimeType
         if (block.isNull(position)) {
             return null;
         }
-        return new SqlIntervalDayTime(block.getLong(position, 0));
+        return new SqlIntervalDayTime(block.getLong(position));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/IntervalYearMonthType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntervalYearMonthType.java
@@ -36,7 +36,7 @@ public final class IntervalYearMonthType
         if (block.isNull(position)) {
             return null;
         }
-        return new SqlIntervalYearMonth(block.getInt(position, 0));
+        return new SqlIntervalYearMonth(block.getInt(position));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -251,28 +251,20 @@ public abstract class AbstractTestBlock
         if (expectedValue instanceof Slice) {
             Slice expectedSliceValue = (Slice) expectedValue;
 
-            if (isByteAccessSupported()) {
-                for (int offset = 0; offset <= expectedSliceValue.length() - SIZE_OF_BYTE; offset++) {
-                    assertEquals(block.getByte(position, offset), expectedSliceValue.getByte(offset));
-                }
+            if (isByteAccessSupported() && expectedSliceValue.length() >= SIZE_OF_BYTE) {
+                assertEquals(block.getByte(position), expectedSliceValue.getByte(0));
             }
 
-            if (isShortAccessSupported()) {
-                for (int offset = 0; offset <= expectedSliceValue.length() - SIZE_OF_SHORT; offset++) {
-                    assertEquals(block.getShort(position, offset), expectedSliceValue.getShort(offset));
-                }
+            if (isShortAccessSupported() && expectedSliceValue.length() >= SIZE_OF_SHORT) {
+                assertEquals(block.getShort(position), expectedSliceValue.getShort(0));
             }
 
-            if (isIntAccessSupported()) {
-                for (int offset = 0; offset <= expectedSliceValue.length() - SIZE_OF_INT; offset++) {
-                    assertEquals(block.getInt(position, offset), expectedSliceValue.getInt(offset));
-                }
+            if (isIntAccessSupported() && expectedSliceValue.length() >= SIZE_OF_INT) {
+                assertEquals(block.getInt(position), expectedSliceValue.getInt(0));
             }
 
-            if (isLongAccessSupported()) {
-                for (int offset = 0; offset <= expectedSliceValue.length() - SIZE_OF_LONG; offset++) {
-                    assertEquals(block.getLong(position, offset), expectedSliceValue.getLong(offset));
-                }
+            if (isLongAccessSupported() && expectedSliceValue.length() >= SIZE_OF_LONG) {
+                assertEquals(block.getLong(position), expectedSliceValue.getLong(0));
             }
 
             if (isSliceAccessSupported()) {

--- a/presto-main/src/test/java/com/facebook/presto/block/TestBlockBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestBlockBuilder.java
@@ -109,7 +109,7 @@ public class TestBlockBuilder
     private static void assertInvalidMask(Block block, int[] positions)
     {
         try {
-            block.getPositions(positions).getLong(0, 0);
+            block.getPositions(positions).getLong(0);
             fail("Expected to fail");
         }
         catch (IllegalArgumentException e) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
@@ -144,7 +144,7 @@ public class BenchmarkGroupByHash
             Block block = page.getBlock(0);
             int positionCount = block.getPositionCount();
             for (int position = 0; position < positionCount; position++) {
-                long value = block.getLong(position, 0);
+                long value = block.getLong(position);
 
                 int tablePosition = (int) (value & mask);
                 while (table[tablePosition] != -1 && table[tablePosition] != value) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDictionaryLookupJoinPageBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDictionaryLookupJoinPageBuilder.java
@@ -65,13 +65,13 @@ public class TestDictionaryLookupJoinPageBuilder
         for (int i = 0; i < output.getPositionCount(); i++) {
             assertFalse(output.getBlock(0).isNull(i));
             assertFalse(output.getBlock(1).isNull(i));
-            assertEquals(output.getBlock(0).getLong(i, 0), i / 2);
-            assertEquals(output.getBlock(1).getLong(i, 0), i / 2);
+            assertEquals(output.getBlock(0).getLong(i), i / 2);
+            assertEquals(output.getBlock(1).getLong(i), i / 2);
             if (i % 2 == 0) {
                 assertFalse(output.getBlock(2).isNull(i));
                 assertFalse(output.getBlock(3).isNull(i));
-                assertEquals(output.getBlock(2).getLong(i, 0), i / 2);
-                assertEquals(output.getBlock(3).getLong(i, 0), i / 2);
+                assertEquals(output.getBlock(2).getLong(i), i / 2);
+                assertEquals(output.getBlock(3).getLong(i), i / 2);
             }
             else {
                 assertTrue(output.getBlock(2).isNull(i));
@@ -120,8 +120,8 @@ public class TestDictionaryLookupJoinPageBuilder
         assertTrue(output.getBlock(0) instanceof DictionaryBlock);
         assertEquals(output.getPositionCount(), entries / 2);
         for (int i = 0; i < entries / 2; i++) {
-            assertEquals(output.getBlock(0).getLong(i, 0), i * 2);
-            assertEquals(output.getBlock(1).getLong(i, 0), i * 2);
+            assertEquals(output.getBlock(0).getLong(i), i * 2);
+            assertEquals(output.getBlock(1).getLong(i), i * 2);
         }
         lookupJoinPageBuilder.reset();
 
@@ -135,8 +135,8 @@ public class TestDictionaryLookupJoinPageBuilder
         assertFalse(output.getBlock(0) instanceof DictionaryBlock);
         assertEquals(output.getPositionCount(), entries);
         for (int i = 0; i < entries; i++) {
-            assertEquals(output.getBlock(0).getLong(i, 0), i);
-            assertEquals(output.getBlock(1).getLong(i, 0), i);
+            assertEquals(output.getBlock(0).getLong(i), i);
+            assertEquals(output.getBlock(1).getLong(i), i);
         }
         lookupJoinPageBuilder.reset();
 
@@ -153,8 +153,8 @@ public class TestDictionaryLookupJoinPageBuilder
         assertFalse(output.getBlock(0) instanceof DictionaryBlock);
         assertEquals(output.getPositionCount(), 40);
         for (int i = 10; i < 50; i++) {
-            assertEquals(output.getBlock(0).getLong(i - 10, 0), i);
-            assertEquals(output.getBlock(1).getLong(i - 10, 0), i);
+            assertEquals(output.getBlock(0).getLong(i - 10), i);
+            assertEquals(output.getBlock(1).getLong(i - 10), i);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeHashSort.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeHashSort.java
@@ -97,7 +97,7 @@ public class TestMergeHashSort
         Page actualPage = mergedPage.next();
         assertEquals(actualPage.getPositionCount(), 1);
         assertEquals(actualPage.getChannelCount(), 1);
-        assertEquals(actualPage.getBlock(0).getLong(0, 0), 42);
+        assertEquals(actualPage.getBlock(0).getLong(0), 42);
 
         assertFalse(mergedPage.hasNext());
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
@@ -264,7 +264,7 @@ public class TestRowNumberOperator
         assertEquals(rowNumberColumn.getPositionCount(), 8);
         // Check that all row numbers generated are <= 3
         for (int i = 0; i < rowNumberColumn.getPositionCount(); i++) {
-            assertTrue(rowNumberColumn.getLong(i, 0) <= 3);
+            assertTrue(rowNumberColumn.getLong(i) <= 3);
         }
 
         pages = stripRowNumberColumn(pages);
@@ -341,7 +341,7 @@ public class TestRowNumberOperator
         for (Page page : pages) {
             int rowNumberChannel = page.getChannelCount() - 1;
             for (int i = 0; i < page.getPositionCount(); i++) {
-                BIGINT.writeLong(builder, page.getBlock(rowNumberChannel).getLong(i, 0));
+                BIGINT.writeLong(builder, page.getBlock(rowNumberChannel).getLong(i));
             }
         }
         return builder.build();

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
@@ -235,8 +235,8 @@ public class TestStateCompiler
         assertEquals(deserializedState.getSlice(), singleState.getSlice());
         assertEquals(deserializedState.getAnotherSlice(), singleState.getAnotherSlice());
         assertEquals(deserializedState.getYetAnotherSlice(), singleState.getYetAnotherSlice());
-        assertEquals(deserializedState.getBlock().getLong(0, 0), singleState.getBlock().getLong(0, 0));
-        assertEquals(deserializedState.getAnotherBlock().getLong(0, 0), singleState.getAnotherBlock().getLong(0, 0));
+        assertEquals(deserializedState.getBlock().getLong(0), singleState.getBlock().getLong(0));
+        assertEquals(deserializedState.getAnotherBlock().getLong(0), singleState.getAnotherBlock().getLong(0));
         assertEquals(deserializedState.getAnotherBlock().getSlice(1, 0, 9), singleState.getAnotherBlock().getSlice(1, 0, 9));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageFilter.java
@@ -197,7 +197,7 @@ public class TestDictionaryAwarePageFilter
 
         IntSet expectedSelectedPositions = new IntArraySet(block.getPositionCount());
         for (int position = 0; position < block.getPositionCount(); position++) {
-            if (isSelected(filterRange, block.getLong(position, 0))) {
+            if (isSelected(filterRange, block.getLong(position))) {
                 expectedSelectedPositions.add(position);
             }
         }
@@ -281,7 +281,7 @@ public class TestDictionaryAwarePageFilter
             boolean sequential = true;
             IntArrayList selectedPositions = new IntArrayList();
             for (int position = 0; position < block.getPositionCount(); position++) {
-                long value = block.getLong(position, 0);
+                long value = block.getLong(position);
                 verifyPositive(value);
 
                 boolean selected = isSelected(filterRange, value);

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -351,7 +351,7 @@ public class TestDictionaryAwarePageProjection
                     int offset = selectedPositions.getOffset();
                     int[] positions = selectedPositions.getPositions();
                     for (int index = nextIndexOrPosition + offset; index < offset + selectedPositions.size(); index++) {
-                        blockBuilder.writeLong(verifyPositive(block.getLong(positions[index], 0)));
+                        blockBuilder.writeLong(verifyPositive(block.getLong(positions[index])));
                         if (yieldSignal.isSet()) {
                             nextIndexOrPosition = index + 1 - offset;
                             return false;
@@ -361,7 +361,7 @@ public class TestDictionaryAwarePageProjection
                 else {
                     int offset = selectedPositions.getOffset();
                     for (int position = nextIndexOrPosition + offset; position < offset + selectedPositions.size(); position++) {
-                        blockBuilder.writeLong(verifyPositive(block.getLong(position, 0)));
+                        blockBuilder.writeLong(verifyPositive(block.getLong(position)));
                         if (yieldSignal.isSet()) {
                             nextIndexOrPosition = position + 1 - offset;
                             return false;

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
@@ -240,7 +240,7 @@ public class TestGenericPartitioningSpiller
         @Override
         public int getPartition(Page page, int position)
         {
-            long value = page.getBlock(valueChannel).getLong(position, 0);
+            long value = page.getBlock(valueChannel).getLong(position);
             if (value >= FOURTH_PARTITION_START) {
                 return 3;
             }
@@ -276,7 +276,7 @@ public class TestGenericPartitioningSpiller
         @Override
         public int getPartition(Page page, int position)
         {
-            long value = page.getBlock(valueChannel).getLong(position, 0);
+            long value = page.getBlock(valueChannel).getLong(position);
             return toIntExact(Math.abs(value) % partitionCount);
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
@@ -68,7 +68,7 @@ public class TestSimpleRowType
 
         Block block = (Block) value;
         singleRowBlockWriter = blockBuilder.beginBlockEntry();
-        BIGINT.writeLong(singleRowBlockWriter, block.getSingleValueBlock(0).getLong(0, 0) + 1);
+        BIGINT.writeLong(singleRowBlockWriter, block.getSingleValueBlock(0).getLong(0) + 1);
         VARCHAR.writeSlice(singleRowBlockWriter, block.getSingleValueBlock(1).getSlice(0, 0, 1));
         blockBuilder.closeEntry();
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPageSink.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPageSink.java
@@ -337,7 +337,7 @@ public class RaptorPageSink
             }
 
             if (temporalColumnType.equals(TIMESTAMP)) {
-                return (temporalBlock, position) -> toIntExact(MILLISECONDS.toDays(temporalBlock.getLong(position, 0)));
+                return (temporalBlock, position) -> toIntExact(MILLISECONDS.toDays(temporalBlock.getLong(position)));
             }
 
             throw new IllegalArgumentException("Wrong type for temporal column: " + temporalColumnType);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
@@ -46,31 +46,31 @@ public abstract class AbstractFixedWidthBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice().getByte(valueOffset(position) + offset);
+        return getRawSlice().getByte(valueOffset(position));
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice().getShort(valueOffset(position) + offset);
+        return getRawSlice().getShort(valueOffset(position));
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice().getInt(valueOffset(position) + offset);
+        return getRawSlice().getInt(valueOffset(position));
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice().getLong(valueOffset(position) + offset);
+        return getRawSlice().getLong(valueOffset(position));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -44,31 +44,31 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        return getBlock().getByte(position + start, offset);
+        return getBlock().getByte(position + start);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        return getBlock().getShort(position + start, offset);
+        return getBlock().getShort(position + start);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        return getBlock().getInt(position + start, offset);
+        return getBlock().getInt(position + start);
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         checkReadablePosition(position);
-        return getBlock().getLong(position + start, offset);
+        return getBlock().getLong(position + start);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
@@ -51,50 +51,50 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         position = getAbsolutePosition(position);
         if (position % 2 == 0) {
-            return getKeyBlock().getByte(position / 2, offset);
+            return getKeyBlock().getByte(position / 2);
         }
         else {
-            return getValueBlock().getByte(position / 2, offset);
+            return getValueBlock().getByte(position / 2);
         }
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         position = getAbsolutePosition(position);
         if (position % 2 == 0) {
-            return getKeyBlock().getShort(position / 2, offset);
+            return getKeyBlock().getShort(position / 2);
         }
         else {
-            return getValueBlock().getShort(position / 2, offset);
+            return getValueBlock().getShort(position / 2);
         }
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         position = getAbsolutePosition(position);
         if (position % 2 == 0) {
-            return getKeyBlock().getInt(position / 2, offset);
+            return getKeyBlock().getInt(position / 2);
         }
         else {
-            return getValueBlock().getInt(position / 2, offset);
+            return getValueBlock().getInt(position / 2);
         }
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         position = getAbsolutePosition(position);
         if (position % 2 == 0) {
-            return getKeyBlock().getLong(position / 2, offset);
+            return getKeyBlock().getLong(position / 2);
         }
         else {
-            return getValueBlock().getLong(position / 2, offset);
+            return getValueBlock().getLong(position / 2);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
@@ -50,31 +50,31 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         position = getAbsolutePosition(position);
-        return getFieldBlock(position % numFields).getByte(position / numFields, offset);
+        return getFieldBlock(position % numFields).getByte(position / numFields);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         position = getAbsolutePosition(position);
-        return getFieldBlock(position % numFields).getShort(position / numFields, offset);
+        return getFieldBlock(position % numFields).getShort(position / numFields);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         position = getAbsolutePosition(position);
-        return getFieldBlock(position % numFields).getInt(position / numFields, offset);
+        return getFieldBlock(position % numFields).getInt(position / numFields);
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         position = getAbsolutePosition(position);
-        return getFieldBlock(position % numFields).getLong(position / numFields, offset);
+        return getFieldBlock(position % numFields).getLong(position / numFields);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
@@ -35,31 +35,31 @@ public abstract class AbstractVariableWidthBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice(position).getByte(getPositionOffset(position) + offset);
+        return getRawSlice(position).getByte(getPositionOffset(position));
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice(position).getShort(getPositionOffset(position) + offset);
+        return getRawSlice(position).getShort(getPositionOffset(position));
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice(position).getInt(getPositionOffset(position) + offset);
+        return getRawSlice(position).getInt(getPositionOffset(position));
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice(position).getLong(getPositionOffset(position) + offset);
+        return getRawSlice(position).getLong(getPositionOffset(position));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -30,33 +30,33 @@ public interface Block
     }
 
     /**
-     * Gets a byte at {@code offset} in the value at {@code position}.
+     * Gets a byte in the value at {@code position}.
      */
-    default byte getByte(int position, int offset)
+    default byte getByte(int position)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
 
     /**
-     * Gets a little endian short at {@code offset} in the value at {@code position}.
+     * Gets a little endian short in the value at {@code position}.
      */
-    default short getShort(int position, int offset)
+    default short getShort(int position)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
 
     /**
-     * Gets a little endian int at {@code offset} in the value at {@code position}.
+     * Gets a little endian int in the value at {@code position}.
      */
-    default int getInt(int position, int offset)
+    default int getInt(int position)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
 
     /**
-     * Gets a little endian long at {@code offset} in the value at {@code position}.
+     * Gets a little endian long in the value at {@code position}.
      */
-    default long getLong(int position, int offset)
+    default long getLong(int position)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -98,12 +98,9 @@ public class ByteArrayBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position + arrayOffset];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -158,12 +158,9 @@ public class ByteArrayBlockBuilder
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
@@ -42,7 +42,7 @@ public class ByteArrayBlockEncoding
 
         for (int position = 0; position < positionCount; position++) {
             if (!block.isNull(position)) {
-                sliceOutput.writeByte(block.getByte(position, 0));
+                sliceOutput.writeByte(block.getByte(position));
             }
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -103,27 +103,27 @@ public class DictionaryBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
-        return dictionary.getByte(getId(position), offset);
+        return dictionary.getByte(getId(position));
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
-        return dictionary.getShort(getId(position), offset);
+        return dictionary.getShort(getId(position));
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
-        return dictionary.getInt(getId(position), offset);
+        return dictionary.getInt(getId(position));
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
-        return dictionary.getLong(getId(position), offset);
+        return dictionary.getLong(getId(position));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -98,12 +98,9 @@ public class IntArrayBlock
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position + arrayOffset];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -159,12 +159,9 @@ public class IntArrayBlockBuilder
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
@@ -42,7 +42,7 @@ public class IntArrayBlockEncoding
 
         for (int position = 0; position < positionCount; position++) {
             if (!block.isNull(position)) {
-                sliceOutput.writeInt(block.getInt(position, 0));
+                sliceOutput.writeInt(block.getInt(position));
             }
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -51,31 +51,31 @@ public class LazyBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         assureLoaded();
-        return block.getByte(position, offset);
+        return block.getByte(position);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         assureLoaded();
-        return block.getShort(position, offset);
+        return block.getShort(position);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         assureLoaded();
-        return block.getInt(position, offset);
+        return block.getInt(position);
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         assureLoaded();
-        return block.getLong(position, offset);
+        return block.getLong(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -99,36 +99,27 @@ public class LongArrayBlock
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position + arrayOffset];
     }
 
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return toIntExact(values[position + arrayOffset]);
     }
 
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
 
         short value = (short) (values[position + arrayOffset]);
         if (value != values[position + arrayOffset]) {
@@ -140,12 +131,9 @@ public class LongArrayBlock
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
 
         byte value = (byte) (values[position + arrayOffset]);
         if (value != values[position + arrayOffset]) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -160,37 +160,27 @@ public class LongArrayBlockBuilder
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position];
     }
 
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return toIntExact(values[position]);
     }
 
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
-
         short value = (short) (values[position]);
         if (value != values[position]) {
             throw new ArithmeticException("short overflow");
@@ -201,13 +191,9 @@ public class LongArrayBlockBuilder
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
-
         byte value = (byte) (values[position]);
         if (value != values[position]) {
             throw new ArithmeticException("byte overflow");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
@@ -42,7 +42,7 @@ public class LongArrayBlockEncoding
 
         for (int position = 0; position < positionCount; position++) {
             if (!block.isNull(position)) {
-                sliceOutput.writeLong(block.getLong(position, 0));
+                sliceOutput.writeLong(block.getLong(position));
             }
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -129,27 +129,27 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
-        return value.getByte(0, offset);
+        return value.getByte(0);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
-        return value.getShort(0, offset);
+        return value.getShort(0);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
-        return value.getInt(0, offset);
+        return value.getInt(0);
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
-        return value.getLong(0, offset);
+        return value.getLong(0);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -98,12 +98,9 @@ public class ShortArrayBlock
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position + arrayOffset];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -159,12 +159,9 @@ public class ShortArrayBlockBuilder
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
@@ -42,7 +42,7 @@ public class ShortArrayBlockEncoding
 
         for (int position = 0; position < positionCount; position++) {
             if (!block.isNull(position)) {
-                sliceOutput.writeShort(block.getShort(position, 0));
+                sliceOutput.writeShort(block.getShort(position));
             }
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
@@ -51,7 +51,7 @@ public abstract class AbstractIntType
     @Override
     public final long getLong(Block block, int position)
     {
-        return block.getInt(position, 0);
+        return block.getInt(position);
     }
 
     @Override
@@ -73,22 +73,22 @@ public abstract class AbstractIntType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeInt(block.getInt(position, 0)).closeEntry();
+            blockBuilder.writeInt(block.getInt(position)).closeEntry();
         }
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        int leftValue = leftBlock.getInt(leftPosition, 0);
-        int rightValue = rightBlock.getInt(rightPosition, 0);
+        int leftValue = leftBlock.getInt(leftPosition);
+        int rightValue = rightBlock.getInt(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return hash(block.getInt(position, 0));
+        return hash(block.getInt(position));
     }
 
     @Override
@@ -96,8 +96,8 @@ public abstract class AbstractIntType
     {
         // WARNING: the correctness of InCodeGenerator is dependent on the implementation of this
         // function being the equivalence of internal long representation.
-        int leftValue = leftBlock.getInt(leftPosition, 0);
-        int rightValue = rightBlock.getInt(rightPosition, 0);
+        int leftValue = leftBlock.getInt(leftPosition);
+        int rightValue = rightBlock.getInt(rightPosition);
         return Integer.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
@@ -51,7 +51,7 @@ public abstract class AbstractLongType
     @Override
     public final long getLong(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override
@@ -73,29 +73,29 @@ public abstract class AbstractLongType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeLong(block.getLong(position, 0)).closeEntry();
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
         }
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return hash(block.getLong(position, 0));
+        return hash(block.getLong(position));
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
         return Long.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BigintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BigintType.java
@@ -35,7 +35,7 @@ public final class BigintType
             return null;
         }
 
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
@@ -84,29 +84,29 @@ public final class BooleanType
             return null;
         }
 
-        return block.getByte(position, 0) != 0;
+        return block.getByte(position) != 0;
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        boolean leftValue = leftBlock.getByte(leftPosition, 0) != 0;
-        boolean rightValue = rightBlock.getByte(rightPosition, 0) != 0;
+        boolean leftValue = leftBlock.getByte(leftPosition) != 0;
+        boolean rightValue = rightBlock.getByte(rightPosition) != 0;
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        boolean value = block.getByte(position, 0) != 0;
+        boolean value = block.getByte(position) != 0;
         return value ? 1231 : 1237;
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        boolean leftValue = leftBlock.getByte(leftPosition, 0) != 0;
-        boolean rightValue = rightBlock.getByte(rightPosition, 0) != 0;
+        boolean leftValue = leftBlock.getByte(leftPosition) != 0;
+        boolean rightValue = rightBlock.getByte(rightPosition) != 0;
         return Boolean.compare(leftValue, rightValue);
     }
 
@@ -117,14 +117,14 @@ public final class BooleanType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeByte(block.getByte(position, 0)).closeEntry();
+            blockBuilder.writeByte(block.getByte(position)).closeEntry();
         }
     }
 
     @Override
     public boolean getBoolean(Block block, int position)
     {
-        return block.getByte(position, 0) != 0;
+        return block.getByte(position) != 0;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DateType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DateType.java
@@ -43,7 +43,7 @@ public final class DateType
             return null;
         }
 
-        int days = block.getInt(position, 0);
+        int days = block.getInt(position);
         return new SqlDate(days);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -58,14 +58,14 @@ public final class DoubleType
         if (block.isNull(position)) {
             return null;
         }
-        return longBitsToDouble(block.getLong(position, 0));
+        return longBitsToDouble(block.getLong(position));
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition, 0));
-        double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition, 0));
+        double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition));
+        double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition));
 
         // direct equality is correct here
         // noinspection FloatingPointEquality
@@ -75,14 +75,14 @@ public final class DoubleType
     @Override
     public long hash(Block block, int position)
     {
-        return AbstractLongType.hash(block.getLong(position, 0));
+        return AbstractLongType.hash(block.getLong(position));
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition, 0));
-        double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition, 0));
+        double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition));
+        double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition));
         return Double.compare(leftValue, rightValue);
     }
 
@@ -93,14 +93,14 @@ public final class DoubleType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeLong(block.getLong(position, 0)).closeEntry();
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
         }
     }
 
     @Override
     public double getDouble(Block block, int position)
     {
-        return longBitsToDouble(block.getLong(position, 0));
+        return longBitsToDouble(block.getLong(position));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/IntegerType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/IntegerType.java
@@ -38,7 +38,7 @@ public final class IntegerType
             return null;
         }
 
-        return block.getInt(position, 0);
+        return block.getInt(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -88,18 +88,21 @@ final class LongDecimalType
     @Override
     public long hash(Block block, int position)
     {
-        long low = block.getLong(position, 0);
-        long high = block.getLong(position, SIZE_OF_LONG);
+        Slice slice = block.getSlice(position, 0, getFixedSize());
+        long low = slice.getLong(0);
+        long high = slice.getLong(SIZE_OF_LONG);
         return UnscaledDecimal128Arithmetic.hash(low, high);
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftLow = leftBlock.getLong(leftPosition, 0);
-        long leftHigh = leftBlock.getLong(leftPosition, SIZE_OF_LONG);
-        long rightLow = rightBlock.getLong(rightPosition, 0);
-        long rightHigh = rightBlock.getLong(rightPosition, SIZE_OF_LONG);
+        Slice leftSlice = leftBlock.getSlice(leftPosition, 0, getFixedSize());
+        long leftLow = leftSlice.getLong(0);
+        long leftHigh = leftSlice.getLong(SIZE_OF_LONG);
+        Slice rightSlice = rightBlock.getSlice(rightPosition, 0, getFixedSize());
+        long rightLow = rightSlice.getLong(0);
+        long rightHigh = rightSlice.getLong(SIZE_OF_LONG);
         return compare(leftLow, leftHigh, rightLow, rightHigh);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RealType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RealType.java
@@ -40,14 +40,14 @@ public final class RealType
         if (block.isNull(position)) {
             return null;
         }
-        return intBitsToFloat(block.getInt(position, 0));
+        return intBitsToFloat(block.getInt(position));
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        float leftValue = intBitsToFloat(leftBlock.getInt(leftPosition, 0));
-        float rightValue = intBitsToFloat(rightBlock.getInt(rightPosition, 0));
+        float leftValue = intBitsToFloat(leftBlock.getInt(leftPosition));
+        float rightValue = intBitsToFloat(rightBlock.getInt(rightPosition));
 
         // direct equality is correct here
         // noinspection FloatingPointEquality
@@ -59,8 +59,8 @@ public final class RealType
     {
         // WARNING: the correctness of InCodeGenerator is dependent on the implementation of this
         // function being the equivalence of internal long representation.
-        float leftValue = intBitsToFloat(leftBlock.getInt(leftPosition, 0));
-        float rightValue = intBitsToFloat(rightBlock.getInt(rightPosition, 0));
+        float leftValue = intBitsToFloat(leftBlock.getInt(leftPosition));
+        float rightValue = intBitsToFloat(rightBlock.getInt(rightPosition));
         return Float.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -72,29 +72,29 @@ final class ShortDecimalType
         if (block.isNull(position)) {
             return null;
         }
-        long unscaledValue = block.getLong(position, 0);
+        long unscaledValue = block.getLong(position);
         return new SqlDecimal(BigInteger.valueOf(unscaledValue), getPrecision(), getScale());
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
         return Long.compare(leftValue, rightValue);
     }
 
@@ -105,14 +105,14 @@ final class ShortDecimalType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeLong(block.getLong(position, 0)).closeEntry();
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
         }
     }
 
     @Override
     public long getLong(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
@@ -87,21 +87,21 @@ public final class SmallintType
             return null;
         }
 
-        return block.getShort(position, 0);
+        return block.getShort(position);
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        int leftValue = leftBlock.getShort(leftPosition, 0);
-        int rightValue = rightBlock.getShort(rightPosition, 0);
+        int leftValue = leftBlock.getShort(leftPosition);
+        int rightValue = rightBlock.getShort(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return hash(block.getShort(position, 0));
+        return hash(block.getShort(position));
     }
 
     @Override
@@ -109,8 +109,8 @@ public final class SmallintType
     {
         // WARNING: the correctness of InCodeGenerator is dependent on the implementation of this
         // function being the equivalence of internal long representation.
-        short leftValue = leftBlock.getShort(leftPosition, 0);
-        short rightValue = rightBlock.getShort(rightPosition, 0);
+        short leftValue = leftBlock.getShort(leftPosition);
+        short rightValue = rightBlock.getShort(rightPosition);
         return Short.compare(leftValue, rightValue);
     }
 
@@ -121,14 +121,14 @@ public final class SmallintType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeShort(block.getShort(position, 0)).closeEntry();
+            blockBuilder.writeShort(block.getShort(position)).closeEntry();
         }
     }
 
     @Override
     public long getLong(Block block, int position)
     {
-        return (long) block.getShort(position, 0);
+        return (long) block.getShort(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeType.java
@@ -39,7 +39,7 @@ public final class TimeType
             return null;
         }
 
-        return new SqlTime(block.getLong(position, 0), session.getTimeZoneKey());
+        return new SqlTime(block.getLong(position), session.getTimeZoneKey());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
@@ -36,27 +36,27 @@ public final class TimeWithTimeZoneType
             return null;
         }
 
-        return new SqlTimeWithTimeZone(block.getLong(position, 0));
+        return new SqlTimeWithTimeZone(block.getLong(position));
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition, 0));
-        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition, 0));
+        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition));
+        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition));
         return leftValue == rightValue;
     }
 
     public long hash(Block block, int position)
     {
-        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position, 0)));
+        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position)));
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition, 0));
-        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition, 0));
+        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition));
+        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition));
         return Long.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampType.java
@@ -39,7 +39,7 @@ public final class TimestampType
             return null;
         }
 
-        return new SqlTimestamp(block.getLong(position, 0), session.getTimeZoneKey());
+        return new SqlTimestamp(block.getLong(position), session.getTimeZoneKey());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
@@ -36,28 +36,28 @@ public final class TimestampWithTimeZoneType
             return null;
         }
 
-        return new SqlTimestampWithTimeZone(block.getLong(position, 0));
+        return new SqlTimestampWithTimeZone(block.getLong(position));
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition, 0));
-        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition, 0));
+        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition));
+        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition));
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position, 0)));
+        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position)));
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition, 0));
-        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition, 0));
+        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition));
+        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition));
         return Long.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
@@ -87,21 +87,21 @@ public final class TinyintType
             return null;
         }
 
-        return block.getByte(position, 0);
+        return block.getByte(position);
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        int leftValue = leftBlock.getByte(leftPosition, 0);
-        int rightValue = rightBlock.getByte(rightPosition, 0);
+        int leftValue = leftBlock.getByte(leftPosition);
+        int rightValue = rightBlock.getByte(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return hash(block.getByte(position, 0));
+        return hash(block.getByte(position));
     }
 
     @Override
@@ -109,8 +109,8 @@ public final class TinyintType
     {
         // WARNING: the correctness of InCodeGenerator is dependent on the implementation of this
         // function being the equivalence of internal long representation.
-        byte leftValue = leftBlock.getByte(leftPosition, 0);
-        byte rightValue = rightBlock.getByte(rightPosition, 0);
+        byte leftValue = leftBlock.getByte(leftPosition);
+        byte rightValue = rightBlock.getByte(rightPosition);
         return Byte.compare(leftValue, rightValue);
     }
 
@@ -121,14 +121,14 @@ public final class TinyintType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeByte(block.getByte(position, 0)).closeEntry();
+            blockBuilder.writeByte(block.getByte(position)).closeEntry();
         }
     }
 
     @Override
     public long getLong(Block block, int position)
     {
-        return (long) block.getByte(position, 0);
+        return (long) block.getByte(position);
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestPage.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestPage.java
@@ -120,11 +120,11 @@ public class TestPage
         Page page = new Page(block, block, block).getPositions(new int[]{1, 1, 1, 2, 5});
         assertEquals(page.getPositionCount(), 5);
         for (int i = 0; i < 3; i++) {
-            assertEquals(page.getBlock(i).getLong(0, 0), 1);
-            assertEquals(page.getBlock(i).getLong(1, 0), 1);
-            assertEquals(page.getBlock(i).getLong(2, 0), 1);
-            assertEquals(page.getBlock(i).getLong(3, 0), 2);
-            assertEquals(page.getBlock(i).getLong(4, 0), 5);
+            assertEquals(page.getBlock(i).getLong(0), 1);
+            assertEquals(page.getBlock(i).getLong(1), 1);
+            assertEquals(page.getBlock(i).getLong(2), 1);
+            assertEquals(page.getBlock(i).getLong(3), 2);
+            assertEquals(page.getBlock(i).getLong(4), 5);
         }
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingIdType.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingIdType.java
@@ -44,21 +44,21 @@ public class TestingIdType
             return null;
         }
 
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override
@@ -68,14 +68,14 @@ public class TestingIdType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeLong(block.getLong(position, 0)).closeEntry();
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
         }
     }
 
     @Override
     public long getLong(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override

--- a/presto-thrift-connector-api/src/test/java/com/facebook/presto/connector/thrift/api/datatypes/TestPrestoThriftBigint.java
+++ b/presto-thrift-connector-api/src/test/java/com/facebook/presto/connector/thrift/api/datatypes/TestPrestoThriftBigint.java
@@ -167,7 +167,7 @@ public class TestPrestoThriftBigint
                 assertTrue(block.isNull(i));
             }
             else {
-                assertEquals(block.getLong(i, 0), expected.get(i).longValue());
+                assertEquals(block.getLong(i), expected.get(i).longValue());
             }
         }
     }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
@@ -118,7 +118,7 @@ public class TestThriftIndexPageSource
         Page page = pageSource.getNextPage();
         assertNotNull(page);
         assertEquals(page.getPositionCount(), 1);
-        assertEquals(page.getBlock(0).getInt(0, 0), 20);
+        assertEquals(page.getBlock(0).getInt(0), 20);
         // not complete yet
         assertFalse(pageSource.isFinished());
         assertEquals(client.timesClosed(), 2);
@@ -132,7 +132,7 @@ public class TestThriftIndexPageSource
         page = pageSource.getNextPage();
         assertNotNull(page);
         assertEquals(page.getPositionCount(), 1);
-        assertEquals(page.getBlock(0).getInt(0, 0), 10);
+        assertEquals(page.getBlock(0).getInt(0), 10);
         // still not complete
         assertFalse(pageSource.isFinished());
         assertEquals(client.timesClosed(), 3);
@@ -142,7 +142,7 @@ public class TestThriftIndexPageSource
         page = pageSource.getNextPage();
         assertNotNull(page);
         assertEquals(page.getPositionCount(), 1);
-        assertEquals(page.getBlock(0).getInt(0, 0), 30);
+        assertEquals(page.getBlock(0).getInt(0), 30);
         // finished now
         assertTrue(pageSource.isFinished());
         assertEquals(client.timesClosed(), 4);
@@ -204,7 +204,7 @@ public class TestThriftIndexPageSource
             if (page != null) {
                 Block block = page.getBlock(0);
                 for (int position = 0; position < block.getPositionCount(); position++) {
-                    actual.add(block.getInt(position, 0));
+                    actual.add(block.getInt(position));
                 }
             }
         }


### PR DESCRIPTION
Historically, the offset parameter in primitive type getter in block (getByte, getShort, getInt, getLong) are mainly used for encode/decode complex types before InterleavedBlock is introduced. Now we can natural columnar representations for complex types, the offsets are no longer used except in `LongDecimalType`, where `getLong(position, SIZE_OF_LONG)` is used to retrieve the high 64 bit int a 128 bit unscaled decimal value.



