### PR TITLE
Support reading MongoDB documents as map type.

### DIFF
--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <mongo-java.version>3.1.0</mongo-java.version>
+        <mongo-java.version>3.6.0</mongo-java.version>
         <mongo-server.version>1.5.0</mongo-server.version>
         <netty.version>4.0.32.Final</netty.version>
     </properties>

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoPageSource.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoPageSource.java
@@ -31,6 +31,7 @@ import org.bson.types.ObjectId;
 import org.joda.time.chrono.ISOChronology;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -177,11 +178,22 @@ public class MongoPageSource
         }
     }
 
+    private String toVarcharValue(Object value)
+    {
+        if (value instanceof Collection<?>) {
+            return "[" + String.join(", ", ((Collection<?>) value).stream().map(this::toVarcharValue).collect(toList())) + "]";
+        }
+        if (value instanceof Document) {
+            return ((Document) value).toJson();
+        }
+        return String.valueOf(value);
+    }
+
     private void writeSlice(BlockBuilder output, Type type, Object value)
     {
         String base = type.getTypeSignature().getBase();
         if (base.equals(StandardTypes.VARCHAR)) {
-            type.writeSlice(output, utf8Slice(value.toString()));
+            type.writeSlice(output, utf8Slice(toVarcharValue(value)));
         }
         else if (type.equals(OBJECT_ID)) {
             type.writeSlice(output, wrappedBuffer(((ObjectId) value).toByteArray()));
@@ -227,6 +239,16 @@ public class MongoPageSource
                     }
                 }
 
+                output.closeEntry();
+                return;
+            }
+            else if (value instanceof Map) {
+                BlockBuilder builder = output.beginBlockEntry();
+                Map<?, ?> document = (Map<?, ?>) value;
+                for (Map.Entry<?, ?> entry : document.entrySet()) {
+                    appendTo(type.getTypeParameters().get(0), entry.getKey(), builder);
+                    appendTo(type.getTypeParameters().get(1), entry.getValue(), builder);
+                }
                 output.closeEntry();
                 return;
             }

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/MongoQueryRunner.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/MongoQueryRunner.java
@@ -18,6 +18,8 @@ import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
 import de.bwaldvogel.mongo.MongoServer;
 import io.airlift.tpch.TpchTable;
 
@@ -37,6 +39,7 @@ public class MongoQueryRunner
     private static final String TPCH_SCHEMA = "tpch";
 
     private final MongoServer server;
+    private final MongoClient client;
     private final InetSocketAddress address;
 
     private MongoQueryRunner(Session session, int workers)
@@ -46,6 +49,7 @@ public class MongoQueryRunner
 
         server = new MongoServer(new SyncMemoryBackend());
         address = server.bind();
+        client = new MongoClient(new ServerAddress(address));
     }
 
     public static MongoQueryRunner createMongoQueryRunner(TpchTable<?>... tables)
@@ -96,9 +100,15 @@ public class MongoQueryRunner
         return address;
     }
 
+    public MongoClient getMongoClient()
+    {
+        return client;
+    }
+
     public void shutdown()
     {
         close();
+        client.close();
         server.shutdown();
     }
 }

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -16,12 +16,16 @@ package com.facebook.presto.mongodb;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.bson.Document;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 
 import static com.facebook.presto.mongodb.MongoQueryRunner.createMongoQueryRunner;
 import static io.airlift.tpch.TpchTable.ORDERS;
@@ -149,6 +153,32 @@ public class TestMongoIntegrationSmokeTest
         assertOneNotNullResult("SELECT col[DATE '2014-09-30'] FROM tmp_map6");
         assertUpdate("CREATE TABLE tmp_map7 AS SELECT MAP(ARRAY[TIMESTAMP '2001-08-22 03:04:05.321'], ARRAY[TIMESTAMP '2001-08-22 03:04:05.321']) AS col", 1);
         assertOneNotNullResult("SELECT col[TIMESTAMP '2001-08-22 03:04:05.321'] FROM tmp_map7");
+
+        assertUpdate("CREATE TABLE test.tmp_map8 (col MAP<VARCHAR, VARCHAR>)");
+        mongoQueryRunner.getMongoClient().getDatabase("test").getCollection("tmp_map8").insertOne(new Document(
+                ImmutableMap.of("col", new Document(ImmutableMap.of("key1", "value1", "key2", "value2")))));
+        assertQuery("SELECT col['key1'] FROM test.tmp_map8", "SELECT 'value1'");
+
+        assertUpdate("CREATE TABLE test.tmp_map9 (col VARCHAR)");
+        mongoQueryRunner.getMongoClient().getDatabase("test").getCollection("tmp_map9").insertOne(new Document(
+                ImmutableMap.of("col", new Document(ImmutableMap.of("key1", "value1", "key2", "value2")))));
+        assertQuery("SELECT col FROM test.tmp_map9", "SELECT '{ \"key1\" : \"value1\", \"key2\" : \"value2\" }'");
+
+        assertUpdate("CREATE TABLE test.tmp_map10 (col VARCHAR)");
+        mongoQueryRunner.getMongoClient().getDatabase("test").getCollection("tmp_map10").insertOne(new Document(
+                ImmutableMap.of("col", ImmutableList.of(new Document(ImmutableMap.of("key1", "value1", "key2", "value2")),
+                        new Document(ImmutableMap.of("key3", "value3", "key4", "value4"))))));
+        assertQuery("SELECT col FROM test.tmp_map10", "SELECT '[{ \"key1\" : \"value1\", \"key2\" : \"value2\" }, { \"key3\" : \"value3\", \"key4\" : \"value4\" }]'");
+
+        assertUpdate("CREATE TABLE test.tmp_map11 (col VARCHAR)");
+        mongoQueryRunner.getMongoClient().getDatabase("test").getCollection("tmp_map11").insertOne(new Document(
+                ImmutableMap.of("col", 10)));
+        assertQuery("SELECT col FROM test.tmp_map11", "SELECT '10'");
+
+        assertUpdate("CREATE TABLE test.tmp_map12 (col VARCHAR)");
+        mongoQueryRunner.getMongoClient().getDatabase("test").getCollection("tmp_map12").insertOne(new Document(
+                ImmutableMap.of("col", Arrays.asList(10, null, 11))));
+        assertQuery("SELECT col FROM test.tmp_map12", "SELECT '[10, null, 11]'");
     }
 
     @Test


### PR DESCRIPTION
The existing MongoDB connector only supports PrestoDB Map type as an array/list in MongoDB, which may not be sufficient if the MongoDB data is a document type.
This commit enhanced the MongoDB connector so that it can convert a MongoDB document directly into PrestoDB Map type.
It also enhanced the MongoDB connector so that when it converts a MongoDB document into a varchar type, it uses the BSON JSON representation instead of the simple .toString() representation. By doing this, we have the opportunity to easily write a function plugin to decode the JSON back into BSON document and do further custom processing.