### PR TITLE
Update deprecated use of AWS SDK & Guava methods in PrestoS3FileSystem

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3ConfigurationUpdater.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3ConfigurationUpdater.java
@@ -87,42 +87,42 @@ public class PrestoS3ConfigurationUpdater
         config.set("fs.s3n.impl", PrestoS3FileSystem.class.getName());
 
         if (awsAccessKey != null) {
-            config.set(PrestoS3FileSystem.S3_ACCESS_KEY, awsAccessKey);
+            config.set(S3_ACCESS_KEY, awsAccessKey);
         }
         if (awsSecretKey != null) {
-            config.set(PrestoS3FileSystem.S3_SECRET_KEY, awsSecretKey);
+            config.set(S3_SECRET_KEY, awsSecretKey);
         }
         if (endpoint != null) {
-            config.set(PrestoS3FileSystem.S3_ENDPOINT, endpoint);
+            config.set(S3_ENDPOINT, endpoint);
         }
         if (signerType != null) {
-            config.set(PrestoS3FileSystem.S3_SIGNER_TYPE, signerType.name());
+            config.set(S3_SIGNER_TYPE, signerType.name());
         }
-        config.setBoolean(PrestoS3FileSystem.S3_PATH_STYLE_ACCESS, pathStyleAccess);
-        config.setBoolean(PrestoS3FileSystem.S3_USE_INSTANCE_CREDENTIALS, useInstanceCredentials);
-        config.setBoolean(PrestoS3FileSystem.S3_SSL_ENABLED, sslEnabled);
-        config.setBoolean(PrestoS3FileSystem.S3_SSE_ENABLED, sseEnabled);
-        config.set(PrestoS3FileSystem.S3_SSE_TYPE, sseType.name());
+        config.setBoolean(S3_PATH_STYLE_ACCESS, pathStyleAccess);
+        config.setBoolean(S3_USE_INSTANCE_CREDENTIALS, useInstanceCredentials);
+        config.setBoolean(S3_SSL_ENABLED, sslEnabled);
+        config.setBoolean(S3_SSE_ENABLED, sseEnabled);
+        config.set(S3_SSE_TYPE, sseType.name());
         if (encryptionMaterialsProvider != null) {
-            config.set(PrestoS3FileSystem.S3_ENCRYPTION_MATERIALS_PROVIDER, encryptionMaterialsProvider);
+            config.set(S3_ENCRYPTION_MATERIALS_PROVIDER, encryptionMaterialsProvider);
         }
         if (kmsKeyId != null) {
-            config.set(PrestoS3FileSystem.S3_KMS_KEY_ID, kmsKeyId);
+            config.set(S3_KMS_KEY_ID, kmsKeyId);
         }
         if (sseKmsKeyId != null) {
-            config.set(PrestoS3FileSystem.S3_SSE_KMS_KEY_ID, sseKmsKeyId);
+            config.set(S3_SSE_KMS_KEY_ID, sseKmsKeyId);
         }
-        config.setInt(PrestoS3FileSystem.S3_MAX_CLIENT_RETRIES, maxClientRetries);
-        config.setInt(PrestoS3FileSystem.S3_MAX_ERROR_RETRIES, maxErrorRetries);
-        config.set(PrestoS3FileSystem.S3_MAX_BACKOFF_TIME, maxBackoffTime.toString());
-        config.set(PrestoS3FileSystem.S3_MAX_RETRY_TIME, maxRetryTime.toString());
-        config.set(PrestoS3FileSystem.S3_CONNECT_TIMEOUT, connectTimeout.toString());
-        config.set(PrestoS3FileSystem.S3_SOCKET_TIMEOUT, socketTimeout.toString());
-        config.set(PrestoS3FileSystem.S3_STAGING_DIRECTORY, stagingDirectory.toString());
-        config.setInt(PrestoS3FileSystem.S3_MAX_CONNECTIONS, maxConnections);
-        config.setLong(PrestoS3FileSystem.S3_MULTIPART_MIN_FILE_SIZE, multipartMinFileSize.toBytes());
-        config.setLong(PrestoS3FileSystem.S3_MULTIPART_MIN_PART_SIZE, multipartMinPartSize.toBytes());
-        config.setBoolean(PrestoS3FileSystem.S3_PIN_CLIENT_TO_CURRENT_REGION, pinClientToCurrentRegion);
-        config.set(PrestoS3FileSystem.S3_USER_AGENT_PREFIX, userAgentPrefix);
+        config.setInt(S3_MAX_CLIENT_RETRIES, maxClientRetries);
+        config.setInt(S3_MAX_ERROR_RETRIES, maxErrorRetries);
+        config.set(S3_MAX_BACKOFF_TIME, maxBackoffTime.toString());
+        config.set(S3_MAX_RETRY_TIME, maxRetryTime.toString());
+        config.set(S3_CONNECT_TIMEOUT, connectTimeout.toString());
+        config.set(S3_SOCKET_TIMEOUT, socketTimeout.toString());
+        config.set(S3_STAGING_DIRECTORY, stagingDirectory.toString());
+        config.setInt(S3_MAX_CONNECTIONS, maxConnections);
+        config.setLong(S3_MULTIPART_MIN_FILE_SIZE, multipartMinFileSize.toBytes());
+        config.setLong(S3_MULTIPART_MIN_PART_SIZE, multipartMinPartSize.toBytes());
+        config.setBoolean(S3_PIN_CLIENT_TO_CURRENT_REGION, pinClientToCurrentRegion);
+        config.set(S3_USER_AGENT_PREFIX, userAgentPrefix);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -49,7 +49,6 @@ import com.amazonaws.services.s3.transfer.TransferManagerConfiguration;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.facebook.presto.hadoop.HadoopFileStatus;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.Iterators;
 import io.airlift.log.Logger;
