### PR TITLE
Asynchronously clean up backup shards created when rolling back a Raptor transaction

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupConfig.java
@@ -31,6 +31,7 @@ public class BackupConfig
     private int timeoutThreads = 1000;
     private String provider;
     private int backupThreads = 5;
+    private long backupQueueThreshold;
 
     @NotNull
     @MinDuration("1s")
@@ -87,6 +88,20 @@ public class BackupConfig
     public BackupConfig setBackupThreads(int backupThreads)
     {
         this.backupThreads = backupThreads;
+        return this;
+    }
+
+    @Min(0)
+    public long getBackupQueueThreshold()
+    {
+        return backupQueueThreshold;
+    }
+
+    @Config("backup.backup-queue-threshold")
+    @ConfigDescription("Threshold of pending backup operations to block more writes. Zero means unlimited.")
+    public BackupConfig setBackupQueueThreshold(long backupQueueThreshold)
+    {
+        this.backupQueueThreshold = backupQueueThreshold;
         return this;
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupManager.java
@@ -16,7 +16,6 @@ package com.facebook.presto.raptor.backup;
 import com.facebook.presto.raptor.storage.BackupStats;
 import com.facebook.presto.raptor.storage.StorageService;
 import com.facebook.presto.spi.PrestoException;
-import com.google.common.base.Throwables;
 import com.google.common.io.Files;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
@@ -36,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_BACKUP_CORRUPTION;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.Objects.requireNonNull;
@@ -140,7 +140,7 @@ public class BackupManager
             }
             catch (Throwable t) {
                 stats.incrementBackupFailure();
-                throw Throwables.propagate(t);
+                throw propagate(t);
             }
         }
     }
