### PR TITLE
Update MemoryPool to return futures that are not cancellable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -16,8 +16,8 @@ package com.facebook.presto.memory;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.memory.MemoryPoolInfo;
+import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.DataSize;
 import org.weakref.jmx.Managed;
 
@@ -47,7 +47,7 @@ public class MemoryPool
 
     @Nullable
     @GuardedBy("this")
-    private SettableFuture<?> future;
+    private NonCancellableMemoryFuture<?> future;
 
     @GuardedBy("this")
     // TODO: It would be better if we just tracked QueryContexts, but their lifecycle is managed by a weak reference, so we can't do that
@@ -99,7 +99,7 @@ public class MemoryPool
             reservedBytes += bytes;
             if (getFreeBytes() <= 0) {
                 if (future == null) {
-                    future = SettableFuture.create();
+                    future = NonCancellableMemoryFuture.create();
                 }
                 checkState(!future.isDone(), "future is already completed");
                 result = future;
@@ -130,7 +130,7 @@ public class MemoryPool
             reservedRevocableBytes += bytes;
             if (getFreeBytes() <= 0) {
                 if (future == null) {
-                    future = SettableFuture.create();
+                    future = NonCancellableMemoryFuture.create();
                 }
                 checkState(!future.isDone(), "future is already completed");
                 result = future;
@@ -254,5 +254,26 @@ public class MemoryPool
                 .add("reservedRevocableBytes", reservedRevocableBytes)
                 .add("future", future)
                 .toString();
+    }
+
+    private static class NonCancellableMemoryFuture<V>
+            extends AbstractFuture<V>
+    {
+        public static <V> NonCancellableMemoryFuture<V> create()
+        {
+            return new NonCancellableMemoryFuture<V>();
+        }
+
+        @Override
+        public boolean set(@Nullable V value)
+        {
+            return super.set(value);
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning)
+        {
+            throw new UnsupportedOperationException("cancellation is not supported");
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -56,6 +56,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
 public class TestMemoryPools
@@ -161,6 +162,23 @@ public class TestMemoryPools
         userPool.reserve(fakeQueryId, 3);
         assertEquals(notifiedPool.get(), userPool);
         assertEquals(notifiedBytes.get(), 3L);
+    }
+
+    @Test
+    public void testMemoryFutureCancellation()
+    {
+        setUpCountStarFromOrdersWithJoin();
+        ListenableFuture future = userPool.reserve(fakeQueryId, TEN_MEGABYTES.toBytes());
+        assertTrue(!future.isDone());
+        try {
+            future.cancel(true);
+            fail("cancel should fail");
+        }
+        catch (UnsupportedOperationException e) {
+            assertEquals(e.getMessage(), "cancellation is not supported");
+        }
+        userPool.free(fakeQueryId, TEN_MEGABYTES.toBytes());
+        assertTrue(future.isDone());
     }
 
     @Test


### PR DESCRIPTION
It's possible to cancel the ListenableFutures that the MemoryPool
returns (and unblock the callers waiting on those futures to allocate
more memory), so this change makes sure that the returned futures do not
support cancellation just to be safe. (as discussed in #9636)