### PR TITLE
[Benchmark] Benchmark support directly writing to output block builder for scalar functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -214,6 +214,8 @@ import static com.facebook.presto.operator.aggregation.MultimapAggregationFuncti
 import static com.facebook.presto.operator.scalar.ArrayConcatFunction.ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayConstructor.ARRAY_CONSTRUCTOR;
 import static com.facebook.presto.operator.scalar.ArrayFlattenFunction.ARRAY_FLATTEN_FUNCTION;
+import static com.facebook.presto.operator.scalar.ArrayIdentityDirectFunction.ARRAY_IDENTITY_DIRECT_FUNCTION;
+import static com.facebook.presto.operator.scalar.ArrayIdentityFunction.ARRAY_IDENTITY_FUNCTION;
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN;
 import static com.facebook.presto.operator.scalar.ArrayJoin.ARRAY_JOIN_WITH_NULL_REPLACEMENT;
 import static com.facebook.presto.operator.scalar.ArrayReduceFunction.ARRAY_REDUCE_FUNCTION;
@@ -546,6 +548,7 @@ public class FunctionRegistry
                 .function(MAP_ELEMENT_AT)
                 .function(MAP_CONCAT_FUNCTION)
                 .function(ARRAY_FLATTEN_FUNCTION)
+                .functions(ARRAY_IDENTITY_DIRECT_FUNCTION, ARRAY_IDENTITY_FUNCTION)
                 .function(ARRAY_CONCAT_FUNCTION)
                 .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_TO_JSON, JSON_TO_ARRAY, JSON_STRING_TO_ARRAY)
                 .functions(new MapSubscriptOperator(featuresConfig.isLegacyMapSubscript()))

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
@@ -101,6 +101,7 @@ public final class ArrayConcatFunction
                 nCopies(arity, Optional.empty()),
                 methodHandleAndConstructor.getMethodHandle(),
                 Optional.of(methodHandleAndConstructor.getConstructor()),
+                false,
                 isDeterministic());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIdentityDirectFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIdentityDirectFunction.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayIdentityDirectFunction
