### PR TITLE
 Allow SHOW PARTITIONS .. WHERE.. for table above partition limit

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -131,7 +131,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testInformationSchemaTablesWithoutEqualityConstraint()
-            throws Exception
     {
         @Language("SQL") String actual = "" +
                 "SELECT lower(table_name) " +
@@ -148,7 +147,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testInformationSchemaColumnsWithoutEqualityConstraint()
-            throws Exception
     {
         @Language("SQL") String actual = "" +
                 "SELECT lower(table_name), lower(column_name) " +
@@ -165,7 +163,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void createTableWithEveryType()
-            throws Exception
     {
         @Language("SQL") String query = "" +
                 "CREATE TABLE test_types_table AS " +
@@ -205,7 +202,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void createPartitionedTable()
-            throws Exception
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
             if (insertOperationsSupported(storageFormat.getFormat())) {
@@ -343,7 +339,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void createTableLike()
-            throws Exception
     {
         createTableLike("", false);
         createTableLike("EXCLUDING PROPERTIES", false);
@@ -455,7 +450,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void createTableAs()
-            throws Exception
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
             if (insertOperationsSupported(storageFormat.getFormat())) {
@@ -506,7 +500,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void createPartitionedTableAs()
-            throws Exception
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
             createPartitionedTableAs(storageFormat.getSession(), storageFormat.getFormat());
@@ -552,7 +545,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Partition keys must be the last columns in the table and in the same order as the table properties.*")
     public void testCreatePartitionedTableAsInvalidColumnOrdering()
-            throws Exception
     {
         assertUpdate("" +
                 "CREATE TABLE test_create_table_as_invalid_column_ordering " +
@@ -588,7 +580,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testCreatePartitionedBucketedTableAsFewRows()
-            throws Exception
     {
         // go through all storage formats to make sure the empty buckets are correctly created
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
@@ -645,7 +636,6 @@ public class TestHiveIntegrationSmokeTest
     }
 
     private void testCreatePartitionedBucketedTableAs(HiveStorageFormat storageFormat)
-            throws Exception
     {
         String tableName = "test_create_partitioned_bucketed_table_as";
 
@@ -681,7 +671,6 @@ public class TestHiveIntegrationSmokeTest
     }
 
     private void testCreatePartitionedBucketedTableAsWithUnionAll(HiveStorageFormat storageFormat)
-            throws Exception
     {
         String tableName = "test_create_partitioned_bucketed_table_as_with_union_all";
 
@@ -745,7 +734,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testCreateInvalidBucketedTable()
-            throws Exception
     {
         testCreateInvalidBucketedTable(HiveStorageFormat.RCBINARY);
     }
@@ -795,7 +783,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testInsertPartitionedBucketedTableFewRows()
-            throws Exception
     {
         // go through all storage formats to make sure the empty buckets are correctly created
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
@@ -865,7 +852,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testInsertPartitionedBucketedTable()
-            throws Exception
     {
         testInsertPartitionedBucketedTable(HiveStorageFormat.RCBINARY);
     }
@@ -909,7 +895,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testInsertPartitionedBucketedTableWithUnionAll()
-            throws Exception
     {
         testInsertPartitionedBucketedTableWithUnionAll(HiveStorageFormat.RCBINARY);
     }
@@ -957,7 +942,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void insertTable()
-            throws Exception
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
             if (insertOperationsSupported(storageFormat.getFormat())) {
@@ -1044,7 +1028,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void insertPartitionedTable()
-            throws Exception
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
             insertPartitionedTable(storageFormat.getSession(), storageFormat.getFormat());
@@ -1116,7 +1099,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testInsertPartitionedTableExistingPartition()
-            throws Exception
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
             testInsertPartitionedTableExistingPartition(storageFormat.getSession(), storageFormat.getFormat());
@@ -1173,7 +1155,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testPartitionPerScanLimit()
-            throws Exception
     {
         TestingHiveStorageFormat storageFormat = new TestingHiveStorageFormat(getSession(), HiveStorageFormat.DWRF);
         testPartitionPerScanLimit(storageFormat.getSession(), storageFormat.getFormat());
@@ -1254,7 +1235,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testInsertUnpartitionedTable()
-            throws Exception
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
             testInsertUnpartitionedTable(storageFormat.getSession(), storageFormat.getFormat());
@@ -1305,7 +1285,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testDeleteFromUnpartitionedTable()
-            throws Exception
     {
         assertUpdate("CREATE TABLE test_delete_unpartitioned AS SELECT orderstatus FROM tpch.tiny.orders", "SELECT count(*) from orders");
 
@@ -1321,7 +1300,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testMetadataDelete()
-            throws Exception
     {
         @Language("SQL") String createTable = "" +
                 "CREATE TABLE test_metadata_delete " +
@@ -1434,7 +1412,6 @@ public class TestHiveIntegrationSmokeTest
     // TODO: These should be moved to another class, when more connectors support arrays
     @Test
     public void testArrays()
-            throws Exception
     {
         assertUpdate("CREATE TABLE tmp_array1 AS SELECT ARRAY[1, 2, NULL] AS col", 1);
         assertQuery("SELECT col[2] FROM tmp_array1", "SELECT 2");
@@ -1477,7 +1454,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testTemporalArrays()
-            throws Exception
     {
         assertUpdate("CREATE TABLE tmp_array11 AS SELECT ARRAY[DATE '2014-09-30'] AS col", 1);
         assertOneNotNullResult("SELECT col[1] FROM tmp_array11");
@@ -1487,7 +1463,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testMaps()
-            throws Exception
     {
         assertUpdate("CREATE TABLE tmp_map1 AS SELECT MAP(ARRAY[0,1], ARRAY[2,NULL]) AS col", 1);
         assertQuery("SELECT col[0] FROM tmp_map1", "SELECT 2");
@@ -1529,7 +1504,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testRows()
-            throws Exception
     {
         assertUpdate("CREATE TABLE tmp_row1 AS SELECT cast(row(CAST(1 as BIGINT), CAST(NULL as BIGINT)) AS row(col0 bigint, col1 bigint)) AS a", 1);
         assertQuery(
@@ -1539,7 +1513,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testComplex()
-            throws Exception
     {
         assertUpdate("CREATE TABLE tmp_complex1 AS SELECT " +
                         "ARRAY [MAP(ARRAY['a', 'b'], ARRAY[2.0E0, 4.0E0]), MAP(ARRAY['c', 'd'], ARRAY[12.0E0, 14.0E0])] AS a",
@@ -1552,7 +1525,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testBucketedCatalog()
-            throws Exception
     {
         String bucketedCatalog = bucketedSession.getCatalog().get();
         String bucketedSchema = bucketedSession.getSchema().get();
@@ -1568,7 +1540,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testBucketedExecution()
-            throws Exception
     {
         assertQuery(bucketedSession, "select count(*) a from orders t1 join orders t2 on t1.custkey=t2.custkey");
         assertQuery(bucketedSession, "select count(*) a from orders t1 join customer t2 on t1.custkey=t2.custkey", "SELECT count(*) from orders");
@@ -1612,7 +1583,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testShowCreateTable()
-            throws Exception
     {
         String createTableSql = format("" +
                         "CREATE TABLE %s.%s.%s (\n" +
@@ -1692,7 +1662,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testPathHiddenColumn()
-            throws Exception
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {
             doTestPathHiddenColumn(storageFormat.getSession(), storageFormat.getFormat());
@@ -1757,7 +1726,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testBucketHiddenColumn()
-            throws Exception
     {
         @Language("SQL") String createTable = "CREATE TABLE test_bucket_hidden_column " +
                 "WITH (" +
@@ -1909,7 +1877,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testRenameColumn()
-            throws Exception
     {
         @Language("SQL") String createTable = "" +
                 "CREATE TABLE test_rename_column\n" +
@@ -1930,7 +1897,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testDropColumn()
-            throws Exception
     {
         @Language("SQL") String createTable = "" +
                 "CREATE TABLE test_drop_column\n" +
@@ -1964,7 +1930,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testOrderByChar()
-            throws Exception
     {
         assertUpdate("CREATE TABLE char_order_by (c_char char(2))");
         assertUpdate("INSERT INTO char_order_by (c_char) VALUES" +
@@ -1991,7 +1956,6 @@ public class TestHiveIntegrationSmokeTest
      */
     @Test
     public void testPredicatePushDownToTableScan()
-            throws Exception
     {
         // Test not specific to Hive, but needs a connector supporting table creation
 
@@ -2122,7 +2086,6 @@ public class TestHiveIntegrationSmokeTest
     }
 
     private void testRcTextCharDecoding(boolean rcFileOptimizedWriterEnabled)
-            throws Exception
     {
         String catalog = getSession().getCatalog().get();
         Session session = Session.builder(getSession())
@@ -2142,7 +2105,6 @@ public class TestHiveIntegrationSmokeTest
 
     @Test
     public void testInvalidPartitionValue()
-            throws Exception
     {
         assertUpdate("CREATE TABLE invalid_partition_value (a int, b varchar) WITH (partitioned_by = ARRAY['b'])");
         assertQueryFails(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1106,6 +1106,9 @@ public class TestHiveIntegrationSmokeTest
                 "SHOW PARTITIONS FROM test_insert_partitioned_table WHERE order_status = 'O'",
                 "SELECT DISTINCT shippriority, orderstatus FROM orders WHERE orderstatus = 'O'");
 
+        assertQueryFails(session, "SHOW PARTITIONS FROM test_insert_partitioned_table WHERE no_such_column = 1", "line \\S*: Column 'no_such_column' cannot be resolved");
+        assertQueryFails(session, "SHOW PARTITIONS FROM test_insert_partitioned_table WHERE orderkey = 1", "line \\S*: Column 'orderkey' cannot be resolved");
+
         assertUpdate(session, "DROP TABLE test_insert_partitioned_table");
 
         assertFalse(getQueryRunner().tableExists(session, "test_insert_partitioned_table"));
@@ -1209,6 +1212,16 @@ public class TestHiveIntegrationSmokeTest
 
             assertUpdate(session, insertPartitions, 100);
         }
+
+        // verify can show partitions
+        assertQuery(
+                session,
+                "SHOW PARTITIONS FROM " + tableName + " WHERE part > 490 and part <= 500",
+                "VALUES 491, 492, 493, 494, 495, 496, 497, 498, 499, 500");
+        assertQuery(
+                session,
+                "SHOW PARTITIONS FROM " + tableName + " WHERE part < 0",
+                "SELECT null WHERE false");
 
         // verify can query 1000 partitions
         assertQuery(

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -57,7 +57,6 @@ public class InformationSchemaMetadata
     public static final SchemaTableName TABLE_TABLES = new SchemaTableName(INFORMATION_SCHEMA, "tables");
     public static final SchemaTableName TABLE_VIEWS = new SchemaTableName(INFORMATION_SCHEMA, "views");
     public static final SchemaTableName TABLE_SCHEMATA = new SchemaTableName(INFORMATION_SCHEMA, "schemata");
-    public static final SchemaTableName TABLE_INTERNAL_PARTITIONS = new SchemaTableName(INFORMATION_SCHEMA, "__internal_partitions__");
     public static final SchemaTableName TABLE_TABLE_PRIVILEGES = new SchemaTableName(INFORMATION_SCHEMA, "table_privileges");
 
     public static final Map<SchemaTableName, ConnectorTableMetadata> TABLES = schemaMetadataBuilder()
@@ -88,14 +87,6 @@ public class InformationSchemaMetadata
             .table(tableMetadataBuilder(TABLE_SCHEMATA)
                     .column("catalog_name", createUnboundedVarcharType())
                     .column("schema_name", createUnboundedVarcharType())
-                    .build())
-            .table(tableMetadataBuilder(TABLE_INTERNAL_PARTITIONS)
-                    .column("table_catalog", createUnboundedVarcharType())
-                    .column("table_schema", createUnboundedVarcharType())
-                    .column("table_name", createUnboundedVarcharType())
-                    .column("partition_number", BIGINT)
-                    .column("partition_key", createUnboundedVarcharType())
-                    .column("partition_value", createUnboundedVarcharType())
                     .build())
             .table(tableMetadataBuilder(TABLE_TABLE_PRIVILEGES)
                     .column("grantor", createUnboundedVarcharType())

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -16,13 +16,8 @@ package com.facebook.presto.connector.informationSchema;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.InternalTable;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.metadata.OperatorNotFoundException;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
-import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.metadata.TableHandle;
-import com.facebook.presto.metadata.TableLayout;
-import com.facebook.presto.metadata.TableLayoutResult;
 import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnHandle;
@@ -30,28 +25,20 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
-import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.NullableValue;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrivilegeInfo;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.airlift.slice.Slice;
 
-import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -59,7 +46,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_COLUMNS;
-import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_INTERNAL_PARTITIONS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_SCHEMATA;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLES;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES;
@@ -70,9 +56,7 @@ import static com.facebook.presto.metadata.MetadataListing.listTableColumns;
 import static com.facebook.presto.metadata.MetadataListing.listTablePrivileges;
 import static com.facebook.presto.metadata.MetadataListing.listTables;
 import static com.facebook.presto.metadata.MetadataListing.listViews;
-import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Sets.union;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -151,9 +135,6 @@ public class InformationSchemaPageSourceProvider
         }
         if (table.equals(TABLE_SCHEMATA)) {
             return buildSchemata(session, catalog);
-        }
-        if (table.equals(TABLE_INTERNAL_PARTITIONS)) {
-            return buildPartitions(session, catalog, filters);
         }
         if (table.equals(TABLE_TABLE_PRIVILEGES)) {
             return buildTablePrivileges(session, catalog, filters);
@@ -255,80 +236,6 @@ public class InformationSchemaPageSourceProvider
             table.add(catalogName, schema);
         }
         return table.build();
-    }
-
-    private InternalTable buildPartitions(Session session, String catalogName, Map<String, NullableValue> filters)
-    {
-        QualifiedObjectName tableName = extractQualifiedTableName(catalogName, filters);
-
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_INTERNAL_PARTITIONS));
-
-        Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
-        if (!tableHandle.isPresent()) {
-            throw new TableNotFoundException(tableName.asSchemaTableName());
-        }
-
-        List<TableLayoutResult> layouts = metadata.getLayouts(session, tableHandle.get(), Constraint.alwaysTrue(), Optional.empty());
-
-        if (layouts.size() == 1) {
-            Map<ColumnHandle, String> columnHandles = ImmutableBiMap.copyOf(metadata.getColumnHandles(session, tableHandle.get())).inverse();
-            Map<ColumnHandle, MethodHandle> methodHandles = new HashMap<>();
-            for (ColumnHandle columnHandle : columnHandles.keySet()) {
-                try {
-                    ColumnMetadata columnMetadata = metadata.getColumnMetadata(session, tableHandle.get(), columnHandle);
-                    Signature operator = metadata.getFunctionRegistry().getCoercion(columnMetadata.getType(), createUnboundedVarcharType());
-                    MethodHandle methodHandle = metadata.getFunctionRegistry().getScalarFunctionImplementation(operator).getMethodHandle();
-                    methodHandles.put(columnHandle, methodHandle);
-                }
-                catch (OperatorNotFoundException exception) {
-                    // Do not put the columnHandle in the map.
-                }
-            }
-
-            TableLayout layout = Iterables.getOnlyElement(layouts).getLayout();
-            layout.getDiscretePredicates().ifPresent(predicates -> {
-                int partitionNumber = 1;
-                for (TupleDomain<ColumnHandle> domain : predicates.getPredicates()) {
-                    for (Entry<ColumnHandle, NullableValue> entry : TupleDomain.extractFixedValues(domain).get().entrySet()) {
-                        ColumnHandle columnHandle = entry.getKey();
-                        String columnName = columnHandles.get(columnHandle);
-                        String value = null;
-                        if (entry.getValue().getValue() != null) {
-                            if (methodHandles.containsKey(columnHandle)) {
-                                try {
-                                    value = ((Slice) methodHandles.get(columnHandle).invokeWithArguments(entry.getValue().getValue())).toStringUtf8();
-                                }
-                                catch (Throwable throwable) {
-                                    throw Throwables.propagate(throwable);
-                                }
-                            }
-                            else {
-                                // OperatorNotFoundException was thrown for this columnHandle
-                                value = "<UNREPRESENTABLE VALUE>";
-                            }
-                        }
-                        table.add(
-                                catalogName,
-                                tableName.getSchemaName(),
-                                tableName.getObjectName(),
-                                partitionNumber,
-                                columnName,
-                                value);
-                    }
-                    partitionNumber++;
-                }
-            });
-        }
-        return table.build();
-    }
-
-    private static QualifiedObjectName extractQualifiedTableName(String catalogName, Map<String, NullableValue> filters)
-    {
-        Optional<String> schemaName = getFilterColumn(filters, "table_schema");
-        checkArgument(schemaName.isPresent(), "filter is required for column: %s.%s", TABLE_INTERNAL_PARTITIONS, "table_schema");
-        Optional<String> tableName = getFilterColumn(filters, "table_name");
-        checkArgument(tableName.isPresent(), "filter is required for column: %s.%s", TABLE_INTERNAL_PARTITIONS, "table_name");
-        return new QualifiedObjectName(catalogName, schemaName.get(), tableName.get());
     }
 
     private static QualifiedTablePrefix extractQualifiedTablePrefix(String catalogName, Map<String, NullableValue> filters)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
@@ -95,10 +95,14 @@ public class PlanNodeSearcher
     public <T extends PlanNode> Optional<T> findSingle()
     {
         List<T> all = findAll();
-        if (all.size() == 1) {
-            return Optional.of(all.get(0));
+        switch (all.size()) {
+            case 0:
+                return Optional.empty();
+            case 1:
+                return Optional.of(all.get(0));
+            default:
+                throw new IllegalStateException("Multiple nodes found");
         }
-        return Optional.empty();
     }
 
     public <T extends PlanNode> List<T> findAll()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedSingleRowSubqueryToProject.java
@@ -28,7 +28,6 @@ import com.facebook.presto.sql.planner.plan.ValuesNode;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
@@ -82,12 +81,12 @@ public class TransformCorrelatedSingleRowSubqueryToProject
                 return rewrittenLateral;
             }
 
-            Optional<ValuesNode> values = searchFrom(lateral.getSubquery())
+            List<ValuesNode> values = searchFrom(lateral.getSubquery())
                     .recurseOnlyWhen(ProjectNode.class::isInstance)
                     .where(ValuesNode.class::isInstance)
-                    .findSingle();
+                    .findAll();
 
-            if (!values.isPresent() || !isSingleRowValuesWithNoColumns(values.get())) {
+            if (values.size() != 1 || !isSingleRowValuesWithNoColumns(values.get(0))) {
                 return rewrittenLateral;
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -22,43 +22,47 @@ import com.facebook.presto.metadata.SessionPropertyManager.SessionPropertyValue;
 import com.facebook.presto.metadata.SqlFunction;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.metadata.TableLayout;
-import com.facebook.presto.metadata.TableLayoutResult;
+import com.facebook.presto.metadata.TableLayoutHandle;
 import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.CatalogSchemaName;
 import com.facebook.presto.spi.ColumnHandle;
-import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
-import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.DiscretePredicates;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.sql.QueryUtil;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.LiteralInterpreter;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.tree.AllColumns;
 import com.facebook.presto.sql.tree.ArrayConstructor;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.BooleanLiteral;
-import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ColumnDefinition;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.Explain;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LikePredicate;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.Relation;
-import com.facebook.presto.sql.tree.SelectItem;
+import com.facebook.presto.sql.tree.Row;
 import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreate;
@@ -68,26 +72,27 @@ import com.facebook.presto.sql.tree.ShowPartitions;
 import com.facebook.presto.sql.tree.ShowSchemas;
 import com.facebook.presto.sql.tree.ShowSession;
 import com.facebook.presto.sql.tree.ShowTables;
-import com.facebook.presto.sql.tree.SimpleGroupBy;
-import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.TableElement;
 import com.facebook.presto.sql.tree.Values;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_COLUMNS;
-import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_INTERNAL_PARTITIONS;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_SCHEMATA;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLES;
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_TABLE_PRIVILEGES;
@@ -102,7 +107,6 @@ import static com.facebook.presto.sql.QueryUtil.aliased;
 import static com.facebook.presto.sql.QueryUtil.aliasedName;
 import static com.facebook.presto.sql.QueryUtil.aliasedNullToEmpty;
 import static com.facebook.presto.sql.QueryUtil.ascending;
-import static com.facebook.presto.sql.QueryUtil.caseWhen;
 import static com.facebook.presto.sql.QueryUtil.equal;
 import static com.facebook.presto.sql.QueryUtil.functionCall;
 import static com.facebook.presto.sql.QueryUtil.identifier;
@@ -113,9 +117,7 @@ import static com.facebook.presto.sql.QueryUtil.selectAll;
 import static com.facebook.presto.sql.QueryUtil.selectList;
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
 import static com.facebook.presto.sql.QueryUtil.singleValueQuery;
-import static com.facebook.presto.sql.QueryUtil.subquery;
 import static com.facebook.presto.sql.QueryUtil.table;
-import static com.facebook.presto.sql.QueryUtil.unaliasedName;
 import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.CATALOG_NOT_SPECIFIED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_CATALOG;
@@ -123,16 +125,17 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_SCHEMA;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.VIEW_PARSE_ERROR;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ShowCreate.Type.TABLE;
 import static com.facebook.presto.sql.tree.ShowCreate.Type.VIEW;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 final class ShowQueriesRewrite
         implements StatementRewrite.Rewrite
@@ -365,72 +368,89 @@ final class ShowQueriesRewrite
         protected Node visitShowPartitions(ShowPartitions showPartitions, Void context)
         {
             QualifiedObjectName table = createQualifiedObjectName(session, showPartitions, showPartitions.getTable());
-            Optional<TableHandle> tableHandle = metadata.getTableHandle(session, table);
-            if (!tableHandle.isPresent()) {
-                throw new SemanticException(MISSING_TABLE, showPartitions, "Table '%s' does not exist", table);
+            TableHandle tableHandle = metadata.getTableHandle(session, table)
+                    .orElseThrow(() -> new SemanticException(MISSING_TABLE, showPartitions, "Table '%s' does not exist", table));
+
+            TableLayout layout = getLayout(showPartitions, showPartitions.getTable(), showPartitions.getWhere())
+                    .orElseThrow(() -> new SemanticException(NOT_SUPPORTED, showPartitions, "Could not find layout for table: %s", table));
+
+            Map<ColumnHandle, String> columnHandleNames = ImmutableBiMap.copyOf(metadata.getColumnHandles(session, tableHandle)).inverse();
+
+            DiscretePredicates discretePredicates = layout.getDiscretePredicates()
+                    .orElseThrow(() -> new SemanticException(NOT_SUPPORTED, showPartitions, "Table does not have partition columns: %s", table));
+
+            List<String> partitioningColumns = discretePredicates.getColumns().stream()
+                    .map(columnHandle -> requireNonNull(columnHandleNames.get(columnHandle), "no column name for handle"))
+                    .collect(toImmutableList());
+
+            Map<ColumnHandle, Integer> partitioningColumnIndex = IntStream.range(0, discretePredicates.getColumns().size())
+                    .boxed()
+                    .collect(toMap(index -> discretePredicates.getColumns().get(index), index -> index));
+
+            List<TupleDomain<ColumnHandle>> predicates = ImmutableList.copyOf(discretePredicates.getPredicates());
+            ImmutableList.Builder<Expression> rowBuilder = ImmutableList.builder();
+            for (TupleDomain<ColumnHandle> domain : predicates) {
+                List<Expression> row = TupleDomain.extractFixedValues(domain).get()
+                        .entrySet().stream()
+                        .sorted(Comparator.comparing(entry -> requireNonNull(partitioningColumnIndex.get(entry.getKey()), "not a partitioning column")))
+                        .map(Entry::getValue)
+                        .map(nullableValue -> LiteralInterpreter.toExpression(nullableValue.getValue(), nullableValue.getType()))
+                        .collect(toImmutableList());
+
+                rowBuilder.add(new Row(row));
             }
 
-            List<TableLayoutResult> layouts = metadata.getLayouts(session, tableHandle.get(), Constraint.alwaysTrue(), Optional.empty());
-            if (layouts.size() != 1) {
-                throw new SemanticException(NOT_SUPPORTED, showPartitions, "Table does not have exactly one layout: %s", table);
+            List<Expression> rows = rowBuilder.build();
+            Optional<Expression> where;
+            if (rows.isEmpty()) {
+                // VALUES does not allow no rows
+                List<Expression> row = partitioningColumns.stream()
+                        .map(partitioningColumn -> new NullLiteral())
+                        .collect(toImmutableList());
+                rows = ImmutableList.of(new Row(row));
+                where = Optional.of(FALSE_LITERAL);
             }
-            TableLayout layout = getOnlyElement(layouts).getLayout();
-            if (!layout.getDiscretePredicates().isPresent()) {
-                throw new SemanticException(NOT_SUPPORTED, showPartitions, "Table does not have partition columns: %s", table);
-            }
-            List<ColumnHandle> partitionColumns = layout.getDiscretePredicates().get().getColumns();
-
-            /*
-                Generate a dynamic pivot to output one column per partition key.
-                For example, a table with two partition keys (ds, cluster_name)
-                would generate the following query:
-
-                SELECT
-                  partition_number
-                , max(CASE WHEN partition_key = 'ds' THEN partition_value END) ds
-                , max(CASE WHEN partition_key = 'cluster_name' THEN partition_value END) cluster_name
-                FROM ...
-                GROUP BY partition_number
-
-                The values are also cast to the type of the partition column.
-                The query is then wrapped to allow custom filtering and ordering.
-            */
-
-            ImmutableList.Builder<SelectItem> selectList = ImmutableList.builder();
-            ImmutableList.Builder<SelectItem> wrappedList = ImmutableList.builder();
-            selectList.add(unaliasedName("partition_number"));
-            for (ColumnHandle columnHandle : partitionColumns) {
-                ColumnMetadata column = metadata.getColumnMetadata(session, tableHandle.get(), columnHandle);
-                Expression key = equal(identifier("partition_key"), new StringLiteral(column.getName()));
-                Expression value = caseWhen(key, identifier("partition_value"));
-                value = new Cast(value, column.getType().getTypeSignature().toString());
-                Expression function = functionCall("max", value);
-                selectList.add(new SingleColumn(function, new Identifier(column.getName())));
-                wrappedList.add(unaliasedName(column.getName()));
+            else {
+                where = showPartitions.getWhere();
             }
 
-            Query query = simpleQuery(
-                    selectAll(selectList.build()),
-                    from(table.getCatalogName(), TABLE_INTERNAL_PARTITIONS),
-                    Optional.of(logicalAnd(
-                            equal(identifier("table_schema"), new StringLiteral(table.getSchemaName())),
-                            equal(identifier("table_name"), new StringLiteral(table.getObjectName())))),
-                    Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of(identifier("partition_number")))))),
+            return simpleQuery(
+                    selectList(partitioningColumns.stream().map(QueryUtil::identifier).collect(toImmutableList())),
+                    aliased(new Values(rows), "x", partitioningColumns),
+                    where,
+                    Optional.empty(),
+                    Optional.empty(),
+                    orderBy(showPartitions.getOrderBy()),
+                    showPartitions.getLimit());
+        }
+
+        private Optional<TableLayout> getLayout(Node node, QualifiedName tableName, Optional<Expression> where)
+        {
+            QualifiedObjectName table = createQualifiedObjectName(session, node, tableName);
+            QuerySpecification querySpecification = new QuerySpecification(
+                    selectList(new AllColumns()),
+                    Optional.of(QueryUtil.table(tableName)),
+                    where,
+                    Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty());
 
-            return simpleQuery(
-                    selectAll(wrappedList.build()),
-                    subquery(query),
-                    showPartitions.getWhere(),
-                    Optional.empty(),
-                    Optional.empty(),
-                    Optional.of(new OrderBy(ImmutableList.<SortItem>builder()
-                            .addAll(showPartitions.getOrderBy())
-                            .add(ascending("partition_number"))
-                            .build())),
-                    showPartitions.getLimit());
+            Plan plan = queryExplainer.get().getLogicalPlan(session, new Query(Optional.empty(), querySpecification, Optional.empty(), Optional.empty()), parameters);
+
+            Optional<TableScanNode> scanNode = searchFrom(plan.getRoot())
+                    .where(TableScanNode.class::isInstance)
+                    .findSingle();
+
+            if (!scanNode.isPresent()) {
+                // Probably WHERE clause caused scan to be optimized away
+                return Optional.empty();
+            }
+            TableLayoutHandle tableLayoutHandle = scanNode.get()
+                    .getLayout()
+                    .orElseThrow(() -> new SemanticException(NOT_SUPPORTED, node, "Table does not have a layout: %s", table));
+
+            return Optional.of(metadata.getLayout(session, tableLayoutHandle));
         }
 
         @Override
@@ -617,6 +637,15 @@ final class ShowQueriesRewrite
         private static Relation from(String catalog, SchemaTableName table)
         {
             return table(QualifiedName.of(catalog, table.getSchemaName(), table.getTableName()));
+        }
+
+        private static Optional<OrderBy> orderBy(List<SortItem> sortItems)
+        {
+            requireNonNull(sortItems, "sortItems is null");
+            if (sortItems.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(new OrderBy(sortItems));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
@@ -229,7 +229,7 @@ public class ShowStatsRewrite
 
             Optional<TableScanNode> scanNode = searchFrom(plan.getRoot())
                     .where(TableScanNode.class::isInstance)
-                    .findFirst();
+                    .findSingle();
 
             if (!scanNode.isPresent()) {
                 return new Constraint<>(TupleDomain.none(), bindings -> true);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/QueryUtil.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static java.util.Arrays.asList;
 
 public final class QueryUtil
 {
@@ -74,6 +75,11 @@ public final class QueryUtil
     }
 
     public static Select selectList(Expression... expressions)
+    {
+        return selectList(asList(expressions));
+    }
+
+    public static Select selectList(List<Expression> expressions)
     {
         ImmutableList.Builder<SelectItem> items = ImmutableList.builder();
         for (Expression expression : expressions) {

--- a/presto-product-tests/conf/presto/etc/catalog/hive.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/hive.properties
@@ -15,3 +15,4 @@ hive.allow-drop-table=true
 hive.allow-rename-table=true
 hive.metastore-cache-ttl=0s
 hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
@@ -17,3 +17,4 @@ hive.metastore-cache-ttl=0s
 hive.hdfs.authentication.type=NONE
 hive.hdfs.impersonation.enabled=true
 hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -20,6 +20,7 @@ hive.hdfs.impersonation.enabled=true
 hive.hdfs.presto.principal=presto-server/_HOST@LABS.TERADATA.COM
 hive.hdfs.presto.keytab=/etc/presto/conf/presto-server.keytab
 hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100
 
 #required for testGrantRevoke() product test
 hive.security=sql-standard

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -25,3 +25,4 @@ hive.hdfs.impersonation.enabled=false
 hive.hdfs.presto.principal=hdfs/hadoop-master@LABS.TERADATA.COM
 hive.hdfs.presto.keytab=/etc/hadoop/conf/hdfs.keytab
 hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/convention/TestShowPartitions.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/convention/TestShowPartitions.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.tests.convention;
 
+import com.google.common.math.IntMath;
 import com.teradata.tempto.ProductTest;
 import com.teradata.tempto.Requirement;
 import com.teradata.tempto.RequirementsProvider;
@@ -27,7 +28,10 @@ import org.testng.annotations.Test;
 
 import javax.inject.Inject;
 
+import java.math.RoundingMode;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.tests.TestGroups.BASIC_SQL;
 import static com.teradata.tempto.Requirements.compose;
@@ -37,12 +41,21 @@ import static com.teradata.tempto.fulfillment.table.TableRequirements.mutableTab
 import static com.teradata.tempto.fulfillment.table.hive.InlineDataSource.createResourceDataSource;
 import static com.teradata.tempto.fulfillment.table.hive.InlineDataSource.createStringDataSource;
 import static com.teradata.tempto.query.QueryExecutor.query;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
 
 public class TestShowPartitions
         extends ProductTest
         implements RequirementsProvider
 {
+    // We use hive.max-partitions-per-scan=100 in tests, so this many partitions is too many
+    private static final int TOO_MANY_PARTITIONS = 105;
+
     private static final String PARTITIONED_TABLE = "partitioned_table";
+    private static final String PARTITIONED_TABLE_WITH_VARIABLE_PARTITIONS = "partitioned_table_with_variable_partitions";
 
     @Inject
     private MutableTablesState tablesState;
@@ -50,7 +63,9 @@ public class TestShowPartitions
     @Override
     public Requirement getRequirements(Configuration configuration)
     {
-        return compose(mutableTable(partitionedTableDefinition(), PARTITIONED_TABLE, MutableTableRequirement.State.CREATED));
+        return compose(
+                mutableTable(partitionedTableDefinition(), PARTITIONED_TABLE, MutableTableRequirement.State.CREATED),
+                mutableTable(partitionedTableWithVariablePartitionsDefinition(), PARTITIONED_TABLE_WITH_VARIABLE_PARTITIONS, MutableTableRequirement.State.CREATED));
     }
 
     private static TableDefinition partitionedTableDefinition()
@@ -68,13 +83,87 @@ public class TestShowPartitions
                 .build();
     }
 
+    private static TableDefinition partitionedTableWithVariablePartitionsDefinition()
+    {
+        String createTableDdl = "CREATE TABLE %NAME%(col INT) " +
+                "PARTITIONED BY (part_col INT) " +
+                "STORED AS ORC";
+
+        return HiveTableDefinition.builder(PARTITIONED_TABLE_WITH_VARIABLE_PARTITIONS)
+                .setCreateTableDDLTemplate(createTableDdl)
+                .setNoData()
+                .build();
+    }
+
     @Test(groups = {BASIC_SQL})
     public void testShowPartitionsFromHiveTable()
     {
         String tableNameInDatabase = tablesState.get(PARTITIONED_TABLE).getNameInDatabase();
 
-        String selectFromOnePartitionsSql = "show partitions from " + tableNameInDatabase;
-        QueryResult partitionListResult = query(selectFromOnePartitionsSql);
+        QueryResult partitionListResult;
+
+        partitionListResult = query("SHOW PARTITIONS FROM " + tableNameInDatabase);
         assertThat(partitionListResult).containsExactly(row(1), row(2));
+        assertColumnNames(partitionListResult, "part_col");
+
+        partitionListResult = query(format("SHOW PARTITIONS FROM %s WHERE part_col = 1", tableNameInDatabase));
+        assertThat(partitionListResult).containsExactly(row(1));
+        assertColumnNames(partitionListResult, "part_col");
+
+        assertThat(() -> query(format("SHOW PARTITIONS FROM %s WHERE no_such_column = 1", tableNameInDatabase)))
+                .failsWithMessage("Column 'no_such_column' cannot be resolved");
+        assertThat(() -> query(format("SHOW PARTITIONS FROM %s WHERE col = 1", tableNameInDatabase)))
+                .failsWithMessage("Column 'col' cannot be resolved");
+    }
+
+    @Test(groups = {BASIC_SQL})
+    public void testShowPartitionsFromHiveTableWithTooManyPartitions()
+    {
+        String tableName = tablesState.get(PARTITIONED_TABLE_WITH_VARIABLE_PARTITIONS).getNameInDatabase();
+        createPartitions(tableName, TOO_MANY_PARTITIONS);
+
+        // Verify we created enough partitions for the test to be meaningful
+        assertThatThrownBy(() -> query("SELECT * FROM " + tableName))
+                .hasMessageMatching(".*: Query over table '\\S+' can potentially read more than \\d+ partitions");
+
+        QueryResult partitionListResult;
+
+        partitionListResult = query(format("SHOW PARTITIONS FROM %s WHERE part_col < 7", tableName));
+        assertThat(partitionListResult).containsExactly(row(0), row(1), row(2), row(3), row(4), row(5), row(6));
+        assertColumnNames(partitionListResult, "part_col");
+
+        partitionListResult = query(format("SHOW PARTITIONS FROM %s WHERE part_col < -10", tableName));
+        assertThat(partitionListResult).hasNoRows();
+    }
+
+    private void createPartitions(String tableName, int partitionsToCreate)
+    {
+        // This is done in tests rather than as a requirement, because TableRequirements.immutableTable cannot be partitioned
+        // and mutable table is recreated before every test (and this takes a lot of time).
+        // TODO convert to immutableTable + TableDefinition once immutableTable supports partitioned tables
+
+        requireNonNull(tableName, "tableName is null");
+
+        int maxPartitionsAtOnce = 100;
+
+        IntStream.range(0, IntMath.divide(partitionsToCreate, maxPartitionsAtOnce, RoundingMode.UP))
+                .forEach(batch -> {
+                    int rangeStart = batch * maxPartitionsAtOnce;
+                    int rangeEndInclusive = min((batch + 1) * maxPartitionsAtOnce, partitionsToCreate) - 1;
+                    query(format(
+                            "INSERT INTO %s (part_col, col) " +
+                                    "SELECT CAST(id AS integer), 42 FROM UNNEST (sequence(%s, %s)) AS u(id)",
+                            tableName,
+                            rangeStart,
+                            rangeEndInclusive));
+                });
+    }
+
+    private static void assertColumnNames(QueryResult queryResult, String... columnNames)
+    {
+        for (int i = 0; i < columnNames.length; i++) {
+            assertEquals(queryResult.tryFindColumnIndex(columnNames[i]), Optional.of(i + 1), "Index of column " + columnNames[i]);
+        }
+        assertEquals(queryResult.getColumnsCount(), columnNames.length);
     }
 }

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -1,10 +1,4 @@
 -- delimiter: |; trimValues:true;
-system| information_schema| __internal_partitions__| table_catalog| varchar| YES| null| null|
-system| information_schema| __internal_partitions__| table_schema| varchar| YES| null| null|
-system| information_schema| __internal_partitions__| table_name| varchar| YES| null| null|
-system| information_schema| __internal_partitions__| partition_number| bigint| YES| null| null|
-system| information_schema| __internal_partitions__| partition_key| varchar| YES| null| null|
-system| information_schema| __internal_partitions__| partition_value| varchar| YES| null| null|
 system| information_schema| columns| table_catalog| varchar| YES| null| null|
 system| information_schema| columns| table_schema| varchar| YES| null| null|
 system| information_schema| columns| table_name| varchar| YES| null| null|

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -164,6 +164,15 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testShowPartitions()
+    {
+        assertQueryFails("SHOW PARTITIONS FROM orders", "line 1:1: Table does not have partition columns: \\S+\\.orders");
+        assertQueryFails("SHOW PARTITIONS FROM orders WHERE orderkey < 10", "line 1:1: Table does not have partition columns: \\S+\\.orders");
+        assertQueryFails("SHOW PARTITIONS FROM orders WHERE invalid_column < 10", "line 1:35: Column 'invalid_column' cannot be resolved");
+        assertQueryFails("SHOW PARTITIONS FROM orders LIMIT 2", "line 1:1: Table does not have partition columns: \\S+\\.orders");
+    }
+
+    @Test
     public void selectLargeInterval()
     {
         MaterializedResult result = computeActual("SELECT INTERVAL '30' DAY");


### PR DESCRIPTION
Previously, `SHOW PARTITIONS FROM <table>` would fail for Hive table
having more partitions than `hive.max-partitions-per-scan`.
However, the `hive.max-partitions-per-scan` setting is supposed to
control scans (`SELECT` queries).  In the case of `SHOW PARTITIONS` the
check was applied after all relevant partition information was already
retrieved from metastore, so it didn't give any kind of resource
over-allocation counter-measure.

This commit moves the check from `HivePartitionManager` to
`HiveSplitManager`, so that remains applied in `SELECT` queries but not
for `SHOW PARTITIONS`.

Based on #9648, fixes #7358