### PR TITLE
 Use dedicated executor for running listeners in HttpPageBufferClient

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
@@ -61,7 +61,7 @@ public class ExchangeClient
     private final Duration minErrorDuration;
     private final Duration maxErrorDuration;
     private final HttpClient httpClient;
-    private final ScheduledExecutorService executor;
+    private final ScheduledExecutorService scheduler;
 
     @GuardedBy("this")
     private boolean noMoreLocations;
@@ -100,7 +100,7 @@ public class ExchangeClient
             Duration minErrorDuration,
             Duration maxErrorDuration,
             HttpClient httpClient,
-            ScheduledExecutorService executor,
+            ScheduledExecutorService scheduler,
             SystemMemoryUsageListener systemMemoryUsageListener)
     {
         this.bufferCapacity = bufferCapacity.toBytes();
@@ -109,7 +109,7 @@ public class ExchangeClient
         this.minErrorDuration = minErrorDuration;
         this.maxErrorDuration = maxErrorDuration;
         this.httpClient = httpClient;
-        this.executor = executor;
+        this.scheduler = scheduler;
         this.systemMemoryUsageListener = systemMemoryUsageListener;
         this.maxBufferBytes = Long.MIN_VALUE;
     }
@@ -157,7 +157,7 @@ public class ExchangeClient
                 maxErrorDuration,
                 location,
                 new ExchangeClientCallback(),
-                executor);
+                scheduler);
         allClients.put(location, client);
         queuedClients.add(client);
 
@@ -333,7 +333,7 @@ public class ExchangeClient
         blockedCallers.clear();
         for (SettableFuture<?> blockedCaller : callers) {
             // Notify callers in a separate thread to avoid callbacks while holding a lock
-            executor.execute(() -> blockedCaller.set(null));
+            scheduler.execute(() -> blockedCaller.set(null));
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
@@ -34,6 +34,7 @@ public class ExchangeClientConfig
     private Duration maxErrorDuration = new Duration(5, TimeUnit.MINUTES);
     private DataSize maxResponseSize = new HttpClientConfig().getMaxContentLength();
     private int clientThreads = 25;
+    private int pageBufferClientMaxCallbackThreads = 25;
 
     @NotNull
     public DataSize getMaxBufferSize()
@@ -113,6 +114,19 @@ public class ExchangeClientConfig
     public ExchangeClientConfig setClientThreads(int clientThreads)
     {
         this.clientThreads = clientThreads;
+        return this;
+    }
+
+    @Min(1)
+    public int getPageBufferClientMaxCallbackThreads()
+    {
+        return pageBufferClientMaxCallbackThreads;
+    }
+
+    @Config("exchange.page-buffer-client.max-callback-threads")
+    public ExchangeClientConfig setPageBufferClientMaxCallbackThreads(int pageBufferClientMaxCallbackThreads)
+    {
+        this.pageBufferClientMaxCallbackThreads = pageBufferClientMaxCallbackThreads;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
@@ -14,17 +14,27 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.execution.SystemMemoryUsageListener;
+import io.airlift.concurrent.BoundedExecutor;
+import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.http.client.HttpClient;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 
 public class ExchangeClientFactory
         implements ExchangeClientSupplier
@@ -36,6 +46,9 @@ public class ExchangeClientFactory
     private final HttpClient httpClient;
     private final DataSize maxResponseSize;
     private final ScheduledExecutorService scheduler;
+    private final ThreadPoolExecutorMBean executorMBean;
+    private final ExecutorService pageBufferClientCallbackExecutor;
+    private final Executor boundedExecutor;
 
     @Inject
     public ExchangeClientFactory(
@@ -49,6 +62,7 @@ public class ExchangeClientFactory
                 config.getConcurrentRequestMultiplier(),
                 config.getMinErrorDuration(),
                 config.getMaxErrorDuration(),
+                config.getPageBufferClientMaxCallbackThreads(),
                 httpClient,
                 scheduler);
     }
@@ -59,6 +73,7 @@ public class ExchangeClientFactory
             int concurrentRequestMultiplier,
             Duration minErrorDuration,
             Duration maxErrorDuration,
+            int pageBufferClientMaxCallbackThreads,
             HttpClient httpClient,
             ScheduledExecutorService scheduler)
     {
@@ -76,9 +91,26 @@ public class ExchangeClientFactory
 
         this.scheduler = requireNonNull(scheduler, "scheduler is null");
 
+        this.pageBufferClientCallbackExecutor = newFixedThreadPool(pageBufferClientMaxCallbackThreads, daemonThreadsNamed("page-buffer-client-callback-%s"));
+        this.boundedExecutor = new BoundedExecutor(pageBufferClientCallbackExecutor, pageBufferClientMaxCallbackThreads);
+        this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) pageBufferClientCallbackExecutor);
+
         checkArgument(maxBufferedBytes.toBytes() > 0, "maxBufferSize must be at least 1 byte: %s", maxBufferedBytes);
         checkArgument(maxResponseSize.toBytes() > 0, "maxResponseSize must be at least 1 byte: %s", maxResponseSize);
         checkArgument(concurrentRequestMultiplier > 0, "concurrentRequestMultiplier must be at least 1: %s", concurrentRequestMultiplier);
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        pageBufferClientCallbackExecutor.shutdownNow();
+    }
+
+    @Managed
+    @Nested
+    public ThreadPoolExecutorMBean getExecutor()
+    {
+        return executorMBean;
     }
 
     @Override
