### PR TITLE
Optimize arbitrary()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
@@ -17,12 +17,13 @@ import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.SqlAggregationFunction;
-import com.facebook.presto.operator.aggregation.state.BlockState;
-import com.facebook.presto.operator.aggregation.state.BlockStateSerializer;
 import com.facebook.presto.operator.aggregation.state.NullableBooleanState;
 import com.facebook.presto.operator.aggregation.state.NullableDoubleState;
 import com.facebook.presto.operator.aggregation.state.NullableLongState;
-import com.facebook.presto.operator.aggregation.state.SliceState;
+import com.facebook.presto.operator.aggregation.state.ObjectBlockPositionState;
+import com.facebook.presto.operator.aggregation.state.ObjectBlockPositionStateSerializer;
+import com.facebook.presto.operator.aggregation.state.SliceBlockPositionState;
+import com.facebook.presto.operator.aggregation.state.SliceBlockPositionStateSerializer;
 import com.facebook.presto.operator.aggregation.state.StateCompiler;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -54,21 +55,21 @@ public class ArbitraryAggregationFunction
 
     private static final MethodHandle LONG_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, NullableLongState.class, Block.class, int.class);
     private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, NullableDoubleState.class, Block.class, int.class);
-    private static final MethodHandle SLICE_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, SliceState.class, Block.class, int.class);
+    private static final MethodHandle SLICE_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, SliceBlockPositionState.class, Block.class, int.class);
     private static final MethodHandle BOOLEAN_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, NullableBooleanState.class, Block.class, int.class);
-    private static final MethodHandle BLOCK_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, BlockState.class, Block.class, int.class);
+    private static final MethodHandle BLOCK_INPUT_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "input", Type.class, ObjectBlockPositionState.class, Block.class, int.class);
 
     private static final MethodHandle LONG_OUTPUT_FUNCTION = methodHandle(NullableLongState.class, "write", Type.class, NullableLongState.class, BlockBuilder.class);
     private static final MethodHandle DOUBLE_OUTPUT_FUNCTION = methodHandle(NullableDoubleState.class, "write", Type.class, NullableDoubleState.class, BlockBuilder.class);
-    private static final MethodHandle SLICE_OUTPUT_FUNCTION = methodHandle(SliceState.class, "write", Type.class, SliceState.class, BlockBuilder.class);
+    private static final MethodHandle SLICE_OUTPUT_FUNCTION = methodHandle(SliceBlockPositionState.class, "write", Type.class, SliceBlockPositionState.class, BlockBuilder.class);
     private static final MethodHandle BOOLEAN_OUTPUT_FUNCTION = methodHandle(NullableBooleanState.class, "write", Type.class, NullableBooleanState.class, BlockBuilder.class);
-    private static final MethodHandle BLOCK_OUTPUT_FUNCTION = methodHandle(BlockState.class, "write", Type.class, BlockState.class, BlockBuilder.class);
+    private static final MethodHandle BLOCK_OUTPUT_FUNCTION = methodHandle(ObjectBlockPositionState.class, "write", Type.class, ObjectBlockPositionState.class, BlockBuilder.class);
 
     private static final MethodHandle LONG_COMBINE_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "combine", NullableLongState.class, NullableLongState.class);
     private static final MethodHandle DOUBLE_COMBINE_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "combine", NullableDoubleState.class, NullableDoubleState.class);
-    private static final MethodHandle SLICE_COMBINE_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "combine", SliceState.class, SliceState.class);
+    private static final MethodHandle SLICE_COMBINE_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "combine", SliceBlockPositionState.class, SliceBlockPositionState.class);
     private static final MethodHandle BOOLEAN_COMBINE_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "combine", NullableBooleanState.class, NullableBooleanState.class);
