### PR TITLE
Optimize TopNRowNumberOperator and TopNOperator

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlTopNBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlTopNBenchmark.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+import static java.lang.String.format;
+
+public class SqlTopNBenchmark
+        extends AbstractSqlBenchmark
+{
+    public SqlTopNBenchmark(LocalQueryRunner localQueryRunner, int topN)
+    {
+        super(localQueryRunner,
+                format("sql_top_%s", topN),
+                4,
+                5,
+                format("select * from tpch.sf1.orders order by orderdate desc, totalprice, orderstatus, orderpriority desc limit %s", topN));
+    }
+
+    public static void main(String[] args)
+    {
+        LocalQueryRunner localQueryRunner = createLocalQueryRunner(ImmutableMap.of("resource_overcommit", "true"));
+        for (int i = 0; i < 11; i++) {
+            new SqlTopNBenchmark(localQueryRunner, (int) Math.pow(4, i)).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        }
+    }
+}

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlTopNRowNumberBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlTopNRowNumberBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+import static java.lang.String.format;
+
+public class SqlTopNRowNumberBenchmark
+        extends AbstractSqlBenchmark
+{
+    public SqlTopNRowNumberBenchmark(LocalQueryRunner localQueryRunner, String function, String partitions, int topN)
+    {
+        super(localQueryRunner,
+                format("sql_%s_partition_by_(%s)_top_%s", function, partitions, topN),
+                4,
+                5,
+                format("WITH t AS (" +
+                        "  SELECT *, %s() OVER (PARTITION BY %s ORDER BY shipdate DESC) AS rnk" +
+                        "  FROM lineitem" +
+                        ")" +
+                        "SELECT * FROM t WHERE rnk <= %s", function, partitions, topN));
+    }
+
+    public static void main(String[] args)
+    {
+        LocalQueryRunner localQueryRunner = createLocalQueryRunner(ImmutableMap.of("resource_overcommit", "true"));
+        for (String function : ImmutableList.of("row_number", "rank")) {
+            for (String partitions : ImmutableList.of("orderkey, partkey", "partkey", "linestatus")) {
+                for (int topN : ImmutableList.of(1, 100, 10_000)) {
+                    new SqlTopNRowNumberBenchmark(localQueryRunner, function, partitions, topN).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+                }
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupedTopNBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupedTopNBuilder.java
@@ -1,0 +1,469 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Ordering;
+import it.unimi.dsi.fastutil.ints.IntArrayFIFOQueue;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.objects.ObjectHeapPriorityQueue;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class finds the top N rows defined by {@param comparator} for each group specified by {@param groupByHash}.
+ */
+public class GroupedTopNBuilder
+{
+    private static final long INSTANCE_SIZE = ClassLayout.parseClass(GroupedTopNBuilder.class).instanceSize();
+    // compact a page when 50% of its positions are unreferenced
+    private static final int COMPACT_THRESHOLD = 2;
+
+    private final List<Type> sourceTypes;
+    private final int topN;
+    private final boolean produceRowNumber;
+    private final GroupByHash groupByHash;
+
+    // a map of heaps, each of which records the top N rows
+    private final ObjectBigArray<RowHeap> groupedRows = new ObjectBigArray<>();
+    // a list of input pages, each of which has information of which row in which heap references which position
+    private final ObjectBigArray<PageReference> pageReferences = new ObjectBigArray<>();
+    // for heap element comparison
+    private final Comparator<Row> comparator;
+    // when there is no row referenced in a page, it will be removed instead of compacted; use a list to record those empty slots to reuse them
+    private final IntFIFOQueue emptyPageReferenceSlots;
+
+    // keeps track sizes of input pages and heaps
+    private long memorySizeInBytes;
+    private int currentPageCount;
+
+    public GroupedTopNBuilder(
+            List<Type> sourceTypes,
+            PageWithPositionComparator comparator,
+            int topN,
+            boolean produceRowNumber,
+            GroupByHash groupByHash)
+    {
+        this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null");
+        checkArgument(topN > 0, "topN must be > 0");
+        this.topN = topN;
+        this.produceRowNumber = produceRowNumber;
+        this.groupByHash = requireNonNull(groupByHash, "groupByHash is not null");
+
+        requireNonNull(comparator, "comparator is null");
+        this.comparator = (left, right) -> comparator.compareTo(
+                pageReferences.get(left.getPageId()).getPage(),
+                left.getPosition(),
+                pageReferences.get(right.getPageId()).getPage(),
+                right.getPosition());
+        this.emptyPageReferenceSlots = new IntFIFOQueue();
+    }
+
+    public Work<?> processPage(Page page)
+    {
+        return new TransformWork<>(
+                groupByHash.getGroupIds(page),
+                groupIds -> {
+                    processPage(page, groupIds);
+                    return null;
+                });
+    }
+
+    public Iterator<Page> buildResult()
+    {
+        return new ResultIterator();
+    }
+
+    public long getEstimatedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                memorySizeInBytes +
+                groupByHash.getEstimatedSize() +
+                groupedRows.sizeOf() +
+                pageReferences.sizeOf() +
+                emptyPageReferenceSlots.getEstimatedSizeInBytes();
+    }
+
+    @VisibleForTesting
+    List<Page> getBufferedPages()
+    {
+        return IntStream.range(0, currentPageCount)
+                .filter(i -> pageReferences.get(i) != null)
+                .mapToObj(i -> pageReferences.get(i).getPage())
+                .collect(toImmutableList());
+    }
+
+    private void processPage(Page newPage, GroupByIdBlock groupIds)
+    {
+        checkArgument(newPage != null);
+        checkArgument(groupIds != null);
+
+        // save the new page
+        PageReference newPageReference = new PageReference(newPage);
+        memorySizeInBytes += newPageReference.getEstimatedSizeInBytes();
+        int newPageId;
+        if (emptyPageReferenceSlots.isEmpty()) {
+            // all the previous slots are full; create a new one
+            pageReferences.ensureCapacity(currentPageCount + 1);
+            newPageId = currentPageCount;
+            currentPageCount++;
+        }
+        else {
+            // reuse a previously removed page's slot
+            newPageId = emptyPageReferenceSlots.dequeueInt();
+        }
+        verify(pageReferences.get(newPageId) == null, "should not overwrite a non-empty slot");
+        pageReferences.set(newPageId, newPageReference);
+
+        // update the affected heaps and record candidate pages that need compaction
+        IntSet pagesToCompact = new IntOpenHashSet();
+        for (int position = 0; position < newPage.getPositionCount(); position++) {
+            long groupId = groupIds.getGroupId(position);
+            groupedRows.ensureCapacity(groupId + 1);
+
+            RowHeap rows = groupedRows.get(groupId);
+            if (rows == null) {
+                // a new group
+                rows = new RowHeap(Ordering.from(comparator).reversed());
+                groupedRows.set(groupId, rows);
+            }
+            else {
+                // update an existing group;
+                // remove the memory usage for this group for now; add it back after update
+                memorySizeInBytes -= rows.getEstimatedSizeInBytes();
+            }
+
+            if (rows.size() < topN) {
+                // still have space for the current group
+                Row row = new Row(newPageId, position);
+                rows.enqueue(row);
+                newPageReference.reference(row);
+            }
+            else {
+                // may compare with the topN-th element with in the heap to decide if update is necessary
+                Row previousRow = rows.first();
+                Row newRow = new Row(newPageId, position);
+                if (comparator.compare(newRow, previousRow) < 0) {
+                    // update reference and the heap
+                    rows.dequeue();
+                    PageReference previousPageReference = pageReferences.get(previousRow.getPageId());
+                    previousPageReference.dereference(previousRow.getPosition());
+                    newPageReference.reference(newRow);
+                    rows.enqueue(newRow);
+
+                    // compact a page if it is not the current input page and the reference count is below the threshold
+                    if (previousPageReference.getPage() != newPage &&
+                            previousPageReference.getUsedPositionCount() * COMPACT_THRESHOLD < previousPageReference.getPage().getPositionCount()) {
+                        pagesToCompact.add(previousRow.getPageId());
+                    }
+                }
+            }
+
+            memorySizeInBytes += rows.getEstimatedSizeInBytes();
+        }
+
+        // may compact the new page as well
+        if (newPageReference.getUsedPositionCount() * COMPACT_THRESHOLD < newPage.getPositionCount()) {
+            verify(!pagesToCompact.contains(newPageId));
+            pagesToCompact.add(newPageId);
+        }
+
+        // compact pages
+        IntIterator iterator = pagesToCompact.iterator();
+        while (iterator.hasNext()) {
+            int pageId = iterator.nextInt();
+            PageReference pageReference = pageReferences.get(pageId);
+            if (pageReference.getUsedPositionCount() == 0) {
+                pageReferences.set(pageId, null);
+                emptyPageReferenceSlots.enqueue(pageId);
+                memorySizeInBytes -= pageReference.getEstimatedSizeInBytes();
+            }
+            else {
+                memorySizeInBytes -= pageReference.getEstimatedSizeInBytes();
+                pageReference.compact();
+                memorySizeInBytes += pageReference.getEstimatedSizeInBytes();
+            }
+        }
+    }
+
+    /**
+     * The class is a pointer to a row in a page.
+     * The actual position in the page is mutable because as pages are compacted, the position will change.
+     */
+    private class Row
+    {
+        private final int pageId;
+        private int position;
+
+        private Row(int pageId, int position)
+        {
+            this.pageId = pageId;
+            reset(position);
+        }
+
+        public void reset(int position)
+        {
+            this.position = position;
+        }
+
+        public int getPageId()
+        {
+            return pageId;
+        }
+
+        public int getPosition()
+        {
+            return position;
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("pageId", pageId)
+                    .add("position", position)
+                    .toString();
+        }
+    }
+
+    private static class PageReference
+    {
+        private static final long INSTANCE_SIZE = ClassLayout.parseClass(PageReference.class).instanceSize();
+
+        private Page page;
+        private Row[] reference;
+
+        private int usedPositionCount;
+
+        public PageReference(Page page)
+        {
+            this.page = requireNonNull(page, "page is null");
+            this.reference = new Row[page.getPositionCount()];
+        }
+
+        public void reference(Row row)
+        {
+            int position = row.getPosition();
+            reference[position] = row;
+            usedPositionCount++;
+        }
+
+        public void dereference(int position)
+        {
+            checkArgument(reference[position] != null && usedPositionCount > 0);
+            reference[position] = null;
+            usedPositionCount--;
+        }
+
+        public int getUsedPositionCount()
+        {
+            return usedPositionCount;
+        }
+
+        public void compact()
+        {
+            checkState(usedPositionCount > 0);
+
+            if (usedPositionCount == page.getPositionCount()) {
+                return;
+            }
+
+            // re-assign reference
+            Row[] newReference = new Row[usedPositionCount];
+            int[] positions = new int[usedPositionCount];
+            int index = 0;
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                if (reference[i] != null) {
+                    newReference[index] = reference[i];
+                    positions[index] = i;
+                    index++;
+                }
+            }
+            verify(index == usedPositionCount);
+
+            // compact page
+            Block[] blocks = new Block[page.getChannelCount()];
+            for (int i = 0; i < page.getChannelCount(); i++) {
+                Block block = page.getBlock(i);
+                blocks[i] = block.copyPositions(positions, 0, usedPositionCount);
+            }
+
+            // update all the elements in the heaps that reference the current page
+            for (int i = 0; i < usedPositionCount; i++) {
+                // this does not change the elements in the heap;
+                // it only updates the value of the elements; while keeping the same order
+                newReference[i].reset(i);
+            }
+            page = new Page(usedPositionCount, blocks);
+            reference = newReference;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+
+        public long getEstimatedSizeInBytes()
+        {
+            return page.getRetainedSizeInBytes() + sizeOf(reference) + INSTANCE_SIZE;
+        }
+    }
+
+    // this class is for precise memory tracking
+    private static class IntFIFOQueue
+            extends IntArrayFIFOQueue
+    {
+        private static final long INSTANCE_SIZE = ClassLayout.parseClass(IntFIFOQueue.class).instanceSize();
+
+        private long getEstimatedSizeInBytes()
+        {
+            return INSTANCE_SIZE + sizeOf(array);
+        }
+    }
+
+    // this class is for precise memory tracking
+    private static class RowHeap
+            extends ObjectHeapPriorityQueue<Row>
+    {
+        private static final long INSTANCE_SIZE = ClassLayout.parseClass(RowHeap.class).instanceSize();
+        private static final long ROW_ENTRY_SIZE = ClassLayout.parseClass(Row.class).instanceSize();
+
+        private RowHeap(Comparator<Row> comparator)
+        {
+            super(1, comparator);
+        }
+
+        private long getEstimatedSizeInBytes()
+        {
+            return INSTANCE_SIZE + sizeOf(heap) + size() * ROW_ENTRY_SIZE;
+        }
+    }
+
+    private class ResultIterator
+            extends AbstractIterator<Page>
+    {
+        private final PageBuilder pageBuilder;
+        // we may have 0 groups if there is no input page processed
+        private final int groupCount = groupByHash.getGroupCount();
+
+        private int currentGroupNumber;
+        private long currentGroupSizeInBytes;
+
+        // the row number of the current position in the group
+        private int currentGroupPosition;
+        // number of rows in the group
+        private int currentGroupSize;
+
+        private ObjectBigArray<Row> currentRows = nextGroupedRows();
+
+        ResultIterator()
+        {
+            if (produceRowNumber) {
+                pageBuilder = new PageBuilder(new ImmutableList.Builder<Type>().addAll(sourceTypes).add(BIGINT).build());
+            }
+            else {
+                pageBuilder = new PageBuilder(sourceTypes);
+            }
+        }
+
+        @Override
+        protected Page computeNext()
+        {
+            pageBuilder.reset();
+            while (!pageBuilder.isFull()) {
+                if (currentRows == null) {
+                    // no more groups
+                    break;
+                }
+                if (currentGroupPosition == currentGroupSize) {
+                    // the current group has produced all its rows
+                    memorySizeInBytes -= currentGroupSizeInBytes;
+                    currentGroupPosition = 0;
+                    currentRows = nextGroupedRows();
+                    continue;
+                }
+
+                Row row = currentRows.get(currentGroupPosition);
+                for (int i = 0; i < sourceTypes.size(); i++) {
+                    sourceTypes.get(i).appendTo(pageReferences.get(row.getPageId()).getPage().getBlock(i), row.getPosition(), pageBuilder.getBlockBuilder(i));
+                }
+
+                if (produceRowNumber) {
+                    BIGINT.writeLong(pageBuilder.getBlockBuilder(sourceTypes.size()), currentGroupPosition + 1);
+                }
+                pageBuilder.declarePosition();
+                currentGroupPosition++;
+
+                // deference the row; no need to compact the pages but remove them if completely unused
+                PageReference pageReference = pageReferences.get(row.getPageId());
+                pageReference.dereference(row.getPosition());
+                if (pageReference.getUsedPositionCount() == 0) {
+                    pageReferences.set(row.getPageId(), null);
+                    memorySizeInBytes -= pageReference.getEstimatedSizeInBytes();
+                }
+            }
+
+            if (pageBuilder.isEmpty()) {
+                return endOfData();
+            }
+            return pageBuilder.build();
+        }
+
+        private ObjectBigArray<Row> nextGroupedRows()
+        {
+            if (currentGroupNumber < groupCount) {
+                RowHeap rows = groupedRows.get(currentGroupNumber);
+                verify(rows != null && !rows.isEmpty(), "impossible to have inserted a group without a witness row");
+                groupedRows.set(currentGroupNumber, null);
+                currentGroupSizeInBytes = rows.getEstimatedSizeInBytes();
+                currentGroupNumber++;
+                currentGroupSize = rows.size();
+
+                // sort output rows in a big array in case there are too many rows
+                ObjectBigArray<Row> sortedRows = new ObjectBigArray<>();
+                sortedRows.ensureCapacity(currentGroupSize);
+                int index = currentGroupSize - 1;
+                while (!rows.isEmpty()) {
+                    sortedRows.set(index, rows.dequeue());
+                    index--;
+                }
+
+                return sortedRows;
+            }
+            return null;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/NoChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NoChannelGroupByHash.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+
+public class NoChannelGroupByHash
+        implements GroupByHash
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(NoChannelGroupByHash.class).instanceSize();
+
+    private int groupCount;
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return INSTANCE_SIZE;
+    }
+
+    @Override
+    public long getHashCollisions()
+    {
+        return 0;
+    }
+
+    @Override
+    public double getExpectedHashCollisions()
+    {
+        return 0;
+    }
+
+    @Override
+    public List<Type> getTypes()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public int getGroupCount()
+    {
+        return groupCount;
+    }
+
+    @Override
+    public void appendValuesTo(int groupId, PageBuilder pageBuilder, int outputChannelOffset)
+    {
+        throw new UnsupportedOperationException("NoChannelGroupByHash does not support appendValuesTo");
+    }
+
+    @Override
+    public Work<?> addPage(Page page)
+    {
+        updateGroupCount(page);
+        // create a dump work whose result is never used.
+        return new CompletedWork<>(0);
+    }
+
+    @Override
+    public Work<GroupByIdBlock> getGroupIds(Page page)
+    {
+        updateGroupCount(page);
+        return new CompletedWork<>(new GroupByIdBlock(page.getPositionCount() > 0 ? 1 : 0, RunLengthEncodedBlock.create(BIGINT, 0L, page.getPositionCount())));
+    }
+
+    @Override
+    public boolean contains(int position, Page page, int[] hashChannels)
+    {
+        throw new UnsupportedOperationException("NoChannelGroupByHash does not support getHashCollisions");
+    }
+
+    @Override
+    public long getRawHash(int groupyId)
+    {
+        throw new UnsupportedOperationException("NoChannelGroupByHash does not support getHashCollisions");
+    }
+
+    @Override
+    public int getCapacity()
+    {
+        return 2;
+    }
+
+    private void updateGroupCount(Page page)
+    {
+        if (page.getPositionCount() > 0 && groupCount == 0) {
+            groupCount = 1;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/TopNOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TopNOperator.java
@@ -15,20 +15,18 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.PageBuilder;
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Ordering;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.PriorityQueue;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static java.util.Collections.emptyIterator;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -44,7 +42,6 @@ public class TopNOperator
         private final PlanNodeId planNodeId;
         private final List<Type> sourceTypes;
         private final int n;
-        private final List<Type> sortTypes;
         private final List<Integer> sortChannels;
         private final List<SortOrder> sortOrders;
         private boolean closed;
@@ -61,11 +58,6 @@ public class TopNOperator
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.sourceTypes = ImmutableList.copyOf(requireNonNull(types, "types is null"));
             this.n = n;
-            ImmutableList.Builder<Type> sortTypes = ImmutableList.builder();
-            for (int channel : sortChannels) {
-                sortTypes.add(types.get(channel));
-            }
-            this.sortTypes = sortTypes.build();
             this.sortChannels = ImmutableList.copyOf(requireNonNull(sortChannels, "sortChannels is null"));
             this.sortOrders = ImmutableList.copyOf(requireNonNull(sortOrders, "sortOrders is null"));
         }
@@ -85,7 +77,6 @@ public class TopNOperator
                     operatorContext,
                     sourceTypes,
                     n,
-                    sortTypes,
                     sortChannels,
                     sortOrders);
         }
@@ -103,18 +94,11 @@ public class TopNOperator
         }
     }
 
-    private static final int MAX_INITIAL_PRIORITY_QUEUE_SIZE = 10000;
-
     private final OperatorContext operatorContext;
+    private final LocalMemoryContext localUserMemoryContext;
     private final List<Type> types;
-    private final int n;
-    private final List<Type> sortTypes;
-    private final List<Integer> sortChannels;
-    private final List<SortOrder> sortOrders;
 
-    private final PageBuilder pageBuilder;
-
-    private TopNBuilder topNBuilder;
+    private GroupedTopNBuilder topNBuilder;
     private boolean finishing;
 
     private Iterator<Page> outputIterator;
@@ -123,24 +107,26 @@ public class TopNOperator
             OperatorContext operatorContext,
             List<Type> types,
             int n,
-            List<Type> sortTypes,
             List<Integer> sortChannels,
             List<SortOrder> sortOrders)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.localUserMemoryContext = operatorContext.localUserMemoryContext();
         this.types = requireNonNull(types, "types is null");
 
         checkArgument(n >= 0, "n must be positive");
-        this.n = n;
-
-        this.sortTypes = requireNonNull(sortTypes, "sortTypes is null");
-        this.sortChannels = requireNonNull(sortChannels, "sortChannels is null");
-        this.sortOrders = requireNonNull(sortOrders, "sortOrders is null");
-
-        this.pageBuilder = new PageBuilder(types);
 
         if (n == 0) {
             finishing = true;
+            outputIterator = emptyIterator();
+        }
+        else {
+            topNBuilder = new GroupedTopNBuilder(
+                    types,
+                    new SimplePageWithPositionComparator(types, sortChannels, sortOrders),
+                    n,
+                    false,
+                    new NoChannelGroupByHash());
         }
     }
 
