### PR TITLE
Remove driver peak memory reservation stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -388,7 +388,6 @@ public class QueryMonitor
                                     ofMillis(driverStats.getRawInputReadTime().toMillis()),
                                     driverStats.getRawInputPositions(),
                                     driverStats.getRawInputDataSize().toBytes(),
-                                    driverStats.getPeakMemoryReservation().toBytes(),
                                     timeToStart,
                                     timeToEnd),
                             splitFailureMetadata,

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -22,7 +22,6 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.stats.CounterStat;
 import io.airlift.units.DataSize;
@@ -395,7 +394,6 @@ public class DriverContext
                 queuedTime.convertToMostSuccinctTimeUnit(),
                 elapsedTime.convertToMostSuccinctTimeUnit(),
                 succinctBytes(driverMemoryContext.getUserMemory()),
-                succinctBytes(getPeakUserMemory()),
                 succinctBytes(driverMemoryContext.getRevocableMemory()),
                 succinctBytes(driverMemoryContext.getSystemMemory()),
                 new Duration(totalScheduledTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
@@ -413,14 +411,6 @@ public class DriverContext
                 outputPositions,
                 succinctBytes(physicalWrittenDataSize),
                 ImmutableList.copyOf(transform(operatorContexts, OperatorContext::getOperatorStats)));
-    }
-
-    private long getPeakUserMemory()
-    {
-        if (operatorContexts.isEmpty()) {
-            return 0L;
-        }
-        return Ordering.natural().max(transform(operatorContexts, OperatorContext::getPeakUserMemory));
     }
 
     public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverStats.java
@@ -43,7 +43,6 @@ public class DriverStats
     private final Duration elapsedTime;
 
     private final DataSize memoryReservation;
-    private final DataSize peakMemoryReservation;
     private final DataSize revocableMemoryReservation;
     private final DataSize systemMemoryReservation;
 
@@ -77,7 +76,6 @@ public class DriverStats
         this.elapsedTime = new Duration(0, MILLISECONDS);
 
         this.memoryReservation = new DataSize(0, BYTE);
-        this.peakMemoryReservation = new DataSize(0, BYTE);
         this.revocableMemoryReservation = new DataSize(0, BYTE);
         this.systemMemoryReservation = new DataSize(0, BYTE);
 
@@ -112,7 +110,6 @@ public class DriverStats
             @JsonProperty("elapsedTime") Duration elapsedTime,
 
             @JsonProperty("memoryReservation") DataSize memoryReservation,
-            @JsonProperty("peakMemoryReservation") DataSize peakMemoryReservation,
             @JsonProperty("revocableMemoryReservation") DataSize revocableMemoryReservation,
             @JsonProperty("systemMemoryReservation") DataSize systemMemoryReservation,
 
@@ -144,7 +141,6 @@ public class DriverStats
         this.elapsedTime = requireNonNull(elapsedTime, "elapsedTime is null");
 
         this.memoryReservation = requireNonNull(memoryReservation, "memoryReservation is null");
-        this.peakMemoryReservation = requireNonNull(peakMemoryReservation, "peakMemoryReservation is null");
         this.revocableMemoryReservation = requireNonNull(revocableMemoryReservation, "revocableMemoryReservation is null");
         this.systemMemoryReservation = requireNonNull(systemMemoryReservation, "systemMemoryReservation is null");
 
@@ -209,12 +205,6 @@ public class DriverStats
     public DataSize getMemoryReservation()
     {
         return memoryReservation;
-    }
-
-    @JsonProperty
-    public DataSize getPeakMemoryReservation()
-    {
-        return peakMemoryReservation;
     }
 
     @JsonProperty

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriverStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriverStats.java
@@ -38,7 +38,6 @@ public class TestDriverStats
             new Duration(5, NANOSECONDS),
 
             new DataSize(6, BYTE),
-            new DataSize(20, BYTE),
             new DataSize(7, BYTE),
             new DataSize(8, BYTE),
 
@@ -83,7 +82,6 @@ public class TestDriverStats
         assertEquals(actual.getElapsedTime(), new Duration(5, NANOSECONDS));
 
         assertEquals(actual.getMemoryReservation(), new DataSize(6, BYTE));
-        assertEquals(actual.getPeakMemoryReservation(), new DataSize(20, BYTE));
         assertEquals(actual.getRevocableMemoryReservation(), new DataSize(7, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(8, BYTE));
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/SplitStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/SplitStatistics.java
@@ -29,8 +29,6 @@ public class SplitStatistics
     private final long completedPositions;
     private final long completedDataSizeBytes;
 
-    private final long peakMemoryReservation;
-
     private final Optional<Duration> timeToFirstByte;
     private final Optional<Duration> timeToLastByte;
 
@@ -42,7 +40,6 @@ public class SplitStatistics
             Duration completedReadTime,
             long completedPositions,
             long completedDataSizeBytes,
-            long peakMemoryReservation,
             Optional<Duration> timeToFirstByte,
             Optional<Duration> timeToLastByte)
     {
@@ -53,7 +50,6 @@ public class SplitStatistics
         this.completedReadTime = requireNonNull(completedReadTime, "completedReadTime is null");
         this.completedPositions = completedPositions;
         this.completedDataSizeBytes = completedDataSizeBytes;
-        this.peakMemoryReservation = peakMemoryReservation;
         this.timeToFirstByte = requireNonNull(timeToFirstByte, "timeToFirstByte is null");
         this.timeToLastByte = requireNonNull(timeToLastByte, "timeToLastByte is null");
     }
@@ -91,11 +87,6 @@ public class SplitStatistics
     public long getCompletedDataSizeBytes()
     {
         return completedDataSizeBytes;
-    }
-
-    public long getPeakMemoryReservation()
-    {
-        return peakMemoryReservation;
     }
 
     public Optional<Duration> getTimeToFirstByte()


### PR DESCRIPTION
    This change removes it for mainly two reasons: (as discussed offline)
    - It's non-trivial to collect these stats with the new memory tracking framework
    - These stats are not used much, so it will probably not pay off to collect them