### PR TITLE
Fix packages in presto-product-tests

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/blackhole/BlackHoleConnector.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/blackhole/BlackHoleConnector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.tests.nullconnector;
+package com.facebook.presto.tests.blackhole;
 
 import com.teradata.tempto.query.QueryResult;
 import org.testng.annotations.Test;

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/teradata/TestTeradataFunctions.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/teradata/TestTeradataFunctions.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.tests.querygrid;
+package com.facebook.presto.tests.teradata;
 
 import com.teradata.tempto.ProductTest;
 import org.testng.annotations.Test;


### PR DESCRIPTION
Fix packages in presto-product-tests

Querygrid relates to one of the Teradata product, there is no much sense
to use it name it here. Using Teradata would be just enough.

Also there is no longer such thing like nullconnector, so renaming it to
blackhole.