@@ -92,6 +124,7 @@ public class ExchangeClientFactory
                 maxErrorDuration,
                 httpClient,
                 scheduler,
-                systemMemoryUsageListener);
+                systemMemoryUsageListener,
+                boundedExecutor);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
@@ -35,13 +35,13 @@ public class ExchangeClientFactory
     private final Duration maxErrorDuration;
     private final HttpClient httpClient;
     private final DataSize maxResponseSize;
-    private final ScheduledExecutorService executor;
+    private final ScheduledExecutorService scheduler;
 
     @Inject
     public ExchangeClientFactory(
             ExchangeClientConfig config,
             @ForExchange HttpClient httpClient,
-            @ForExchange ScheduledExecutorService executor)
+            @ForExchange ScheduledExecutorService scheduler)
     {
         this(
                 config.getMaxBufferSize(),
@@ -50,7 +50,7 @@ public class ExchangeClientFactory
                 config.getMinErrorDuration(),
                 config.getMaxErrorDuration(),
                 httpClient,
-                executor);
+                scheduler);
     }
 
     public ExchangeClientFactory(
@@ -60,7 +60,7 @@ public class ExchangeClientFactory
             Duration minErrorDuration,
             Duration maxErrorDuration,
             HttpClient httpClient,
-            ScheduledExecutorService executor)
+            ScheduledExecutorService scheduler)
     {
         this.maxBufferedBytes = requireNonNull(maxBufferedBytes, "maxBufferedBytes is null");
         this.concurrentRequestMultiplier = concurrentRequestMultiplier;
@@ -74,7 +74,7 @@ public class ExchangeClientFactory
         long maxResponseSizeBytes = (long) (Math.min(httpClient.getMaxContentLength(), maxResponseSize.toBytes()) * 0.75);
         this.maxResponseSize = new DataSize(maxResponseSizeBytes, BYTE);
 
-        this.executor = requireNonNull(executor, "executor is null");
+        this.scheduler = requireNonNull(scheduler, "scheduler is null");
 
         checkArgument(maxBufferedBytes.toBytes() > 0, "maxBufferSize must be at least 1 byte: %s", maxBufferedBytes);
         checkArgument(maxResponseSize.toBytes() > 0, "maxResponseSize must be at least 1 byte: %s", maxResponseSize);
@@ -91,7 +91,7 @@ public class ExchangeClientFactory
                 minErrorDuration,
                 maxErrorDuration,
                 httpClient,
-                executor,
+                scheduler,
                 systemMemoryUsageListener);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -110,7 +110,7 @@ public final class HttpPageBufferClient
     private final DataSize maxResponseSize;
     private final URI location;
     private final ClientCallback clientCallback;
-    private final ScheduledExecutorService executor;
+    private final ScheduledExecutorService scheduler;
     private final Backoff backoff;
 
     @GuardedBy("this")
@@ -145,9 +145,9 @@ public final class HttpPageBufferClient
             Duration maxErrorDuration,
             URI location,
             ClientCallback clientCallback,