+        extends SqlScalarFunction
+{
+    public static final ArrayIdentityDirectFunction ARRAY_IDENTITY_DIRECT_FUNCTION = new ArrayIdentityDirectFunction();
+    private static final String FUNCTION_NAME = "array_identity_direct";
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayIdentityDirectFunction.class, "identity", Type.class, Type.class, BlockBuilder.class, Block.class);
+
+    private ArrayIdentityDirectFunction()
+    {
+        super(new Signature(FUNCTION_NAME,
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("E")),
+                ImmutableList.of(),
+                parseTypeSignature("array(E)"),
+                ImmutableList.of(parseTypeSignature("array(E)")),
+                false));
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "array identity";
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type elementType = boundVariables.getTypeVariable("E");
+        Type arrayType = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(TypeSignatureParameter.of(elementType.getTypeSignature())));
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(elementType).bindTo(arrayType);
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(false),
+                ImmutableList.of(false),
+                ImmutableList.of(Optional.empty()),
+                methodHandle,
+                Optional.empty(),
+                true,
+                isDeterministic());
+    }
+
+    public static void identity(Type type, Type arrayType, BlockBuilder outputBlock, Block array)
+    {
+        BlockBuilder entryBlockBuilder = outputBlock.beginBlockEntry();
+        for (int i = 0; i < array.getPositionCount(); i++) {
+            if (array.isNull(i)) {
+                entryBlockBuilder.appendNull();
+            }
+            else {
+                type.appendTo(array, i, entryBlockBuilder);
+            }
+        }
+        outputBlock.closeEntry();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIdentityFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIdentityFunction.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class ArrayIdentityFunction
+        extends SqlScalarFunction
+{
+    public static final ArrayIdentityFunction ARRAY_IDENTITY_FUNCTION = new ArrayIdentityFunction();
+    private static final String FUNCTION_NAME = "array_identity";
+
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayIdentityFunction.class, "identity", Type.class, Type.class, Object.class, Block.class);
+    private static final MethodHandle STATE_FACTORY = methodHandle(ArrayIdentityFunction.class, "createState", ArrayType.class);
+
+    private ArrayIdentityFunction()
+    {
+        super(new Signature(FUNCTION_NAME,
+                FunctionKind.SCALAR,
+                ImmutableList.of(typeVariable("E")),
+                ImmutableList.of(),
+                parseTypeSignature("array(E)"),
+                ImmutableList.of(parseTypeSignature("array(E)")),
+                false));
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return true;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "array identity";
+    }
+
+    @Override
+    public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type elementType = boundVariables.getTypeVariable("E");
+        Type arrayType = typeManager.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(TypeSignatureParameter.of(elementType.getTypeSignature())));
+        MethodHandle methodHandle = METHOD_HANDLE.bindTo(elementType).bindTo(arrayType);
+        return new ScalarFunctionImplementation(
+                false,
+                ImmutableList.of(false),
+                ImmutableList.of(false),
+                ImmutableList.of(Optional.empty()),
+                methodHandle,
+                Optional.of(STATE_FACTORY.bindTo(arrayType)),
+                false,
+                isDeterministic());
+    }
+
+    @UsedByGeneratedCode
+    public static Object createState(ArrayType arrayType)
+    {
+        return new PageBuilder(ImmutableList.of(arrayType));
+    }
+
+    public static Block identity(Type type, Type arrayType, Object state, Block array)
+    {
+        PageBuilder pageBuilder = (PageBuilder) state;
+        if (pageBuilder.isFull()) {
+            pageBuilder.reset();
+        }
+        BlockBuilder arrayBlockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder blockBuilder = arrayBlockBuilder.beginBlockEntry();
+
+        for (int i = 0; i < array.getPositionCount(); i++) {
+            if (array.isNull(i)) {
+                blockBuilder.appendNull();
+            }
+            else {
+                type.appendTo(array, i, blockBuilder);
+            }
+        }
+
+        arrayBlockBuilder.closeEntry();
+        pageBuilder.declarePosition();
+        return (Block) arrayType.getObject(arrayBlockBuilder, arrayBlockBuilder.getPositionCount() - 1);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayTransformFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayTransformFunction.java
@@ -111,6 +111,7 @@ public final class ArrayTransformFunction
                 ImmutableList.of(Optional.empty(), Optional.of(UnaryFunctionInterface.class)),
                 methodHandle(generatedClass, "transform", PageBuilder.class, Block.class, UnaryFunctionInterface.class),
                 Optional.of(methodHandle(generatedClass, "createPageBuilder")),
+                false,
                 isDeterministic());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConcatFunction.java
@@ -110,6 +110,7 @@ public final class MapConcatFunction
                 nCopies(arity, Optional.empty()),
                 methodHandleAndConstructor.getMethodHandle(),
                 Optional.of(methodHandleAndConstructor.getConstructor()),
+                false,
                 isDeterministic());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
@@ -98,6 +98,7 @@ public final class MapConstructor
                 ImmutableList.of(Optional.empty(), Optional.empty()),
                 METHOD_HANDLE.bindTo(mapType).bindTo(keyEqual).bindTo(keyHashCode),
                 Optional.of(instanceFactory),
+                false,
                 isDeterministic());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapFilterFunction.java
@@ -119,6 +119,7 @@ public final class MapFilterFunction
                 ImmutableList.of(Optional.empty(), Optional.of(BinaryFunctionInterface.class)),
                 generateFilter(mapType),
                 Optional.of(STATE_FACTORY.bindTo(mapType)),
+                false,
                 isDeterministic());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
@@ -130,6 +130,7 @@ public final class MapTransformKeyFunction
                 ImmutableList.of(Optional.empty(), Optional.of(BinaryFunctionInterface.class)),
                 generateTransformKey(keyType, transformedKeyType, valueType, resultMapType),
                 Optional.of(STATE_FACTORY.bindTo(resultMapType)),
