### PR TITLE
Make read transformations extensible in base-jdbc

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BooleanReadFunction.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BooleanReadFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface BooleanReadFunction
+        extends ReadFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return boolean.class;
+    }
+
+    boolean readBoolean(ResultSet resultSet, int columnIndex)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/DoubleReadFunction.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/DoubleReadFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface DoubleReadFunction
+        extends ReadFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return double.class;
+    }
+
+    double readDouble(ResultSet resultSet, int columnIndex)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface JdbcClient
@@ -35,6 +36,8 @@ public interface JdbcClient
     JdbcTableHandle getTableHandle(SchemaTableName schemaTableName);
 
     List<JdbcColumnHandle> getColumns(JdbcTableHandle tableHandle);
+
+    Optional<ReadMapping> toPrestoType(JdbcTypeHandle typeHandle);
 
     ConnectorSplitSource getSplits(JdbcTableLayoutHandle layoutHandle);
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcColumnHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcColumnHandle.java
@@ -29,16 +29,19 @@ public final class JdbcColumnHandle
 {
     private final String connectorId;
     private final String columnName;
+    private final JdbcTypeHandle jdbcTypeHandle;
     private final Type columnType;
 
     @JsonCreator
     public JdbcColumnHandle(
             @JsonProperty("connectorId") String connectorId,
             @JsonProperty("columnName") String columnName,
+            @JsonProperty("jdbcTypeHandle") JdbcTypeHandle jdbcTypeHandle,
             @JsonProperty("columnType") Type columnType)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.columnName = requireNonNull(columnName, "columnName is null");
+        this.jdbcTypeHandle = requireNonNull(jdbcTypeHandle, "jdbcTypeHandle is null");
         this.columnType = requireNonNull(columnType, "columnType is null");
     }
 
@@ -52,6 +55,12 @@ public final class JdbcColumnHandle
     public String getColumnName()
     {
         return columnName;
+    }
+
+    @JsonProperty
+    public JdbcTypeHandle getJdbcTypeHandle()
+    {
+        return jdbcTypeHandle;
     }
 
     @JsonProperty
@@ -91,6 +100,7 @@ public final class JdbcColumnHandle
         return toStringHelper(this)
                 .add("connectorId", connectorId)
                 .add("columnName", columnName)
+                .add("jdbcTypeHandle", jdbcTypeHandle)
                 .add("columnType", columnType)
                 .toString();
     }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTypeHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTypeHandle.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public final class JdbcTypeHandle