-            ScheduledExecutorService executor)
+            ScheduledExecutorService scheduler)
     {
-        this(httpClient, maxResponseSize, minErrorDuration, maxErrorDuration, location, clientCallback, executor, Ticker.systemTicker());
+        this(httpClient, maxResponseSize, minErrorDuration, maxErrorDuration, location, clientCallback, scheduler, Ticker.systemTicker());
     }
 
     public HttpPageBufferClient(
@@ -157,14 +157,14 @@ public final class HttpPageBufferClient
             Duration maxErrorDuration,
             URI location,
             ClientCallback clientCallback,
-            ScheduledExecutorService executor,
+            ScheduledExecutorService scheduler,
             Ticker ticker)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.maxResponseSize = requireNonNull(maxResponseSize, "maxResponseSize is null");
         this.location = requireNonNull(location, "location is null");
         this.clientCallback = requireNonNull(clientCallback, "clientCallback is null");
-        this.executor = requireNonNull(executor, "executor is null");
+        this.scheduler = requireNonNull(scheduler, "scheduler is null");
         requireNonNull(minErrorDuration, "minErrorDuration is null");
         requireNonNull(maxErrorDuration, "maxErrorDuration is null");
         requireNonNull(ticker, "ticker is null");
@@ -262,7 +262,7 @@ public final class HttpPageBufferClient
         backoff.startRequest();
 
         long delayNanos = backoff.getBackoffDelayNanos();
-        executor.schedule(() -> {
+        scheduler.schedule(() -> {
             try {
                 initiateRequest();
             }
@@ -383,7 +383,7 @@ public final class HttpPageBufferClient
                 }
                 handleFailure(t, resultFuture);
             }
-        }, executor);
+        }, scheduler);
     }
 
     private synchronized void sendDelete()
@@ -423,7 +423,7 @@ public final class HttpPageBufferClient
                 }
                 handleFailure(t, resultFuture);
             }
-        }, executor);
+        }, scheduler);
     }
 
     private void checkNotHoldsLock()

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -48,6 +48,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -138,6 +139,8 @@ public final class HttpPageBufferClient
     private final AtomicInteger requestsCompleted = new AtomicInteger();
     private final AtomicInteger requestsFailed = new AtomicInteger();
 
+    private final Executor pageBufferClientCallbackExecutor;
+
     public HttpPageBufferClient(
             HttpClient httpClient,
             DataSize maxResponseSize,
@@ -145,9 +148,10 @@ public final class HttpPageBufferClient
             Duration maxErrorDuration,
             URI location,
             ClientCallback clientCallback,
-            ScheduledExecutorService scheduler)
+            ScheduledExecutorService scheduler,
+            Executor pageBufferClientCallbackExecutor)
     {
-        this(httpClient, maxResponseSize, minErrorDuration, maxErrorDuration, location, clientCallback, scheduler, Ticker.systemTicker());
+        this(httpClient, maxResponseSize, minErrorDuration, maxErrorDuration, location, clientCallback, scheduler, Ticker.systemTicker(), pageBufferClientCallbackExecutor);
     }
 
     public HttpPageBufferClient(
@@ -158,13 +162,15 @@ public final class HttpPageBufferClient
             URI location,
             ClientCallback clientCallback,
             ScheduledExecutorService scheduler,
-            Ticker ticker)
+            Ticker ticker,
+            Executor pageBufferClientCallbackExecutor)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.maxResponseSize = requireNonNull(maxResponseSize, "maxResponseSize is null");
         this.location = requireNonNull(location, "location is null");
         this.clientCallback = requireNonNull(clientCallback, "clientCallback is null");
         this.scheduler = requireNonNull(scheduler, "scheduler is null");
+        this.pageBufferClientCallbackExecutor = requireNonNull(pageBufferClientCallbackExecutor, "pageBufferClientCallbackExecutor is null");
         requireNonNull(minErrorDuration, "minErrorDuration is null");
         requireNonNull(maxErrorDuration, "maxErrorDuration is null");
         requireNonNull(ticker, "ticker is null");
@@ -383,7 +389,7 @@ public final class HttpPageBufferClient
                 }
                 handleFailure(t, resultFuture);
             }
-        }, scheduler);
+        }, pageBufferClientCallbackExecutor);
     }
 
     private synchronized void sendDelete()
@@ -423,7 +429,7 @@ public final class HttpPageBufferClient
                 }
                 handleFailure(t, resultFuture);
             }
