### PR TITLE
Allow SHOW PARTITIONS .. WHERE for table above partition limit

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1106,6 +1106,9 @@ public class TestHiveIntegrationSmokeTest
                 "SHOW PARTITIONS FROM test_insert_partitioned_table WHERE order_status = 'O'",
                 "SELECT DISTINCT shippriority, orderstatus FROM orders WHERE orderstatus = 'O'");
 
+        assertQueryFails(session, "SHOW PARTITIONS FROM test_insert_partitioned_table WHERE no_such_column = 1", "line \\S*: Column 'no_such_column' cannot be resolved");
+        assertQueryFails(session, "SHOW PARTITIONS FROM test_insert_partitioned_table WHERE orderkey = 1", "line \\S*: Column 'orderkey' cannot be resolved");
+
         assertUpdate(session, "DROP TABLE test_insert_partitioned_table");
 
         assertFalse(getQueryRunner().tableExists(session, "test_insert_partitioned_table"));
@@ -1209,6 +1212,16 @@ public class TestHiveIntegrationSmokeTest
 
             assertUpdate(session, insertPartitions, 100);
         }
+
+        // verify can show partitions
+        assertQuery(
+                session,
+                "SHOW PARTITIONS FROM " + tableName + " WHERE part > 490 and part <= 500",
+                "VALUES 491, 492, 493, 494, 495, 496, 497, 498, 499, 500");
+        assertQuery(
+                session,
+                "SHOW PARTITIONS FROM " + tableName + " WHERE part < 0",
+                "SELECT null WHERE false");
 
         // verify can query 1000 partitions
         assertQuery(

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -57,7 +57,6 @@ public class InformationSchemaMetadata
     public static final SchemaTableName TABLE_TABLES = new SchemaTableName(INFORMATION_SCHEMA, "tables");
     public static final SchemaTableName TABLE_VIEWS = new SchemaTableName(INFORMATION_SCHEMA, "views");
     public static final SchemaTableName TABLE_SCHEMATA = new SchemaTableName(INFORMATION_SCHEMA, "schemata");
-    public static final SchemaTableName TABLE_INTERNAL_PARTITIONS = new SchemaTableName(INFORMATION_SCHEMA, "__internal_partitions__");
     public static final SchemaTableName TABLE_TABLE_PRIVILEGES = new SchemaTableName(INFORMATION_SCHEMA, "table_privileges");
 
     public static final Map<SchemaTableName, ConnectorTableMetadata> TABLES = schemaMetadataBuilder()
@@ -88,14 +87,6 @@ public class InformationSchemaMetadata
             .table(tableMetadataBuilder(TABLE_SCHEMATA)
                     .column("catalog_name", createUnboundedVarcharType())
                     .column("schema_name", createUnboundedVarcharType())
-                    .build())
-            .table(tableMetadataBuilder(TABLE_INTERNAL_PARTITIONS)
-                    .column("table_catalog", createUnboundedVarcharType())
-                    .column("table_schema", createUnboundedVarcharType())
-                    .column("table_name", createUnboundedVarcharType())
-                    .column("partition_number", BIGINT)
-                    .column("partition_key", createUnboundedVarcharType())
-                    .column("partition_value", createUnboundedVarcharType())
                     .build())
             .table(tableMetadataBuilder(TABLE_TABLE_PRIVILEGES)
                     .column("grantor", createUnboundedVarcharType())

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -16,13 +16,8 @@ package com.facebook.presto.connector.informationSchema;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.InternalTable;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.metadata.OperatorNotFoundException;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
-import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.metadata.TableHandle;
-import com.facebook.presto.metadata.TableLayout;
-import com.facebook.presto.metadata.TableLayoutResult;
 import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnHandle;
@@ -30,28 +25,20 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
-import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.NullableValue;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrivilegeInfo;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.airlift.slice.Slice;
 
-import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -59,7 +46,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_COLUMNS;
-import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_INTERNAL_PARTITIONS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_SCHEMATA;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLES;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES;
@@ -70,9 +56,7 @@ import static com.facebook.presto.metadata.MetadataListing.listTableColumns;
 import static com.facebook.presto.metadata.MetadataListing.listTablePrivileges;
 import static com.facebook.presto.metadata.MetadataListing.listTables;
 import static com.facebook.presto.metadata.MetadataListing.listViews;
-import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Sets.union;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -151,9 +135,6 @@ public class InformationSchemaPageSourceProvider
         }
         if (table.equals(TABLE_SCHEMATA)) {
             return buildSchemata(session, catalog);
-        }
-        if (table.equals(TABLE_INTERNAL_PARTITIONS)) {
-            return buildPartitions(session, catalog, filters);
         }
         if (table.equals(TABLE_TABLE_PRIVILEGES)) {
             return buildTablePrivileges(session, catalog, filters);
@@ -255,80 +236,6 @@ public class InformationSchemaPageSourceProvider
             table.add(catalogName, schema);
         }
         return table.build();
-    }
-
-    private InternalTable buildPartitions(Session session, String catalogName, Map<String, NullableValue> filters)
-    {
-        QualifiedObjectName tableName = extractQualifiedTableName(catalogName, filters);
-
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_INTERNAL_PARTITIONS));
-
-        Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
-        if (!tableHandle.isPresent()) {
-            throw new TableNotFoundException(tableName.asSchemaTableName());
-        }
-
-        List<TableLayoutResult> layouts = metadata.getLayouts(session, tableHandle.get(), Constraint.alwaysTrue(), Optional.empty());
-
-        if (layouts.size() == 1) {
-            Map<ColumnHandle, String> columnHandles = ImmutableBiMap.copyOf(metadata.getColumnHandles(session, tableHandle.get())).inverse();
-            Map<ColumnHandle, MethodHandle> methodHandles = new HashMap<>();
-            for (ColumnHandle columnHandle : columnHandles.keySet()) {
-                try {
-                    ColumnMetadata columnMetadata = metadata.getColumnMetadata(session, tableHandle.get(), columnHandle);
-                    Signature operator = metadata.getFunctionRegistry().getCoercion(columnMetadata.getType(), createUnboundedVarcharType());
-                    MethodHandle methodHandle = metadata.getFunctionRegistry().getScalarFunctionImplementation(operator).getMethodHandle();
-                    methodHandles.put(columnHandle, methodHandle);
-                }
-                catch (OperatorNotFoundException exception) {
-                    // Do not put the columnHandle in the map.
-                }
-            }
-
-            TableLayout layout = Iterables.getOnlyElement(layouts).getLayout();
-            layout.getDiscretePredicates().ifPresent(predicates -> {
-                int partitionNumber = 1;
-                for (TupleDomain<ColumnHandle> domain : predicates.getPredicates()) {
-                    for (Entry<ColumnHandle, NullableValue> entry : TupleDomain.extractFixedValues(domain).get().entrySet()) {
-                        ColumnHandle columnHandle = entry.getKey();
-                        String columnName = columnHandles.get(columnHandle);
-                        String value = null;
-                        if (entry.getValue().getValue() != null) {
-                            if (methodHandles.containsKey(columnHandle)) {
-                                try {
-                                    value = ((Slice) methodHandles.get(columnHandle).invokeWithArguments(entry.getValue().getValue())).toStringUtf8();
-                                }
-                                catch (Throwable throwable) {
-                                    throw Throwables.propagate(throwable);
-                                }
-                            }
-                            else {
-                                // OperatorNotFoundException was thrown for this columnHandle
-                                value = "<UNREPRESENTABLE VALUE>";
-                            }
-                        }
-                        table.add(
-                                catalogName,
-                                tableName.getSchemaName(),
-                                tableName.getObjectName(),
-                                partitionNumber,
-                                columnName,
-                                value);
-                    }
-                    partitionNumber++;
-                }
-            });
-        }
-        return table.build();
-    }
-
-    private static QualifiedObjectName extractQualifiedTableName(String catalogName, Map<String, NullableValue> filters)
-    {
-        Optional<String> schemaName = getFilterColumn(filters, "table_schema");
-        checkArgument(schemaName.isPresent(), "filter is required for column: %s.%s", TABLE_INTERNAL_PARTITIONS, "table_schema");
-        Optional<String> tableName = getFilterColumn(filters, "table_name");
-        checkArgument(tableName.isPresent(), "filter is required for column: %s.%s", TABLE_INTERNAL_PARTITIONS, "table_name");
-        return new QualifiedObjectName(catalogName, schemaName.get(), tableName.get());
     }
 
     private static QualifiedTablePrefix extractQualifiedTablePrefix(String catalogName, Map<String, NullableValue> filters)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
