### PR TITLE
Add succinct duration and data size functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions.rst
+++ b/presto-docs/src/main/sphinx/functions.rst
@@ -26,3 +26,4 @@ Functions and Operators
     functions/geospatial
     functions/color
     functions/teradata
+    functions/unit

--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -164,10 +164,12 @@ Unit              Description
 
     Returns ``timestamp2 - timestamp1`` expressed in terms of ``unit``.
 
-Duration Function
------------------
+.. _duration_functions:
 
-The ``parse_duration`` function supports the following units:
+Duration Functions
+------------------
+
+The duration functions support the following time units:
 
 ======= =============
 Unit    Description
@@ -189,6 +191,22 @@ Unit    Description
         SELECT parse_duration('42.8ms'); -- 0 00:00:00.043
         SELECT parse_duration('3.81 d'); -- 3 19:26:24.000
         SELECT parse_duration('5m');     -- 0 00:05:00.000
+
+.. function:: succinct_duration(value, unit) -> varchar
+
+    Returns a succinct string representation of a given time value. ``unit`` is one of the time units in the above::
+
+        SELECT succinct_duration(3600, 's');     -- 1.00h
+        SELECT succinct_duration(1234.5, 'ms');  -- 1.23s
+
+.. function:: succinct_nanos(nanos) -> varchar
+
+    Returns a succinct string representation of a nanosecond value. This is equivalent to ``succinct_duration(nanos, 'ns')``.
+
+.. function:: succinct_millis(millis) -> varchar
+
+    Returns a succinct string representation of a millisecond value. This is equivalent to ``succinct_duration(millis, 'ms')``.
+
 
 MySQL Date Functions
 --------------------

--- a/presto-docs/src/main/sphinx/functions/datetime.rst
+++ b/presto-docs/src/main/sphinx/functions/datetime.rst
@@ -194,7 +194,7 @@ Unit    Description
 
 .. function:: succinct_duration(value, unit) -> varchar
 
-    Returns a succinct string representation of a given time value. ``unit`` is one of the time units in the above::
+    Returns a succinct string representation of a given time value. ``unit`` must be one of the supported time units::
 
         SELECT succinct_duration(3600, 's');     -- 1.00h
         SELECT succinct_duration(1234.5, 'ms');  -- 1.23s

--- a/presto-docs/src/main/sphinx/functions/unit.rst
+++ b/presto-docs/src/main/sphinx/functions/unit.rst
@@ -11,22 +11,23 @@ The data size functions support the following units:
 Unit    Description
 ======= =============
 ``B``   Bytes
-``kB``  Kilo bytes
-``MB``  Mega bytes
-``GB``  Giga bytes
-``TB``  Tera bytes
-``PB``  Peta bytes
+``kB``  Kilobyte
+``MB``  Megabyte
+``GB``  Gigabyte
+``TB``  Terabyte
+``PB``  Petabyte
 ======= =============
 
 .. function:: succinct_bytes(bytes) -> varchar
 
-    Returns a succinct representation of the byte size::
+    Returns a succinct representation of ``bytes``.::
 
         SELECT succinct_bytes(1024 * 1024); -- '1.00MB'
 
 .. function:: succinct_data_size(value, unit) -> varchar
 
-    Returns a succinct representation of the data size. ``unit`` is one of the data size units in the above::
+    Returns a succinct representation of the data size specified by ``value`` and ``unit``.
+    ``unit`` must be one of the supported data size units::
 
         SELECT succinct_data_size(2048, 'MB') -- '2.00GB'
 

--- a/presto-docs/src/main/sphinx/functions/unit.rst
+++ b/presto-docs/src/main/sphinx/functions/unit.rst
@@ -1,0 +1,36 @@
+==============
+Unit Functions
+==============
+
+Data Size Functions
+-------------------
+
+The data size functions support the following units:
+
+======= =============
+Unit    Description
+======= =============
+``B``   Bytes
+``kB``  Kilo bytes
+``MB``  Mega bytes
+``GB``  Giga bytes
+``TB``  Tera bytes
+``PB``  Peta bytes
+======= =============
+
+.. function:: succinct_bytes(bytes) -> varchar
+
+    Returns a succinct representation of the byte size::
+
+        SELECT succinct_bytes(1024 * 1024); -- '1.00MB'
+
+.. function:: succinct_data_size(value, unit) -> varchar
+
+    Returns a succinct representation of the data size. ``unit`` is one of the data size units in the above::
+
+        SELECT succinct_data_size(2048, 'MB') -- '2.00GB'
+
+Duration Functions
+------------------
+
+See :ref:`duration_functions`.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -111,6 +111,7 @@ import com.facebook.presto.operator.scalar.SplitToMapFunction;
 import com.facebook.presto.operator.scalar.StringFunctions;
 import com.facebook.presto.operator.scalar.TryFunction;
 import com.facebook.presto.operator.scalar.TypeOfFunction;