+{
+    private final int jdbcType;
+    private final int columnSize;
+    private final int decimalDigits;
+
+    @JsonCreator
+    public JdbcTypeHandle(
+            @JsonProperty("jdbcType") int jdbcType,
+            @JsonProperty("columnSize") int columnSize,
+            @JsonProperty("decimalDigits") int decimalDigits)
+    {
+        this.jdbcType = jdbcType;
+        this.columnSize = columnSize;
+        this.decimalDigits = decimalDigits;
+    }
+
+    @JsonProperty
+    public int getJdbcType()
+    {
+        return jdbcType;
+    }
+
+    @JsonProperty
+    public int getColumnSize()
+    {
+        return columnSize;
+    }
+
+    @JsonProperty
+    public int getDecimalDigits()
+    {
+        return decimalDigits;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(jdbcType, columnSize, decimalDigits);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JdbcTypeHandle that = (JdbcTypeHandle) o;
+        return jdbcType == that.jdbcType &&
+                columnSize == that.columnSize &&
+                decimalDigits == that.decimalDigits;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("jdbcType", jdbcType)
+                .add("columnSize", columnSize)
+                .add("decimalDigits", decimalDigits)
+                .toString();
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/LongReadFunction.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/LongReadFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface LongReadFunction
+        extends ReadFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return long.class;
+    }
+
+    long readLong(ResultSet resultSet, int columnIndex)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/ReadFunction.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/ReadFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+public interface ReadFunction
+{
+    Class<?> getJavaType();
+
+    // This should be considered to have a method as below (it doesn't to avoid autoboxing)
+    //    T read(ResultSet resultSet, int columnIndex)
+    //            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/ReadMapping.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/ReadMapping.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.presto.spi.type.Type;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class ReadMapping
+{
+    public static ReadMapping booleanReadMapping(Type prestoType, BooleanReadFunction readFunction)
+    {
+        return new ReadMapping(prestoType, readFunction);
+    }
+
+    public static ReadMapping longReadMapping(Type prestoType, LongReadFunction readFunction)
+    {
+        return new ReadMapping(prestoType, readFunction);
+    }
+
+    public static ReadMapping doubleReadMapping(Type prestoType, DoubleReadFunction readFunction)
+    {
+        return new ReadMapping(prestoType, readFunction);
+    }
+
+    public static ReadMapping sliceReadMapping(Type prestoType, SliceReadFunction readFunction)
+    {
+        return new ReadMapping(prestoType, readFunction);
+    }
+
+    private final Type type;
+    private final ReadFunction readFunction;
+
+    private ReadMapping(Type type, ReadFunction readFunction)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.readFunction = requireNonNull(readFunction, "readFunction is null");
+        checkArgument(
+                type.getJavaType() == readFunction.getJavaType(),
+                "Presto type %s is not compatible with read function %s returning %s",
+                type,
+                readFunction,
+                readFunction.getJavaType());
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public ReadFunction getReadFunction()
+    {
+        return readFunction;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("type", type)
+                .toString();
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/SliceReadFunction.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/SliceReadFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import io.airlift.slice.Slice;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface SliceReadFunction
+        extends ReadFunction
+{
+    @Override
+    default Class<?> getJavaType()
+    {
+        return Slice.class;
+    }
+
+    Slice readSlice(ResultSet resultSet, int columnIndex)
+            throws SQLException;
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/StandardReadMappings.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/StandardReadMappings.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.presto.spi.type.CharType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.base.CharMatcher;
+import org.joda.time.chrono.ISOChronology;
+
+import java.sql.ResultSet;
+import java.sql.Time;
+import java.sql.Timestamp;
+
+import static com.facebook.presto.plugin.jdbc.ReadMapping.longReadMapping;
+import static com.facebook.presto.plugin.jdbc.ReadMapping.sliceReadMapping;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.Float.floatToRawIntBits;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.joda.time.DateTimeZone.UTC;
+
+public final class StandardReadMappings
+{
+    private StandardReadMappings() {}
+
+    private static final ISOChronology UTC_CHRONOLOGY = ISOChronology.getInstanceUTC();
+
+    public static ReadMapping booleanReadMapping()
+    {
+        return ReadMapping.booleanReadMapping(BOOLEAN, ResultSet::getBoolean);
+    }
+
+    public static ReadMapping tinyintReadMapping()
+    {
+        return longReadMapping(TINYINT, ResultSet::getByte);
+    }
+
+    public static ReadMapping smallintReadMapping()
+    {
+        return longReadMapping(SMALLINT, ResultSet::getShort);
+    }
+
+    public static ReadMapping integerReadMapping()
+    {
+        return longReadMapping(INTEGER, ResultSet::getInt);
+    }
+
+    public static ReadMapping bigintReadMapping()
+    {
+        return longReadMapping(BIGINT, ResultSet::getLong);
+    }
+
+    public static ReadMapping realReadMapping()
+    {
+        return longReadMapping(REAL, (resultSet, columnIndex) -> floatToRawIntBits(resultSet.getFloat(columnIndex)));
+    }
+
+    public static ReadMapping doubleReadMapping()
+    {
+        return ReadMapping.doubleReadMapping(DOUBLE, ResultSet::getDouble);
+    }
+
+    public static ReadMapping decimalReadMapping(DecimalType decimalType)
+    {
+        if (decimalType.isShort()) {
+            return longReadMapping(decimalType, (resultSet, columnIndex) -> resultSet.getBigDecimal(columnIndex).unscaledValue().longValueExact());
+        }
+        return sliceReadMapping(decimalType, (resultSet, columnIndex) -> encodeScaledValue(resultSet.getBigDecimal(columnIndex)));
+    }
+
+    protected static ReadMapping charReadMapping(CharType charType)
+    {
+        requireNonNull(charType, "charType is null");
+        return sliceReadMapping(charType, (resultSet, columnIndex) -> utf8Slice(CharMatcher.is(' ').trimTrailingFrom(resultSet.getString(columnIndex))));
+    }
+
+    public static ReadMapping varcharReadMapping(VarcharType varcharType)
+    {
+        return sliceReadMapping(varcharType, (resultSet, columnIndex) -> utf8Slice(resultSet.getString(columnIndex)));
+    }
+
+    public static ReadMapping varbinaryReadMapping()
+    {
+        return sliceReadMapping(VARBINARY, (resultSet, columnIndex) -> wrappedBuffer(resultSet.getBytes(columnIndex)));
+    }
+
+    public static ReadMapping dateReadMapping()
+    {
+        return longReadMapping(DATE, (resultSet, columnIndex) -> {
+            // JDBC returns a date using a timestamp at midnight in the JVM timezone
+            long localMillis = resultSet.getDate(columnIndex).getTime();
+            // Convert it to a midnight in UTC
+            long utcMillis = ISOChronology.getInstance().getZone().getMillisKeepLocal(UTC, localMillis);
+            // convert to days
+            return MILLISECONDS.toDays(utcMillis);
+        });
+    }
+
+    public static ReadMapping timeReadMapping()
+    {
+        return longReadMapping(TIME, (resultSet, columnIndex) -> {
+            Time time = resultSet.getTime(columnIndex);
+            return UTC_CHRONOLOGY.millisOfDay().get(time.getTime());
+        });
+    }
+
+    public static ReadMapping timestampReadMapping()
+    {
+        return longReadMapping(TIMESTAMP, (resultSet, columnIndex) -> {
+            Timestamp timestamp = resultSet.getTimestamp(columnIndex);
+            return timestamp.getTime();
+        });
+    }
+}

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
@@ -21,6 +21,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.plugin.jdbc.TestingDatabase.CONNECTOR_ID;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DOUBLE;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_REAL;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -75,9 +79,9 @@ public class TestJdbcClient
         assertEquals(table.getTableName(), "NUMBERS");
         assertEquals(table.getSchemaTableName(), schemaTableName);
         assertEquals(jdbcClient.getColumns(table), ImmutableList.of(
-                new JdbcColumnHandle(CONNECTOR_ID, "TEXT", VARCHAR),
-                new JdbcColumnHandle(CONNECTOR_ID, "TEXT_SHORT", createVarcharType(32)),
-                new JdbcColumnHandle(CONNECTOR_ID, "VALUE", BIGINT)));
+                new JdbcColumnHandle(CONNECTOR_ID, "TEXT", JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle(CONNECTOR_ID, "TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
+                new JdbcColumnHandle(CONNECTOR_ID, "VALUE", JDBC_BIGINT, BIGINT)));
     }
 
     @Test
@@ -88,8 +92,8 @@ public class TestJdbcClient
         JdbcTableHandle table = jdbcClient.getTableHandle(schemaTableName);
         assertNotNull(table, "table is null");
         assertEquals(jdbcClient.getColumns(table), ImmutableList.of(
-                new JdbcColumnHandle(CONNECTOR_ID, "TE_T", VARCHAR),
-                new JdbcColumnHandle(CONNECTOR_ID, "VA%UE", BIGINT)));
+                new JdbcColumnHandle(CONNECTOR_ID, "TE_T", JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle(CONNECTOR_ID, "VA%UE", JDBC_BIGINT, BIGINT)));
     }
 
     @Test
@@ -100,9 +104,9 @@ public class TestJdbcClient
         JdbcTableHandle table = jdbcClient.getTableHandle(schemaTableName);
         assertNotNull(table, "table is null");
         assertEquals(jdbcClient.getColumns(table), ImmutableList.of(
-                new JdbcColumnHandle(CONNECTOR_ID, "COL1", BIGINT),
-                new JdbcColumnHandle(CONNECTOR_ID, "COL2", DOUBLE),
-                new JdbcColumnHandle(CONNECTOR_ID, "COL3", DOUBLE),
-                new JdbcColumnHandle(CONNECTOR_ID, "COL4", REAL)));
+                new JdbcColumnHandle(CONNECTOR_ID, "COL1", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle(CONNECTOR_ID, "COL2", JDBC_DOUBLE, DOUBLE),
+                new JdbcColumnHandle(CONNECTOR_ID, "COL3", JDBC_DOUBLE, DOUBLE),
+                new JdbcColumnHandle(CONNECTOR_ID, "COL4", JDBC_REAL, REAL)));
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcColumnHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcColumnHandle.java
@@ -18,6 +18,8 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.plugin.jdbc.MetadataUtil.COLUMN_CODEC;
 import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertJsonRoundTrip;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 
@@ -26,7 +28,7 @@ public class TestJdbcColumnHandle
     @Test
     public void testJsonRoundTrip()
     {
-        assertJsonRoundTrip(COLUMN_CODEC, new JdbcColumnHandle("connectorId", "columnName", VARCHAR));
+        assertJsonRoundTrip(COLUMN_CODEC, new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR));
     }
 
     @Test