@@ -165,149 +151,55 @@ public class TopNOperator
     @Override
     public boolean isFinished()
     {
-        return finishing && topNBuilder == null && (outputIterator == null || !outputIterator.hasNext());
+        return finishing && noMoreOutput();
     }
 
     @Override
     public boolean needsInput()
     {
-        return !finishing && (outputIterator == null || !outputIterator.hasNext());
+        return !finishing && !noMoreOutput();
     }
 
     @Override
     public void addInput(Page page)
     {
         checkState(!finishing, "Operator is already finishing");
-        requireNonNull(page, "page is null");
-        if (topNBuilder == null) {
-            topNBuilder = new TopNBuilder(
-                    n,
-                    sortTypes,
-                    sortChannels,
-                    sortOrders,
-                    operatorContext.localUserMemoryContext());
-        }
-
-        topNBuilder.processPage(page);
+        boolean done = topNBuilder.processPage(requireNonNull(page, "page is null")).process();
+        // there is no grouping so work will always be done
+        verify(done);
+        updateMemoryReservation();
     }
 
     @Override
     public Page getOutput()
     {
-        if (outputIterator == null || !outputIterator.hasNext()) {
-            // no data or not finishing
-            if (topNBuilder == null || !finishing) {
-                return null;
-            }
-
-            outputIterator = topNBuilder.build();
-            topNBuilder = null;
+        if (!finishing || noMoreOutput()) {
+            return null;
         }
 
-        pageBuilder.reset();
-        while (!pageBuilder.isFull() && outputIterator.hasNext()) {
-            Page next = outputIterator.next();
-            pageBuilder.declarePosition();
-            for (int i = 0; i < next.getChannelCount(); i++) {
-                Type type = types.get(i);
-                type.appendTo(next.getBlock(i), 0, pageBuilder.getBlockBuilder(i));
-            }
+        if (outputIterator == null) {
+            // start flushing
+            outputIterator = topNBuilder.buildResult();
         }
 
-        return pageBuilder.build();
+        Page output = null;
+        if (outputIterator.hasNext()) {
+            output = outputIterator.next();
+        }
+        else {
+            outputIterator = emptyIterator();
+        }
+        updateMemoryReservation();
+        return output;
     }
 
-    private static class TopNBuilder
+    private void updateMemoryReservation()
     {
-        private final int n;
-        private final List<Type> sortTypes;
-        private final List<Integer> sortChannels;
-        private final List<SortOrder> sortOrders;
-        private final PriorityQueue<Page> globalCandidates;
-        private final LocalMemoryContext localUserMemoryContext;
+        localUserMemoryContext.setBytes(topNBuilder.getEstimatedSizeInBytes());
+    }
 
-        private long memorySize;
-
-        private TopNBuilder(int n,
-                List<Type> sortTypes,
-                List<Integer> sortChannels,
-                List<SortOrder> sortOrders,
-                LocalMemoryContext localUserMemoryContext)
-        {
-            this.n = n;
-
-            this.sortTypes = sortTypes;
-            this.sortChannels = sortChannels;
-            this.sortOrders = sortOrders;
-
-            this.localUserMemoryContext = requireNonNull(localUserMemoryContext, "localUserMemoryContext is null");
-
-            Ordering<Page> comparator = Ordering.from(new RowComparator(sortTypes, sortChannels, sortOrders)).reverse();
-            this.globalCandidates = new PriorityQueue<>(Math.min(n, MAX_INITIAL_PRIORITY_QUEUE_SIZE), comparator);
-        }
-
-        public void processPage(Page page)
-        {
-            long sizeDelta = mergeWithGlobalCandidates(page);
-            memorySize += sizeDelta;
-            localUserMemoryContext.setBytes(memorySize);
-        }
-
-        private long mergeWithGlobalCandidates(Page page)
-        {
-            long sizeDelta = 0;
-
-            for (int position = 0; position < page.getPositionCount(); position++) {
-                if (globalCandidates.size() < n || compare(position, page, globalCandidates.peek()) < 0) {
-                    sizeDelta += addRow(position, page);
-                }
-            }
-
-            return sizeDelta;
-        }
-
-        private int compare(int position, Page page, Page currentMax)
-        {
-            for (int i = 0; i < sortChannels.size(); i++) {
-                Type type = sortTypes.get(i);
-                int sortChannel = sortChannels.get(i);
-                SortOrder sortOrder = sortOrders.get(i);
-
-                Block block = page.getBlock(sortChannel);
-                Block currentMaxValue = currentMax.getBlock(sortChannel);
-
-                // compare the right value to the left block but negate the result since we are evaluating in the opposite order
-                int compare = -sortOrder.compareBlockValue(type, currentMaxValue, 0, block, position);
-                if (compare != 0) {
-                    return compare;
-                }
-            }
-            return 0;
-        }
-
-        private long addRow(int position, Page page)
-        {
-            long sizeDelta = 0;
-            Page row = page.getSingleValuePage(position);
-
-            sizeDelta += row.getRetainedSizeInBytes();
-            globalCandidates.add(row);
-
-            while (globalCandidates.size() > n) {
-                Page previous = globalCandidates.remove();
-                sizeDelta -= previous.getRetainedSizeInBytes();
-            }
-            return sizeDelta;
-        }
-
-        public Iterator<Page> build()
-        {
-            ImmutableList.Builder<Page> minSortedGlobalCandidates = ImmutableList.builder();
-            while (!globalCandidates.isEmpty()) {
-                Page row = globalCandidates.remove();
-                minSortedGlobalCandidates.add(row);
-            }
-            return minSortedGlobalCandidates.build().reverse().iterator();
-        }
+    private boolean noMoreOutput()
+    {
+        return outputIterator != null && !outputIterator.hasNext();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
@@ -15,28 +15,24 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.MinMaxPriorityQueue;
-import com.google.common.collect.Ordering;
 import com.google.common.primitives.Ints;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.SystemSessionProperties.isDictionaryAggregationEnabled;
 import static com.facebook.presto.operator.GroupByHash.createGroupByHash;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class TopNRowNumberOperator
@@ -61,7 +57,6 @@ public class TopNRowNumberOperator
         private final int expectedPositions;
 
         private final List<Type> types;
-        private final List<Type> sortTypes;
         private final boolean generateRowNumber;
         private boolean closed;
         private final JoinCompiler joinCompiler;
@@ -97,13 +92,7 @@ public class TopNRowNumberOperator
             this.generateRowNumber = !partial || !partitionChannels.isEmpty();
             this.expectedPositions = expectedPositions;
             this.joinCompiler = requireNonNull(joinCompiler, "joinCompiler is null");
-
             this.types = toTypes(sourceTypes, outputChannels, generateRowNumber);
-            ImmutableList.Builder<Type> sortTypes = ImmutableList.builder();
-            for (int channel : sortChannels) {
-                sortTypes.add(types.get(channel));
-            }
-            this.sortTypes = sortTypes.build();
         }
 
         @Override
@@ -125,7 +114,6 @@ public class TopNRowNumberOperator
                     partitionTypes,
                     sortChannels,
                     sortOrder,
-                    sortTypes,
                     maxRowCountPerPartition,
                     generateRowNumber,
                     hashChannel,
@@ -148,20 +136,16 @@ public class TopNRowNumberOperator
 
     private final OperatorContext operatorContext;
     private final LocalMemoryContext localUserMemoryContext;
-    private boolean finishing;
+
     private final List<Type> types;
-    private final int[] outputChannels;
+    private final List<Integer> outputChannels;
 
-    private final List<Integer> sortChannels;
-    private final List<SortOrder> sortOrders;
-    private final List<Type> sortTypes;
-    private final boolean generateRowNumber;
-    private final int maxRowCountPerPartition;
+    private final GroupByHash groupByHash;
+    private final GroupedTopNBuilder groupedTopNBuilder;
 
-    private final Map<Long, PartitionBuilder> partitionRows;
-    private Optional<FlushingPartition> flushingPartition;
-    private final PageBuilder pageBuilder;
-    private final Optional<GroupByHash> groupByHash;
+    private boolean finishing;
+    private Work<?> unfinishedWork;
+    private Iterator<Page> outputIterator;
 
     public TopNRowNumberOperator(
             OperatorContext operatorContext,
@@ -171,7 +155,6 @@ public class TopNRowNumberOperator
             List<Type> partitionTypes,
             List<Integer> sortChannels,
             List<SortOrder> sortOrders,
-            List<Type> sortTypes,
             int maxRowCountPerPartition,
             boolean generateRowNumber,
             Optional<Integer> hashChannel,
@@ -179,30 +162,42 @@ public class TopNRowNumberOperator
             JoinCompiler joinCompiler)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.outputChannels = Ints.toArray(requireNonNull(outputChannels, "outputChannels is null"));
         this.localUserMemoryContext = operatorContext.localUserMemoryContext();
 
-        this.sortChannels = requireNonNull(sortChannels, "sortChannels is null");
-        this.sortOrders = requireNonNull(sortOrders, "sortOrders is null");
-        this.sortTypes = requireNonNull(sortTypes, "sortTypes is null");
+        ImmutableList.Builder<Integer> outputChannelsBuilder = ImmutableList.builder();
+        for (int channel : requireNonNull(outputChannels, "outputChannels is null")) {
+            outputChannelsBuilder.add(channel);
+        }
+        if (generateRowNumber) {
+            outputChannelsBuilder.add(outputChannels.size());
+        }
+        this.outputChannels = outputChannelsBuilder.build();
 
         checkArgument(maxRowCountPerPartition > 0, "maxRowCountPerPartition must be > 0");
-        this.maxRowCountPerPartition = maxRowCountPerPartition;
-        this.generateRowNumber = generateRowNumber;
-        checkArgument(expectedPositions > 0, "expectedPositions must be > 0");
 
         this.types = toTypes(sourceTypes, outputChannels, generateRowNumber);
-        this.partitionRows = new HashMap<>();
-        if (partitionChannels.isEmpty()) {
-            this.groupByHash = Optional.empty();
+
+        if (!partitionChannels.isEmpty()) {
+            checkArgument(expectedPositions > 0, "expectedPositions must be > 0");
+            groupByHash = createGroupByHash(
+                    partitionTypes,
+                    Ints.toArray(partitionChannels),
+                    hashChannel,
+                    expectedPositions,
+                    isDictionaryAggregationEnabled(operatorContext.getSession()),
+                    joinCompiler,
+                    this::updateMemoryReservation);
         }
         else {
-            GroupByHash groupByHash = createGroupByHash(operatorContext.getSession(), partitionTypes, Ints.toArray(partitionChannels), hashChannel, expectedPositions, joinCompiler);
-            this.groupByHash = Optional.of(groupByHash);
-            localUserMemoryContext.setBytes(groupByHash.getEstimatedSize());
+            groupByHash = new NoChannelGroupByHash();
         }
-        this.flushingPartition = Optional.empty();
-        this.pageBuilder = new PageBuilder(types);
+
+        this.groupedTopNBuilder = new GroupedTopNBuilder(
+                ImmutableList.copyOf(sourceTypes),
+                new SimplePageWithPositionComparator(types, sortChannels, sortOrders),
+                maxRowCountPerPartition,
+                generateRowNumber,
+                groupByHash);
     }
 
     @Override
@@ -226,155 +221,78 @@ public class TopNRowNumberOperator
     @Override
     public boolean isFinished()
     {
-        return finishing && isEmpty() && !isFlushing();
+        // has no more input, has finished flushing, and has no unfinished work
+        return finishing && outputIterator != null && !outputIterator.hasNext() && unfinishedWork == null;
     }
 
     @Override
     public boolean needsInput()
     {
-        return !finishing && !isFlushing();
+        // still has more input, has not started flushing yet, and has no unfinished work
+        return !finishing && outputIterator == null && unfinishedWork == null;
     }
 
     @Override
     public void addInput(Page page)
     {
         checkState(!finishing, "Operator is already finishing");
+        checkState(unfinishedWork == null, "Cannot add input with the operator when unfinished work is not empty");
+        checkState(outputIterator == null, "Cannot add input with the operator when flushing");
         requireNonNull(page, "page is null");
-        checkState(!isFlushing(), "Cannot add input with the operator is flushing data");
-        processPage(page);
+        unfinishedWork = groupedTopNBuilder.processPage(page);
+        if (unfinishedWork.process()) {
+            unfinishedWork = null;
+        }
+        updateMemoryReservation();
     }
 
     @Override
     public Page getOutput()
     {
-        if (finishing && !isFinished()) {
-            return getPage();
-        }
-        return null;
-    }
-
-    private void processPage(Page page)
-    {
-        long currentMemoryBytes = localUserMemoryContext.getBytes();
-        Optional<GroupByIdBlock> partitionIds = Optional.empty();
-        if (groupByHash.isPresent()) {
-            GroupByHash hash = groupByHash.get();
-            long groupByHashSize = hash.getEstimatedSize();
-            Work<GroupByIdBlock> work = hash.getGroupIds(page);
-            boolean done = work.process();
-            // TODO: this class does not yield wrt memory limit; enable it
-            verify(done);
-            partitionIds = Optional.of(work.getResult());
-            currentMemoryBytes += (hash.getEstimatedSize() - groupByHashSize);
+        if (unfinishedWork != null) {
+            boolean finished = unfinishedWork.process();
+            updateMemoryReservation();
+            if (!finished) {
+                return null;
+            }
+            unfinishedWork = null;
         }
 
-        long sizeDelta = 0;
-        for (int position = 0; position < page.getPositionCount(); position++) {
-            long partitionId = groupByHash.isPresent() ? partitionIds.get().getGroupId(position) : 0;
-            if (!partitionRows.containsKey(partitionId)) {
-                partitionRows.put(partitionId, new PartitionBuilder(sortTypes, sortChannels, sortOrders, maxRowCountPerPartition));
-            }
-            PartitionBuilder partitionBuilder = partitionRows.get(partitionId);
-            if (partitionBuilder.getRowCount() < maxRowCountPerPartition) {
-                Page row = page.getSingleValuePage(position);
-                sizeDelta += partitionBuilder.addRow(row);
-            }
-            else if (compare(position, page, partitionBuilder.peekLastRow()) < 0) {
-                Page row = page.getSingleValuePage(position);
-                sizeDelta += partitionBuilder.replaceRow(row);
-            }
-        }
-        currentMemoryBytes += sizeDelta;
-        localUserMemoryContext.setBytes(currentMemoryBytes);
-    }
-
-    private int compare(int position, Page blocks, Page currentMax)
-    {
-        for (int i = 0; i < sortChannels.size(); i++) {
-            Type type = sortTypes.get(i);
-            int sortChannel = sortChannels.get(i);
-            SortOrder sortOrder = sortOrders.get(i);
-
-            Block block = blocks.getBlock(sortChannel);
-            Block currentMaxValue = currentMax.getBlock(sortChannel);
-
-            int compare = sortOrder.compareBlockValue(type, block, position, currentMaxValue, 0);
-            if (compare != 0) {
-                return compare;
-            }
-        }
-        return 0;
-    }
-
-    private Page getPage()
-    {
-        if (!flushingPartition.isPresent()) {
-            flushingPartition = getFlushingPartition();
-        }
-
-        pageBuilder.reset();
-        long sizeDelta = 0;
-        while (!pageBuilder.isFull() && flushingPartition.isPresent()) {
-            FlushingPartition currentFlushingPartition = flushingPartition.get();
-
-            while (!pageBuilder.isFull() && currentFlushingPartition.hasNext()) {
-                Page next = currentFlushingPartition.next();
-                sizeDelta += next.getRetainedSizeInBytes();
-
-                pageBuilder.declarePosition();
-                for (int i = 0; i < outputChannels.length; i++) {
-                    int channel = outputChannels[i];
-                    Type type = types.get(i);
-                    type.appendTo(next.getBlock(channel), 0, pageBuilder.getBlockBuilder(i));
-                }
-                if (generateRowNumber) {
-                    BIGINT.writeLong(pageBuilder.getBlockBuilder(outputChannels.length), currentFlushingPartition.getRowNumber());
-                }
-            }
-            if (!currentFlushingPartition.hasNext()) {
-                flushingPartition = getFlushingPartition();
-            }
-        }
-        if (pageBuilder.isEmpty()) {
+        if (!finishing) {
             return null;
         }
-        Page page = pageBuilder.build();
-        localUserMemoryContext.setBytes(localUserMemoryContext.getBytes() - sizeDelta);
-        return page;
-    }
 
-    private Optional<FlushingPartition> getFlushingPartition()
-    {
-        int maxPartitionSize = 0;
-        PartitionBuilder chosenPartitionBuilder = null;
-        long chosenPartitionId = -1;
+        if (outputIterator == null) {
+            // start flushing
+            outputIterator = groupedTopNBuilder.buildResult();
+        }
 
-        for (Map.Entry<Long, PartitionBuilder> entry : partitionRows.entrySet()) {
-            if (entry.getValue().getRowCount() > maxPartitionSize) {
-                chosenPartitionBuilder = entry.getValue();
-                maxPartitionSize = chosenPartitionBuilder.getRowCount();
-                chosenPartitionId = entry.getKey();
-                if (maxPartitionSize == maxRowCountPerPartition) {
-                    break;
-                }
+        Page output = null;
+        if (outputIterator.hasNext()) {
+            Page page = outputIterator.next();
+            // rewrite to expected column ordering
+            Block[] blocks = new Block[page.getChannelCount()];
+            for (int i = 0; i < outputChannels.size(); i++) {
+                blocks[i] = page.getBlock(outputChannels.get(i));
             }
+            output = new Page(blocks);
         }
-        if (chosenPartitionBuilder == null) {
-            return Optional.empty();
-        }
-        FlushingPartition flushingPartition = new FlushingPartition(chosenPartitionBuilder.build());
-        partitionRows.remove(chosenPartitionId);
-        return Optional.of(flushingPartition);
+        updateMemoryReservation();
+        return output;
     }
 
-    public boolean isFlushing()
+    @VisibleForTesting
+    public int getCapacity()
     {
-        return flushingPartition.isPresent();
+        checkState(groupByHash != null);
+        return groupByHash.getCapacity();
     }
 
-    public boolean isEmpty()
+    private boolean updateMemoryReservation()
     {
-        return partitionRows.isEmpty();
+        // TODO: may need to use trySetMemoryReservation with a compaction to free memory (but that may cause GC pressure)
+        localUserMemoryContext.setBytes(groupedTopNBuilder.getEstimatedSizeInBytes());
+        return operatorContext.isWaitingForMemory().isDone();
     }
 
     private static List<Type> toTypes(List<? extends Type> sourceTypes, List<Integer> outputChannels, boolean generateRowNumber)
@@ -387,89 +305,5 @@ public class TopNRowNumberOperator
             types.add(BIGINT);
         }
         return types.build();
-    }
-
-    private static class PartitionBuilder
-    {
-        private final MinMaxPriorityQueue<Page> candidateRows;
-        private final int maxRowCountPerPartition;
-
-        private PartitionBuilder(List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders, int maxRowCountPerPartition)
-        {
-            this.maxRowCountPerPartition = maxRowCountPerPartition;
-            Ordering<Page> comparator = Ordering.from(new RowComparator(sortTypes, sortChannels, sortOrders));
-            this.candidateRows = MinMaxPriorityQueue.orderedBy(comparator).maximumSize(maxRowCountPerPartition).create();
-        }
-
-        private long replaceRow(Page row)
-        {
-            checkState(candidateRows.size() == maxRowCountPerPartition);
-            Page previousRow = candidateRows.removeLast();
-            long sizeDelta = addRow(row);
-            return sizeDelta - previousRow.getRetainedSizeInBytes();
-        }
-
-        private long addRow(Page row)
-        {
-            checkState(candidateRows.size() < maxRowCountPerPartition);
-            long sizeDelta = row.getRetainedSizeInBytes();
-            candidateRows.add(row);
-            return sizeDelta;
-        }
-
-        private Iterator<Page> build()
-        {
-            ImmutableList.Builder<Page> sortedRows = ImmutableList.builder();
-            while (!candidateRows.isEmpty()) {
-                sortedRows.add(candidateRows.poll());
-            }
-            return sortedRows.build().iterator();
-        }
-
-        private int getRowCount()
-        {
-            return candidateRows.size();
-        }
-
-        private Page peekLastRow()
-        {
-            return candidateRows.peekLast();
-        }
-    }
-
-    private static class FlushingPartition
-            implements Iterator<Page>
-    {
-        private final Iterator<Page> outputIterator;
-        private int rowNumber;
-
-        private FlushingPartition(Iterator<Page> outputIterator)
-        {
-            this.outputIterator = outputIterator;
-        }
-
-        @Override
-        public boolean hasNext()
-        {
-            return outputIterator.hasNext();
-        }
-
-        @Override
-        public Page next()
-        {
-            rowNumber++;
-            return outputIterator.next();
-        }
-
-        @Override
-        public void remove()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        public int getRowNumber()
-        {
-            return rowNumber;
-        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupedTopNBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupedTopNBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import io.airlift.tpch.LineItem;
+import io.airlift.tpch.LineItemGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_FIRST;
+import static com.facebook.presto.spi.block.SortOrder.DESC_NULLS_LAST;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(4)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkGroupedTopNBuilder
+{
+    private static final int EXTENDED_PRICE = 0;
+    private static final int DISCOUNT = 1;
+    private static final int SHIP_DATE = 2;
+    private static final int QUANTITY = 3;
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private final List<Type> types = ImmutableList.of(DOUBLE, DOUBLE, VARCHAR, DOUBLE);
+        private final PageWithPositionComparator comparator = new SimplePageWithPositionComparator(
+                types,
+                ImmutableList.of(0, 2),
+                ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST));
+
+        @Param({"1", "100", "10000", "1000000"})
+        private String topN = "1";
+
+        @Param({"1", "100", "10000", "1000000"})
+        private String positions = "1";
+
+        private Page page;
+        private GroupedTopNBuilder topNBuilder;
+
+        @Setup
+        public void setup()
+        {
+            page = createInputPage(Integer.valueOf(positions), types);
+            topNBuilder = new GroupedTopNBuilder(types, comparator, Integer.valueOf(topN), false, new NoChannelGroupByHash());
+        }
+
+        public GroupedTopNBuilder getTopNBuilder()
+        {
+            return topNBuilder;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+    }
+
+    @Benchmark
+    public List<Page> topN(BenchmarkData data)
+    {
+        data.getTopNBuilder().processPage(data.getPage()).process();
+        return ImmutableList.copyOf(data.getTopNBuilder().buildResult());
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkGroupedTopNBuilder().topN(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkGroupedTopNBuilder.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+
+    private static Page createInputPage(int positions, List<Type> types)
+    {
+        PageBuilder pageBuilder = new PageBuilder(types);
+        LineItemGenerator lineItemGenerator = new LineItemGenerator(1, 1, 1);
+        Iterator<LineItem> iterator = lineItemGenerator.iterator();
+        for (int i = 0; i < positions; i++) {
+            pageBuilder.declarePosition();
+
+            LineItem lineItem = iterator.next();
+            DOUBLE.writeDouble(pageBuilder.getBlockBuilder(EXTENDED_PRICE), lineItem.getExtendedPrice());
+            DOUBLE.writeDouble(pageBuilder.getBlockBuilder(DISCOUNT), lineItem.getDiscount());
+            DATE.writeLong(pageBuilder.getBlockBuilder(SHIP_DATE), lineItem.getShipDate());
+            DOUBLE.writeDouble(pageBuilder.getBlockBuilder(QUANTITY), lineItem.getQuantity());
+        }
+        return pageBuilder.build();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestGroupedTopNBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestGroupedTopNBuilder.java
@@ -1,0 +1,523 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.gen.JoinCompiler;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import it.unimi.dsi.fastutil.ints.IntArrayFIFOQueue;
+import it.unimi.dsi.fastutil.objects.ObjectHeapPriorityQueue;
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
+import static com.facebook.presto.operator.UpdateMemory.NOOP;
+import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_LAST;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static io.airlift.testing.Assertions.assertGreaterThan;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestGroupedTopNBuilder
+{
+    private static final long INSTANCE_SIZE = ClassLayout.parseClass(GroupedTopNBuilder.class).instanceSize();
+    private static final long INT_FIFO_QUEUE_SIZE = ClassLayout.parseClass(IntArrayFIFOQueue.class).instanceSize();
+    private static final long OBJECT_OVERHEAD = ClassLayout.parseClass(Object.class).instanceSize();
+    private static final long PAGE_REFERENCE_INSTANCE_SIZE = ClassLayout.parseClass(TestPageReference.class).instanceSize();
+
+    @DataProvider
+    public static Object[][] produceRowNumbers()
+    {
+        return new Object[][] {{true}, {false}};
+    }
+
+    @DataProvider
+    public static Object[][] pageRowCounts()
+    {
+        // make either page or row count > 1024 to expand the big arrays
+        return new Object[][] {{10000, 20}, {20, 10000}};
+    }
+
+    @Test
+    public void testEmptyInput()
+    {
+        GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNBuilder(
+                ImmutableList.of(BIGINT),
+                (left, leftPosition, right, rightPosition) -> {
+                    throw new UnsupportedOperationException();
+                },
+                5,
+                false,
+                new NoChannelGroupByHash());
+        assertFalse(groupedTopNBuilder.buildResult().hasNext());
+    }
+
+    @Test(dataProvider = "produceRowNumbers")
+    public void testMultiGroupTopN(boolean produceRowNumbers)
+    {
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE);
+        List<Page> input = rowPagesBuilder(types)
+                .row(1L, 0.3)
+                .row(2L, 0.2)
+                .row(3L, 0.9)
+                .row(3L, 0.1)
+                .pageBreak()
+                .row(1L, 0.4)
+                .pageBreak()
+                .row(1L, 0.5)
+                .row(1L, 0.6)
+                .row(4L, 0.6)
+                .row(2L, 0.8)
+                .row(2L, 0.7)
+                .pageBreak()
+                .row(2L, 0.9)
+                .build();
+
+        for (Page page : input) {
+            page.compact();
+        }
+
+        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(types.get(0)), ImmutableList.of(0), NOOP);
+        GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNBuilder(
+                types,
+                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST)),
+                2,
+                produceRowNumbers,
+                groupByHash);
+        assertBuilderSize(groupByHash, types, ImmutableList.of(), ImmutableList.of(), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        // add 4 rows for the first page and created three heaps with 1, 1, 2 rows respectively
+        assertTrue(groupedTopNBuilder.processPage(input.get(0)).process());
+        assertBuilderSize(groupByHash, types, ImmutableList.of(4), ImmutableList.of(1, 1, 2), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        // add 1 row for the second page and the three heaps become 2, 1, 2 rows respectively
+        assertTrue(groupedTopNBuilder.processPage(input.get(1)).process());
+        assertBuilderSize(groupByHash, types, ImmutableList.of(4, 1), ImmutableList.of(2, 1, 2), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        // add 2 new rows for the third page (which will be compacted into two rows only) and we have four heaps with 2, 2, 2, 1 rows respectively
+        assertTrue(groupedTopNBuilder.processPage(input.get(2)).process());
+        assertBuilderSize(groupByHash, types, ImmutableList.of(4, 1, 2), ImmutableList.of(2, 2, 2, 1), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        // the last page will be discarded
+        assertTrue(groupedTopNBuilder.processPage(input.get(3)).process());
+        assertBuilderSize(groupByHash, types, ImmutableList.of(4, 1, 2, 0), ImmutableList.of(2, 2, 2, 1), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        List<Page> output = ImmutableList.copyOf(groupedTopNBuilder.buildResult());
+        assertEquals(output.size(), 1);
+
+        Page expected = rowPagesBuilder(BIGINT, DOUBLE, BIGINT)
+                .row(1L, 0.3, 1)
+                .row(1L, 0.4, 2)
+                .row(2L, 0.2, 1)
+                .row(2L, 0.7, 2)
+                .row(3L, 0.1, 1)
+                .row(3L, 0.9, 2)
+                .row(4L, 0.6, 1)
+                .build()
+                .get(0);
+        if (produceRowNumbers) {
+            assertPageEquals(ImmutableList.of(BIGINT, DOUBLE, BIGINT), output.get(0), expected);
+        }
+        else {
+            assertPageEquals(types, output.get(0), new Page(expected.getBlock(0), expected.getBlock(1)));
+        }
+
+        assertBuilderSize(groupByHash, types, ImmutableList.of(0, 0, 0, 0), ImmutableList.of(0, 0, 0, 0), groupedTopNBuilder.getEstimatedSizeInBytes());
+    }
+
+    @Test(dataProvider = "produceRowNumbers")
+    public void testSingleGroupTopN(boolean produceRowNumbers)
+    {
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE);
+        List<Page> input = rowPagesBuilder(types)
+                .row(1L, 0.3)
+                .row(2L, 0.2)
+                .row(3L, 0.9)
+                .row(3L, 0.1)
+                .pageBreak()
+                .row(1L, 0.4)
+                .pageBreak()
+                .row(1L, 0.5)
+                .row(1L, 0.6)
+                .row(4L, 0.6)
+                .row(2L, 0.8)
+                .row(2L, 0.7)
+                .pageBreak()
+                .row(2L, 0.9)
+                .build();
+
+        for (Page page : input) {
+            page.compact();
+        }
+
+        GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNBuilder(
+                types,
+                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST)),
+                5,
+                produceRowNumbers,
+                new NoChannelGroupByHash());
+        assertBuilderSize(new NoChannelGroupByHash(), types, ImmutableList.of(), ImmutableList.of(), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        // add 4 rows for the first page and created a single heap with 4 rows
+        assertTrue(groupedTopNBuilder.processPage(input.get(0)).process());
+        assertBuilderSize(new NoChannelGroupByHash(), types, ImmutableList.of(4), ImmutableList.of(4), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        // add 1 row for the second page and the heap is with 5 rows
+        assertTrue(groupedTopNBuilder.processPage(input.get(1)).process());
+        assertBuilderSize(new NoChannelGroupByHash(), types, ImmutableList.of(4, 1), ImmutableList.of(5), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        // update 1 new row from the third page (which will be compacted into a single row only)
+        assertTrue(groupedTopNBuilder.processPage(input.get(2)).process());
+        assertBuilderSize(new NoChannelGroupByHash(), types, ImmutableList.of(4, 1, 1), ImmutableList.of(5), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        // the last page will be discarded
+        assertTrue(groupedTopNBuilder.processPage(input.get(3)).process());
+        assertBuilderSize(new NoChannelGroupByHash(), types, ImmutableList.of(4, 1, 1), ImmutableList.of(5), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        List<Page> output = ImmutableList.copyOf(groupedTopNBuilder.buildResult());
+        assertEquals(output.size(), 1);
+
+        Page expected = rowPagesBuilder(BIGINT, DOUBLE, BIGINT)
+                .row(3L, 0.1, 1)
+                .row(2L, 0.2, 2)
+                .row(1L, 0.3, 3)
+                .row(1L, 0.4, 4)
+                .row(1L, 0.5, 5)
+                .build()
+                .get(0);
+        if (produceRowNumbers) {
+            assertPageEquals(ImmutableList.of(BIGINT, DOUBLE, BIGINT), output.get(0), expected);
+        }
+        else {
+            assertPageEquals(types, output.get(0), new Page(expected.getBlock(0), expected.getBlock(1)));
+        }
+
+        assertBuilderSize(new NoChannelGroupByHash(), types, ImmutableList.of(0, 0, 0), ImmutableList.of(0), groupedTopNBuilder.getEstimatedSizeInBytes());
+    }
+
+    @Test
+    public void testYield()
+    {
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE);
+        Page input = rowPagesBuilder(types)
+                .row(1L, 0.3)
+                .row(1L, 0.2)
+                .row(1L, 0.9)
+                .row(1L, 0.1)
+                .build()
+                .get(0);
+        input.compact();
+
+        AtomicBoolean unblock = new AtomicBoolean();
+        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(types.get(0)), ImmutableList.of(0), unblock::get);
+        GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNBuilder(
+                types,
+                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST)),
+                5,
+                false,
+                groupByHash);
+        assertBuilderSize(groupByHash, types, ImmutableList.of(), ImmutableList.of(), groupedTopNBuilder.getEstimatedSizeInBytes());
+
+        Work<?> work = groupedTopNBuilder.processPage(input);
+        assertFalse(work.process());
+        assertFalse(work.process());
+        unblock.set(true);
+        assertTrue(work.process());
+        List<Page> output = ImmutableList.copyOf(groupedTopNBuilder.buildResult());
+        assertEquals(output.size(), 1);
+
+        Page expected = rowPagesBuilder(types)
+                .row(1L, 0.1)
+                .row(1L, 0.2)
+                .row(1L, 0.3)
+                .row(1L, 0.9)
+                .build()
+                .get(0);
+        assertPageEquals(types, output.get(0), expected);
+        assertBuilderSize(groupByHash, types, ImmutableList.of(0), ImmutableList.of(), groupedTopNBuilder.getEstimatedSizeInBytes());
+    }
+
+    @Test
+    public void testAutoCompact()
+    {
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE);
+        List<Page> input = rowPagesBuilder(types)
+                .row(1L, 0.8)
+                .row(2L, 0.7)
+                .row(3L, 0.9)
+                .row(3L, 0.2)
+                .row(3L, 0.2)
+                .row(3L, 0.2)
+                .row(3L, 0.2)
+                .pageBreak()
+                .row(3L, 0.8)
+                .pageBreak()
+                .row(2L, 0.6)
+                .row(3L, 0.1)
+                .pageBreak()
+                .row(1L, 0.7)
+                .pageBreak()
+                .row(1L, 0.6)
+                .build();
+
+        GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNBuilder(
+                types,
+                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST)),
+                1,
+                false,
+                createGroupByHash(ImmutableList.of(types.get(0)), ImmutableList.of(0), NOOP));
+
+        // page 1:
+        // the first page will be compacted
+        assertTrue(groupedTopNBuilder.processPage(input.get(0)).process());
+        assertEquals(groupedTopNBuilder.getBufferedPages().size(), 1);
+        Page firstCompactPage = groupedTopNBuilder.getBufferedPages().get(0);
+        Page expected = rowPagesBuilder(types)
+                .row(1L, 0.8)
+                .row(2L, 0.7)
+                .row(3L, 0.2)
+                .build()
+                .get(0);
+        assertPageEquals(types, firstCompactPage, expected);
+
+        // page 2:
+        // the second page will be removed
+        assertTrue(groupedTopNBuilder.processPage(input.get(1)).process());
+        assertEquals(groupedTopNBuilder.getBufferedPages().size(), 1);
+        // assert the first page is not affected
+        assertEquals(firstCompactPage, groupedTopNBuilder.getBufferedPages().get(0));
+
+        // page 3:
+        // the third page will trigger another compaction of the first page
+        assertTrue(groupedTopNBuilder.processPage(input.get(2)).process());
+        List<Page> bufferedPages = groupedTopNBuilder.getBufferedPages();
+        assertEquals(bufferedPages.size(), 2);
+        // assert the previously compacted first page no longer exists
+        assertNotEquals(firstCompactPage, bufferedPages.get(0));
+        assertNotEquals(firstCompactPage, bufferedPages.get(1));
+
+        List<Page> expectedPages = rowPagesBuilder(types)
+                .row(1L, 0.8)
+                .pageBreak()
+                .row(2L, 0.6)
+                .row(3L, 0.1)
+                .build();
+        assertPageEquals(types, bufferedPages.get(0), expectedPages.get(0));
+        assertPageEquals(types, bufferedPages.get(1), expectedPages.get(1));
+
+        // page 4:
+        // the fourth page will remove the first page; also it leaves it with an empty slot
+        assertTrue(groupedTopNBuilder.processPage(input.get(3)).process());
+        bufferedPages = groupedTopNBuilder.getBufferedPages();
+        assertEquals(bufferedPages.size(), 2);
+
+        expectedPages = rowPagesBuilder(types)
+                .row(2L, 0.6)
+                .row(3L, 0.1)
+                .pageBreak()
+                .row(1L, 0.7)
+                .build();
+        assertPageEquals(types, bufferedPages.get(0), expectedPages.get(0));
+        assertPageEquals(types, bufferedPages.get(1), expectedPages.get(1));
+
+        // page 5:
+        // the fifth page will remove the fourth page and it will take the empty slot from the first page
+        assertTrue(groupedTopNBuilder.processPage(input.get(4)).process());
+        bufferedPages = groupedTopNBuilder.getBufferedPages();
+        assertEquals(bufferedPages.size(), 2);
+
+        // assert the fifth page indeed takes the first empty slot
+        expectedPages = rowPagesBuilder(types)
+                .row(1L, 0.6)
+                .pageBreak()
+                .row(2L, 0.6)
+                .row(3L, 0.1)
+                .build();
+        assertPageEquals(types, bufferedPages.get(0), expectedPages.get(0));
+        assertPageEquals(types, bufferedPages.get(1), expectedPages.get(1));
+    }
+
+    @Test(dataProvider = "pageRowCounts")
+    public void testLargePagesMemoryTracking(int pageCount, int rowCount)
+    {
+        // Memory tracking has been tested in other tests for various cases (e.g., compaction, row removal, etc).
+        // The purpose of this test is to verify:
+        // (1) the sizes of containers (e.g., big array, heap, etc) are properly tracked when they grow and
+        // (2) when we flush, the memory usage decreases accordingly.
+        List<Type> types = ImmutableList.of(BIGINT, DOUBLE);
+
+        // Create pageCount pages each page is with rowCount positions:
+        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(types);
+        for (int i = 0; i < pageCount; i++) {
+            rowPagesBuilder.addSequencePage(rowCount, 0, rowCount * i);
+        }
+        List<Page> input = rowPagesBuilder.build();
+
+        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(types.get(0)), ImmutableList.of(0), NOOP);
+        GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNBuilder(
+                types,
+                new SimplePageWithPositionComparator(types, ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST)),
+                pageCount * rowCount,
+                false,
+                groupByHash);
+
+        // Assert memory usage gradually goes up
+        for (int i = 0; i < pageCount; i++) {
+            assertTrue(groupedTopNBuilder.processPage(input.get(i)).process());
+            assertBuilderSize(groupByHash, types, Collections.nCopies(i + 1, rowCount), Collections.nCopies(rowCount, i + 1), groupedTopNBuilder.getEstimatedSizeInBytes());
+        }
+
+        // Assert memory usage gradually goes down (i.e., proportional to the number of rows/pages we have produced)
+        int outputPageCount = 0;
+        int remainingRows = pageCount * rowCount;
+        Iterator<Page> output = groupedTopNBuilder.buildResult();
+        while (output.hasNext()) {
+            remainingRows -= output.next().getPositionCount();
+            assertBuilderSize(
+                    groupByHash,
+                    types,
+                    remainingRows == 0 ? Collections.nCopies(pageCount, 0) : Collections.nCopies(pageCount, rowCount),
+                    new ImmutableList.Builder<Integer>()
+                            .addAll(Collections.nCopies((remainingRows + pageCount - 1) / pageCount, pageCount))
+                            .addAll(Collections.nCopies(rowCount - (remainingRows + pageCount - 1) / pageCount, 0))
+                            .build(),
+                    groupedTopNBuilder.getEstimatedSizeInBytes());
+            outputPageCount++;
+        }
+        assertEquals(remainingRows, 0);
+        assertGreaterThan(outputPageCount, 3);
+        assertBuilderSize(groupByHash, types, Collections.nCopies(pageCount, 0), Collections.nCopies(rowCount, 0), groupedTopNBuilder.getEstimatedSizeInBytes());
+    }
+
+    private static GroupByHash createGroupByHash(List<Type> partitionTypes, List<Integer> partitionChannels, UpdateMemory updateMemory)
+    {
+        return GroupByHash.createGroupByHash(
+                partitionTypes,
+                Ints.toArray(partitionChannels),
+                Optional.empty(),
+                1,
+                false,
+                new JoinCompiler(createTestMetadataManager(), new FeaturesConfig()),
+                updateMemory);
+    }
+
+    /**
+     * Assert the retained size in Bytes of {@param builder} with
+     * {@param groupByHash},
+     * a list of {@param types} of the input pages,
+     * a list of how many positions ({@param pagePositions}) of each page, and
+     * a list of how many rows ({}@param rowCounts}) of each group.
+     * Currently we do not assert the size of emptyPageReferenceSlots and assume the queue is always with INITIAL_CAPACITY = 4.
+     */
+    private static void assertBuilderSize(
+            GroupByHash groupByHash,
+            List<Type> types,
+            List<Integer> pagePositions,
+            List<Integer> rowCounts,
+            long actualSizeInBytes)
+    {
+        ObjectBigArray<Object> pageReferences = new ObjectBigArray<>();
+        pageReferences.ensureCapacity(pagePositions.size());
+        long pageReferencesSizeInBytes = pageReferences.sizeOf();
+
+        ObjectBigArray<Object> groupedRows = new ObjectBigArray<>();
+        groupedRows.ensureCapacity(rowCounts.size());
+        long groupedRowsSizeInBytes = groupedRows.sizeOf();
+
+        int emptySlots = 4;
+        long emptyPageReferenceSlotsSizeInBytes = INT_FIFO_QUEUE_SIZE + sizeOf(new int[emptySlots]);
+
+        // build fake pages to get the real retained sizes
+        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(types);
+        for (int pagePosition : pagePositions) {
+            if (pagePosition > 0) {
+                rowPagesBuilder.addSequencePage(pagePosition, new int[types.size()]);
+            }
+        }
+
+        long referencedPagesSizeInBytes = 0;
+        for (Page page : rowPagesBuilder.build()) {
+            // each page reference is with two arrays and a page
+            referencedPagesSizeInBytes += PAGE_REFERENCE_INSTANCE_SIZE +
+                    page.getRetainedSizeInBytes() +
+                    sizeOf(new Object[page.getPositionCount()]);
+        }
+
+        long rowHeapsSizeInBytes = 0;
+        for (int count : rowCounts) {
+            if (count > 0) {
+                rowHeapsSizeInBytes += new TestRowHeap(count).getEstimatedSizeInBytes();
+            }
+        }
+
+        long expectedSizeInBytes = INSTANCE_SIZE +
+                groupByHash.getEstimatedSize() +
+                referencedPagesSizeInBytes +
+                rowHeapsSizeInBytes +
+                pageReferencesSizeInBytes +
+                groupedRowsSizeInBytes +
+                emptyPageReferenceSlotsSizeInBytes;
+        assertEquals(actualSizeInBytes, expectedSizeInBytes);
+    }
+
+    // this class is for memory tracking comparison
+    private static class TestRowHeap
+            extends ObjectHeapPriorityQueue<Object>
+    {
+        private static final long INSTANCE_SIZE = ClassLayout.parseClass(TestRowHeap.class).instanceSize();
+        // each Row is with two integers
+        private static final long ROW_ENTRY_SIZE = 2 * Integer.BYTES + OBJECT_OVERHEAD;
+
+        private TestRowHeap(int count)
+        {
+            super((left, right) -> 0);
+            for (int i = 0; i < count; i++) {
+                enqueue(new Object());
+            }
+        }
+
+        private long getEstimatedSizeInBytes()
+        {
+            return INSTANCE_SIZE + sizeOf(heap) + size() * ROW_ENTRY_SIZE;
+        }
+    }
+
+    // this class is for memory tracking comparison
+    private static class TestPageReference
+    {
+        // only need reference overhead
+        private Object page;
+        private Object reference;
+
+        private int usedPositionCount;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
@@ -17,6 +17,7 @@ import com.facebook.presto.RowPagesBuilder;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
@@ -35,6 +36,8 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.operator.GroupByHashYieldAssertion.createPagesWithDistinctHashKeys;
+import static com.facebook.presto.operator.GroupByHashYieldAssertion.finishOperatorWithYieldingGroupByHash;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
 import static com.facebook.presto.operator.TopNRowNumberOperator.TopNRowNumberOperatorFactory;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -42,8 +45,10 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.testing.Assertions.assertGreaterThan;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
 public class TestTopNRowNumberOperator
@@ -77,8 +82,14 @@ public class TestTopNRowNumberOperator
         return new Object[][] {{true}, {false}};
     }
 
+    @DataProvider
+    public Object[][] partial()
+    {
+        return new Object[][] {{true}, {false}};
+    }
+
     @Test(dataProvider = "hashEnabledValues")
-    public void testTopNRowNumberPartitioned(boolean hashEnabled)
+    public void testPartitioned(boolean hashEnabled)
     {
         RowPagesBuilder rowPagesBuilder = rowPagesBuilder(hashEnabled, Ints.asList(0), BIGINT, DOUBLE);
         List<Page> input = rowPagesBuilder
@@ -126,8 +137,8 @@ public class TestTopNRowNumberOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testTopNRowNumberUnPartitioned()
+    @Test(dataProvider = "partial")
+    public void testUnPartitioned(boolean partial)
     {
         List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)
                 .row(1L, 0.3)
@@ -155,17 +166,68 @@ public class TestTopNRowNumberOperator
                 Ints.asList(1),
                 ImmutableList.of(SortOrder.ASC_NULLS_LAST),
                 3,
+                partial,
+                Optional.empty(),
+                10,
+                joinCompiler);
+
+        MaterializedResult expected;
+        if (partial) {
+            expected = resultBuilder(driverContext.getSession(), DOUBLE, BIGINT)
+                    .row(0.1, 3L)
+                    .row(0.2, 2L)
+                    .row(0.3, 1L)
+                    .build();
+        }
+        else {
+            expected = resultBuilder(driverContext.getSession(), DOUBLE, BIGINT, BIGINT)
+                    .row(0.1, 3L, 1L)
+                    .row(0.2, 2L, 2L)
+                    .row(0.3, 1L, 3L)
+                    .build();
+        }
+
+        assertOperatorEquals(operatorFactory, driverContext, input, expected);
+    }
+
+    public void testMemoryReservationYield()
+    {
+        Type type = BIGINT;
+        List<Page> input = createPagesWithDistinctHashKeys(type, 6_000, 600);
+
+        OperatorFactory operatorFactory = new TopNRowNumberOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                ImmutableList.of(type),
+                ImmutableList.of(0),
+                ImmutableList.of(0),
+                ImmutableList.of(type),
+                Ints.asList(0),
+                ImmutableList.of(SortOrder.ASC_NULLS_LAST),
+                3,
                 false,
                 Optional.empty(),
                 10,
                 joinCompiler);
 
-        MaterializedResult expected = resultBuilder(driverContext.getSession(), DOUBLE, BIGINT, BIGINT)
-                .row(0.1, 3L, 1L)
-                .row(0.2, 2L, 2L)
-                .row(0.3, 1L, 3L)
-                .build();
+        // get result with yield; pick a relatively small buffer for heaps
+        GroupByHashYieldAssertion.GroupByHashYieldResult result = finishOperatorWithYieldingGroupByHash(
+                input,
+                type,
+                operatorFactory,
+                operator -> ((TopNRowNumberOperator) operator).getCapacity(),
+                1_000_000);
+        assertGreaterThan(result.getYieldCount(), 3);
+        assertGreaterThan(result.getMaxReservedBytes(), 5L << 20);
 
-        assertOperatorEquals(operatorFactory, driverContext, input, expected);
+        int count = 0;
+        for (Page page : result.getOutput()) {
+            assertEquals(page.getChannelCount(), 2);
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                assertEquals(page.getBlock(1).getByte(i, 0), 1);
+                count++;
+            }
+        }
+        assertEquals(count, 6_000 * 600);
     }
 }


### PR DESCRIPTION
Resolves #5298
 
Optimizations:
* Use `GroupedTopNBuilder` to avoid copy of positions originally through `getSingleValueBlock()`
* (`TopNRowNumberOperator` only) reduce complexity of flushing pages from quadratic to linear