+import com.facebook.presto.operator.scalar.UnitFunctions;
 import com.facebook.presto.operator.scalar.UrlFunctions;
 import com.facebook.presto.operator.scalar.VarbinaryFunctions;
 import com.facebook.presto.operator.window.CumulativeDistributionFunction;
@@ -487,6 +488,7 @@ public class FunctionRegistry
                 .scalars(JoniRegexpCasts.class)
                 .scalars(CharacterStringCasts.class)
                 .scalars(CharOperators.class)
+                .scalars(UnitFunctions.class)
                 .scalar(DecimalOperators.Negation.class)
                 .scalar(DecimalOperators.HashCode.class)
                 .functions(IDENTITY_CAST, CAST_FROM_UNKNOWN)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/UnitFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/UnitFunctions.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import io.airlift.slice.Slice;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * UDFs for reporting values in succinct representations
+ */
+public final class UnitFunctions
+{
+    private UnitFunctions()
+    {
+    }
+
+    @Description("succinct duration string")
+    @ScalarFunction("succinct_duration")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice succinctDuration(@SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.VARCHAR) Slice unit)
+    {
+        try {
+            Duration duration = Duration.succinctDuration(value, valueOfTimeUnit(unit.toStringUtf8()));
+            return utf8Slice(duration.toString());
+        }
+        catch (IllegalArgumentException e) {
+            // When value is negative, NaN, etc.
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
+    }
+
+    @Description("succinct duration string of nanoseconds")
+    @ScalarFunction("succinct_nanos")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice succinctNanos(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        return succinctNanos((double) value);
+    }
+
+    @Description("succinct duration string of nanoseconds")
+    @ScalarFunction("succinct_nanos")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice succinctNanos(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        try {
+            Duration duration = Duration.succinctDuration(value, NANOSECONDS);
+            return utf8Slice(duration.toString());
+        }
+        catch (IllegalArgumentException e) {
+            // When value is negative, etc.
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
+    }
+
+    @Description("succinct duration string of milliseconds")
+    @ScalarFunction("succinct_millis")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice succinctMillis(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        return succinctMillis((double) value);
+    }
+
+    @Description("succinct duration string of milliseconds")
+    @ScalarFunction("succinct_millis")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice succinctMillis(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        try {
+            Duration duration = Duration.succinctDuration(value, MILLISECONDS);
+            return utf8Slice(duration.toString());
+        }
+        catch (IllegalArgumentException e) {
+            // When value is negative, etc.
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
+    }
+
+    @Description("succinct data size string")
+    @ScalarFunction("succinct_data_size")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice succinctDataSize(@SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.VARCHAR) Slice unit)
+    {
+        try {
+            DataSize dataSize = DataSize.succinctDataSize(value, valueOfUnit(unit.toStringUtf8()));
+            return utf8Slice(dataSize.toString());
+        }
+        catch (IllegalArgumentException e) {
+            // When value is negative, NaN, etc.
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
+    }
+
+    @Description("succinct byte size string")
+    @ScalarFunction("succinct_bytes")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice succinctBytes(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        try {
+            DataSize dataSize = DataSize.succinctBytes(value);
+            return utf8Slice(dataSize.toString());
+        }
+        catch (IllegalArgumentException e) {
+            // When value is negative, etc.
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
+    }
+
+    @Description("succinct byte size string")
+    @ScalarFunction("succinct_bytes")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice succinctBytes(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        try {
+            DataSize dataSize = DataSize.succinctDataSize(value, BYTE);
+            return utf8Slice(dataSize.toString());
+        }
+        catch (IllegalArgumentException e) {
+            // When value is negative, etc.
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
+    }
+
+    private static TimeUnit valueOfTimeUnit(String timeUnitString)
+    {
+        try {
+            return Duration.valueOfTimeUnit(timeUnitString);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "TimeUnit string must be one of [ns, us, ms, s, m, h, d]");
+        }
+    }
+
+    private static DataSize.Unit valueOfUnit(String unitString)
+    {
+        for (DataSize.Unit unit : DataSize.Unit.values()) {
+            if (unit.getUnitString().equals(unitString)) {
+                return unit;
+            }
+        }
+        throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Unit string must be one of [B, kB, MB, GB, TB, PB]");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/UnitFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/UnitFunctions.java
@@ -121,7 +121,7 @@ public final class UnitFunctions
         return utf8Slice(dataSize.toString());
     }
 
-    @Description("Returns the succinct string representation of a byte size")
+    @Description("Returns the succinct string representation of a data size specified in bytes")
     @ScalarFunction("succinct_bytes")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctBytes(@SqlType(StandardTypes.BIGINT) long value)
@@ -137,7 +137,7 @@ public final class UnitFunctions
         return utf8Slice(dataSize.toString());
     }
 
-    @Description("Returns the succinct string representation of a byte size")
+    @Description("Returns the succinct string representation of a data size specified in bytes")
     @ScalarFunction("succinct_bytes")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctBytes(@SqlType(StandardTypes.DOUBLE) double value)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/UnitFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/UnitFunctions.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
+import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
 
 import java.util.concurrent.TimeUnit;
@@ -32,7 +33,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
- * UDFs for reporting values in succinct representations
+ * Functions for reporting values in succinct representations
  */
 public final class UnitFunctions
 {
@@ -40,22 +41,23 @@ public final class UnitFunctions
     {
     }
 
-    @Description("succinct duration string")
+    @Description("Returns the succinct string representation of a time value")
     @ScalarFunction("succinct_duration")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctDuration(@SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.VARCHAR) Slice unit)
     {
+        Duration duration;
         try {
-            Duration duration = Duration.succinctDuration(value, valueOfTimeUnit(unit.toStringUtf8()));
-            return utf8Slice(duration.toString());
+            duration = Duration.succinctDuration(value, valueOfTimeUnit(unit.toStringUtf8()));
         }
         catch (IllegalArgumentException e) {
             // When value is negative, NaN, etc.
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
         }
+        return utf8Slice(duration.toString());
     }
 
-    @Description("succinct duration string of nanoseconds")
+    @Description("Returns the succinct string representation of a nanosecond value")
     @ScalarFunction("succinct_nanos")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctNanos(@SqlType(StandardTypes.BIGINT) long value)
@@ -63,22 +65,23 @@ public final class UnitFunctions
         return succinctNanos((double) value);
     }
 
-    @Description("succinct duration string of nanoseconds")
+    @Description("Returns the succinct string representation of a nanosecond value")
     @ScalarFunction("succinct_nanos")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctNanos(@SqlType(StandardTypes.DOUBLE) double value)
     {
+        Duration duration;
         try {
-            Duration duration = Duration.succinctDuration(value, NANOSECONDS);
-            return utf8Slice(duration.toString());
+            duration = Duration.succinctDuration(value, NANOSECONDS);
         }
         catch (IllegalArgumentException e) {
             // When value is negative, etc.
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
         }
+        return utf8Slice(duration.toString());
     }
 
-    @Description("succinct duration string of milliseconds")
+    @Description("Returns the succinct string representation of a millisecond value")
     @ScalarFunction("succinct_millis")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctMillis(@SqlType(StandardTypes.BIGINT) long value)
@@ -86,64 +89,68 @@ public final class UnitFunctions
         return succinctMillis((double) value);
     }
 
-    @Description("succinct duration string of milliseconds")
+    @Description("Returns the succinct string representation of a millisecond value")
     @ScalarFunction("succinct_millis")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctMillis(@SqlType(StandardTypes.DOUBLE) double value)
     {
+        Duration duration;
         try {
-            Duration duration = Duration.succinctDuration(value, MILLISECONDS);
-            return utf8Slice(duration.toString());
+            duration = Duration.succinctDuration(value, MILLISECONDS);
         }
         catch (IllegalArgumentException e) {
             // When value is negative, etc.
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
         }
+        return utf8Slice(duration.toString());
     }
 
-    @Description("succinct data size string")
+    @Description("Returns the succinct string representation of a data size")
     @ScalarFunction("succinct_data_size")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctDataSize(@SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.VARCHAR) Slice unit)
     {
+        DataSize dataSize;
         try {
-            DataSize dataSize = DataSize.succinctDataSize(value, valueOfUnit(unit.toStringUtf8()));
-            return utf8Slice(dataSize.toString());
+            dataSize = DataSize.succinctDataSize(value, valueOfUnit(unit.toStringUtf8()));
         }
         catch (IllegalArgumentException e) {
             // When value is negative, NaN, etc.
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
         }
+        return utf8Slice(dataSize.toString());
     }
 
