### PR TITLE
Make getRegion always return a new Block for structural block

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -79,10 +79,6 @@ public abstract class AbstractArrayBlock
         int positionCount = getPositionCount();
         checkValidRegion(positionCount, position, length);
 
-        if (position == 0 && length == positionCount) {
-            return this;
-        }
-
         return new ArrayBlock(
                 position + getOffsetBase(),
                 length,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -129,10 +129,6 @@ public abstract class AbstractMapBlock
         int positionCount = getPositionCount();
         checkValidRegion(positionCount, position, length);
 
-        if (position == 0 && length == positionCount) {
-            return this;
-        }
-
         return new MapBlock(
                 position + getOffsetBase(),
                 length,
@@ -142,7 +138,8 @@ public abstract class AbstractMapBlock
                 getValues(),
                 getHashTables(),
                 keyType,
-                keyBlockNativeEquals, keyNativeHashCode);
+                keyBlockNativeEquals,
+                keyNativeHashCode);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -90,10 +90,6 @@ public abstract class AbstractRowBlock
         int positionCount = getPositionCount();
         checkValidRegion(positionCount, position, length);
 
-        if (position == 0 && length == positionCount) {
-            return this;
-        }
-
         return new RowBlock(position + getOffsetBase(), length, getRowIsNull(), getFieldBlockOffsets(), getFieldBlocks());
     }
 


### PR DESCRIPTION
For structural types (array/map/row), AbstractBlock.getRegion over
the whole block currently returns `this` instead of constructing
a new block.

As a result, for structural type, BlockBuilder.getRegion() will return
a BlockBuilder instead of a Block when it is slicing the whole block,
which is unexpected behavior.