@@ -95,10 +95,14 @@ public class PlanNodeSearcher
     public <T extends PlanNode> Optional<T> findSingle()
     {
         List<T> all = findAll();
-        if (all.size() == 1) {
-            return Optional.of(all.get(0));
+        switch (all.size()) {
+            case 0:
+                return Optional.empty();
+            case 1:
+                return Optional.of(all.get(0));
+            default:
+                throw new IllegalStateException("Multiple nodes found");
         }
-        return Optional.empty();
     }
 
     public <T extends PlanNode> List<T> findAll()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedSingleRowSubqueryToProject.java
@@ -28,7 +28,6 @@ import com.facebook.presto.sql.planner.plan.ValuesNode;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
@@ -82,12 +81,12 @@ public class TransformCorrelatedSingleRowSubqueryToProject
                 return rewrittenLateral;
             }
 
-            Optional<ValuesNode> values = searchFrom(lateral.getSubquery())
+            List<ValuesNode> values = searchFrom(lateral.getSubquery())
                     .recurseOnlyWhen(ProjectNode.class::isInstance)
                     .where(ValuesNode.class::isInstance)
-                    .findSingle();
+                    .findAll();
 
-            if (!values.isPresent() || !isSingleRowValuesWithNoColumns(values.get())) {
+            if (values.size() != 1 || !isSingleRowValuesWithNoColumns(values.get(0))) {
                 return rewrittenLateral;
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
@@ -229,7 +229,7 @@ public class ShowStatsRewrite
 
             Optional<TableScanNode> scanNode = searchFrom(plan.getRoot())
                     .where(TableScanNode.class::isInstance)
-                    .findFirst();
+                    .findSingle();
 
             if (!scanNode.isPresent()) {
                 return new Constraint<>(TupleDomain.none(), bindings -> true);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static java.util.Arrays.asList;
 
 public final class QueryUtil
 {
@@ -74,6 +75,11 @@ public final class QueryUtil
     }
 
     public static Select selectList(Expression... expressions)
+    {
+        return selectList(asList(expressions));
+    }
+
+    public static Select selectList(List<Expression> expressions)
     {
         ImmutableList.Builder<SelectItem> items = ImmutableList.builder();
         for (Expression expression : expressions) {

--- a/presto-product-tests/conf/presto/etc/catalog/hive.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/hive.properties
@@ -15,3 +15,4 @@ hive.allow-drop-table=true
 hive.allow-rename-table=true
 hive.metastore-cache-ttl=0s
 hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
@@ -17,3 +17,4 @@ hive.metastore-cache-ttl=0s
 hive.hdfs.authentication.type=NONE
 hive.hdfs.impersonation.enabled=true
 hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -20,6 +20,7 @@ hive.hdfs.impersonation.enabled=true
 hive.hdfs.presto.principal=presto-server/_HOST@LABS.TERADATA.COM
 hive.hdfs.presto.keytab=/etc/presto/conf/presto-server.keytab
 hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100
 
 #required for testGrantRevoke() product test
 hive.security=sql-standard

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -25,3 +25,4 @@ hive.hdfs.impersonation.enabled=false
 hive.hdfs.presto.principal=hdfs/hadoop-master@LABS.TERADATA.COM
 hive.hdfs.presto.keytab=/etc/hadoop/conf/hdfs.keytab
 hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/convention/TestShowPartitions.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/convention/TestShowPartitions.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.tests.convention;
 
+import com.google.common.math.IntMath;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.Requirement;
 import com.teradata.tempto.RequirementsProvider;
@@ -23,11 +24,16 @@ import com.teradata.tempto.fulfillment.table.TableDefinition;
 import com.teradata.tempto.fulfillment.table.hive.HiveDataSource;
 import com.teradata.tempto.fulfillment.table.hive.HiveTableDefinition;
 import com.teradata.tempto.query.QueryResult;
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.Assertions;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
 
+import java.math.RoundingMode;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.tests.TestGroups.BASIC_SQL;
 import static com.teradata.tempto.Requirements.compose;
@@ -37,12 +43,20 @@ import static com.teradata.tempto.fulfillment.table.TableRequirements.mutableTab
 import static com.teradata.tempto.fulfillment.table.hive.InlineDataSource.createResourceDataSource;
 import static com.teradata.tempto.fulfillment.table.hive.InlineDataSource.createStringDataSource;
 import static com.teradata.tempto.query.QueryExecutor.query;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
 
 public class TestShowPartitions
         extends ProductTest
         implements RequirementsProvider
 {
+    // We use hive.max-partitions-per-scan=100 in tests, so this many partitions is too many
+    private static final int TOO_MANY_PARTITIONS = 105;
+
     private static final String PARTITIONED_TABLE = "partitioned_table";
+    private static final String PARTITIONED_TABLE_WITH_VARIABLE_PARTITIONS = "partitioned_table_with_variable_partitions";
 
     @Inject
     private MutableTablesState tablesState;
@@ -50,7 +64,9 @@ public class TestShowPartitions
     @Override
     public Requirement getRequirements(Configuration configuration)
     {
-        return compose(mutableTable(partitionedTableDefinition(), PARTITIONED_TABLE, MutableTableRequirement.State.CREATED));
+        return compose(
+                mutableTable(partitionedTableDefinition(), PARTITIONED_TABLE, MutableTableRequirement.State.CREATED),
+                mutableTable(partitionedTableWithVariablePartitionsDefinition(), PARTITIONED_TABLE_WITH_VARIABLE_PARTITIONS, MutableTableRequirement.State.CREATED));
     }
 
     private static TableDefinition partitionedTableDefinition()
@@ -68,13 +84,98 @@ public class TestShowPartitions
                 .build();
     }
 
+    private static TableDefinition partitionedTableWithVariablePartitionsDefinition()
+    {
+        String createTableDdl = "CREATE TABLE %NAME%(col INT) " +
+                "PARTITIONED BY (part_col INT) " +
+                "STORED AS ORC";
+
+        return HiveTableDefinition.builder(PARTITIONED_TABLE_WITH_VARIABLE_PARTITIONS)
+                .setCreateTableDDLTemplate(createTableDdl)
+                .setNoData()
+                .build();
+    }
+
     @Test(groups = {BASIC_SQL})
     public void testShowPartitionsFromHiveTable()
     {
         String tableNameInDatabase = tablesState.get(PARTITIONED_TABLE).getNameInDatabase();
 
-        String selectFromOnePartitionsSql = "show partitions from " + tableNameInDatabase;
-        QueryResult partitionListResult = query(selectFromOnePartitionsSql);
+        QueryResult partitionListResult;
+
+        partitionListResult = query("SHOW PARTITIONS FROM " + tableNameInDatabase);
         assertThat(partitionListResult).containsExactly(row(1), row(2));
+        assertColumnNames(partitionListResult, "part_col");
+
+        partitionListResult = query(format("SHOW PARTITIONS FROM %s WHERE part_col = 1", tableNameInDatabase));
+        assertThat(partitionListResult).containsExactly(row(1));
+        assertColumnNames(partitionListResult, "part_col");
+
+        assertThat(() -> query(format("SHOW PARTITIONS FROM %s WHERE no_such_column = 1", tableNameInDatabase)))
+                .failsWithMessage("Column 'no_such_column' cannot be resolved");
+        assertThat(() -> query(format("SHOW PARTITIONS FROM %s WHERE col = 1", tableNameInDatabase)))
+                .failsWithMessage("Column 'col' cannot be resolved");
+    }
+
+    @Test(groups = {BASIC_SQL})
+    public void testShowPartitionsFromHiveTableWithTooManyPartitions()
+    {
+        String tableName = tablesState.get(PARTITIONED_TABLE_WITH_VARIABLE_PARTITIONS).getNameInDatabase();
+        createPartitions(tableName, TOO_MANY_PARTITIONS);
+
+        // Verify we created enough partitions for the test to be meaningful
+        assertExceptionThrownBy(() -> query("SELECT * FROM " + tableName))
+                .hasMessageMatching(".*: Query over table '\\S+' can potentially read more than \\d+ partitions");
+
+        QueryResult partitionListResult;
+
+        partitionListResult = query(format("SHOW PARTITIONS FROM %s WHERE part_col < 7", tableName));
+        assertThat(partitionListResult).containsExactly(row(0), row(1), row(2), row(3), row(4), row(5), row(6));
+        assertColumnNames(partitionListResult, "part_col");
+
+        partitionListResult = query(format("SHOW PARTITIONS FROM %s WHERE part_col < -10", tableName));
+        assertThat(partitionListResult).hasNoRows();
+    }
+
+    private void createPartitions(String tableName, int partitionsToCreate)
+    {
+        // This is done in tests rather than as a requirement, because TableRequirements.immutableTable cannot be partitioned
+        // and mutable table is recreated before every test (and this takes a lot of time).
+        // TODO convert to immutableTable + TableDefinition once immutableTable supports partitioned tables
+
+        requireNonNull(tableName, "tableName is null");
+
+        int maxPartitionsAtOnce = 100;
+
+        IntStream.range(0, IntMath.divide(partitionsToCreate, maxPartitionsAtOnce, RoundingMode.UP))
+                .forEach(batch -> {
+                    int rangeStart = batch * maxPartitionsAtOnce;
+                    int rangeEndInclusive = min((batch + 1) * maxPartitionsAtOnce, partitionsToCreate) - 1;
+                    query(format(
+                            "INSERT INTO %s (part_col, col) " +
+                                    "SELECT CAST(id AS integer), 42 FROM UNNEST (sequence(%s, %s)) AS u(id)",
+                            tableName,
+                            rangeStart,
+                            rangeEndInclusive));
+                });
+    }
+
+    private static AbstractThrowableAssert<?, ? extends Throwable> assertExceptionThrownBy(Runnable runnable)
+    {
+        try {
+            runnable.run();
+        }
+        catch (RuntimeException expected) {
+            return Assertions.assertThat(expected);
+        }
+        throw new AssertionError("Failure was expected");
+    }
+
+    private static void assertColumnNames(QueryResult queryResult, String... columnNames)
+    {
+        for (int i = 0; i < columnNames.length; i++) {
+            assertEquals(queryResult.tryFindColumnIndex(columnNames[i]), Optional.of(i + 1), "Index of column " + columnNames[i]);
+        }
+        assertEquals(queryResult.getColumnsCount(), columnNames.length);
     }
 }

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -1,10 +1,4 @@
 -- delimiter: |; trimValues:true;
-system| information_schema| __internal_partitions__| table_catalog| varchar| YES| null| null|
-system| information_schema| __internal_partitions__| table_schema| varchar| YES| null| null|
-system| information_schema| __internal_partitions__| table_name| varchar| YES| null| null|
-system| information_schema| __internal_partitions__| partition_number| bigint| YES| null| null|
-system| information_schema| __internal_partitions__| partition_key| varchar| YES| null| null|
-system| information_schema| __internal_partitions__| partition_value| varchar| YES| null| null|
 system| information_schema| columns| table_catalog| varchar| YES| null| null|
 system| information_schema| columns| table_schema| varchar| YES| null| null|
 system| information_schema| columns| table_name| varchar| YES| null| null|

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -164,6 +164,15 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testShowPartitions()
+    {
+        assertQueryFails("SHOW PARTITIONS FROM orders", "line \\S*: Table does not have partition columns: \\S+\\.orders");
+        assertQueryFails("SHOW PARTITIONS FROM orders WHERE orderkey < 10", "line \\S*: Table does not have partition columns: \\S+\\.orders");
+        assertQueryFails("SHOW PARTITIONS FROM orders WHERE invalid_column < 10", "line 1:35: Column 'invalid_column' cannot be resolved");
+        assertQueryFails("SHOW PARTITIONS FROM orders LIMIT 2", "line \\S*: Table does not have partition columns: \\S+\\.orders");
+    }
+
+    @Test
     public void selectLargeInterval()
     {
         MaterializedResult result = computeActual("SELECT INTERVAL '30' DAY");


### PR DESCRIPTION
Previously, `SHOW PARTITIONS FROM <table> WHERE <condition>` would fail for
Hive table having more partitions than `hive.max-partitions-per-scan`
regardless of how many partitions were to be shown.

This reimplements `SHOW PARTITIONS .. WHERE ..` so that it works extracts all
information from `TableLayout` and not only partition column names,
allowing it to work with multi-partition tables.

Fixes #7358

cc @wenleix 