### PR TITLE
Update tempto to 1.37

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dep.aws-sdk.version>1.11.165</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.0.0</dep.jdbi3.version>
-        <dep.tempto.version>1.36</dep.tempto.version>
+        <dep.tempto.version>1.37</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.nifty.version>0.15.1</dep.nifty.version>


### PR DESCRIPTION
Update tempto to 1.37

Tempto 1.37 displays used configuration and prevents to be called with
wrong CLI arguments. No more changes over 1.36.
