### PR TITLE
Make failAbandonedQueries method more robust

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -80,6 +80,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.airlift.units.Duration.succinctNanos;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 @ThreadSafe
@@ -361,10 +362,10 @@ public class QueryStateMachine
             totalMemoryReservation += stageStats.getTotalMemoryReservation().toBytes();
             peakMemoryReservation = getPeakMemoryInBytes();
 
-            totalScheduledTime += stageStats.getTotalScheduledTime().roundTo(NANOSECONDS);
-            totalCpuTime += stageStats.getTotalCpuTime().roundTo(NANOSECONDS);
-            totalUserTime += stageStats.getTotalUserTime().roundTo(NANOSECONDS);
-            totalBlockedTime += stageStats.getTotalBlockedTime().roundTo(NANOSECONDS);
+            totalScheduledTime += stageStats.getTotalScheduledTime().roundTo(MILLISECONDS);
+            totalCpuTime += stageStats.getTotalCpuTime().roundTo(MILLISECONDS);
+            totalUserTime += stageStats.getTotalUserTime().roundTo(MILLISECONDS);
+            totalBlockedTime += stageStats.getTotalBlockedTime().roundTo(MILLISECONDS);
             if (!stageInfo.getState().isDone()) {
                 fullyBlocked &= stageStats.isFullyBlocked();
                 blockedReasons.addAll(stageStats.getBlockedReasons());
@@ -422,10 +423,10 @@ public class QueryStateMachine
 
                 isScheduled,
 
-                new Duration(totalScheduledTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                new Duration(totalCpuTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                new Duration(totalUserTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                new Duration(totalBlockedTime, NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(totalScheduledTime, MILLISECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(totalCpuTime, MILLISECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(totalUserTime, MILLISECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(totalBlockedTime, MILLISECONDS).convertToMostSuccinctTimeUnit(),
                 fullyBlocked,
                 blockedReasons,
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -636,14 +636,19 @@ public class SqlQueryManager
     public void failAbandonedQueries()
     {
         for (QueryExecution queryExecution : queries.values()) {
-            QueryInfo queryInfo = queryExecution.getQueryInfo();
-            if (queryInfo.getState().isDone()) {
-                continue;
-            }
+            try {
+                QueryInfo queryInfo = queryExecution.getQueryInfo();
+                if (queryInfo.getState().isDone()) {
+                    continue;
+                }
 
-            if (isAbandoned(queryInfo)) {
-                log.info("Failing abandoned query %s", queryExecution.getQueryId());
-                queryExecution.fail(new PrestoException(ABANDONED_QUERY, format("Query %s has not been accessed since %s: currentTime %s", queryInfo.getQueryId(), queryInfo.getQueryStats().getLastHeartbeat(), DateTime.now())));
+                if (isAbandoned(queryInfo)) {
+                    log.info("Failing abandoned query %s", queryExecution.getQueryId());
+                    queryExecution.fail(new PrestoException(ABANDONED_QUERY, format("Query %s has not been accessed since %s: currentTime %s", queryInfo.getQueryId(), queryInfo.getQueryStats().getLastHeartbeat(), DateTime.now())));
+                }
+            }
+            catch (RuntimeException e) {
+                log.error(e, "Exception failing abandoned query %s", queryExecution.getQueryId());
             }
         }
     }


### PR DESCRIPTION
When we fail the abandoned queries if for some reason an exception
is thrown for a query the rest of the queries will not be processed.
This change fixes that.

This PR also logs the problematic query.

We still didn't couldn't get to the bottom of the issue, but here is one instance that we saw in production:

```
2018-01-09T09:18:03.588-0800    WARN    query-management-2      com.facebook.presto.execution.SqlQueryManager   Error cancelling abandoned queries
java.lang.IllegalArgumentException: value is negative
        at io.airlift.units.Preconditions.checkArgument(Preconditions.java:26)
        at io.airlift.units.Duration.<init>(Duration.java:63)
        at com.facebook.presto.execution.QueryStateMachine.getQueryInfo(QueryStateMachine.java:427)
        at com.facebook.presto.execution.QueryStateMachine.updateQueryInfo(QueryStateMachine.java:789)
        at com.facebook.presto.execution.SqlQueryExecution.buildQueryInfo(SqlQueryExecution.java:586)
        at com.facebook.presto.execution.SqlQueryExecution.getQueryInfo(SqlQueryExecution.java:552)
        at com.facebook.presto.execution.SqlQueryManager.failAbandonedQueries(SqlQueryManager.java:627)
        at com.facebook.presto.execution.SqlQueryManager$1.run(SqlQueryManager.java:200)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```