-        }, scheduler);
+        }, pageBufferClientCallbackExecutor);
     }
 
     private void checkNotHoldsLock()

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -29,6 +29,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -51,6 +53,7 @@ import static org.testng.Assert.assertTrue;
 public class TestExchangeClient
 {
     private ScheduledExecutorService scheduler;
+    private ExecutorService pageBufferClientCallbackExecutor;
 
     private static final PagesSerde PAGES_SERDE = testingPagesSerde();
 
@@ -58,6 +61,7 @@ public class TestExchangeClient
     public void setUp()
     {
         scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
+        pageBufferClientCallbackExecutor = Executors.newSingleThreadExecutor();
     }
 
     @AfterClass(alwaysRun = true)
@@ -66,6 +70,10 @@ public class TestExchangeClient
         if (scheduler != null) {
             scheduler.shutdownNow();
             scheduler = null;
+        }
+        if (pageBufferClientCallbackExecutor != null) {
+            pageBufferClientCallbackExecutor.shutdownNow();
+            pageBufferClientCallbackExecutor = null;
         }
     }
 
@@ -83,7 +91,7 @@ public class TestExchangeClient
         processor.setComplete(location);
 
         @SuppressWarnings("resource")
-        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(32, Unit.MEGABYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, scheduler), scheduler, deltaMemoryInBytes -> {});
+        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(32, Unit.MEGABYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, scheduler), scheduler, deltaMemoryInBytes -> {}, pageBufferClientCallbackExecutor);
 
         exchangeClient.addLocation(location);
         exchangeClient.noMoreLocations();
@@ -113,7 +121,7 @@ public class TestExchangeClient
         MockExchangeRequestProcessor processor = new MockExchangeRequestProcessor(maxResponseSize);
 
         @SuppressWarnings("resource")
-        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(32, Unit.MEGABYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), scheduler, deltaMemoryInBytes -> {});
+        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(32, Unit.MEGABYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), scheduler, deltaMemoryInBytes -> {}, pageBufferClientCallbackExecutor);
 
         URI location1 = URI.create("http://localhost:8081/foo");
         processor.addPage(location1, createPage(1));
@@ -177,7 +185,7 @@ public class TestExchangeClient
         processor.setComplete(location);
 
         @SuppressWarnings("resource")
-        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(1, Unit.BYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), scheduler, deltaMemoryInBytes -> {});
+        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(1, Unit.BYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), scheduler, deltaMemoryInBytes -> {}, pageBufferClientCallbackExecutor);
 
         exchangeClient.addLocation(location);
         exchangeClient.noMoreLocations();
@@ -250,7 +258,7 @@ public class TestExchangeClient
         processor.addPage(location, createPage(3));
 
         @SuppressWarnings("resource")
-        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(1, Unit.BYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), scheduler, deltaMemoryInBytes -> {});
+        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(1, Unit.BYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), scheduler, deltaMemoryInBytes -> {}, pageBufferClientCallbackExecutor);
         exchangeClient.addLocation(location);
         exchangeClient.noMoreLocations();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -50,22 +50,22 @@ import static org.testng.Assert.assertTrue;
 @Test(singleThreaded = true)
 public class TestExchangeClient
 {
-    private ScheduledExecutorService executor;
+    private ScheduledExecutorService scheduler;
 
     private static final PagesSerde PAGES_SERDE = testingPagesSerde();
 
     @BeforeClass
     public void setUp()
     {
-        executor = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
+        scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
     }
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
-        if (executor != null) {
-            executor.shutdownNow();
-            executor = null;
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            scheduler = null;
         }
     }
 
@@ -83,7 +83,7 @@ public class TestExchangeClient
         processor.setComplete(location);
 
         @SuppressWarnings("resource")
-        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(32, Unit.MEGABYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, executor), executor, deltaMemoryInBytes -> {});
+        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(32, Unit.MEGABYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, scheduler), scheduler, deltaMemoryInBytes -> {});
 
         exchangeClient.addLocation(location);
         exchangeClient.noMoreLocations();
@@ -113,7 +113,7 @@ public class TestExchangeClient
         MockExchangeRequestProcessor processor = new MockExchangeRequestProcessor(maxResponseSize);
 
         @SuppressWarnings("resource")
-        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(32, Unit.MEGABYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), executor, deltaMemoryInBytes -> {});
+        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(32, Unit.MEGABYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), scheduler, deltaMemoryInBytes -> {});
 
         URI location1 = URI.create("http://localhost:8081/foo");
         processor.addPage(location1, createPage(1));
@@ -177,7 +177,7 @@ public class TestExchangeClient
         processor.setComplete(location);
 
         @SuppressWarnings("resource")
