### PR TITLE
Use requested hadoop image for product test with kerberos

### DIFF
--- a/presto-product-tests/conf/docker/common/kerberos.yml
+++ b/presto-product-tests/conf/docker/common/kerberos.yml
@@ -2,12 +2,12 @@ version: '2'
 services:
 
   hadoop-master:
-    image: 'prestodb/hdp2.5-hive-kerberized:${DOCKER_IMAGES_VERSION}'
+    image: '${HADOOP_MASTER_IMAGE}-kerberized:${DOCKER_IMAGES_VERSION}'
 
   presto-master:
     domainname: docker.cluster
     hostname: presto-master
-    image: 'prestodb/hdp2.5-hive-kerberized:${DOCKER_IMAGES_VERSION}'
+    image: '${HADOOP_MASTER_IMAGE}-kerberized:${DOCKER_IMAGES_VERSION}'
     command: /docker/volumes/conf/docker/files/presto-launcher-wrapper.sh singlenode-kerberized run
     networks:
       default:
@@ -15,6 +15,6 @@ services:
          - presto-master.docker.cluster
 
   application-runner:
-    image: 'prestodb/hdp2.5-hive-kerberized:${DOCKER_IMAGES_VERSION}'
+    image: '${HADOOP_MASTER_IMAGE}-kerberized:${DOCKER_IMAGES_VERSION}'
     volumes:
       - ../../../conf/tempto/tempto-configuration-for-docker-kerberos.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml

--- a/presto-product-tests/conf/docker/common/kerberos.yml
+++ b/presto-product-tests/conf/docker/common/kerberos.yml
@@ -1,8 +1,6 @@
 version: '2'
 services:
 
-  # hdp2.5-hive-kerberized contains keytabs and the `krb5.conf` within
-
   hadoop-master:
     image: 'prestodb/hdp2.5-hive-kerberized:${DOCKER_IMAGES_VERSION}'
 


### PR DESCRIPTION
Use requested hadoop image for product test with kerberos

So far even when developer wanted to run kerberos product tests with
CDH, HDP was used.

This commit makes a convention that when a CDH (prestodb/cdh*) image is
selected, then to test kerberos it will use kerberized CDH docker image
(prestodb/cdh*-kerberized). Same any other hadoop platform (like HDP).
IOP is not yet supported.