-    private static final MethodHandle BLOCK_COMBINE_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "combine", BlockState.class, BlockState.class);
+    private static final MethodHandle BLOCK_COMBINE_FUNCTION = methodHandle(ArbitraryAggregationFunction.class, "combine", ObjectBlockPositionState.class, ObjectBlockPositionState.class);
 
     protected ArbitraryAggregationFunction()
     {
@@ -119,8 +120,8 @@ public class ArbitraryAggregationFunction
             outputFunction = DOUBLE_OUTPUT_FUNCTION;
         }
         else if (type.getJavaType() == Slice.class) {
-            stateInterface = SliceState.class;
-            stateSerializer = StateCompiler.generateStateSerializer(stateInterface, classLoader);
+            stateInterface = SliceBlockPositionState.class;
+            stateSerializer = new SliceBlockPositionStateSerializer(type);
             inputFunction = SLICE_INPUT_FUNCTION;
             combineFunction = SLICE_COMBINE_FUNCTION;
             outputFunction = SLICE_OUTPUT_FUNCTION;
@@ -133,8 +134,8 @@ public class ArbitraryAggregationFunction
             outputFunction = BOOLEAN_OUTPUT_FUNCTION;
         }
         else {
-            stateInterface = BlockState.class;
-            stateSerializer = new BlockStateSerializer(type);
+            stateInterface = ObjectBlockPositionState.class;
+            stateSerializer = new ObjectBlockPositionStateSerializer(type);
             inputFunction = BLOCK_INPUT_FUNCTION;
             combineFunction = BLOCK_COMBINE_FUNCTION;
             outputFunction = BLOCK_OUTPUT_FUNCTION;
@@ -181,12 +182,13 @@ public class ArbitraryAggregationFunction
         state.setLong(type.getLong(block, position));
     }
 
-    public static void input(Type type, SliceState state, Block block, int position)
+    public static void input(Type type, SliceBlockPositionState state, Block block, int position)
     {
-        if (state.getSlice() != null) {
+        if (state.getBlock() != null) {
             return;
         }
-        state.setSlice(type.getSlice(block, position));
+        state.setBlock(block);
+        state.setPosition(position);
     }
 
     public static void input(Type type, NullableBooleanState state, Block block, int position)
@@ -198,12 +200,13 @@ public class ArbitraryAggregationFunction
         state.setBoolean(type.getBoolean(block, position));
     }
 
-    public static void input(Type type, BlockState state, Block block, int position)
+    public static void input(Type type, ObjectBlockPositionState state, Block block, int position)
     {
         if (state.getBlock() != null) {
             return;
         }
-        state.setBlock((Block) type.getObject(block, position));
+        state.setBlock(block);
+        state.setPosition(position);
     }
 
     public static void combine(NullableLongState state, NullableLongState otherState)
@@ -233,19 +236,21 @@ public class ArbitraryAggregationFunction
         state.setBoolean(otherState.getBoolean());
     }
 
