### PR TITLE
Log error when Driver is left with revocable memory reservation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -526,6 +526,9 @@ public class Driver
             if (driverContext.getSystemMemoryUsage() > 0) {
                 log.error("Driver still has system memory reserved after freeing all operator memory. Freeing it.");
             }
+            if (driverContext.getRevocableMemoryUsage() > 0) {
+                log.error("Driver still has revocable memory reserved after freeing all operator memory. Freeing it.");
+            }
             driverContext.freeMemory(driverContext.getMemoryUsage());
             driverContext.freeSystemMemory(driverContext.getSystemMemoryUsage());
             driverContext.freeRevocableMemory(driverContext.getRevocableMemoryUsage());


### PR DESCRIPTION
`Driver` cleans up memory reservation after closing all `Operator`s. It
should log error when there is revocable memory reservation to be
cleaned up just as it does for other memory reservations.