### PR TITLE
Update exception message when no page sink provided

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/split/PageSinkManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/PageSinkManager.java
@@ -64,7 +64,7 @@ public class PageSinkManager
     private ConnectorPageSinkProvider providerFor(ConnectorId connectorId)
     {
         ConnectorPageSinkProvider provider = pageSinkProviders.get(connectorId);
-        checkArgument(provider != null, "No page sink provider for connector '%s'", connectorId);
+        checkArgument(provider != null, "No page sink provider for catalog '%s'", connectorId.getCatalogName());
         return provider;
     }
 }


### PR DESCRIPTION
Previously the exception would say `No page sink provider for connector 'catalog-name'`.

  