### PR TITLE
Fix deserialization of maps of bing tiles on the client

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.StandardTypes.BIGINT;
+import static com.facebook.presto.spi.type.StandardTypes.BING_TILE;
 import static com.facebook.presto.spi.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.spi.type.StandardTypes.CHAR;
 import static com.facebook.presto.spi.type.StandardTypes.DATE;
@@ -332,6 +333,10 @@ public class QueryResults
             case CHAR:
             case GEOMETRY:
                 return String.class.cast(value);
+            case BING_TILE:
+                // Bing tiles are serialized as strings when used as map keys,
+                // they are serialized as json otherwise (value will be a LinkedHashMap).
+                return value;
             default:
                 // for now we assume that only the explicit types above are passed
                 // as a plain text and everything else is base64 encoded binary

--- a/presto-client/src/test/java/com/facebook/presto/client/TestQueryResults.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestQueryResults.java
@@ -53,6 +53,7 @@ public class TestQueryResults
         assertQueryResult("json", "{\"json\": {\"a\": 1}}", "{\"json\": {\"a\": 1}}");
         assertQueryResult("ipaddress", "1.2.3.4", "1.2.3.4");
         assertQueryResult("Geometry", "POINT (1.2 3.4)", "POINT (1.2 3.4)");
+        assertQueryResult("map(BingTile,bigint)", ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1), ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1L));
     }
 
     private void assertQueryResult(String type, Object data, Object expected)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/StandardTypes.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/StandardTypes.java
@@ -41,6 +41,7 @@ public final class StandardTypes
     public static final String JSON = "json";
     public static final String IPADDRESS = "ipaddress";
     public static final String GEOMETRY = "Geometry";
+    public static final String BING_TILE = "BingTile";
 
     private StandardTypes() {}
 }


### PR DESCRIPTION
In most cases objects of BingTileType are serialized as JSON. However, when used as keys in a map they are serialized as strings. Hence, the client needs to handle both cases. 

Here is what the client receives in response to `select map(array[bing_tile(1, 2, 10)], array[bing_tile(3, 4, 11)]);`

`"data":[[{"BingTile{x=1, y=2, zoom_level=10}":{"x":3,"y":4,"zoom":11}}]]`

Fixes #9693.

```
presto> select bing_tile(1,2,3);
select bing_tile(1,2,3);
       _col0        
--------------------
 {x=1, y=2, zoom=3} 
(1 row)

presto> select array[bing_tile(1, 2, 10)];
select array[bing_tile(1, 2, 10)];
         _col0         
-----------------------
 [{x=1, y=2, zoom=10}] 
(1 row)

presto> select map(array[bing_tile(1, 2, 10)], array[bing_tile(3, 4, 11)]);
select map(array[bing_tile(1, 2, 10)], array[bing_tile(3, 4, 11)]);
                          _col0                          
---------------------------------------------------------
 {BingTile{x=1, y=2, zoom_level=10}={x=3, y=4, zoom=11}} 
(1 row)
```