### PR TITLE
Update misleading comment

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlTimeWithTimeZone.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlTimeWithTimeZone.java
@@ -26,7 +26,7 @@ import static com.facebook.presto.spi.type.DateTimeEncoding.unpackZoneKey;
 
 public final class SqlTimeWithTimeZone
 {
-    // This needs to be Locale-independent, work the same in Joda and Java Time and should never change, as it defines the external API data format.
+    // This needs to be Locale-independent, Java Time's DateTimeFormatter compatible and should never change, as it defines the external API data format.
     // TODO when support for political time zones is removed, change the pattern to "HH:mm:ss.SSS XXX" and reuse in TestingPrestoClient
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS VV");
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlTimestamp.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlTimestamp.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 
 public final class SqlTimestamp
 {
-    // This needs to be Locale-independent, work the same in Joda and Java Time and should never change, as it defines the external API data format.
+    // This needs to be Locale-independent, Java Time's DateTimeFormatter compatible and should never change, as it defines the external API data format.
     public static final String JSON_FORMAT = "uuuu-MM-dd HH:mm:ss.SSS";
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(JSON_FORMAT);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlTimestampWithTimeZone.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SqlTimestampWithTimeZone.java
@@ -26,7 +26,7 @@ import static com.facebook.presto.spi.type.DateTimeEncoding.unpackZoneKey;
 
 public final class SqlTimestampWithTimeZone
 {
-    // This needs to be Locale-independent, work the same in Joda and Java Time and should never change, as it defines the external API data format.
+    // This needs to be Locale-independent, Java Time's DateTimeFormatter compatible and should never change, as it defines the external API data format.
     public static final String JSON_FORMAT = "uuuu-MM-dd HH:mm:ss.SSS VV";
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(JSON_FORMAT);
 


### PR DESCRIPTION
The formatting patterns defined by `SqlTimestamp`,
`SqlTimestampWithTimeZone` and `SqlTimeWithTimeZone` are never used (nor
are compatible) with Joda Time.