-    public static void combine(SliceState state, SliceState otherState)
-    {
-        if (state.getSlice() != null) {
-            return;
-        }
-        state.setSlice(otherState.getSlice());
-    }
-
-    public static void combine(BlockState state, BlockState otherState)
+    public static void combine(SliceBlockPositionState state, SliceBlockPositionState otherState)
     {
         if (state.getBlock() != null) {
             return;
         }
         state.setBlock(otherState.getBlock());
+        state.setPosition(otherState.getPosition());
+    }
+
+    public static void combine(ObjectBlockPositionState state, ObjectBlockPositionState otherState)
+    {
+        if (state.getBlock() != null) {
+            return;
+        }
+        state.setBlock(otherState.getBlock());
+        state.setPosition(otherState.getPosition());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ObjectBlockPositionState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ObjectBlockPositionState.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+import com.facebook.presto.spi.type.Type;
+
+@AccumulatorStateMetadata(stateSerializerClass = ObjectBlockPositionStateSerializer.class)
+public interface ObjectBlockPositionState
+        extends AccumulatorState
+{
+    Block getBlock();
+
+    int getPosition();
+
+    void setBlock(Block value);
+
+    void setPosition(int position);
+
+    static void write(Type type, ObjectBlockPositionState state, BlockBuilder out)
+    {
+        if (state.getBlock() == null) {
+            out.appendNull();
+        }
+        else {
+            type.writeObject(out, type.getObject(state.getBlock(), state.getPosition()));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ObjectBlockPositionStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ObjectBlockPositionStateSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+
+public class ObjectBlockPositionStateSerializer
+        implements AccumulatorStateSerializer<ObjectBlockPositionState>
+{
+    private final Type type;
+
+    public ObjectBlockPositionStateSerializer(Type type)
+    {
+        this.type = type;
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return type;
+    }
+
+    @Override
+    public void serialize(ObjectBlockPositionState state, BlockBuilder out)
+    {
+        if (state.getBlock() == null) {
+            out.appendNull();
+        }
+        else {
+            type.writeObject(out, type.getObject(state.getBlock(), state.getPosition()));
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, ObjectBlockPositionState state)
+    {
+        // Use the original serialized block as the underlying block for the state to save object creation overhead
+        state.setPosition(index);
+        state.setBlock(block);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/SliceBlockPositionState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/SliceBlockPositionState.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+import com.facebook.presto.spi.type.Type;
+
+@AccumulatorStateMetadata(stateSerializerClass = SliceBlockPositionStateSerializer.class)
+public interface SliceBlockPositionState
+        extends AccumulatorState
+{
+    Block getBlock();
+
+    int getPosition();
+
+    void setBlock(Block value);
+
+    void setPosition(int position);
+
+    static void write(Type type, SliceBlockPositionState state, BlockBuilder out)
+    {
+        if (state.getBlock() == null) {
+            out.appendNull();
+        }
+        else {
+            type.writeSlice(out, type.getSlice(state.getBlock(), state.getPosition()));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/SliceBlockPositionStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/SliceBlockPositionStateSerializer.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+
+public class SliceBlockPositionStateSerializer
+        implements AccumulatorStateSerializer<SliceBlockPositionState>
+{
+    private final Type type;
+
+    public SliceBlockPositionStateSerializer(Type type)
+    {
+        this.type = type;
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return type;
+    }
+
+    @Override
+    public void serialize(SliceBlockPositionState state, BlockBuilder out)
+    {
+        if (state.getBlock() == null) {
+            out.appendNull();
+        }
+        else {
+            type.writeSlice(out, type.getSlice(state.getBlock(), state.getPosition()));
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, SliceBlockPositionState state)
+    {
+        state.setPosition(index);
+        state.setBlock(block);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
@@ -17,6 +17,7 @@ import com.facebook.presto.array.BlockBigArray;
 import com.facebook.presto.array.BooleanBigArray;
 import com.facebook.presto.array.ByteBigArray;
 import com.facebook.presto.array.DoubleBigArray;
+import com.facebook.presto.array.IntBigArray;
 import com.facebook.presto.array.LongBigArray;
 import com.facebook.presto.array.SliceBigArray;
 import com.facebook.presto.bytecode.BytecodeBlock;
@@ -80,6 +81,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newIns
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
@@ -109,6 +111,9 @@ public class StateCompiler
         if (type.equals(boolean.class)) {
             return BooleanBigArray.class;
         }
+        if (type.equals(int.class)) {
+            return IntBigArray.class;
+        }
         if (type.equals(Slice.class)) {
             return SliceBigArray.class;
         }
@@ -121,8 +126,8 @@ public class StateCompiler
 
     public static Set<Class<?>> getSupportedFieldTypes()
     {
-        // byte.class is needed for TriStateBooleanState
-        return ImmutableSet.of(byte.class, boolean.class, long.class, double.class, Slice.class, Block.class);
+        // byte.class and int.class are needed for TriStateBooleanState and Object/SliceBlockPositionState respectively
+        return ImmutableSet.of(byte.class, boolean.class, long.class, double.class, int.class, Slice.class, Block.class);
     }
 
     public static <T> AccumulatorStateSerializer<T> generateStateSerializer(Class<T> clazz)
@@ -225,7 +230,7 @@ public class StateCompiler
                         .ifFalse(state.cast(setter.getDeclaringClass()).invoke(setter, constantType(binder, field.getSqlType()).getValue(block, index))));
             }
             else {
-                // For primitive type, we need to cast here because we serialize byte fields with TINYINT (whose java type is long).
+                // For primitive type, we need to cast here because we serialize byte fields with TINYINT/INTEGER (whose java type is long).
                 deserializerBody.append(
                         state.cast(setter.getDeclaringClass()).invoke(
                                 setter,
@@ -245,7 +250,7 @@ public class StateCompiler
                             .ifFalse(state.cast(setter.getDeclaringClass()).invoke(setter, constantType(binder, field.getSqlType()).getValue(row, constantInt(position)))));
                 }
                 else {
-                    // For primitive type, we need to cast here because we serialize byte fields with TINYINT (whose java type is long).
+                    // For primitive type, we need to cast here because we serialize byte fields with TINYINT/INTEGER (whose java type is long).
                     deserializerBody.append(
                             state.cast(setter.getDeclaringClass()).invoke(
                                     setter,
@@ -277,7 +282,7 @@ public class StateCompiler
                         .ifFalse(sqlType.writeValue(out, fieldValue)));
             }
             else {
-                // For primitive type, we need to cast here because we serialize byte fields with TINYINT (whose java type is long).
+                // For primitive type, we need to cast here because we serialize byte fields with TINYINT/INTEGER (whose java type is long).
                 serializerBody.append(sqlType.writeValue(out, fieldValue.cast(fields.get(0).getSqlType().getJavaType())));
             }
         }
@@ -295,7 +300,7 @@ public class StateCompiler
                             .ifFalse(sqlType.writeValue(rowBuilder, fieldValue)));
                 }
                 else {
-                    // For primitive type, we need to cast here because we serialize byte fields with TINYINT (whose java type is long).
+                    // For primitive type, we need to cast here because we serialize byte fields with TINYINT/INTEGER (whose java type is long).
                     serializerBody.append(sqlType.writeValue(rowBuilder, fieldValue.cast(field.getSqlType().getJavaType())));
                 }
             }
@@ -561,7 +566,7 @@ public class StateCompiler
     private static List<StateField> enumerateFields(Class<?> clazz, Map<String, Type> fieldTypes)
     {
         ImmutableList.Builder<StateField> builder = ImmutableList.builder();
-        final Set<Class<?>> primitiveClasses = ImmutableSet.of(byte.class, boolean.class, long.class, double.class);
+        final Set<Class<?>> primitiveClasses = ImmutableSet.of(byte.class, boolean.class, long.class, double.class, int.class);
         Set<Class<?>> supportedClasses = getSupportedFieldTypes();
         for (Method method : clazz.getMethods()) {
             if (method.getName().equals("getEstimatedSize")) {
@@ -700,7 +705,9 @@ public class StateCompiler
             checkArgument(sqlType != null, "sqlType is null");
             if (sqlType.isPresent()) {
                 checkArgument(
-                        (sqlType.get().getJavaType() == type) || ((type == byte.class) && TINYINT.equals(sqlType.get())),
+                        (sqlType.get().getJavaType() == type) ||
+                                ((type == byte.class) && TINYINT.equals(sqlType.get())) ||
+                                ((type == int.class) && INTEGER.equals(sqlType.get())),
                         "Stack type (%s) and provided sql type (%s) are incompatible", type.getName(), sqlType.get().getDisplayName());
             }
             else {
@@ -722,6 +729,9 @@ public class StateCompiler
             }
             else if (stackType == byte.class) {
                 return Optional.of(TINYINT);
+            }
+            else if (stackType == int.class) {
+                return Optional.of(INTEGER);
             }
             else if (stackType == Slice.class) {
                 return Optional.of(VARBINARY);
@@ -762,7 +772,7 @@ public class StateCompiler
         boolean isPrimitiveType()
         {
             Class<?> type = getType();
-            return (type == long.class || type == double.class || type == boolean.class || type == byte.class);
+            return (type == long.class || type == double.class || type == boolean.class || type == byte.class || type == int.class);
         }
 
         public BytecodeExpression initialValueExpression()

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
@@ -17,6 +17,7 @@ import com.facebook.presto.array.BlockBigArray;
 import com.facebook.presto.array.BooleanBigArray;
 import com.facebook.presto.array.ByteBigArray;
 import com.facebook.presto.array.DoubleBigArray;
+import com.facebook.presto.array.IntBigArray;
 import com.facebook.presto.array.LongBigArray;
 import com.facebook.presto.array.ReferenceCountMap;
 import com.facebook.presto.array.SliceBigArray;
@@ -51,6 +52,7 @@ import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
@@ -214,6 +216,7 @@ public class TestStateCompiler
         singleState.setLong(1);
         singleState.setDouble(2.0);
         singleState.setByte((byte) 3);
+        singleState.setInt(4);
         singleState.setSlice(utf8Slice("test"));
         singleState.setAnotherSlice(wrappedDoubleArray(1.0, 2.0, 3.0));
         singleState.setYetAnotherSlice(null);
@@ -221,7 +224,7 @@ public class TestStateCompiler
         singleState.setBlock(array);
         singleState.setAnotherBlock(mapBlockOf(BIGINT, VARCHAR, ImmutableMap.of(123L, "testBlock")));
 
-        BlockBuilder builder = new RowType(ImmutableList.of(BOOLEAN, TINYINT, DOUBLE, BIGINT, mapType, VARBINARY, arrayType, VARBINARY, VARBINARY), Optional.empty())
+        BlockBuilder builder = new RowType(ImmutableList.of(BOOLEAN, TINYINT, DOUBLE, INTEGER, BIGINT, mapType, VARBINARY, arrayType, VARBINARY, VARBINARY), Optional.empty())
                 .createBlockBuilder(new BlockBuilderStatus(), 1);
         serializer.serialize(singleState, builder);
 
@@ -232,6 +235,7 @@ public class TestStateCompiler
         assertEquals(deserializedState.getLong(), singleState.getLong());
         assertEquals(deserializedState.getDouble(), singleState.getDouble());
         assertEquals(deserializedState.getByte(), singleState.getByte());
+        assertEquals(deserializedState.getInt(), singleState.getInt());
         assertEquals(deserializedState.getSlice(), singleState.getSlice());
         assertEquals(deserializedState.getAnotherSlice(), singleState.getAnotherSlice());
         assertEquals(deserializedState.getYetAnotherSlice(), singleState.getYetAnotherSlice());
@@ -250,7 +254,7 @@ public class TestStateCompiler
                 Class type = field.getType();
                 field.setAccessible(true);
                 if (type == BlockBigArray.class || type == BooleanBigArray.class || type == SliceBigArray.class ||
-                        type == ByteBigArray.class || type == DoubleBigArray.class || type == LongBigArray.class) {
+                        type == ByteBigArray.class || type == DoubleBigArray.class || type == LongBigArray.class || type == IntBigArray.class) {
                     MethodHandle sizeOf = Reflection.methodHandle(type, "sizeOf", null);
                     retainedSize += (long) sizeOf.invokeWithArguments(field.get(state));
                 }
@@ -309,6 +313,7 @@ public class TestStateCompiler
             groupedState.setLong(1);
             groupedState.setDouble(2.0);
             groupedState.setByte((byte) 3);
+            groupedState.setInt(4);
             Slice slice = utf8Slice("test");
             retainedSize += slice.getRetainedSize();
             groupedState.setSlice(slice);
@@ -337,6 +342,7 @@ public class TestStateCompiler
             groupedState.setLong(1);
             groupedState.setDouble(2.0);
             groupedState.setByte((byte) 3);
+            groupedState.setInt(4);
             Slice slice = utf8Slice("test");
             retainedSize += slice.getRetainedSize();
             groupedState.setSlice(slice);
@@ -377,6 +383,10 @@ public class TestStateCompiler
         byte getByte();
 
         void setByte(byte value);
+
+        int getInt();
+
+        void setInt(int value);
 
         Slice getSlice();
 


### PR DESCRIPTION
Introduced two new `AccumulatorState`s to avoid using `getObject` or `getSlice`. These two methods create new objects, which causes GC pressure.