### PR TITLE
add normal CDF to math functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -67,6 +67,12 @@ Mathematical Functions
     a real value and the standard deviation must be a real and positive value.
     The probability p must lie on the interval (0, 1).
 
+.. function:: normal_cdf(mean, sd, v) -> double
+
+    Compute the Normal cdf with given mean and standard deviation (sd):  P(N < v; mean, sd).
+    The mean and value v must be real values and the standard deviation must be a real
+    and positive value.
+
 .. function:: ln(x) -> double
 
     Returns the natural logarithm of ``x``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -612,6 +612,15 @@ public final class MathFunctions
         return mean + sd * 1.4142135623730951 * Erf.erfInv(2 * p - 1);
     }
 
+    @Description("normal cdf given a mean, std, and value")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double normalCdf(@SqlType(StandardTypes.DOUBLE) double mean, @SqlType(StandardTypes.DOUBLE) double sd, @SqlType(StandardTypes.DOUBLE) double v)
+    {
+        checkCondition(sd > 0, INVALID_FUNCTION_ARGUMENT, "sd must > 0");
+        return 0.5 * (1 + Erf.erf((v - mean) / (sd * Math.sqrt(2))));
+    }
+
     @Description("round to nearest integer")
     @ScalarFunction("round")
     @SqlType(StandardTypes.TINYINT)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1321,4 +1321,23 @@ public class TestMathFunctions
         assertInvalidFunction("inverse_normal_cdf(4, 48, 1)", "p must be 0 > p > 1");
         assertInvalidFunction("inverse_normal_cdf(4, 0, 0.4)", "sd must > 0");
     }
+
+    @Test
+    public void testNormalCdf()
+            throws Exception
+    {
+        assertFunction("normal_cdf(0, 1, 1.96)", DOUBLE, 0.9750021048517796);
+        assertFunction("normal_cdf(10, 9, 10)", DOUBLE, 0.5);
+        assertFunction("normal_cdf(-1.5, 2.1, -7.8)", DOUBLE, 0.0013498980316301035);
+        assertFunction("normal_cdf(0, 1, infinity())", DOUBLE, 1.0);
+        assertFunction("normal_cdf(0, 1, -infinity())", DOUBLE, 0.0);
+        assertFunction("normal_cdf(infinity(), 1, 0)", DOUBLE, 0.0);
+        assertFunction("normal_cdf(-infinity(), 1, 0)", DOUBLE, 1.0);
+        assertFunction("normal_cdf(0, infinity(), 0)", DOUBLE, 0.5);
+        assertFunction("normal_cdf(nan(), 1, 0)", DOUBLE, Double.NaN);
+        assertFunction("normal_cdf(0, 1, nan())", DOUBLE, Double.NaN);
+
+        assertInvalidFunction("normal_cdf(0, 0, 0.1985)", "sd must > 0");
+        assertInvalidFunction("normal_cdf(0, nan(), 0.1985)", "sd must > 0");
+    }
 }


### PR DESCRIPTION
PR adds a normal CDF for convenience next to the existing inverse normal CDF function. 

Reference: https://en.wikipedia.org/wiki/Normal_distribution#Cumulative_distribution_function

I have accepted the CLA 