### PR TITLE
SetBuildOperator to support yielding when memory limit is exceeded

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/SetBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SetBuilderOperator.java
@@ -19,11 +19,13 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.List;
@@ -135,6 +137,9 @@ public class SetBuilderOperator
 
     private boolean finished;
 
+    @Nullable
+    private Work<?> unfinishedWork;  // The pending work for current page.
+
     public SetBuilderOperator(
             OperatorContext operatorContext,
             SetSupplier setSupplier,
@@ -192,7 +197,10 @@ public class SetBuilderOperator
     @Override
     public boolean needsInput()
     {
-        return !finished;
+        // Since SetBuilderOperator doesn't produce any output, the getOutput()
+        // method may never be called. We need to handle any unfinished work
+        // before addInput() can be called again.
+        return !finished && (unfinishedWork == null || processUnfinishedWork());
     }
 
     @Override
@@ -203,12 +211,34 @@ public class SetBuilderOperator
 
         Block sourceBlock = page.getBlock(setChannel);
         Page sourcePage = hashChannel.isPresent() ? new Page(sourceBlock, page.getBlock(hashChannel.get())) : new Page(sourceBlock);
-        channelSetBuilder.addPage(sourcePage);
+
+        unfinishedWork = channelSetBuilder.addPage(sourcePage);
+        processUnfinishedWork();
     }
 
     @Override
     public Page getOutput()
     {
         return null;
+    }
+
+    private boolean processUnfinishedWork()
+    {
+        // Processes the unfinishedWork for this page by adding the data to the hash table. If this page
+        // can't be fully consumed (e.g. rehashing fails), the unfinishedWork will be left with non-empty value.
+        checkState(unfinishedWork != null, "unfinishedWork is empty");
+        boolean done = unfinishedWork.process();
+        if (done) {
+            unfinishedWork = null;
+        }
+        // We need to update the memory reservation again since the page builder memory may also be increasing.
+        channelSetBuilder.updateMemoryReservation();
+        return done;
+    }
+
+    @VisibleForTesting
+    public int getCapacity()
+    {
+        return channelSetBuilder.getCapacity();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
@@ -109,6 +109,7 @@ public final class GroupByHashYieldAssertion
 
             // add a page and verify different behaviors
             operator.addInput(page);
+
             // get output to consume the input
             Page output = operator.getOutput();
             if (output != null) {
@@ -172,11 +173,12 @@ public final class GroupByHashYieldAssertion
                 // Free the pool to unblock
                 memoryPool.free(queryId, reservedMemoryInBytes);
 
-                // Trigger a process
+                // Trigger a process through getOutput() or needsInput()
                 output = operator.getOutput();
                 if (output != null) {
                     result.add(output);
                 }
+                assertTrue(operator.needsInput());
 
                 // Hash table capacity has increased
                 assertGreaterThan(getHashCapacity.apply(operator), oldCapacity);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
@@ -31,20 +31,27 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.operator.GroupByHashYieldAssertion.createPagesWithDistinctHashKeys;
+import static com.facebook.presto.operator.GroupByHashYieldAssertion.finishOperatorWithYieldingGroupByHash;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static com.google.common.collect.Iterables.concat;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.testing.Assertions.assertGreaterThan;
+import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
 public class TestHashSemiJoinOperator
@@ -72,6 +79,12 @@ public class TestHashSemiJoinOperator
     public static Object[][] hashEnabledValuesProvider()
     {
         return new Object[][] {{true}, {false}};
+    }
+
+    @DataProvider
+    public Object[][] dataType()
+    {
+        return new Object[][] {{VARCHAR}, {BIGINT}};
     }
 
     @Test(dataProvider = "hashEnabledValues")
@@ -128,6 +141,35 @@ public class TestHashSemiJoinOperator
                 .build();
 
         OperatorAssertion.assertOperatorEquals(joinOperatorFactory, driverContext, probeInput, expected, hashEnabled, ImmutableList.of(probeTypes.size()));
+    }
+
+    @Test(dataProvider = "dataType")
+    public void testSemiJoinMemoryReservationYield(Type type)
+    {
+        // We only need the first column so we are creating the pages with hashEnabled false
+        List<Page> input = createPagesWithDistinctHashKeys(type, 5_000, 500);
+
+        // create the operator
+        SetBuilderOperatorFactory setBuilderOperatorFactory = new SetBuilderOperatorFactory(
+                1,
+                new PlanNodeId("test"),
+                type,
+                0,
+                Optional.of(1),
+                10,
+                new JoinCompiler());
+
+        // run test
+        GroupByHashYieldAssertion.GroupByHashYieldResult result = finishOperatorWithYieldingGroupByHash(
+                input,
+                type,
+                setBuilderOperatorFactory,
+                operator -> ((SetBuilderOperator) operator).getCapacity(),
+                170_000);
+
+        assertGreaterThanOrEqual(result.getYieldCount(), 7);
+        assertGreaterThan(result.getMaxReservedBytes(), 20L << 20);
+        assertEquals(result.getOutput().stream().mapToInt(Page::getPositionCount).sum(), 0);
     }
 
     @Test(dataProvider = "hashEnabledValues")


### PR DESCRIPTION
SetBuildOperator didn't support yielding when tryRehash() asks for more memory than what the system currently has. To support yielding, we added the logic to handle unfinishedWork to the class, and it is done in needsInput(), which is always called by the Driver in every iteration. We didn't put it in getOutput() since SetBuildOperator is always the last operator in the plan tree.

The added test would force rehashing to fail by reserving a lot of memory, verify yielding happens
correctly, then release the memory and verify rehashing succeeds.