### PR TITLE
Execute PickTableLayout before AddExchanges

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/TableLayoutResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TableLayoutResult.java
@@ -16,8 +16,10 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
@@ -44,11 +46,14 @@ public class TableLayoutResult
 
     public boolean hasAllOutputs(TableScanNode node)
     {
+        if (!layout.getColumns().isPresent()) {
+            return true;
+        }
+        Set<ColumnHandle> columns = ImmutableSet.copyOf(layout.getColumns().get());
         List<ColumnHandle> nodeColumnHandles = node.getOutputSymbols().stream()
                 .map(node.getAssignments()::get)
                 .collect(toImmutableList());
-        return getLayout().getColumns()
-                .map(columnHandles -> columnHandles.containsAll(nodeColumnHandles))
-                .orElse(true);
+
+        return columns.containsAll(nodeColumnHandles);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/TableLayoutResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TableLayoutResult.java
@@ -15,6 +15,11 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class TableLayoutResult
 {
@@ -35,5 +40,15 @@ public class TableLayoutResult
     public TupleDomain<ColumnHandle> getUnenforcedConstraint()
     {
         return unenforcedConstraint;
+    }
+
+    public boolean hasAllOutputs(TableScanNode node)
+    {
+        List<ColumnHandle> nodeColumnHandles = node.getOutputSymbols().stream()
+                .map(node.getAssignments()::get)
+                .collect(toImmutableList());
+        return getLayout().getColumns()
+                .map(columnHandles -> columnHandles.containsAll(nodeColumnHandles))
+                .orElse(true);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -246,6 +246,9 @@ public class PlanOptimizers
                 new TransformCorrelatedSingleRowSubqueryToProject(),
                 new CheckSubqueryNodesAreRewritten(),
                 new PredicatePushDown(metadata, sqlParser),
+                new IterativeOptimizer(
+                        stats,
+                        new PickTableLayout(metadata).rules()),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(
                         stats,
@@ -279,6 +282,9 @@ public class PlanOptimizers
                         stats,
                         ImmutableSet.of(new EliminateCrossJoins())), // This can pull up Filter and Project nodes from between Joins, so we need to push them down again
                 new PredicatePushDown(metadata, sqlParser),
+                new IterativeOptimizer(
+                        stats,
+                        new PickTableLayout(metadata).rules()),
                 projectionPushDown);
 
         if (featuresConfig.isOptimizeSingleDistinct()) {
@@ -308,11 +314,6 @@ public class PlanOptimizers
                             ImmutableSet.of(new PushTableWriteThroughUnion()))); // Must run before AddExchanges
             builder.add(new AddExchanges(metadata, sqlParser));
         }