-    @Description("succinct byte size string")
+    @Description("Returns the succinct string representation of a byte size")
     @ScalarFunction("succinct_bytes")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctBytes(@SqlType(StandardTypes.BIGINT) long value)
     {
+        DataSize dataSize;
         try {
-            DataSize dataSize = DataSize.succinctBytes(value);
-            return utf8Slice(dataSize.toString());
+            dataSize = DataSize.succinctBytes(value);
         }
         catch (IllegalArgumentException e) {
             // When value is negative, etc.
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
         }
+        return utf8Slice(dataSize.toString());
     }
 
-    @Description("succinct byte size string")
+    @Description("Returns the succinct string representation of a byte size")
     @ScalarFunction("succinct_bytes")
     @SqlType(StandardTypes.VARCHAR)
     public static Slice succinctBytes(@SqlType(StandardTypes.DOUBLE) double value)
     {
+        DataSize dataSize;
         try {
-            DataSize dataSize = DataSize.succinctDataSize(value, BYTE);
-            return utf8Slice(dataSize.toString());
+            dataSize = DataSize.succinctDataSize(value, BYTE);
         }
         catch (IllegalArgumentException e) {
             // When value is negative, etc.
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
         }
+        return utf8Slice(dataSize.toString());
     }
 
     private static TimeUnit valueOfTimeUnit(String timeUnitString)
