### PR TITLE
Enable dictionary projection more greedily

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
@@ -204,9 +204,12 @@ public class DictionaryAwarePageProjection
 
             // Process dictionary if:
             //   there is only one entry in the dictionary
+            //   the current projection will use more positions than that in the dictionary
             //   this is the first block
             //   the last dictionary was used for more positions than were in the dictionary
-            boolean shouldProcessDictionary = dictionary.get().getPositionCount() == 1 || lastInputDictionary == null || lastDictionaryUsageCount >= lastInputDictionary.getPositionCount();
+            boolean shouldProcessDictionary = dictionary.get().getPositionCount() == 1
+                    || dictionary.get().getPositionCount() <= selectedPositions.size()
+                    || lastInputDictionary == null || lastDictionaryUsageCount >= lastInputDictionary.getPositionCount();
 
             // record the usage count regardless of dictionary processing choice, so we have stats for next time
             lastDictionaryUsageCount = 0;

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -141,10 +141,32 @@ public class TestDictionaryAwarePageProjection
         // in this case, we don't even check yield signal; make yieldForce to false
         testProjectList(ineffectiveBlock, DictionaryBlock.class, projection, false);
 
-        // last dictionary not effective, so dictionary processing is disabled
+        // last dictionary not effective, and current dictionary is also not effective, so dictionary processing is disabled
+        DictionaryBlock anotherIneffectiveBlock = createDictionaryBlock(100, 20);
+        testProjectRange(anotherIneffectiveBlock, LongArrayBlock.class, projection, forceYield);
+        testProjectList(anotherIneffectiveBlock, LongArrayBlock.class, projection, forceYield);
+
+        // last dictionary not effective, but current dictionary is effective, so dictionary processing is enabled
         DictionaryBlock effectiveBlock = createDictionaryBlock(10, 100);
-        testProjectRange(effectiveBlock, LongArrayBlock.class, projection, forceYield);
-        testProjectList(effectiveBlock, LongArrayBlock.class, projection, forceYield);
+        testProjectRange(effectiveBlock, DictionaryBlock.class, projection, forceYield);
+        testProjectFastReturnIgnoreYield(effectiveBlock, projection);
+        // dictionary processing can reuse the last dictionary
+        // in this case, we don't even check yield signal; make yieldForce to false
+        testProjectList(effectiveBlock, DictionaryBlock.class, projection, false);
+
+        // last dictionary effective, so dictionary processing is enabled
+        testProjectRange(ineffectiveBlock, DictionaryBlock.class, projection, forceYield);
+        testProjectFastReturnIgnoreYield(ineffectiveBlock, projection);
+        // dictionary processing can reuse the last dictionary
+        // in this case, we don't even check yield signal; make yieldForce to false
+        testProjectList(ineffectiveBlock, DictionaryBlock.class, projection, false);
+
+        // last dictionary not effective, but current dictionary is effective, so dictionary processing is keeping enabled
+        testProjectRange(effectiveBlock, DictionaryBlock.class, projection, forceYield);
+        testProjectFastReturnIgnoreYield(effectiveBlock, projection);
+        // dictionary processing can reuse the last dictionary
+        // in this case, we don't even check yield signal; make yieldForce to false
+        testProjectList(effectiveBlock, DictionaryBlock.class, projection, false);
 
         // last dictionary effective, so dictionary processing is enabled again
         testProjectRange(ineffectiveBlock, DictionaryBlock.class, projection, forceYield);
@@ -153,9 +175,9 @@ public class TestDictionaryAwarePageProjection
         // in this case, we don't even check yield signal; make yieldForce to false
         testProjectList(ineffectiveBlock, DictionaryBlock.class, projection, false);
 
-        // last dictionary not effective, so dictionary processing is disabled again
-        testProjectRange(effectiveBlock, LongArrayBlock.class, projection, forceYield);
-        testProjectList(effectiveBlock, LongArrayBlock.class, projection, forceYield);
+        // last dictionary not effective, and current dictionary is also not effective, so dictionary processing is disabled again
+        testProjectRange(anotherIneffectiveBlock, LongArrayBlock.class, projection, forceYield);
+        testProjectList(anotherIneffectiveBlock, LongArrayBlock.class, projection, forceYield);
     }
 
     private static DictionaryBlock createDictionaryBlock(int dictionarySize, int blockSize)


### PR DESCRIPTION
Projection: turn on dictionary projection immediately if the current projection input page selected positions size no less than the size of the dictionary.
Aggregation: Fallback to non-dictionary aggregation when input hash channel isn't dictionary or the dictionary source is different with the groupBy channel; This was failing the query when optimizer.dictionary-aggregation turned on while some pages dynamically fallback to original projection instead of dictionary projection