@@ -34,20 +36,20 @@ public class TestJdbcColumnHandle
     {
         EquivalenceTester.equivalenceTester()
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("connectorId", "columnName", VARCHAR),
-                        new JdbcColumnHandle("connectorId", "columnName", VARCHAR),
-                        new JdbcColumnHandle("connectorId", "columnName", BIGINT),
-                        new JdbcColumnHandle("connectorId", "columnName", VARCHAR))
+                        new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("connectorId", "columnName", JDBC_BIGINT, BIGINT),
+                        new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR))
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("connectorIdX", "columnName", VARCHAR),
-                        new JdbcColumnHandle("connectorIdX", "columnName", VARCHAR),
-                        new JdbcColumnHandle("connectorIdX", "columnName", BIGINT),
-                        new JdbcColumnHandle("connectorIdX", "columnName", VARCHAR))
+                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_BIGINT, BIGINT),
+                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_VARCHAR, VARCHAR))
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("connectorId", "columnNameX", VARCHAR),
-                        new JdbcColumnHandle("connectorId", "columnNameX", VARCHAR),
-                        new JdbcColumnHandle("connectorId", "columnNameX", BIGINT),
-                        new JdbcColumnHandle("connectorId", "columnNameX", VARCHAR))
+                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_VARCHAR, VARCHAR),
+                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_BIGINT, BIGINT),
+                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_VARCHAR, VARCHAR))
                 .check();
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
@@ -26,6 +26,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.plugin.jdbc.TestingDatabase.CONNECTOR_ID;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.StandardErrorCode.PERMISSION_DENIED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -81,9 +83,9 @@ public class TestJdbcMetadata
     {
         // known table
         assertEquals(metadata.getColumnHandles(SESSION, tableHandle), ImmutableMap.of(
-                "text", new JdbcColumnHandle(CONNECTOR_ID, "TEXT", VARCHAR),
-                "text_short", new JdbcColumnHandle(CONNECTOR_ID, "TEXT_SHORT", createVarcharType(32)),
-                "value", new JdbcColumnHandle(CONNECTOR_ID, "VALUE", BIGINT)));
+                "text", new JdbcColumnHandle(CONNECTOR_ID, "TEXT", JDBC_VARCHAR, VARCHAR),
+                "text_short", new JdbcColumnHandle(CONNECTOR_ID, "TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
+                "value", new JdbcColumnHandle(CONNECTOR_ID, "VALUE", JDBC_BIGINT, BIGINT)));
 
         // unknown table
         unknownTableColumnHandle(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("unknown", "unknown"), "unknown", "unknown", "unknown"));
