### PR TITLE
Enforce CPU time limits in SqlQueryManager

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -48,6 +48,7 @@ import org.weakref.jmx.Flatten;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
@@ -191,6 +192,11 @@ public class SqlQueryManager
 
         queryManagementExecutor = Executors.newScheduledThreadPool(queryManagerConfig.getQueryManagerExecutorPoolSize(), threadsNamed("query-management-%s"));
         queryManagementExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) queryManagementExecutor);
+    }
+
+    @PostConstruct
+    public void start()
+    {
         queryManagementExecutor.scheduleWithFixedDelay(new Runnable()
         {
             @Override

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -307,18 +307,6 @@ public class TestMemoryManager
         }
     }
 
-    @Test(timeOut = 60_000, expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Exceeded CPU limit of .*")
-    public void testQueryCpuLimit()
-            throws Exception
-    {
-        Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("query.max-cpu-time", "1ms")
-                .build();
-        try (QueryRunner queryRunner = createQueryRunner(SESSION, properties)) {
-            queryRunner.execute(SESSION, "SELECT COUNT(*), repeat(orderstatus, 1000) FROM orders GROUP BY 2");
-        }
-    }
-
     @Test(timeOut = 60_000, expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Query exceeded local memory limit of 1kB.*")
     public void testQueryMemoryPerNodeLimit()
             throws Exception


### PR DESCRIPTION
Previously it was enforced in `ClusterMemoryManager`. Given that `SqlQueryManager`
is already enforcing a bunch of other limits and given that this limit is not
related to memory, enforcing it in `SqlQueryManager` makes more sense.