### PR TITLE
Fail query gracefully when polling page errors out

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -44,6 +44,8 @@ public interface QueryManager
 
     QueryInfo createQuery(SessionContext sessionContext, String query);
 
+    void failQuery(QueryId queryId, Throwable cause);
+
     void cancelQuery(QueryId queryId);
 
     void cancelStage(StageId stageId);

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -495,6 +495,18 @@ public class SqlQueryManager
     }
 
     @Override
+    public void failQuery(QueryId queryId, Throwable cause)
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(cause, "cause is null");
+
+        QueryExecution query = queries.get(queryId);
+        if (query != null) {
+            query.fail(cause);
+        }
+    }
+
+    @Override
     public void cancelQuery(QueryId queryId)
     {
         requireNonNull(queryId, "queryId is null");

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -313,23 +313,30 @@ class Query
         // client while holding the lock because the query may transition to the finished state when the
         // last page is removed.  If another thread observes this state before the response is cached
         // the pages will be lost.
-        ImmutableList.Builder<RowIterable> pages = ImmutableList.builder();
-        long bytes = 0;
-        long rows = 0;
-        while (bytes < DESIRED_RESULT_BYTES) {
-            SerializedPage serializedPage = exchangeClient.pollPage();
-            if (serializedPage == null) {
-                break;
+        Iterable<List<Object>> data = null;
+        try {
+            ImmutableList.Builder<RowIterable> pages = ImmutableList.builder();
+            long bytes = 0;
+            long rows = 0;
+            while (bytes < DESIRED_RESULT_BYTES) {
+                SerializedPage serializedPage = exchangeClient.pollPage();
+                if (serializedPage == null) {
+                    break;
+                }
+
+                Page page = serde.deserialize(serializedPage);
+                bytes += page.getSizeInBytes();
+                rows += page.getPositionCount();
+                pages.add(new RowIterable(session.toConnectorSession(), types, page));
             }
-
-            Page page = serde.deserialize(serializedPage);
-            bytes += page.getSizeInBytes();
-            rows += page.getPositionCount();
-            pages.add(new RowIterable(session.toConnectorSession(), types, page));
+            if (rows > 0) {
+                // client implementations do not properly handle empty list of data
+                data = Iterables.concat(pages.build());
+            }
         }
-
-        // client implementations do not properly handle empty list of data
-        Iterable<List<Object>> data = (rows == 0) ? null : Iterables.concat(pages.build());
+        catch (Throwable cause) {
+            queryManager.failQuery(queryId, cause);
+        }
 
         // get the query info before returning
         // force update if query manager is closed

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.QueryState;
+import com.facebook.presto.execution.TestingSessionContext;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.QueryId;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+@Test(singleThreaded = true)
+public class TestQueryManager
+{
+    private DistributedQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        queryRunner = createQueryRunner();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+    }
+
+    @Test(timeOut = 60_000L)
+    public void testFailQuery()
+            throws Exception
+    {
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        QueryId queryId = queryManager.createQuery(new TestingSessionContext(TEST_SESSION),
+                "SELECT * FROM lineitem").getQueryId();
+
+        // wait until query starts running
+        while (true) {
+            QueryInfo queryInfo = queryManager.getQueryInfo(queryId);
+            if (queryInfo.getState().isDone()) {
+                fail("unexpected query state: " + queryInfo.getState());
+            }
+            if (queryInfo.getState() == RUNNING) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+
+        // cancel query
+        queryManager.failQuery(queryId, new PrestoException(GENERIC_INTERNAL_ERROR, "mock exception"));
+        QueryInfo queryInfo = queryManager.getQueryInfo(queryId);
+        assertEquals(queryInfo.getState(), QueryState.FAILED);
+        assertEquals(queryInfo.getErrorCode(), GENERIC_INTERNAL_ERROR.toErrorCode());
+        assertNotNull(queryInfo.getFailureInfo());
+        assertEquals(queryInfo.getFailureInfo().getMessage(), "mock exception");
+    }
+}


### PR DESCRIPTION
When coordinator is pulling data from workers, pollPage can throw errors
causing returning 500 response back to the client with stacktraces.
However, the query can still be alive given no one can kill it. The
patch catches the exception, fails the query, and returns normal 200
response to the client.