@@ -168,7 +170,7 @@ public class TestJdbcMetadata
     public void getColumnMetadata()
     {
         assertEquals(
-                metadata.getColumnMetadata(SESSION, tableHandle, new JdbcColumnHandle(CONNECTOR_ID, "text", VARCHAR)),
+                metadata.getColumnMetadata(SESSION, tableHandle, new JdbcColumnHandle(CONNECTOR_ID, "text", JDBC_VARCHAR, VARCHAR)),
                 new ColumnMetadata("text", VARCHAR));
     }
 

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -37,6 +37,17 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BOOLEAN;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DATE;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DOUBLE;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_INTEGER;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_REAL;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_SMALLINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_TIME;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_TIMESTAMP;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_TINYINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
@@ -71,17 +82,17 @@ public class TestJdbcQueryBuilder
         jdbcClient = database.getJdbcClient();
 
         columns = ImmutableList.of(
-                new JdbcColumnHandle("test_id", "col_0", BIGINT),
-                new JdbcColumnHandle("test_id", "col_1", DOUBLE),
-                new JdbcColumnHandle("test_id", "col_2", BOOLEAN),
-                new JdbcColumnHandle("test_id", "col_3", VARCHAR),
-                new JdbcColumnHandle("test_id", "col_4", DATE),
-                new JdbcColumnHandle("test_id", "col_5", TIME),
-                new JdbcColumnHandle("test_id", "col_6", TIMESTAMP),
-                new JdbcColumnHandle("test_id", "col_7", TINYINT),
-                new JdbcColumnHandle("test_id", "col_8", SMALLINT),
-                new JdbcColumnHandle("test_id", "col_9", INTEGER),
-                new JdbcColumnHandle("test_id", "col_10", REAL));
+                new JdbcColumnHandle("test_id", "col_0", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("test_id", "col_1", JDBC_DOUBLE, DOUBLE),
+                new JdbcColumnHandle("test_id", "col_2", JDBC_BOOLEAN, BOOLEAN),
+                new JdbcColumnHandle("test_id", "col_3", JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle("test_id", "col_4", JDBC_DATE, DATE),
+                new JdbcColumnHandle("test_id", "col_5", JDBC_TIME, TIME),
+                new JdbcColumnHandle("test_id", "col_6", JDBC_TIMESTAMP, TIMESTAMP),
+                new JdbcColumnHandle("test_id", "col_7", JDBC_TINYINT, TINYINT),
+                new JdbcColumnHandle("test_id", "col_8", JDBC_SMALLINT, SMALLINT),
+                new JdbcColumnHandle("test_id", "col_9", JDBC_INTEGER, INTEGER),
+                new JdbcColumnHandle("test_id", "col_10", JDBC_REAL, REAL));
 
         Connection connection = database.getConnection();
         try (PreparedStatement preparedStatement = connection.prepareStatement("create table \"test_table\" (" + "" +

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSet.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSet.java
@@ -24,6 +24,8 @@ import org.testng.annotations.Test;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
@@ -60,20 +62,20 @@ public class TestJdbcRecordSet
             throws Exception
     {
         RecordSet recordSet = new JdbcRecordSet(jdbcClient, split, ImmutableList.of(
-                new JdbcColumnHandle("test", "text", VARCHAR),
-                new JdbcColumnHandle("test", "text_short", createVarcharType(32)),
-                new JdbcColumnHandle("test", "value", BIGINT)));
+                new JdbcColumnHandle("test", "text", JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle("test", "text_short", JDBC_VARCHAR, createVarcharType(32)),
+                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(VARCHAR, createVarcharType(32), BIGINT));
 
         recordSet = new JdbcRecordSet(jdbcClient, split, ImmutableList.of(
-                new JdbcColumnHandle("test", "value", BIGINT),
-                new JdbcColumnHandle("test", "text", VARCHAR)));
+                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("test", "text", JDBC_VARCHAR, VARCHAR)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, VARCHAR));
 
         recordSet = new JdbcRecordSet(jdbcClient, split, ImmutableList.of(
-                new JdbcColumnHandle("test", "value", BIGINT),
-                new JdbcColumnHandle("test", "value", BIGINT),
-                new JdbcColumnHandle("test", "text", VARCHAR)));
+                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("test", "text", JDBC_VARCHAR, VARCHAR)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, BIGINT, VARCHAR));
 
         recordSet = new JdbcRecordSet(jdbcClient, split, ImmutableList.of());

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import java.sql.Types;
+
+public final class TestingJdbcTypeHandle
+{
+    private TestingJdbcTypeHandle() {}
+
+    public static final JdbcTypeHandle JDBC_BOOLEAN = new JdbcTypeHandle(Types.BOOLEAN, 1, 0);
+
+    public static final JdbcTypeHandle JDBC_SMALLINT = new JdbcTypeHandle(Types.SMALLINT, 1, 0);
+    public static final JdbcTypeHandle JDBC_TINYINT = new JdbcTypeHandle(Types.TINYINT, 2, 0);
+    public static final JdbcTypeHandle JDBC_INTEGER = new JdbcTypeHandle(Types.INTEGER, 4, 0);
+    public static final JdbcTypeHandle JDBC_BIGINT = new JdbcTypeHandle(Types.BIGINT, 8, 0);
+
+    public static final JdbcTypeHandle JDBC_REAL = new JdbcTypeHandle(Types.REAL, 8, 0);
+    public static final JdbcTypeHandle JDBC_DOUBLE = new JdbcTypeHandle(Types.DOUBLE, 8, 0);
+
+    public static final JdbcTypeHandle JDBC_VARCHAR = new JdbcTypeHandle(Types.VARCHAR, 10, 0);
+
+    public static final JdbcTypeHandle JDBC_DATE = new JdbcTypeHandle(Types.DATE, 8, 0);
+    public static final JdbcTypeHandle JDBC_TIME = new JdbcTypeHandle(Types.TIME, 4, 0);
+    public static final JdbcTypeHandle JDBC_TIMESTAMP = new JdbcTypeHandle(Types.TIMESTAMP, 8, 0);
+}


### PR DESCRIPTION
This allows connectors extending `presto-base-jdbc` to support other
data types than supported by `BaseJdbcClient` and `JdbcRecordCursor` out
of the box.