### PR TITLE
Remove unused imports

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
@@ -43,9 +43,6 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantTrue;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invokeDynamic;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentType.VALUE_TYPE;
-import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
-import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_BOXED_TYPE;
-import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_NULL_FLAG;
 import static com.facebook.presto.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;


### PR DESCRIPTION
Checkstyle didn't catch them as unused, because the enum names are used in a switch statement -(of course this doesn't require an import, but seems enough to mislead the checkstyle)