### PR TITLE
Make order of Authenticators to be determined

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.server.security;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
 import javax.servlet.Filter;
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.Principal;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.io.ByteStreams.copy;
@@ -41,12 +42,12 @@ import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 public class AuthenticationFilter
         implements Filter
 {
-    private final Set<Authenticator> authenticators;
+    private final List<Authenticator> authenticators;
 
     @Inject
-    public AuthenticationFilter(Set<Authenticator> authenticators)
+    public AuthenticationFilter(List<Authenticator> authenticators)
     {
-        this.authenticators = ImmutableSet.copyOf(authenticators);
+        this.authenticators = ImmutableList.copyOf(authenticators);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -14,16 +14,16 @@
 package com.facebook.presto.server.security;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 
 import javax.validation.constraints.NotNull;
 
-import java.util.Set;
+import java.util.List;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.stream;
 
 @DefunctConfig("http.server.authentication.enabled")
@@ -31,7 +31,7 @@ public class SecurityConfig
 {
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
-    private Set<AuthenticationType> authenticationTypes = ImmutableSet.of();
+    private List<AuthenticationType> authenticationTypes = ImmutableList.of();
 
     public enum AuthenticationType
     {
@@ -41,14 +41,14 @@ public class SecurityConfig
     }
 
     @NotNull
-    public Set<AuthenticationType> getAuthenticationTypes()
+    public List<AuthenticationType> getAuthenticationTypes()
     {
         return authenticationTypes;
     }
 
-    public SecurityConfig setAuthenticationTypes(Set<AuthenticationType> authenticationTypes)
+    public SecurityConfig setAuthenticationTypes(List<AuthenticationType> authenticationTypes)
     {
-        this.authenticationTypes = ImmutableSet.copyOf(authenticationTypes);
+        this.authenticationTypes = ImmutableList.copyOf(authenticationTypes);
         return this;
     }
 
@@ -63,7 +63,7 @@ public class SecurityConfig
 
         authenticationTypes = stream(SPLITTER.split(types))
                 .map(AuthenticationType::valueOf)
-                .collect(toImmutableSet());
+                .collect(toImmutableList());
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/ServerSecurityModule.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.server.security;
 
 import com.facebook.presto.server.security.SecurityConfig.AuthenticationType;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
@@ -22,6 +24,7 @@ import io.airlift.http.server.TheServlet;
 
 import javax.servlet.Filter;
 
+import java.util.List;
 import java.util.Set;
 
 import static com.facebook.presto.server.security.SecurityConfig.AuthenticationType.CERTIFICATE;
@@ -39,21 +42,29 @@ public class ServerSecurityModule
         newSetBinder(binder, Filter.class, TheServlet.class).addBinding()
                 .to(AuthenticationFilter.class).in(Scopes.SINGLETON);
 
-        Set<AuthenticationType> authTypes = buildConfigObject(SecurityConfig.class).getAuthenticationTypes();
+        List<AuthenticationType> authTypes = buildConfigObject(SecurityConfig.class).getAuthenticationTypes();
         Multibinder<Authenticator> authBinder = newSetBinder(binder, Authenticator.class);
 
-        if (authTypes.contains(CERTIFICATE)) {
-            authBinder.addBinding().to(CertificateAuthenticator.class).in(Scopes.SINGLETON);
-        }
+        for (AuthenticationType authType : authTypes) {
+            if (authType == CERTIFICATE) {
+                authBinder.addBinding().to(CertificateAuthenticator.class).in(Scopes.SINGLETON);
+            }
 
-        if (authTypes.contains(KERBEROS)) {
-            configBinder(binder).bindConfig(KerberosConfig.class);
-            authBinder.addBinding().to(KerberosAuthenticator.class).in(Scopes.SINGLETON);
-        }
+            if (authType == KERBEROS) {
+                configBinder(binder).bindConfig(KerberosConfig.class);
+                authBinder.addBinding().to(KerberosAuthenticator.class).in(Scopes.SINGLETON);
+            }
 
-        if (authTypes.contains(LDAP)) {
-            configBinder(binder).bindConfig(LdapConfig.class);
-            authBinder.addBinding().to(LdapAuthenticator.class).in(Scopes.SINGLETON);
+            if (authType == LDAP) {
+                configBinder(binder).bindConfig(LdapConfig.class);
+                authBinder.addBinding().to(LdapAuthenticator.class).in(Scopes.SINGLETON);
+            }
         }
+    }
+
+    @Provides
+    List<Authenticator> getAuthenticatorList(Set<Authenticator> authenticators)
+    {
+        return ImmutableList.copyOf(authenticators);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.server.security;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.testing.ConfigAssertions;
 import org.testng.annotations.Test;
 
@@ -40,7 +40,7 @@ public class TestSecurityConfig
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
-                .setAuthenticationTypes(ImmutableSet.of(KERBEROS, LDAP));
+                .setAuthenticationTypes(ImmutableList.of(KERBEROS, LDAP));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Make order of Authenticators to be determined

This commits make that AuthenticationFilter will apply Authenticators in
order of how they were specified in http-server.authentication.type.

So far order was hard-coded causing CERTIFICATE authorization to have the
highest priority, however it may depends of the use case. Sometimes user
may prefer KERBEROS or LDAP over CERTIFICATE.
