### PR TITLE
Add PEM support to cli

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,12 @@
 
             <dependency>
                 <groupId>io.airlift</groupId>
+                <artifactId>security</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
                 <artifactId>units</artifactId>
                 <version>1.0</version>
             </dependency>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -49,6 +49,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 


### PR DESCRIPTION
Existing keystore and truststore properties can now be used for PEM files in the CLI