+                false,
                 isDeterministic());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
@@ -125,6 +125,7 @@ public final class MapTransformValueFunction
                 ImmutableList.of(Optional.empty(), Optional.of(BinaryFunctionInterface.class)),
                 generateTransform(keyType, valueType, transformedValueType, resultMapType),
                 Optional.of(STATE_FACTORY.bindTo(resultMapType)),
+                false,
                 isDeterministic());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ParametricScalar.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ParametricScalar.java
@@ -89,6 +89,7 @@ public class ParametricScalar
                     implementation.getLambdaInterface(),
                     methodHandleAndConstructor.get().getMethodHandle(),
                     methodHandleAndConstructor.get().getConstructor(),
+                    false,
                     isDeterministic());
         }
 
@@ -104,6 +105,7 @@ public class ParametricScalar
                         implementation.getLambdaInterface(),
                         methodHandle.get().getMethodHandle(),
                         methodHandle.get().getConstructor(),
+                        false,
                         isDeterministic());
             }
         }
@@ -122,6 +124,7 @@ public class ParametricScalar
                         implementation.getLambdaInterface(),
                         methodHandle.get().getMethodHandle(),
                         methodHandle.get().getConstructor(),
+                        false,
                         isDeterministic());
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ScalarFunctionImplementation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ScalarFunctionImplementation.java
@@ -33,6 +33,7 @@ public final class ScalarFunctionImplementation
     private final List<Optional<Class>> lambdaInterface;
     private final MethodHandle methodHandle;
     private final Optional<MethodHandle> instanceFactory;
+    private final boolean writeToBlockBuilderParamater;
     private final boolean deterministic;
 
     public ScalarFunctionImplementation(boolean nullable, List<Boolean> nullableArguments, MethodHandle methodHandle, boolean deterministic)
@@ -44,6 +45,7 @@ public final class ScalarFunctionImplementation
                 nCopies(nullableArguments.size(), Optional.empty()),
                 methodHandle,
                 Optional.empty(),
+                false,
                 deterministic);
     }
 
@@ -56,6 +58,7 @@ public final class ScalarFunctionImplementation
                 nCopies(nullableArguments.size(), Optional.empty()),
                 methodHandle,
                 Optional.empty(),
+                false,
                 deterministic);
     }
 
@@ -74,6 +77,7 @@ public final class ScalarFunctionImplementation
                 lambdaInterface,
                 methodHandle,
                 Optional.empty(),
+                false,
                 deterministic);
     }
 
@@ -84,6 +88,7 @@ public final class ScalarFunctionImplementation
             List<Optional<Class>> lambdaInterface,
             MethodHandle methodHandle,
             Optional<MethodHandle> instanceFactory,
