### PR TITLE
Update to ASM 6.0_BETA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -579,8 +579,8 @@
 
             <dependency>
                 <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-all</artifactId>
-                <version>5.2</version>
+                <artifactId>asm-debug-all</artifactId>
+                <version>6.0_BETA</version>
             </dependency>
 
             <dependency>

--- a/presto-bytecode/pom.xml
+++ b/presto-bytecode/pom.xml
@@ -18,7 +18,7 @@
     <dependencies>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
+            <artifactId>asm-debug-all</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -259,7 +259,7 @@
 
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
+            <artifactId>asm-debug-all</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This version is required to read Java 9 bytecode.