-        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(1, Unit.BYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), executor, deltaMemoryInBytes -> {});
+        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(1, Unit.BYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), scheduler, deltaMemoryInBytes -> {});
 
         exchangeClient.addLocation(location);
         exchangeClient.noMoreLocations();
@@ -250,7 +250,7 @@ public class TestExchangeClient
         processor.addPage(location, createPage(3));
 
         @SuppressWarnings("resource")
-        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(1, Unit.BYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), executor, deltaMemoryInBytes -> {});
+        ExchangeClient exchangeClient = new ExchangeClient(new DataSize(1, Unit.BYTE), maxResponseSize, 1, new Duration(1, TimeUnit.MINUTES), new Duration(1, TimeUnit.MINUTES), new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))), scheduler, deltaMemoryInBytes -> {});
         exchangeClient.addLocation(location);
         exchangeClient.noMoreLocations();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
@@ -38,6 +38,7 @@ public class TestExchangeClientConfig
                 .setMinErrorDuration(new Duration(1, TimeUnit.MINUTES))
                 .setMaxErrorDuration(new Duration(5, TimeUnit.MINUTES))
                 .setMaxResponseSize(new HttpClientConfig().getMaxContentLength())
+                .setPageBufferClientMaxCallbackThreads(25)
                 .setClientThreads(25));
     }
 
@@ -51,6 +52,7 @@ public class TestExchangeClientConfig
                 .put("exchange.max-error-duration", "33s")
                 .put("exchange.max-response-size", "1MB")
                 .put("exchange.client-threads", "2")
+                .put("exchange.page-buffer-client.max-callback-threads", "16")
                 .build();
 
         ExchangeClientConfig expected = new ExchangeClientConfig()
@@ -59,7 +61,8 @@ public class TestExchangeClientConfig
                 .setMinErrorDuration(new Duration(13, TimeUnit.SECONDS))
                 .setMaxErrorDuration(new Duration(33, TimeUnit.SECONDS))
                 .setMaxResponseSize(new DataSize(1, Unit.MEGABYTE))
-                .setClientThreads(2);
+                .setClientThreads(2)
+                .setPageBufferClientMaxCallbackThreads(16);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
@@ -87,7 +87,7 @@ public class TestExchangeOperator
 
     private final LoadingCache<String, TaskBuffer> taskBuffers = CacheBuilder.newBuilder().build(CacheLoader.from(TaskBuffer::new));
 
-    private ScheduledExecutorService executor;
+    private ScheduledExecutorService scheduler;
     private ScheduledExecutorService scheduledExecutor;
     private HttpClient httpClient;
     private ExchangeClientSupplier exchangeClientSupplier;
@@ -97,10 +97,10 @@ public class TestExchangeOperator
     public void setUp()
             throws Exception
     {
-        executor = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
+        scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
 
-        httpClient = new TestingHttpClient(new HttpClientHandler(taskBuffers), executor);
+        httpClient = new TestingHttpClient(new HttpClientHandler(taskBuffers), scheduler);
 
         exchangeClientSupplier = (systemMemoryUsageListener) -> new ExchangeClient(
                 new DataSize(32, MEGABYTE),
@@ -109,7 +109,7 @@ public class TestExchangeOperator
                 new Duration(1, TimeUnit.MINUTES),
                 new Duration(1, TimeUnit.MINUTES),
                 httpClient,
-                executor,
+                scheduler,
                 systemMemoryUsageListener);
     }
 
@@ -120,8 +120,8 @@ public class TestExchangeOperator
         httpClient.close();
         httpClient = null;
 
-        executor.shutdownNow();
-        executor = null;
+        scheduler.shutdownNow();
+        scheduler = null;
 
         scheduledExecutor.shutdownNow();
         scheduledExecutor = null;
@@ -265,7 +265,7 @@ public class TestExchangeOperator
     {
         ExchangeOperatorFactory operatorFactory = new ExchangeOperatorFactory(0, new PlanNodeId("test"), exchangeClientSupplier, SERDE_FACTORY, TYPES);
 
-        DriverContext driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
+        DriverContext driverContext = createTaskContext(scheduler, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true)
                 .addDriverContext();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
@@ -61,22 +61,22 @@ import static org.testng.Assert.assertEquals;
 
 public class TestHttpPageBufferClient
 {
-    private ScheduledExecutorService executor;
+    private ScheduledExecutorService scheduler;
 
     private static final PagesSerde PAGES_SERDE = testingPagesSerde();
 
     @BeforeClass
     public void setUp()
     {
-        executor = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
+        scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
     }
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
-        if (executor != null) {
-            executor.shutdownNow();
-            executor = null;
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            scheduler = null;
         }
     }
 
@@ -94,13 +94,13 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, executor),
+        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
                 expectedMaxSize,
                 new Duration(1, TimeUnit.MINUTES),
                 new Duration(1, TimeUnit.MINUTES),
                 location,
                 callback,