-
-        builder.add(
-                new IterativeOptimizer(
-                        stats,
-                        new PickTableLayout(metadata).rules()));
 
         builder.add(
                 new IterativeOptimizer(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.isNewOptimizerEnabled;
 import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.sql.planner.iterative.rule.PreconditionRules.checkRulesAreFiredBeforeAddExchangesRule;
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
 import static com.facebook.presto.sql.planner.plan.Patterns.tableScan;
@@ -52,6 +53,7 @@ public class PickTableLayout
     public Set<Rule<?>> rules()
     {
         return ImmutableSet.of(
+                checkRulesAreFiredBeforeAddExchangesRule(),
                 pickTableLayoutForPredicate(),
                 pickTableLayoutWithoutPredicate());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreconditionRules.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreconditionRules.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import static com.facebook.presto.sql.planner.plan.Patterns.exchange;
+import static java.util.Objects.requireNonNull;
+
+public final class PreconditionRules
+{
+    private PreconditionRules() {}
+
+    public static Rule<ExchangeNode> checkRulesAreFiredBeforeAddExchangesRule()
+    {
+        return checkPlanDoNotMatch(exchange(), "Expected rules to be fired before 'AddExchanges' optimizer");
+    }
+
+    public static <T extends PlanNode> Rule<T> checkPlanDoNotMatch(Pattern<T> pattern, String message)
+    {
+        requireNonNull(pattern, "pattern is null");
+        requireNonNull(message, "message is null");
+
+        return new Rule<T>() {
+            @Override
+            public Pattern<T> getPattern()
+            {
+                return pattern;
+            }
+
+            @Override
+            public Result apply(T node, Captures captures, Context context)
+            {
+                throw new IllegalStateException(message);
+            }
+        };
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -604,7 +604,7 @@ public class AddExchanges
 
             // Filter out layouts that cannot supply all the required columns
             layouts = layouts.stream()
-                    .filter(layout -> hasAllNeededOutputs(layout, node))
+                    .filter(layout -> layout.hasAllOutputs(node))
                     .collect(toList());
             checkState(!layouts.isEmpty(), "No usable layouts for %s", node);
 
@@ -637,16 +637,6 @@ public class AddExchanges
                     .collect(toList());
 
             return pickPlan(possiblePlans, context);
-        }
-
-        private boolean hasAllNeededOutputs(TableLayoutResult layout, TableScanNode node)
-        {
-            List<ColumnHandle> nodeColumnHandles = node.getOutputSymbols().stream()
-                    .map(node.getAssignments()::get)
-                    .collect(toImmutableList());
-            return layout.getLayout().getColumns()
-                    .map(columnHandles -> columnHandles.containsAll(nodeColumnHandles))
-                    .orElse(true);
         }
 
         /**

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -1207,6 +1207,28 @@ public class TestDomainTranslator
     }
 
     @Test
+    public void testConjunctExpression()
+            throws Exception
+    {
+        Expression originalExpression = and(
+                comparison(GREATER_THAN, C_DOUBLE.toSymbolReference(), doubleLiteral(0)),
+                comparison(GREATER_THAN, C_BIGINT.toSymbolReference(), bigintLiteral(0)));
+
+        ExtractionResult result = fromPredicate(originalExpression);
+        assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(
+                C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 0L)), false),
+                C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, .0)), false))));
+
+        Expression expression = toPredicate(result.getTupleDomain());
+        assertEquals(
+                expression,
+                and(
+                        comparison(GREATER_THAN, C_BIGINT.toSymbolReference(), bigintLiteral(0)),
+                        comparison(GREATER_THAN, C_DOUBLE.toSymbolReference(), doubleLiteral(0))));
+    }
+
+    @Test
     void testMultipleCoercionsOnSymbolSide()
     {
         ComparisonExpression originalExpression = comparison(GREATER_THAN, cast(cast(C_SMALLINT, REAL), DOUBLE), doubleLiteral(3.7));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/BasePickTableLayoutTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/BasePickTableLayoutTest.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.metadata.TableLayoutHandle;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.sql.planner.iterative.Rule;
@@ -36,21 +37,28 @@ import static com.facebook.presto.spi.predicate.Domain.singleValue;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.constrainedTableScanWithTableLayout;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 
-public class TestPickTableLayout
+public abstract class BasePickTableLayoutTest
         extends BaseRuleTest
 {
-    private PickTableLayout pickTableLayout;
+    protected PickTableLayout pickTableLayout;
     private TableHandle nationTableHandle;
     private TableLayoutHandle nationTableLayoutHandle;
+    protected ConnectorId connectorId;
+
+    public BasePickTableLayoutTest(boolean predicatePushDownEnabled)
+    {
+        super(predicatePushDownEnabled);
+    }
 
     @BeforeMethod
     public void setUpPerMethod()
     {
         pickTableLayout = new PickTableLayout(tester().getMetadata());
 
-        ConnectorId connectorId = tester().getCurrentConnectorId();
+        connectorId = tester().getCurrentConnectorId();
         nationTableHandle = new TableHandle(
                 connectorId,
                 new TpchTableHandle(connectorId.toString(), "nation", 1.0));
@@ -83,7 +91,7 @@ public class TestPickTableLayout
     }
 
     @Test
-    public void doesNotFireIfTableScanNonDefaultConstraint()
+    public void eliminateTableScanWhenNoLayoutExist()
     {
         tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
                 .on(p -> p.filter(expression("nationkey = BIGINT '44'"),
@@ -91,9 +99,28 @@ public class TestPickTableLayout
                                 nationTableHandle,
                                 ImmutableList.of(p.symbol("nationkey", BIGINT)),
                                 ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)),
+                                Optional.of(nationTableLayoutHandle))))
+                .matches(
+                        filter("nationkey = BIGINT '44'",
+                                constrainedTableScanWithTableLayout(
+                                        "nation",
+                                        ImmutableMap.of("nationkey", singleValue(BIGINT, 44L)),
+                                        ImmutableMap.of("nationkey", "nationkey"))));
+    }
+
+    @Test
+    public void replaceWithExistsWhenNoLayoutExist()
+    {
+        ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);
+        tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
+                .on(p -> p.filter(expression("nationkey = BIGINT '44'"),
+                        p.tableScan(
+                                nationTableHandle,
+                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
+                                ImmutableMap.of(p.symbol("nationkey", BIGINT), columnHandle),
                                 Optional.of(nationTableLayoutHandle),
                                 TupleDomain.none())))
-                .doesNotFire();
+                .matches(values("A"));
     }
 
     @Test
@@ -113,23 +140,18 @@ public class TestPickTableLayout
     @Test
     public void ruleAddedTableLayoutToTableScan()
     {
-        // The TPCH connector returns a TableLayout, but that TableLayout doesn't handle any of the constraints.
-        // However, we know that the rule fired because the constraints and TableLayout are included in the new plan.
-        Map<String, Domain> emptyConstraint = ImmutableMap.<String, Domain>builder().build();
         tester().assertThat(pickTableLayout.pickTableLayoutWithoutPredicate())
                 .on(p -> p.tableScan(
                         nationTableHandle,
                         ImmutableList.of(p.symbol("nationkey", BIGINT)),
                         ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT))))
                 .matches(
-                        constrainedTableScanWithTableLayout("nation", emptyConstraint, ImmutableMap.of("nationkey", "nationkey")));
+                        constrainedTableScanWithTableLayout("nation", ImmutableMap.of(), ImmutableMap.of("nationkey", "nationkey")));
     }
 
     @Test
     public void ruleAddedTableLayoutToFilterTableScan()
     {
-        // The TPCH connector returns a TableLayout, but that TableLayout doesn't handle any of the constraints.
-        // However, we know that the rule fired because the constraints and TableLayout are included in the new plan.
         Map<String, Domain> filterConstraint = ImmutableMap.<String, Domain>builder()
                 .put("nationkey", singleValue(BIGINT, 44L))
                 .build();
@@ -147,9 +169,6 @@ public class TestPickTableLayout
     @Test
     public void ruleAddedNewTableLayoutIfTableScanHasEmptyConstraint()
     {
-        Map<String, Domain> filterConstraint = ImmutableMap.<String, Domain>builder()
-                .put("nationkey", singleValue(BIGINT, 44L))
-                .build();
         tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
                 .on(p -> p.filter(expression("nationkey = BIGINT '44'"),
                         p.tableScan(
@@ -159,6 +178,9 @@ public class TestPickTableLayout
                                 Optional.of(nationTableLayoutHandle))))
                 .matches(
                         filter("nationkey = BIGINT '44'",
-                                constrainedTableScanWithTableLayout("nation", filterConstraint, ImmutableMap.of("nationkey", "nationkey"))));
+                                constrainedTableScanWithTableLayout(
+                                        "nation",
+                                        ImmutableMap.of("nationkey", singleValue(BIGINT, 44L)),
+                                        ImmutableMap.of("nationkey", "nationkey"))));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayoutWithPredicatePushDown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayoutWithPredicatePushDown.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.predicate.Domain.singleValue;
+import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.constrainedTableScanWithTableLayout;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.airlift.slice.Slices.utf8Slice;
+
+public class TestPickTableLayoutWithPredicatePushDown
+        extends BasePickTableLayoutTest
+{
+    public TestPickTableLayoutWithPredicatePushDown()
+    {
+        super(true);
+    }
+
+    @Test
+    public void ruleWithPushdownableToTableLayoutPredicate()
+    {
+        TableHandle ordersTableHandle = new TableHandle(
+                connectorId,
+                new TpchTableHandle(connectorId.toString(), "orders", 1.0));
+        Type orderStatusType = createVarcharType(1);
+        tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
+                .on(p -> p.filter(expression("orderstatus = 'O'"),
+                        p.tableScan(
+                                ordersTableHandle,
+                                ImmutableList.of(p.symbol("orderstatus", orderStatusType)),
+                                ImmutableMap.of(p.symbol("orderstatus", orderStatusType), new TpchColumnHandle("orderstatus", orderStatusType)))))
+                .matches(constrainedTableScanWithTableLayout(
+                        "orders",
+                        ImmutableMap.of("orderstatus", singleValue(orderStatusType, utf8Slice("O"))),
+                        ImmutableMap.of("orderstatus", "orderstatus")));
+    }
+
+    @Test
+    public void nonDeterministicPredicate()
+    {
+        TableHandle ordersTableHandle = new TableHandle(
+                connectorId,
+                new TpchTableHandle(connectorId.toString(), "orders", 1.0));
+        Type orderStatusType = createVarcharType(1);
+        tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
+                .on(p -> p.filter(expression("orderstatus = 'O' AND rand() = 0"),
+                        p.tableScan(
+                                ordersTableHandle,
+                                ImmutableList.of(p.symbol("orderstatus", orderStatusType)),
+                                ImmutableMap.of(p.symbol("orderstatus", orderStatusType), new TpchColumnHandle("orderstatus", orderStatusType)))))
+                .matches(
+                        filter("rand() = 0",
+                                constrainedTableScanWithTableLayout(
+                                        "orders",
+                                        ImmutableMap.of("orderstatus", singleValue(orderStatusType, utf8Slice("O"))),
+                                        ImmutableMap.of("orderstatus", "orderstatus"))));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayoutWithoutPredicatePushDown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayoutWithoutPredicatePushDown.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+public class TestPickTableLayoutWithoutPredicatePushDown
+        extends BasePickTableLayoutTest
+{
+    public TestPickTableLayoutWithoutPredicatePushDown()
+    {
+        super(false);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/BaseRuleTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/BaseRuleTest.java
@@ -20,12 +20,23 @@ import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
 public abstract class BaseRuleTest
 {
+    private final boolean tpchPredicatePushdownEnabled;
     private RuleTester tester;
+
+    protected BaseRuleTest()
+    {
+        this(false);
+    }
+
+    protected BaseRuleTest(boolean tpchPredicatePushdownEnabled)
+    {
+        this.tpchPredicatePushdownEnabled = tpchPredicatePushdownEnabled;
+    }
 
     @BeforeClass
     public final void setUp()
     {
-        tester = new RuleTester();
+        tester = new RuleTester(tpchPredicatePushdownEnabled);
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -41,7 +41,7 @@ public class RuleTester
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
 
-    public RuleTester()
+    public RuleTester(boolean tpchPredicatePushdownEnabled)
     {
         session = testSessionBuilder()
                 .setCatalog(CATALOG_ID)
@@ -51,7 +51,7 @@ public class RuleTester
 
         queryRunner = new LocalQueryRunner(session);
         queryRunner.createCatalog(session.getCatalog().get(),
-                new TpchConnectorFactory(1),
+                new TpchConnectorFactory(1, tpchPredicatePushdownEnabled),
                 ImmutableMap.of());
 
         this.metadata = queryRunner.getMetadata();

--- a/presto-matching/src/main/java/com/facebook/presto/matching/Pattern.java
+++ b/presto-matching/src/main/java/com/facebook/presto/matching/Pattern.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Iterables;
 
 import java.util.function.Predicate;
 
+import static com.facebook.presto.matching.DefaultMatcher.DEFAULT_MATCHER;
 import static com.google.common.base.Predicates.not;
 
 public abstract class Pattern<T>
@@ -83,6 +84,11 @@ public abstract class Pattern<T>
     public abstract Match<T> accept(Matcher matcher, Object object, Captures captures);
 
     public abstract void accept(PatternVisitor patternVisitor);
+
+    public boolean matches(Object object)
+    {
+        return DEFAULT_MATCHER.match(this, object).isPresent();
+    }
 
     @Override
     public String toString()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5909,6 +5909,9 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT table_name FROM information_schema.tables WHERE table_name = 'orders' LIMIT 1",
                 "SELECT 'orders' table_name");
+        assertQuery(
+                "SELECT table_name FROM information_schema.columns WHERE data_type = 'bigint' AND table_name = 'customer' and column_name = 'custkey' LIMIT 1",
+                "SELECT 'customer' table_name");
     }
 
     @Test


### PR DESCRIPTION
Based on #9699 and #9700. Supersedes #8735.

This work is needed for making cost based decisions. We need to take our best guess at choosing a table layout before AddExchanges so that we can have more accurate statistics.  