### PR TITLE
Allow JdbcClient to provide extended JdbcRecordCursor implementation

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.SchemaTableName;
 
 import javax.annotation.Nullable;
@@ -43,6 +44,11 @@ public interface JdbcClient
 
     PreparedStatement buildSql(Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
             throws SQLException;
+
+    default RecordCursor createRecordCursor(JdbcSplit split, List<JdbcColumnHandle> columnHandles)
+    {
+        return new JdbcRecordCursor(this, split, columnHandles);
+    }
 
     JdbcOutputTableHandle beginCreateTable(ConnectorTableMetadata tableMetadata);
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordCursor.java
@@ -64,10 +64,10 @@ public class JdbcRecordCursor
 
     private final List<JdbcColumnHandle> columnHandles;
 
-    private final Connection connection;
+    protected final Connection connection;
     private final PreparedStatement statement;
-    private final ResultSet resultSet;
-    private boolean closed;
+    protected final ResultSet resultSet;
+    protected boolean closed;
 
     public JdbcRecordCursor(JdbcClient jdbcClient, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
     {
@@ -264,7 +264,7 @@ public class JdbcRecordCursor
         }
     }
 
-    private RuntimeException handleSqlException(Exception e)
+    protected RuntimeException handleSqlException(Exception e)
     {
         try {
             close();

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSet.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcRecordSet.java
@@ -53,6 +53,6 @@ public class JdbcRecordSet
     @Override
     public RecordCursor cursor()
     {
-        return new JdbcRecordCursor(jdbcClient, split, columnHandles);
+        return jdbcClient.createRecordCursor(split, columnHandles);
     }
 }


### PR DESCRIPTION
This is required to a JDBC connector to have broader data type support
than supported out of the box by `JdbcRecordCursor`, e.g. `TIMESTAMP
WITH TIME ZONE`.