+            boolean writeToBlockBuilderParamater,
             boolean deterministic)
     {
         this.nullable = nullable;
@@ -92,6 +97,7 @@ public final class ScalarFunctionImplementation
         this.lambdaInterface = ImmutableList.copyOf(requireNonNull(lambdaInterface, "lambdaInterface is null"));
         this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
         this.instanceFactory = requireNonNull(instanceFactory, "instanceFactory is null");
+        this.writeToBlockBuilderParamater = writeToBlockBuilderParamater;
         this.deterministic = deterministic;
 
         if (instanceFactory.isPresent()) {
@@ -144,6 +150,11 @@ public final class ScalarFunctionImplementation
     public Optional<MethodHandle> getInstanceFactory()
     {
         return instanceFactory;
+    }
+
+    public boolean isWriteToBlockBuilderParamater()
+    {
+        return writeToBlockBuilderParamater;
     }
 
     public boolean isDeterministic()

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/AndCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/AndCodeGenerator.java
@@ -40,8 +40,8 @@ public class AndCodeGenerator
                 .comment("AND")
                 .setDescription("AND");
 
-        BytecodeNode left = generator.generate(arguments.get(0));
-        BytecodeNode right = generator.generate(arguments.get(1));
+        BytecodeNode left = generator.generate(arguments.get(0), generator.getOutputBlockBuilder());
+        BytecodeNode right = generator.generate(arguments.get(1), generator.getOutputBlockBuilder());
 
         block.append(left);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CastCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CastCodeGenerator.java
@@ -33,6 +33,6 @@ public class CastCodeGenerator
                 .getRegistry()
                 .getCoercion(argument.getType(), returnType);
 
-        return generatorContext.generateCall(function.getName(), generatorContext.getRegistry().getScalarFunctionImplementation(function), ImmutableList.of(generatorContext.generate(argument)));
+        return generatorContext.generateCall(function.getName(), generatorContext.getRegistry().getScalarFunctionImplementation(function), ImmutableList.of(generatorContext.generate(argument, generatorContext.getOutputBlockBuilder())));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CoalesceCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CoalesceCodeGenerator.java
@@ -36,7 +36,7 @@ public class CoalesceCodeGenerator
     {
         List<BytecodeNode> operands = new ArrayList<>();
         for (RowExpression expression : arguments) {
-            operands.add(generatorContext.generate(expression));
+            operands.add(generatorContext.generate(expression, generatorContext.getOutputBlockBuilder()));
         }
 
         Variable wasNull = generatorContext.wasNull();

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/DereferenceCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/DereferenceCodeGenerator.java
@@ -47,7 +47,7 @@ public class DereferenceCodeGenerator
 
         // clear the wasNull flag before evaluating the row value
         block.putVariable(wasNull, false);
-        block.append(generator.generate(arguments.get(0))).putVariable(rowBlock);
+        block.append(generator.generate(arguments.get(0), generator.getOutputBlockBuilder())).putVariable(rowBlock);
 
         IfStatement ifRowBlockIsNull = new IfStatement("if row block is null...")
                 .condition(wasNull);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/FunctionCallCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/FunctionCallCodeGenerator.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.relational.RowExpression;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class FunctionCallCodeGenerator
         implements BytecodeGenerator
@@ -36,7 +37,7 @@ public class FunctionCallCodeGenerator
         List<BytecodeNode> argumentsBytecode = new ArrayList<>();
         for (int i = 0; i < arguments.size(); i++) {
             RowExpression argument = arguments.get(i);
-            argumentsBytecode.add(context.generate(argument, function.getLambdaInterface().get(i)));
+            argumentsBytecode.add(context.generate(argument, Optional.empty(), function.getLambdaInterface().get(i)));
         }
 
         return context.generateCall(signature.getName(), function, argumentsBytecode);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/IfCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/IfCodeGenerator.java
@@ -36,7 +36,7 @@ public class IfCodeGenerator
 
         Variable wasNull = context.wasNull();
         BytecodeBlock condition = new BytecodeBlock()
-                .append(context.generate(arguments.get(0)))
+                .append(context.generate(arguments.get(0), context.getOutputBlockBuilder()))
                 .comment("... and condition value was not null")
                 .append(wasNull)
                 .invokeStatic(CompilerOperations.class, "not", boolean.class, boolean.class)
@@ -45,7 +45,7 @@ public class IfCodeGenerator
 
         return new IfStatement()
                 .condition(condition)
-                .ifTrue(context.generate(arguments.get(1)))
-                .ifFalse(context.generate(arguments.get(2)));
+                .ifTrue(context.generate(arguments.get(1), context.getOutputBlockBuilder()))
+                .ifFalse(context.generate(arguments.get(2), context.getOutputBlockBuilder()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
@@ -109,13 +109,13 @@ public class InCodeGenerator
     @Override
     public BytecodeNode generateExpression(Signature signature, BytecodeGeneratorContext generatorContext, Type returnType, List<RowExpression> arguments)
     {
-        BytecodeNode value = generatorContext.generate(arguments.get(0));
+        BytecodeNode value = generatorContext.generate(arguments.get(0), generatorContext.getOutputBlockBuilder());
 
         List<RowExpression> values = arguments.subList(1, arguments.size());
 
         ImmutableList.Builder<BytecodeNode> valuesBytecode = ImmutableList.builder();
         for (int i = 1; i < arguments.size(); i++) {
-            BytecodeNode testNode = generatorContext.generate(arguments.get(i));
+            BytecodeNode testNode = generatorContext.generate(arguments.get(i), generatorContext.getOutputBlockBuilder());
             valuesBytecode.add(testNode);
         }
 
@@ -132,7 +132,7 @@ public class InCodeGenerator
         ImmutableSet.Builder<Object> constantValuesBuilder = ImmutableSet.builder();
 
         for (RowExpression testValue : values) {
-            BytecodeNode testBytecode = generatorContext.generate(testValue);
+            BytecodeNode testBytecode = generatorContext.generate(testValue, generatorContext.getOutputBlockBuilder());
 
             if (testValue instanceof ConstantExpression && ((ConstantExpression) testValue).getValue() != null) {
                 ConstantExpression constant = (ConstantExpression) testValue;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/InvokeFunctionBytecodeExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/InvokeFunctionBytecodeExpression.java
@@ -65,7 +65,7 @@ public class InvokeFunctionBytecodeExpression
     {
         super(type(function.getMethodHandle().type().returnType()));
 
-        this.invocation = generateInvocation(scope, name, function, instance, parameters.stream().map(BytecodeNode.class::cast).collect(toImmutableList()), binding);
+        this.invocation = generateInvocation(scope, name, function, instance, Optional.empty(), parameters.stream().map(BytecodeNode.class::cast).collect(toImmutableList()), binding);
         this.oneLineDescription = name + "(" + Joiner.on(", ").join(parameters) + ")";
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/IsNullCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/IsNullCodeGenerator.java
@@ -40,7 +40,7 @@ public class IsNullCodeGenerator
             return loadBoolean(true);
         }
 
-        BytecodeNode value = generatorContext.generate(argument);
+        BytecodeNode value = generatorContext.generate(argument, generatorContext.getOutputBlockBuilder());
 
         // evaluate the expression, pop the produced value, and load the null flag
         Variable wasNull = generatorContext.wasNull();

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -217,7 +217,7 @@ public class JoinFilterFunctionCompiler
                 metadata.getFunctionRegistry(),
                 preGeneratedExpressions);
 
-        BytecodeNode visitorBody = compiler.compile(filter, scope);
+        BytecodeNode visitorBody = compiler.compile(filter, scope, Optional.empty());
 
         Variable result = scope.declareVariable(boolean.class, "result");
         body.append(visitorBody)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaBytecodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaBytecodeGenerator.java
@@ -47,6 +47,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.bytecode.Access.FINAL;
 import static com.facebook.presto.bytecode.Access.PRIVATE;
@@ -132,7 +133,7 @@ public class LambdaBytecodeGenerator
 
         Scope scope = method.getScope();
         Variable wasNull = scope.declareVariable(boolean.class, "wasNull");
-        BytecodeNode compiledBody = innerExpressionCompiler.compile(lambda.getBody(), scope);
+        BytecodeNode compiledBody = innerExpressionCompiler.compile(lambda.getBody(), scope, Optional.empty());
         method.getBody()
                 .putVariable(wasNull, false)
                 .append(compiledBody)
@@ -193,7 +194,7 @@ public class LambdaBytecodeGenerator
         for (RowExpression captureExpression : captureExpressions) {
             Class<?> valueType = Primitives.wrap(captureExpression.getType().getJavaType());
             Variable valueVariable = scope.createTempVariable(valueType);
-            block.append(context.generate(captureExpression));
+            block.append(context.generate(captureExpression, Optional.empty()));
             block.append(boxPrimitiveIfNecessary(scope, valueType));
             block.putVariable(valueVariable);
             block.append(wasNull.set(constantFalse()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/NullIfCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/NullIfCodeGenerator.java
@@ -46,7 +46,7 @@ public class NullIfCodeGenerator
         // push first arg on the stack
         BytecodeBlock block = new BytecodeBlock()
                 .comment("check if first arg is null")
-                .append(generatorContext.generate(first))
+                .append(generatorContext.generate(first, generatorContext.getOutputBlockBuilder()))
                 .append(BytecodeUtils.ifWasNullPopAndGoto(scope, notMatch, void.class));
 
         Type firstType = first.getType();
@@ -60,7 +60,7 @@ public class NullIfCodeGenerator
                 equalsFunction,
                 ImmutableList.of(
                         cast(generatorContext, new BytecodeBlock().dup(firstType.getJavaType()), firstType, equalsSignature.getArgumentTypes().get(0)),
-                        cast(generatorContext, generatorContext.generate(second), secondType, equalsSignature.getArgumentTypes().get(1))));
+                        cast(generatorContext, generatorContext.generate(second, generatorContext.getOutputBlockBuilder()), secondType, equalsSignature.getArgumentTypes().get(1))));
 
         BytecodeBlock conditionBlock = new BytecodeBlock()
                 .append(equalsCall)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/OrCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/OrCodeGenerator.java
@@ -40,8 +40,8 @@ public class OrCodeGenerator
                 .comment("OR")
                 .setDescription("OR");
 
-        BytecodeNode left = generator.generate(arguments.get(0));
-        BytecodeNode right = generator.generate(arguments.get(1));
+        BytecodeNode left = generator.generate(arguments.get(0), generator.getOutputBlockBuilder());
+        BytecodeNode right = generator.generate(arguments.get(1), generator.getOutputBlockBuilder());
 
         block.append(left);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/RowConstructorCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/RowConstructorCodeGenerator.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.relational.RowExpression;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantFalse;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantInt;
@@ -62,7 +63,7 @@ public class RowConstructorCodeGenerator
                 Variable field = scope.createTempVariable(javaType);
                 block.comment("Clean wasNull and Generate + " + i + "-th field of row");
                 block.append(context.wasNull().set(constantFalse()));
-                block.append(context.generate(arguments.get(i)));
+                block.append(context.generate(arguments.get(i), context.getOutputBlockBuilder()));
                 block.putVariable(field);
                 block.append(new IfStatement()
                         .condition(context.wasNull())

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/SwitchCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/SwitchCodeGenerator.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantFalse;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantTrue;
@@ -74,7 +75,7 @@ public class SwitchCodeGenerator
 
         // process value, else, and all when clauses
         RowExpression value = arguments.get(0);
-        BytecodeNode valueBytecode = generatorContext.generate(value);
+        BytecodeNode valueBytecode = generatorContext.generate(value, generatorContext.getOutputBlockBuilder());
         BytecodeNode elseValue;
 
         List<RowExpression> whenClauses;
@@ -87,7 +88,7 @@ public class SwitchCodeGenerator
         }
         else {
             whenClauses = arguments.subList(1, arguments.size() - 1);
-            elseValue = generatorContext.generate(last);
+            elseValue = generatorContext.generate(last, generatorContext.getOutputBlockBuilder());
         }
 
         // determine the type of the value and result
@@ -123,7 +124,7 @@ public class SwitchCodeGenerator
             BytecodeNode equalsCall = generatorContext.generateCall(
                     equalsFunction.getName(),
                     generatorContext.getRegistry().getScalarFunctionImplementation(equalsFunction),
-                    ImmutableList.of(generatorContext.generate(operand), getTempVariableNode));
+                    ImmutableList.of(generatorContext.generate(operand, generatorContext.getOutputBlockBuilder()), getTempVariableNode));
 
             BytecodeBlock condition = new BytecodeBlock()
                     .append(equalsCall)
@@ -131,7 +132,7 @@ public class SwitchCodeGenerator
 
             elseValue = new IfStatement("when")
                     .condition(condition)
-                    .ifTrue(generatorContext.generate(result))
+                    .ifTrue(generatorContext.generate(result, generatorContext.getOutputBlockBuilder()))
                     .ifFalse(elseValue);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/TryCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/TryCodeGenerator.java
@@ -34,6 +34,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.bytecode.Access.PUBLIC;
 import static com.facebook.presto.bytecode.Access.a;
@@ -102,7 +103,7 @@ public class TryCodeGenerator
         Scope calleeMethodScope = method.getScope();
 
         Variable wasNull = calleeMethodScope.declareVariable(boolean.class, "wasNull");
-        BytecodeNode innerExpression = innerExpressionCompiler.compile(innerRowExpression, calleeMethodScope);
+        BytecodeNode innerExpression = innerExpressionCompiler.compile(innerRowExpression, calleeMethodScope, Optional.empty());
 
         MethodType exceptionHandlerType = methodType(returnType, PrestoException.class);
         MethodHandle exceptionHandler = EXCEPTION_HANDLER.asType(exceptionHandlerType);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpression.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.relational;
 
+import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.spi.type.Type;
 
 public abstract class RowExpression
@@ -29,4 +30,9 @@ public abstract class RowExpression
     public abstract String toString();
 
     public abstract <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context);
+
+    public boolean directWriteToOutputBuilder(FunctionRegistry functionRegistry)
+    {
+        return false;
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayIdentity.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayIdentity.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.FunctionListBuilder;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.operator.project.PageProcessor;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.gen.PageFunctionCompiler;
+import com.facebook.presto.sql.relational.CallExpression;
+import com.facebook.presto.sql.relational.LambdaDefinitionExpression;
+import com.facebook.presto.sql.relational.RowExpression;
+import com.facebook.presto.sql.relational.VariableReferenceExpression;
+import com.google.common.base.Throwables;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.scalar.BenchmarkArrayFilter.ExactArrayFilterFunction.EXACT_ARRAY_FILTER_FUNCTION;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.field;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static java.lang.Boolean.TRUE;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkArrayIdentity
+{
+    private static final int POSITIONS = 100_000;
+    private static final int ARRAY_SIZE = 4;
+    private static final int NUM_TYPES = 1;
+    private static final List<Type> TYPES = ImmutableList.of(BIGINT);
+
+    static {
+        Verify.verify(NUM_TYPES == TYPES.size());
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS * ARRAY_SIZE * NUM_TYPES)
+    public List<Page> benchmark(BenchmarkData data)
+            throws Throwable
+    {
+        return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, data.getPage()));
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"array_identity", "array_identity_direct"})
+        private String name = "array_identity";
+
+        private Page page;
+        private PageProcessor pageProcessor;
+
+        @Setup
+        public void setup()
+        {
+            MetadataManager metadata = MetadataManager.createTestMetadataManager();
+            metadata.addFunctions(new FunctionListBuilder().function(EXACT_ARRAY_FILTER_FUNCTION).getFunctions());
+            ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
+            ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
+            Block[] blocks = new Block[TYPES.size()];
+            for (int i = 0; i < TYPES.size(); i++) {
+                Type elementType = TYPES.get(i);
+                ArrayType arrayType = new ArrayType(elementType);
+                Signature signature = new Signature(name, FunctionKind.SCALAR, arrayType.getTypeSignature(), arrayType.getTypeSignature());
+                projectionsBuilder.add(new CallExpression(signature, arrayType, ImmutableList.of(field(0, arrayType))));
+                blocks[i] = createChannel(POSITIONS, ARRAY_SIZE, arrayType);
+            }
+
+            ImmutableList<RowExpression> projections = projectionsBuilder.build();
+            pageProcessor = compiler.compilePageProcessor(Optional.empty(), projections).get();
+            page = new Page(blocks);
+        }
+
+        private static Block createChannel(int positionCount, int arraySize, ArrayType arrayType)
+        {
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            for (int position = 0; position < positionCount; position++) {
+                BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+                for (int i = 0; i < arraySize; i++) {
+                    if (arrayType.getElementType().getJavaType() == long.class) {
+                        arrayType.getElementType().writeLong(entryBuilder, ThreadLocalRandom.current().nextLong());
+                    }
+                    else {
+                        throw new UnsupportedOperationException();
+                    }
+                }
+                blockBuilder.closeEntry();
+            }
+            return blockBuilder.build();
+        }
+
+        public PageProcessor getPageProcessor()
+        {
+            return pageProcessor;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArrayIdentity().benchmark(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkArrayIdentity.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
@@ -119,6 +119,7 @@ public class TestVarArgsToArrayAdapterGenerator
                     nCopies(arity, Optional.empty()),
                     methodHandleAndConstructor.getMethodHandle(),
                     Optional.of(methodHandleAndConstructor.getConstructor()),
+                    false,
                     isDeterministic());
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -1166,6 +1166,19 @@ public class TestArrayOperators
     }
 
     @Test
+    public void testIdentity()
+    {
+        assertFunction("identity_array(ARRAY[1, 2, 3])", new ArrayType(INTEGER), ImmutableList.of(1, 2, 3));
+    }
+
+    @Test
+    public void testIdentityDirect()
+    {
+        assertFunction("identity_array_direct(ARRAY[1, 2, 3])", new ArrayType(INTEGER), ImmutableList.of(1, 2, 3));
+    }
+
+
+    @Test
     public void testFlatten()
     {
         // BOOLEAN Tests


### PR DESCRIPTION
## Introduction

Today the return convention for scalar function is always to return on stack, and the callee will append the results value on stack into the result BlockBuilder(for out-most function call) or use it to invoke other functions (for inner/nested function call like `f(g(x))` )

While this return convention works well for primitive types, it's not optimal for structural types since it always has to copy the result block.  

## Proposed Solution

To address this inefficiency, one idea is to introduce a new return convention that directly writes to the output block builder. This requires two part of the work:

- We need to support compiling  a `RowExpression` to write to output block builder directly when presented. A prototype is done in https://github.com/prestodb/presto/pull/8747. 
Update: This new return convention is supported via https://github.com/prestodb/presto/pull/12166.

- Since the callee might expect certain return convention (`return on stack` vs. `direct output write`), we need be able to adapt between different return convention. While adapting from `return on stack` to `direct output write` is trivial, the other direction of adaption is more involved, as many functions leverage `CachedInstanceBinder` to maintain function state, and to avoid repeatedly allocating memory for result (see https://github.com/prestodb/presto/pull/9638#issuecomment-354839564). 

An preliminary proof-of-concept of the `InvocationAdapter` can be found in commit https://github.com/wenleix/presto/commit/d0fb108693edf940c64b2627a5339b28fa6bfa48

## Benchmark Result

In this PR we prototyped the preliminary support to directly write to output block builder and benchmark the potential performance gain. **This implementation is not a full support** since the adaption for a caller expect `return on stack` behavior while callee provides `directly write to block` behavior requires more work . 

To see the potential performance gain, we add a fake `array_identity` function which copies the array (see the second commit), and benchmark its performance:

```
Benchmark                                        (name)  Mode  Cnt   Score   Error  Units
BenchmarkArrayIdentity.benchmark         array_identity  avgt   20  22.721 ± 1.298  ns/op
BenchmarkArrayIdentity.benchmark  array_identity_direct  avgt   20  10.557 ± 0.466  ns/op
```

We see about 2x performance gain by directly writing to output block builder (instead of putting the result block on stack and copy to the final block). 


This is based on https://github.com/prestodb/presto/pull/8747.
  