@@ -156,5 +156,11 @@ public class BackupManager
     public BackupStats getStats()
     {
         return stats;
+    }
+
+    private RuntimeException propagate(Throwable t)
+    {
+        throwIfUnchecked(t);
+        throw new RuntimeException(t);
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/NotifyingCounter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/NotifyingCounter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.backup;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+@ThreadSafe
+public class NotifyingCounter
+{
+    private static final CompletableFuture<?> NOT_BLOCKED = CompletableFuture.completedFuture(null);
+
+    private final long threshold;
+    private long counter;
+    private CompletableFuture<?> currentFuture = NOT_BLOCKED;
+
+    public NotifyingCounter(long threshold)
+    {
+        checkArgument(threshold >= 0, "threshold must >= 0");
+        this.threshold = threshold;
+    }
+
+    public synchronized void increment()
+    {
+        counter++;
+        if (counter == threshold) {
+            // moving above the threshold now
+            currentFuture = new CompletableFuture<>();
+        }
+    }
+
+    public void decrement()
+    {
+        CompletableFuture<?> oldFuture = null;
+
+        synchronized (this) {
+            checkState(counter > 0, "counter to decrement must > 0");
+            if (threshold != 0 && counter == threshold) {
+                // moving below the threshold now
+                oldFuture = currentFuture;
+                currentFuture = NOT_BLOCKED;
+            }
+            counter--;
+        }
+
+        // complete the future outside of the lock
+        if (oldFuture != null) {
+            oldFuture.complete(null);
+        }
+    }
+
+    public synchronized CompletableFuture<?> getBelowThreshold()
+    {
+        return currentFuture;
+    }
+
+    public synchronized long getCount()
+    {
+        return counter;
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BackupStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BackupStats.java
@@ -15,6 +15,7 @@ package com.facebook.presto.raptor.storage;
 
 import io.airlift.stats.CounterStat;
 import io.airlift.stats.DistributionStat;
+import io.airlift.stats.TimeStat;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
@@ -23,6 +24,7 @@ import org.weakref.jmx.Nested;
 import javax.annotation.concurrent.ThreadSafe;
 
 import static com.facebook.presto.raptor.storage.ShardRecoveryManager.dataRate;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @ThreadSafe
 public class BackupStats
@@ -30,7 +32,7 @@ public class BackupStats
     private final DistributionStat copyToBackupBytesPerSecond = new DistributionStat();
     private final DistributionStat copyToBackupShardSizeBytes = new DistributionStat();
     private final DistributionStat copyToBackupTimeInMilliSeconds = new DistributionStat();
-    private final DistributionStat queuedTimeMilliSeconds = new DistributionStat();
+    private final TimeStat queuedTimeMilliSeconds = new TimeStat(MILLISECONDS);
 
     private final CounterStat backupSuccess = new CounterStat();
     private final CounterStat backupFailure = new CounterStat();
@@ -46,7 +48,7 @@ public class BackupStats
 
     public void addQueuedTime(Duration queuedTime)
     {
-        queuedTimeMilliSeconds.add(queuedTime.toMillis());
+        queuedTimeMilliSeconds.add(queuedTime);
     }
 
     public void incrementBackupSuccess()
@@ -87,7 +89,7 @@ public class BackupStats
 
     @Managed
     @Nested
-    public DistributionStat getQueuedTimeMilliSeconds()
+    public TimeStat getQueuedTimeMilliSeconds()
     {
         return queuedTimeMilliSeconds;
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BackupStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BackupStats.java
@@ -29,14 +29,18 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @ThreadSafe
 public class BackupStats
 {
+    private final TimeStat queuedTimeMilliSeconds = new TimeStat(MILLISECONDS);
+
     private final DistributionStat copyToBackupBytesPerSecond = new DistributionStat();
     private final DistributionStat copyToBackupShardSizeBytes = new DistributionStat();
     private final DistributionStat copyToBackupTimeInMilliSeconds = new DistributionStat();
-    private final TimeStat queuedTimeMilliSeconds = new TimeStat(MILLISECONDS);
 
     private final CounterStat backupSuccess = new CounterStat();
     private final CounterStat backupFailure = new CounterStat();
     private final CounterStat backupCorruption = new CounterStat();
+
+    private final CounterStat deleteSuccess = new CounterStat();
+    private final CounterStat deleteFailure = new CounterStat();
 
     public void addCopyShardDataRate(DataSize size, Duration duration)
     {
@@ -66,6 +70,23 @@ public class BackupStats
         backupCorruption.update(1);
     }
 
+    public void incrementDeleteSuccess()
+    {
+        deleteSuccess.update(1);
+    }
+
+    public void incrementDeleteFailure()
+    {
+        deleteFailure.update(1);
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getQueuedTimeMilliSeconds()
+    {
+        return queuedTimeMilliSeconds;
+    }
+
     @Managed
     @Nested
     public DistributionStat getCopyToBackupBytesPerSecond()
@@ -89,13 +110,6 @@ public class BackupStats
 
     @Managed
     @Nested
-    public TimeStat getQueuedTimeMilliSeconds()
-    {
-        return queuedTimeMilliSeconds;
-    }
-
-    @Managed
-    @Nested
     public CounterStat getBackupSuccess()
     {
         return backupSuccess;
@@ -113,5 +127,19 @@ public class BackupStats
     public CounterStat getBackupCorruption()
     {
         return backupCorruption;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getDeleteSuccess()
+    {
+        return deleteSuccess;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getDeleteFailure()
+    {
+        return deleteFailure;
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManager.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public interface StorageManager
 {
@@ -35,6 +36,14 @@ public interface StorageManager
     {
         return getPageSource(shardUuid, bucketNumber, columnIds, columnTypes, effectivePredicate, readerAttributes, OptionalLong.empty());
     }
+
+    /**
+     * Return a future that will be completed when the storage manager can
+     * accept more pages. If the storage manager can accept more pages
+     * immediately, this method should return {@code NOT_BLOCKED} defined
+     * in {@code ConnectorPageSink.java}.
+     */
+    CompletableFuture<?> getAcceptMorePageFuture();
 
     ConnectorPageSource getPageSource(
             UUID shardUuid,

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
@@ -53,6 +53,7 @@ public class StorageManagerConfig
     private int recoveryThreads = 10;
     private int organizationThreads = 5;
     private boolean organizationEnabled = true;
+    private boolean asyncRollbackEnabled;
     private Duration organizationInterval = new Duration(7, TimeUnit.DAYS);
 
     private long maxShardRows = 1_000_000;
@@ -334,6 +335,19 @@ public class StorageManagerConfig
     public StorageManagerConfig setOneSplitPerBucketThreshold(int oneSplitPerBucketThreshold)
     {
         this.oneSplitPerBucketThreshold = oneSplitPerBucketThreshold;
+        return this;
+    }
+
+    public boolean isAsyncRollbackEnabled()
+    {
+        return asyncRollbackEnabled;
+    }
+
+    @Config("storage.async-rollback-enabled")
+    @ConfigDescription("Experimental: Enable async backup cleanup when rolling back")
+    public StorageManagerConfig setAsyncRollbackEnabled(boolean asyncRollbackEnabled)
+    {
+        this.asyncRollbackEnabled = asyncRollbackEnabled;
         return this;
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestBackupConfig.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestBackupConfig.java
@@ -34,7 +34,8 @@ public class TestBackupConfig
                 .setProvider(null)
                 .setTimeoutThreads(1000)
                 .setTimeout(new Duration(1, MINUTES))
-                .setBackupThreads(5));
+                .setBackupThreads(5)
+                .setBackupQueueThreshold(0));
     }
 
     @Test
@@ -45,13 +46,15 @@ public class TestBackupConfig
                 .put("backup.timeout", "42s")
                 .put("backup.timeout-threads", "13")
                 .put("backup.threads", "3")
+                .put("backup.backup-queue-threshold", "1000")
                 .build();
 
         BackupConfig expected = new BackupConfig()
                 .setProvider("file")
                 .setTimeout(new Duration(42, SECONDS))
                 .setTimeoutThreads(13)
-                .setBackupThreads(3);
+                .setBackupThreads(3)
+                .setBackupQueueThreshold(1000);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestNotifyingCounter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestNotifyingCounter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.backup;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestNotifyingCounter
+{
+    @Test
+    public void testCounter()
+    {
+        NotifyingCounter notifyingCounter = new NotifyingCounter(3);
+        for (int i = 0; i < 2; ++i) {
+            notifyingCounter.increment();
+            assertTrue(notifyingCounter.getBelowThreshold().isDone());
+        }
+
+        notifyingCounter.increment();
+        assertFalse(notifyingCounter.getBelowThreshold().isDone());
+
+        notifyingCounter.decrement();
+        assertTrue(notifyingCounter.getBelowThreshold().isDone());
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "counter to decrement must > 0")
+    public void testIllegalDecrement()
+    {
+        NotifyingCounter notifyingCounter = new NotifyingCounter(0);
+        notifyingCounter.decrement();
+    }
+}

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
@@ -611,7 +611,7 @@ public class TestOrcStorageManager
                 storageService,
                 backupStore,
                 READER_ATTRIBUTES,
-                new BackupManager(backupStore, storageService, 1),
+                new BackupManager(backupStore, storageService, 1, 0),
                 recoveryManager,
                 shardRecorder,
                 new TypeRegistry(),
@@ -620,7 +620,8 @@ public class TestOrcStorageManager
                 SHARD_RECOVERY_TIMEOUT,
                 maxShardRows,
                 maxFileSize,
-                new DataSize(0, BYTE));
+                new DataSize(0, BYTE),
+                false);
     }
 
     private static void assertFileEquals(File actual, File expected)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
@@ -63,7 +63,8 @@ public class TestStorageManagerConfig
                 .setMaxShardRows(1_000_000)
                 .setMaxShardSize(new DataSize(256, MEGABYTE))
                 .setMaxBufferSize(new DataSize(256, MEGABYTE))
-                .setOneSplitPerBucketThreshold(0));
+                .setOneSplitPerBucketThreshold(0)
+                .setAsyncRollbackEnabled(false));
     }
 
     @Test
@@ -90,6 +91,7 @@ public class TestStorageManagerConfig
                 .put("storage.max-shard-size", "10MB")
                 .put("storage.max-buffer-size", "512MB")
                 .put("storage.one-split-per-bucket-threshold", "4")
+                .put("storage.async-rollback-enabled", "true")
                 .build();
 
         StorageManagerConfig expected = new StorageManagerConfig()
@@ -112,6 +114,7 @@ public class TestStorageManagerConfig
                 .setMaxShardRows(10_000)
                 .setMaxShardSize(new DataSize(10, MEGABYTE))
                 .setMaxBufferSize(new DataSize(512, MEGABYTE))
+                .setAsyncRollbackEnabled(true)
                 .setOneSplitPerBucketThreshold(4);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
- Offload the backup cleanup to the thread pool in `BackupManager`.
- Keep track on the queue size in `BackupManager` and block append page calls in `RaptorPageSink` when the queue size is above a configured threshold. This essentially introduces a back pressure to prevent writes and deletes overload the backup storage.
- Add config options to turn on async rollback and backup storage backup pressure. Current default is sync rollback and no back pressure.

#9321 