### PR TITLE
Use SSL with port 443 as default

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -18,6 +18,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 
 import java.io.File;
+import java.net.URI;
+import java.sql.SQLException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -143,6 +145,23 @@ final class ConnectionProperties
         public Ssl()
         {
             super("SSL", Optional.of("false"), NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+        }
+
+        @Override
+        public Boolean getRequiredValue(URI uri, Properties properties) throws SQLException
+        {
+            if (uri.getPort() == 443) {
+                // Always enable SSL in case of using port 443 unless disabling SSL explicitly.
+                if (uri.getQuery() != null && uri.getQuery().contains("SSL=false")) {
+                    return false;
+                }
+                else {
+                    return true;
+                }
+            }
+            else {
+                return getRequiredValue(properties);
+            }
         }
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperty.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperty.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.jdbc;
 
+import java.net.URI;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Optional;
@@ -40,6 +41,13 @@ interface ConnectionProperty<T>
     {
         return getValue(properties).orElseThrow(() ->
                 new SQLException(format("Connection property '%s' is required", getKey())));
+    }
+
+    // Required value can be decided dynamically by given URI and properties.
+    default T getRequiredValue(URI uri, Properties properties)
+            throws SQLException
+    {
+        return getRequiredValue(properties);
     }
 
     void validate(Properties properties)

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -90,7 +90,7 @@ final class PrestoDriverUri
 
         validateConnectionProperties(properties);
 
-        useSecureConnection = SSL.getRequiredValue(properties);
+        useSecureConnection = SSL.getRequiredValue(uri, properties);
 
         initCatalogAndSchema();
     }

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -154,14 +154,6 @@ public class TestPrestoDriverUri
     }
 
     @Test
-    public void testUriWithSslPortDoesNotUseSsl()
-            throws SQLException
-    {
-        PrestoDriverUri parameters = createDriverUri("presto://somelocalhost:443/blackhole");
-        assertUriPortScheme(parameters, 443, "http");
-    }
-
-    @Test
     public void testUriWithSslDisabled()
             throws SQLException
     {
@@ -175,6 +167,26 @@ public class TestPrestoDriverUri
     {
         PrestoDriverUri parameters = createDriverUri("presto://localhost:8080/blackhole?SSL=true");
         assertUriPortScheme(parameters, 8080, "https");
+
+        Properties properties = parameters.getProperties();
+        assertNull(properties.getProperty(SSL_TRUST_STORE_PATH.getKey()));
+        assertNull(properties.getProperty(SSL_TRUST_STORE_PASSWORD.getKey()));
+    }
+
+    @Test
+    public void testUriWithSslDisabledUsing443()
+            throws SQLException
+    {
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:443/blackhole?SSL=false");
+        assertUriPortScheme(parameters, 443, "http");
+    }
+
+    @Test
+    public void testUriWithSslEnabledUsing443()
+            throws SQLException
+    {
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:443/blackhole");
+        assertUriPortScheme(parameters, 443, "https");
 
         Properties properties = parameters.getProperties();
         assertNull(properties.getProperty(SSL_TRUST_STORE_PATH.getKey()));


### PR DESCRIPTION
Default value can be decided with URI and properties dynamically. We can make `ConnectionProperties` receive URI and properties.

see: https://github.com/prestodb/presto/issues/8577