-                executor);
+                scheduler);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -178,13 +178,13 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, executor),
+        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
                 new DataSize(10, Unit.MEGABYTE),
                 new Duration(1, TimeUnit.MINUTES),
                 new Duration(1, TimeUnit.MINUTES),
                 location,
                 callback,
-                executor);
+                scheduler);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -217,13 +217,13 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, executor),
+        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
                 new DataSize(10, Unit.MEGABYTE),
                 new Duration(1, TimeUnit.MINUTES),
                 new Duration(1, TimeUnit.MINUTES),
                 location,
                 callback,
-                executor);
+                scheduler);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -284,13 +284,13 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, executor),
+        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
                 new DataSize(10, Unit.MEGABYTE),
                 new Duration(1, TimeUnit.MINUTES),
                 new Duration(1, TimeUnit.MINUTES),
                 location,
                 callback,
-                executor);
+                scheduler);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -337,13 +337,13 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, executor),
+        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
                 new DataSize(10, Unit.MEGABYTE),
                 new Duration(1, TimeUnit.MINUTES),
                 new Duration(1, TimeUnit.MINUTES),
                 location,
                 callback,
-                executor,
+                scheduler,
                 ticker);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
@@ -39,6 +39,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -62,6 +64,7 @@ import static org.testng.Assert.assertEquals;
 public class TestHttpPageBufferClient
 {
     private ScheduledExecutorService scheduler;
+    private ExecutorService pageBufferClientCallbackExecutor;
 
     private static final PagesSerde PAGES_SERDE = testingPagesSerde();
 
@@ -69,6 +72,7 @@ public class TestHttpPageBufferClient
     public void setUp()
     {
         scheduler = newScheduledThreadPool(4, daemonThreadsNamed("test-%s"));
+        pageBufferClientCallbackExecutor = Executors.newSingleThreadExecutor();
     }
 
     @AfterClass(alwaysRun = true)
@@ -77,6 +81,10 @@ public class TestHttpPageBufferClient
         if (scheduler != null) {
             scheduler.shutdownNow();
             scheduler = null;
+        }
+        if (pageBufferClientCallbackExecutor != null) {
+            pageBufferClientCallbackExecutor.shutdownNow();
+            pageBufferClientCallbackExecutor = null;
         }
     }
 
@@ -100,7 +108,8 @@ public class TestHttpPageBufferClient
                 new Duration(1, TimeUnit.MINUTES),
                 location,
                 callback,
-                scheduler);
+                scheduler,
+                pageBufferClientCallbackExecutor);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -184,7 +193,8 @@ public class TestHttpPageBufferClient
                 new Duration(1, TimeUnit.MINUTES),
                 location,
                 callback,
-                scheduler);
+                scheduler,
+                pageBufferClientCallbackExecutor);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -223,7 +233,8 @@ public class TestHttpPageBufferClient
                 new Duration(1, TimeUnit.MINUTES),
                 location,
                 callback,
-                scheduler);
+                scheduler,
+                pageBufferClientCallbackExecutor);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -290,7 +301,8 @@ public class TestHttpPageBufferClient
                 new Duration(1, TimeUnit.MINUTES),
                 location,
                 callback,
-                scheduler);
+                scheduler,
+                pageBufferClientCallbackExecutor);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -344,7 +356,8 @@ public class TestHttpPageBufferClient
                 location,
                 callback,
                 scheduler,
-                ticker);
+                ticker,
+                pageBufferClientCallbackExecutor);
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 


### PR DESCRIPTION
Previously we were using a `ScheduledExecutorService` to run the listeners of HTTP response futures, which is probably not what we want. This change updates the `HttpPageBufferClient` to use a dedicated executor with a configurable size to run those listeners. The default value of this config is the same as the config (`exchange.client-threads`) that was setting the size of the `ScheduledExecutorService`.
