### PR TITLE
Remove unnecessary BoundedExecutor

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientFactory.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.memory.context.LocalMemoryContext;
-import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.http.client.HttpClient;
 import io.airlift.units.DataSize;
@@ -25,7 +24,6 @@ import org.weakref.jmx.Nested;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -48,7 +46,6 @@ public class ExchangeClientFactory
     private final ScheduledExecutorService scheduler;
     private final ThreadPoolExecutorMBean executorMBean;
     private final ExecutorService pageBufferClientCallbackExecutor;
-    private final Executor boundedExecutor;
 
     @Inject
     public ExchangeClientFactory(
@@ -92,7 +89,6 @@ public class ExchangeClientFactory
         this.scheduler = requireNonNull(scheduler, "scheduler is null");
 
         this.pageBufferClientCallbackExecutor = newFixedThreadPool(pageBufferClientMaxCallbackThreads, daemonThreadsNamed("page-buffer-client-callback-%s"));
-        this.boundedExecutor = new BoundedExecutor(pageBufferClientCallbackExecutor, pageBufferClientMaxCallbackThreads);
         this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) pageBufferClientCallbackExecutor);
 
         checkArgument(maxBufferedBytes.toBytes() > 0, "maxBufferSize must be at least 1 byte: %s", maxBufferedBytes);
@@ -125,6 +121,6 @@ public class ExchangeClientFactory
                 httpClient,
                 scheduler,
                 systemMemoryContext,
-                boundedExecutor);
+                pageBufferClientCallbackExecutor);
     }
 }


### PR DESCRIPTION
pageBufferClientCallbackExecutor is a fixed-sized thread pool, so
wrapping it with a BoundedExecutor is unnecessary.