@@ -152,13 +159,13 @@ public final class UnitFunctions
             return Duration.valueOfTimeUnit(timeUnitString);
         }
         catch (IllegalArgumentException e) {
-            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "TimeUnit string must be one of [ns, us, ms, s, m, h, d]");
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Time unit must be one of [ns, us, ms, s, m, h, d]", e);
         }
     }
 
-    private static DataSize.Unit valueOfUnit(String unitString)
+    private static Unit valueOfUnit(String unitString)
     {
-        for (DataSize.Unit unit : DataSize.Unit.values()) {
+        for (Unit unit : Unit.values()) {
             if (unit.getUnitString().equals(unitString)) {
                 return unit;
             }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUnitFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUnitFunctions.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.type.VarcharType;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.airlift.units.DataSize.Unit.PETABYTE;
+import static io.airlift.units.DataSize.Unit.TERABYTE;
+import static io.airlift.units.Duration.succinctDuration;
+import static io.airlift.units.Duration.succinctNanos;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestUnitFunctions
+        extends AbstractTestFunctions
+{
+    private void testDuration(String sqlExpr, Duration expected)
+    {
+        assertFunction(sqlExpr, VarcharType.VARCHAR, expected.toString());
+    }
+
+    @Test
+    public void testSuccinctDuration()
+    {
+        testDuration("succinct_duration(123, 'ns')", succinctNanos(123));
+        testDuration("succinct_duration(123.45, 'ns')", succinctDuration(123.45, NANOSECONDS));
+        testDuration("succinct_duration(123.45, 'us')", succinctDuration(123.45, MICROSECONDS));
+        testDuration("succinct_duration(123.45, 'ms')", succinctDuration(123.45, MILLISECONDS));
+        testDuration("succinct_duration(123.45, 's')", succinctDuration(123.45, SECONDS));
+        testDuration("succinct_duration(12.34, 'm')", succinctDuration(12.34, MINUTES));
+        testDuration("succinct_duration(12.34, 'h')", succinctDuration(12.34, HOURS));
+        testDuration("succinct_duration(12.34, 'd')", succinctDuration(12.34, DAYS));
+        testDuration("succinct_duration(3600, 's')", new Duration(1.00, HOURS));
+
+        testDuration("succinct_nanos(123)", succinctNanos(123));
+        testDuration("succinct_nanos(123.4)", succinctDuration(123.4, NANOSECONDS));
+        testDuration("succinct_nanos(123456)", new Duration(123.456, MICROSECONDS));
+        testDuration("succinct_millis(123)", succinctDuration(123, MILLISECONDS));
+        testDuration("succinct_millis(123.4)", succinctDuration(123.4, MILLISECONDS));
+        testDuration("succinct_millis(1234)", new Duration(1.234, SECONDS));
+
+        assertInvalidFunction("succinct_duration(-1, 'ns')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_duration(123, 'sec')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_nanos(-123)", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_millis(-123)", INVALID_FUNCTION_ARGUMENT);
+    }
+
+    private void testDataSize(String sqlExpr, DataSize expected)
+    {
+        assertFunction(sqlExpr, VarcharType.VARCHAR, expected.toString());
+    }
+
+    @Test
+    public void testSuccinctDataSize()
+    {
+        testDataSize("succinct_data_size(123, 'B')", DataSize.succinctDataSize(123, BYTE));
+        testDataSize("succinct_data_size(123, 'kB')", DataSize.succinctDataSize(123, KILOBYTE));
+        testDataSize("succinct_data_size(123, 'MB')", DataSize.succinctDataSize(123, MEGABYTE));
+        testDataSize("succinct_data_size(123, 'TB')", DataSize.succinctDataSize(123, TERABYTE));
+        testDataSize("succinct_data_size(123, 'PB')", DataSize.succinctDataSize(123, PETABYTE));
+
+        testDataSize("succinct_data_size(5.5 * 1024, 'kB')", DataSize.succinctDataSize(5.5, MEGABYTE));
+        testDataSize("succinct_data_size(2048, 'MB')", new DataSize(2.00, GIGABYTE));
+
+        testDataSize("succinct_bytes(1024 * 1024)", new DataSize(1.00, MEGABYTE));
+        testDataSize("succinct_bytes(123)", DataSize.succinctBytes(123));
+        testDataSize("succinct_bytes(123.45)", DataSize.succinctDataSize(123.45, BYTE));
+        testDataSize("succinct_bytes(5.5 * 1024)", DataSize.succinctBytes((long) (5.5 * 1024)));
+        testDataSize("succinct_bytes(12345)", DataSize.succinctBytes(12345));
+        testDataSize("succinct_bytes(123456789)", DataSize.succinctBytes(123456789));
+        testDataSize("succinct_bytes(1000000000)", DataSize.succinctBytes(1_000_000_000L));
+        testDataSize("succinct_bytes(1000000000000)", DataSize.succinctBytes(1_000_000_000_000L));
+        testDataSize("succinct_bytes(1000000000000000)", DataSize.succinctBytes(1_000_000_000_000_000L));
+        testDataSize("succinct_bytes(1000000000000000000)", DataSize.succinctBytes(1_000_000_000_000_000_000L));
+
+        assertInvalidFunction("succinct_data_size(123, 'xx')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_data_size(-1, 'B')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_bytes(-1)", INVALID_FUNCTION_ARGUMENT);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUnitFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestUnitFunctions.java
@@ -39,9 +39,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class TestUnitFunctions
         extends AbstractTestFunctions
 {
-    private void testDuration(String sqlExpr, Duration expected)
+    private void testDuration(String sqlExpression, Duration expected)
     {
-        assertFunction(sqlExpr, VarcharType.VARCHAR, expected.toString());
+        assertFunction(sqlExpression, VarcharType.VARCHAR, expected.toString());
     }
 
     @Test
@@ -64,15 +64,33 @@ public class TestUnitFunctions
         testDuration("succinct_millis(123.4)", succinctDuration(123.4, MILLISECONDS));
         testDuration("succinct_millis(1234)", new Duration(1.234, SECONDS));
 
+        // bigint
         assertInvalidFunction("succinct_duration(-1, 'ns')", INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("succinct_duration(123, 'sec')", INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("succinct_nanos(-123)", INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("succinct_millis(-123)", INVALID_FUNCTION_ARGUMENT);
+
+        // double
+        assertInvalidFunction("succinct_duration(-1.2, 'ns')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_duration(123.45, 'sec')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_nanos(-123.4)", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_millis(-123.4)", INVALID_FUNCTION_ARGUMENT);
+
+        // NaN
+        assertInvalidFunction("succinct_duration(nan(), 'ns')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_duration(infinity(), 'ns')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_duration(-infinity(), 'ns')", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_nanos(nan())", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_nanos(infinity())", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_nanos(-infinity())", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_millis(nan())", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_millis(+infinity())", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("succinct_millis(-infinity())", INVALID_FUNCTION_ARGUMENT);
     }
 
-    private void testDataSize(String sqlExpr, DataSize expected)
+    private void testDataSize(String sqlExpression, DataSize expected)
     {
-        assertFunction(sqlExpr, VarcharType.VARCHAR, expected.toString());
+        assertFunction(sqlExpression, VarcharType.VARCHAR, expected.toString());
     }
 
     @Test


### PR DESCRIPTION
We often need to analyze Presto's query usage (processed bytes, CPU time, etc.) with Presto. In this case, having succinct_xxx functions in airlift-unit as Presto UDFs is convenient. 

For example, we need to write a conversion from Bytes to GB in SQL like this: `round(cast(total_processed_bytes as double) / 1024 / 1024 / 1024, 2)`, but with `succinct_bytes` UDF, we can simply type `succinct_bytes(total_processed_bytes)`.