### PR TITLE
Use explicit charset when creating JSON reader

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
@@ -89,6 +89,7 @@ import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.math.RoundingMode.HALF_UP;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public final class JsonUtil
@@ -109,7 +110,7 @@ public final class JsonUtil
     {
         // Jackson tries to detect the character encoding automatically when using InputStream
         // so we pass an InputStreamReader instead.
-        return factory.createParser(new InputStreamReader(json.getInput()));
+        return factory.createParser(new InputStreamReader(json.getInput(), UTF_8));
     }
 
     public static JsonGenerator createJsonGenerator(JsonFactory factory, SliceOutput output)


### PR DESCRIPTION
It was using the default platform charset, which might not be UTF-8