### PR TITLE
Fix performance regression in SourcePartitionedScheduler

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -223,7 +223,7 @@ public class SourcePartitionedScheduler
                 splitAssignment = splitPlacementResult.getAssignments();
 
                 // remove splits with successful placements
-                pendingSplits.removeAll(splitAssignment.values());
+                splitAssignment.values().forEach(pendingSplits::remove); // AbstractSet.removeAll performs terribly here.
                 overallSplitAssignmentCount += splitAssignment.size();
 
                 // if not completed placed, mark scheduleGroup as blocked on placement


### PR DESCRIPTION
`AbstractSet.removeAll(c)` performs terribly when `this.size() <= c.size()`
and `c.contains` is not `O(1)`.