### PR TITLE
Update Maven resolver library to 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -605,7 +605,7 @@
             <dependency>
                 <groupId>io.airlift.resolver</groupId>
                 <artifactId>resolver</artifactId>
-                <version>1.3</version>
+                <version>1.4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This fixes the server starting in development mode due to Airbase
now having a profile with JDK version activation.

Fixes #9592