### PR TITLE
Docker images v5

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -176,6 +176,20 @@ where profile is one of either:
  `mysql_connector` and `postgresql_connector` tests i.e.
  `-x mysql_connector, postgresql_connector`.
 
+### Hadoop docker image used for testing
+The default Hadoop/Hive docker image used for testing is defined in `conf/common/compose-commons.sh` and can be controlled
+via the `HADOOP_BASE_IMAGE` and `DOCKER_IMAGES_VERSION` env variables.
+- `HADOOP_BASE_IMAGE` defines the Hadoop distribution family (as found in [PrestoDB Hadoop docker
+repo](https://cloud.docker.com/swarm/prestodb/repository/list?name=hive&namespace=prestodb)). The name should be without
+the `-kerberized` suffix, eg. `cdh5.13-hive`. Only images that have their kerberized counterparts can be used with test profiles
+implying a kerberized environment eg. `singlenode-kerberos-hdfs-impersonation`, you should still use the base name for this
+env variable, the `-kerberized` suffix will be added automatically.
+- `DOCKER_IMAGES_VERSION` determines the version of the images used, both Hadoop images and base Centos images to host Presto,
+and serve as various run environments throughout the tests. Versions can be found on the
+[PrestoDB docker repo](https://cloud.docker.com/swarm/prestodb/repository/list) as well. You may use any version, either
+release or snapshot. Note that all images will be required to have this version, because this version is used globally.
+This is to ease maintenance and simplify debugging.
+
 Please keep in mind that if you run tests on Hive of version not greater than 1.0.1, you should exclude test from `post_hive_1_0_1` group by passing the following flag to tempto: `-x post_hive_1_0_1`.
 First version of Hive capable of running tests from `post_hive_1_0_1` group is Hive 1.1.0.
 

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -30,13 +30,6 @@ function check_hadoop() {
     docker exec ${HADOOP_MASTER_CONTAINER} netstat -lpn | grep -iq 0.0.0.0:10000
 }
 
-function stop_unnecessary_hadoop_services() {
-  HADOOP_MASTER_CONTAINER=$(hadoop_master_container)
-  docker exec ${HADOOP_MASTER_CONTAINER} supervisorctl status
-  docker exec ${HADOOP_MASTER_CONTAINER} supervisorctl stop mapreduce-historyserver
-  docker exec ${HADOOP_MASTER_CONTAINER} supervisorctl stop zookeeper
-}
-
 function run_in_application_runner_container() {
   local CONTAINER_NAME=$( environment_compose run -d application-runner "$@" )
   echo "Showing logs from $CONTAINER_NAME:"
@@ -232,7 +225,6 @@ HADOOP_LOGS_PID=$!
 
 # wait until hadoop processes is started
 retry check_hadoop
-stop_unnecessary_hadoop_services
 
 # start presto containers
 environment_compose up -d ${PRESTO_SERVICES}

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -23,8 +23,8 @@ function export_canonical_path() {
 
 source ${BASH_SOURCE%/*}/../../../bin/locations.sh
 
-export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-1}
-export HADOOP_MASTER_IMAGE=${HADOOP_MASTER_IMAGE:-"prestodb/hdp2.5-hive:${DOCKER_IMAGES_VERSION}"}
+export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-5}
+export HADOOP_BASE_IMAGE=${HADOOP_BASE_IMAGE:-"prestodb/hdp2.6-hive"}
 
 # The following variables are defined to enable running product tests with arbitrary/downloaded jars
 # and without building the project. The `presto.env` file should only be sourced if any of the variables

--- a/presto-product-tests/conf/docker/common/kerberos.yml
+++ b/presto-product-tests/conf/docker/common/kerberos.yml
@@ -1,15 +1,13 @@
 version: '2'
 services:
 
-  # hdp2.5-hive-kerberized contains keytabs and the `krb5.conf` within
-
   hadoop-master:
-    image: 'prestodb/hdp2.5-hive-kerberized:${DOCKER_IMAGES_VERSION}'
+    image: '${HADOOP_BASE_IMAGE}-kerberized:${DOCKER_IMAGES_VERSION}'
 
   presto-master:
     domainname: docker.cluster
     hostname: presto-master
-    image: 'prestodb/hdp2.5-hive-kerberized:${DOCKER_IMAGES_VERSION}'
+    image: '${HADOOP_BASE_IMAGE}-kerberized:${DOCKER_IMAGES_VERSION}'
     command: /docker/volumes/conf/docker/files/presto-launcher-wrapper.sh singlenode-kerberized run
     networks:
       default:
@@ -17,6 +15,6 @@ services:
          - presto-master.docker.cluster
 
   application-runner:
-    image: 'prestodb/hdp2.5-hive-kerberized:${DOCKER_IMAGES_VERSION}'
+    image: '${HADOOP_BASE_IMAGE}-kerberized:${DOCKER_IMAGES_VERSION}'
     volumes:
       - ../../../conf/tempto/tempto-configuration-for-docker-kerberos.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -10,7 +10,7 @@ services:
   hadoop-master:
     extends:
       service: java-8-base
-    image: ${HADOOP_MASTER_IMAGE}
+    image: '${HADOOP_BASE_IMAGE}:${DOCKER_IMAGES_VERSION}'
     hostname: hadoop-master
     ports:
       - '${HIVE_PROXY_PORT}:1180'


### PR DESCRIPTION
Changes necessary for the v5 docker images 
1) Images no longer have zookeeper and historyserver so no stopping of
those services is required.
2) Changed the variables used in scripts to allow usage of other
kerberized images (other than hdp), they are new in v5.
3) Changed default values to v5