@@ -122,6 +121,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.Iterables.toArray;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.Math.max;
@@ -565,7 +565,7 @@ public class PrestoS3FileSystem
                                         throw new UnrecoverableS3OperationException(path, e);
                                 }
                             }
-                            throw Throwables.propagate(e);
+                            throw e;
                         }
                     });
         }
@@ -575,7 +575,8 @@ public class PrestoS3FileSystem
         }
         catch (Exception e) {
             throwIfInstanceOf(e, IOException.class);
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -831,7 +832,8 @@ public class PrestoS3FileSystem
             }
             catch (Exception e) {
                 throwIfInstanceOf(e, IOException.class);
-                throw Throwables.propagate(e);
+                throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -919,7 +921,8 @@ public class PrestoS3FileSystem
             }
             catch (Exception e) {
                 throwIfInstanceOf(e, IOException.class);
-                throw Throwables.propagate(e);
+                throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/S3ConfigurationUpdater.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/S3ConfigurationUpdater.java
@@ -17,5 +17,32 @@ import org.apache.hadoop.conf.Configuration;
 
 public interface S3ConfigurationUpdater
 {
+    String S3_USER_AGENT_SUFFIX = "presto";
+    String S3_USER_AGENT_PREFIX = "presto.s3.user-agent-prefix";
+    String S3_CREDENTIALS_PROVIDER = "presto.s3.credentials-provider";
+    String S3_SSE_TYPE = "presto.s3.sse.type";
+    String S3_SSE_ENABLED = "presto.s3.sse.enabled";
+    String S3_SSE_KMS_KEY_ID = "presto.s3.sse.kms-key-id";
+    String S3_KMS_KEY_ID = "presto.s3.kms-key-id";
+    String S3_ENCRYPTION_MATERIALS_PROVIDER = "presto.s3.encryption-materials-provider";
+    String S3_PIN_CLIENT_TO_CURRENT_REGION = "presto.s3.pin-client-to-current-region";
+    String S3_USE_INSTANCE_CREDENTIALS = "presto.s3.use-instance-credentials";
+    String S3_MULTIPART_MIN_PART_SIZE = "presto.s3.multipart.min-part-size";
+    String S3_MULTIPART_MIN_FILE_SIZE = "presto.s3.multipart.min-file-size";
+    String S3_STAGING_DIRECTORY = "presto.s3.staging-directory";
+    String S3_MAX_CONNECTIONS = "presto.s3.max-connections";
+    String S3_SOCKET_TIMEOUT = "presto.s3.socket-timeout";
+    String S3_CONNECT_TIMEOUT = "presto.s3.connect-timeout";
+    String S3_MAX_RETRY_TIME = "presto.s3.max-retry-time";
+    String S3_MAX_BACKOFF_TIME = "presto.s3.max-backoff-time";
+    String S3_MAX_CLIENT_RETRIES = "presto.s3.max-client-retries";
+    String S3_MAX_ERROR_RETRIES = "presto.s3.max-error-retries";
+    String S3_SSL_ENABLED = "presto.s3.ssl.enabled";
+    String S3_PATH_STYLE_ACCESS = "presto.s3.path-style-access";
+    String S3_SIGNER_TYPE = "presto.s3.signer-type";
+    String S3_ENDPOINT = "presto.s3.endpoint";
+    String S3_SECRET_KEY = "presto.s3.secret-key";
+    String S3_ACCESS_KEY = "presto.s3.access-key";
+
     void updateConfiguration(Configuration config);
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -43,16 +43,21 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
 
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_CREDENTIALS_PROVIDER;
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_ENCRYPTION_MATERIALS_PROVIDER;
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_KMS_KEY_ID;
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_MAX_BACKOFF_TIME;
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_MAX_CLIENT_RETRIES;
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_MAX_RETRY_TIME;
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_PATH_STYLE_ACCESS;
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_USER_AGENT_PREFIX;
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_USER_AGENT_SUFFIX;
-import static com.facebook.presto.hive.s3.PrestoS3FileSystem.S3_USE_INSTANCE_CREDENTIALS;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ACCESS_KEY;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_CREDENTIALS_PROVIDER;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ENCRYPTION_MATERIALS_PROVIDER;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ENDPOINT;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_KMS_KEY_ID;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_MAX_BACKOFF_TIME;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_MAX_CLIENT_RETRIES;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_MAX_RETRY_TIME;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_PATH_STYLE_ACCESS;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SECRET_KEY;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SIGNER_TYPE;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_STAGING_DIRECTORY;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_USER_AGENT_PREFIX;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_USER_AGENT_SUFFIX;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_USE_INSTANCE_CREDENTIALS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -73,8 +78,8 @@ public class TestPrestoS3FileSystem
             throws Exception
     {
         Configuration config = new Configuration();
-        config.set(PrestoS3FileSystem.S3_ACCESS_KEY, "test_secret_access_key");
-        config.set(PrestoS3FileSystem.S3_SECRET_KEY, "test_access_key_id");
+        config.set(S3_ACCESS_KEY, "test_secret_access_key");
+        config.set(S3_SECRET_KEY, "test_access_key_id");
         // the static credentials should be preferred
 
         try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
@@ -88,10 +93,10 @@ public class TestPrestoS3FileSystem
             throws Exception
     {
         Configuration config = new Configuration();
-        config.set(PrestoS3FileSystem.S3_ACCESS_KEY, "test_secret_access_key");
-        config.set(PrestoS3FileSystem.S3_SECRET_KEY, "test_access_key_id");
-        config.set(PrestoS3FileSystem.S3_ENDPOINT, "test.example.endpoint.com");
-        config.set(PrestoS3FileSystem.S3_SIGNER_TYPE, "S3SignerType");
+        config.set(S3_ACCESS_KEY, "test_secret_access_key");
+        config.set(S3_SECRET_KEY, "test_access_key_id");
+        config.set(S3_ENDPOINT, "test.example.endpoint.com");
+        config.set(S3_SIGNER_TYPE, "S3SignerType");
         // the static credentials should be preferred
 
         try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
@@ -250,7 +255,7 @@ public class TestPrestoS3FileSystem
         try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
             Configuration conf = new Configuration();
-            conf.set(PrestoS3FileSystem.S3_STAGING_DIRECTORY, staging.toString());
+            conf.set(S3_STAGING_DIRECTORY, staging.toString());
             fs.initialize(new URI("s3n://test-bucket/"), conf);
             fs.setS3Client(s3);
             FSDataOutputStream stream = fs.create(new Path("s3n://test-bucket/test"));
@@ -272,7 +277,7 @@ public class TestPrestoS3FileSystem
         try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
             MockAmazonS3 s3 = new MockAmazonS3();
             Configuration conf = new Configuration();
-            conf.set(PrestoS3FileSystem.S3_STAGING_DIRECTORY, staging.toString());
+            conf.set(S3_STAGING_DIRECTORY, staging.toString());
             fs.initialize(new URI("s3n://test-bucket/"), conf);
             fs.setS3Client(s3);
             fs.create(new Path("s3n://test-bucket/test"));
@@ -302,7 +307,7 @@ public class TestPrestoS3FileSystem
             try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
                 MockAmazonS3 s3 = new MockAmazonS3();
                 Configuration conf = new Configuration();
-                conf.set(PrestoS3FileSystem.S3_STAGING_DIRECTORY, link.toString());
+                conf.set(S3_STAGING_DIRECTORY, link.toString());
                 fs.initialize(new URI("s3n://test-bucket/"), conf);
                 fs.setS3Client(s3);
                 FSDataOutputStream stream = fs.create(new Path("s3n://test-bucket/test"));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -27,6 +27,7 @@ import com.amazonaws.services.s3.model.EncryptionMaterials;
 import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
 import com.facebook.presto.hive.s3.PrestoS3FileSystem.UnrecoverableS3OperationException;
 import com.google.common.base.Throwables;
+import com.google.common.base.VerifyException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -52,6 +53,7 @@ import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_MAX_BACKOFF_
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_MAX_CLIENT_RETRIES;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_MAX_RETRY_TIME;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_PATH_STYLE_ACCESS;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_PIN_CLIENT_TO_CURRENT_REGION;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SECRET_KEY;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SIGNER_TYPE;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_STAGING_DIRECTORY;
@@ -102,6 +104,18 @@ public class TestPrestoS3FileSystem
         try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
             fs.initialize(new URI("s3a://test-bucket/"), config);
             assertInstanceOf(getAwsCredentialsProvider(fs), AWSStaticCredentialsProvider.class);
+        }
+    }
+
+    @Test(expectedExceptions = VerifyException.class, expectedExceptionsMessageRegExp = "Invalid configuration: either endpoint can be set or S3 client can be pinned to the current region")
+    public void testEndpointWithPinToCurrentRegionConfiguration()
+            throws Exception
+    {
+        Configuration config = new Configuration();
+        config.set(S3_ENDPOINT, "test.example.endpoint.com");
+        config.set(S3_PIN_CLIENT_TO_CURRENT_REGION, "true");
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI("s3a://test-bucket/"), config);
         }
     }
 


### PR DESCRIPTION
This PR updates the deprecated use of various AWS SDK and Guava methods in `PrestoS3FileSystem`. I also moved the config key constants from `PrestoS3FileSystem` to `S3ConfigurationUpdater` as that list is getting bigger and bigger.

@z-york @avirtuos I will appreciate if you guys can also take a look and run this in your test environment as we don't have one.