### PR TITLE
Migrate DetermineJoinDistributionType to iterative optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -24,6 +24,8 @@ import com.facebook.presto.sql.planner.iterative.rule.CreatePartialTopN;
 import com.facebook.presto.sql.planner.iterative.rule.DesugarAtTimeZone;
 import com.facebook.presto.sql.planner.iterative.rule.DesugarLambdaExpression;
 import com.facebook.presto.sql.planner.iterative.rule.DesugarTryExpression;
+import com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType;
+import com.facebook.presto.sql.planner.iterative.rule.DetermineSemiJoinDistributionType;
 import com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroLimit;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroSample;
@@ -80,7 +82,6 @@ import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.BeginTableWrite;
 import com.facebook.presto.sql.planner.optimizations.CheckSubqueryNodesAreRewritten;
 import com.facebook.presto.sql.planner.optimizations.DesugaringOptimizer;
-import com.facebook.presto.sql.planner.optimizations.DetermineJoinDistributionType;
 import com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer;
 import com.facebook.presto.sql.planner.optimizations.ImplementIntersectAndExceptAsUnion;
 import com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer;
@@ -93,6 +94,7 @@ import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.optimizations.ProjectionPushDown;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.RemoveUnreferencedScalarLateralNodes;
+import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinUnderDelete;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.TransformCorrelatedNoAggregationSubqueryToJoin;
 import com.facebook.presto.sql.planner.optimizations.TransformCorrelatedScalarAggregationToJoin;
@@ -306,7 +308,13 @@ public class PlanOptimizers
                         new PushTopNThroughUnion())));
 
         if (!forceSingleNode) {
-            builder.add(new DetermineJoinDistributionType()); // Must run before AddExchanges
+            builder.add((new IterativeOptimizer(
+                    stats,
+                    ImmutableList.of(new com.facebook.presto.sql.planner.optimizations.DetermineJoinDistributionType()), // Must run before AddExchanges
+                    ImmutableSet.of(
+                            new DetermineJoinDistributionType(), // Must run before AddExchanges
+                            new DetermineSemiJoinDistributionType())))); // Must run before AddExchanges
+            builder.add(new ReplicateSemiJoinUnderDelete());
             builder.add(
                     new IterativeOptimizer(
                             stats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -56,7 +56,7 @@ public class DetermineJoinDistributionType
             return PARTITIONED;
         }
 
-        if (node.getCriteria().isEmpty() && type == INNER) {
+        if (node.getCriteria().isEmpty() && (type == INNER || type == LEFT)) {
             // There is nothing to partition on
             return REPLICATED;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.JoinNode.DistributionType;
+
+import static com.facebook.presto.SystemSessionProperties.isDistributedJoinEnabled;
+import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isAtMostScalar;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+
+public class DetermineJoinDistributionType
+        implements Rule<JoinNode>
+{
+    private static final Pattern<JoinNode> PATTERN = join().matching(joinNode -> !joinNode.getDistributionType().isPresent());
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(JoinNode node, Captures captures, Context context)
+    {
+        DistributionType distributionType = determineDistributionType(node, context);
+        return Result.ofPlanNode(node.withDistributionType(distributionType));
+    }
+
+    private static DistributionType determineDistributionType(JoinNode node, Context context)
+    {
+        JoinNode.Type type = node.getType();
+        if (type == RIGHT || type == FULL) {
+            // The implementation of full outer join only works if the data is hash partitioned.
+            return PARTITIONED;
+        }
+
+        if (node.getCriteria().isEmpty() && type == INNER) {
+            // There is nothing to partition on
+            return REPLICATED;
+        }
+
+        if (isAtMostScalar(node.getRight(), context.getLookup())) {
+            return REPLICATED;
+        }
+
+        if (isDistributedJoinEnabled(context.getSession())) {
+            return PARTITIONED;
+        }
+
+        return REPLICATED;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Patterns;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode.DistributionType;
+
+import static com.facebook.presto.SystemSessionProperties.isDistributedJoinEnabled;
+import static com.facebook.presto.sql.planner.plan.SemiJoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.SemiJoinNode.DistributionType.REPLICATED;
+
+public class DetermineSemiJoinDistributionType
+        implements Rule<SemiJoinNode>
+{
+    private static final Pattern<SemiJoinNode> PATTERN = Patterns.semiJoin().matching(semiJoinNode -> !semiJoinNode.getDistributionType().isPresent());
+
+    @Override
+    public Pattern<SemiJoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(SemiJoinNode node, Captures captures, Context context)
+    {
+        DistributionType distributionType = determineDistributionType(context.getSession());
+        return Result.ofPlanNode(node.withDistributionType(distributionType));
+    }
+
+    private static DistributionType determineDistributionType(Session session)
+    {
+        if (isDistributedJoinEnabled(session)) {
+            return PARTITIONED;
+        }
+
+        return REPLICATED;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DetermineJoinDistributionType.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 import static java.util.Objects.requireNonNull;
 
+@Deprecated
 public class DetermineJoinDistributionType
         implements PlanOptimizer
 {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinUnderDelete.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplicateSemiJoinUnderDelete.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.DeleteNode;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Map;
+
+import static com.facebook.presto.sql.planner.plan.SemiJoinNode.DistributionType.REPLICATED;
+
+/*
+ * For delete queries, the TableScan node that corresponds to the table being deleted
+ * must be collocated with the Delete node, so any semi-join in between must be replicated
+ */
+// TODO migrate to traits
+public class ReplicateSemiJoinUnderDelete
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, Map<Symbol, Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        return SimplePlanRewriter.rewriteWith(new Rewriter(), plan, false);
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Boolean>
+    {
+        @Override
+        public PlanNode visitDelete(DeleteNode node, RewriteContext<Boolean> context)
+        {
+            return context.defaultRewrite(node, true);
+        }
+
+        @Override
+        public PlanNode visitSemiJoin(SemiJoinNode node, RewriteContext<Boolean> context)
+        {
+            boolean isUnderDelete = context.get();
+            if (!isUnderDelete) {
+                return context.defaultRewrite(node, isUnderDelete);
+            }
+
+            PlanNode source = context.rewrite(node.getSource(), isUnderDelete);
+            PlanNode filteringSource = context.rewrite(node.getFilteringSource(), false);
+
+            return node
+                    .replaceChildren(ImmutableList.of(source, filteringSource))
+                    .withDistributionType(REPLICATED);
+        }
+
+        @Override
+        public PlanNode visitExchange(ExchangeNode node, RewriteContext<Boolean> context)
+        {
+            throw new IllegalStateException("Must be run before adding exchanges");
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -233,6 +233,11 @@ public class JoinNode
         return new JoinNode(getId(), type, newLeft, newRight, criteria, newOutputSymbols, filter, leftHashSymbol, rightHashSymbol, distributionType);
     }
 
+    public JoinNode withDistributionType(DistributionType distributionType)
+    {
+        return new JoinNode(getId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.of(distributionType));
+    }
+
     public boolean isCrossJoin()
     {
         return criteria.isEmpty() && !filter.isPresent() && type == INNER;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SemiJoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SemiJoinNode.java
@@ -140,7 +140,7 @@ public class SemiJoinNode
     }
 
     @Override
-    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    public SemiJoinNode replaceChildren(List<PlanNode> newChildren)
     {
         checkArgument(newChildren.size() == 2, "expected newChildren to contain 2 nodes");
         return new SemiJoinNode(
@@ -153,5 +153,19 @@ public class SemiJoinNode
                 sourceHashSymbol,
                 filteringSourceHashSymbol,
                 distributionType);
+    }
+
+    public SemiJoinNode withDistributionType(DistributionType distributionType)
+    {
+        return new SemiJoinNode(
+                getId(),
+                source,
+                filteringSource,
+                sourceJoinSymbol,
+                filteringSourceJoinSymbol,
+                semiJoinOutput,
+                sourceHashSymbol,
+                filteringSourceHashSymbol,
+                Optional.of(distributionType));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.cost.PlanNodeCost;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.JoinNode.DistributionType;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableSet;
@@ -37,12 +38,14 @@ final class JoinMatcher
     private final JoinNode.Type joinType;
     private final List<ExpectedValueProvider<JoinNode.EquiJoinClause>> equiCriteria;
     private final Optional<Expression> filter;
+    private final Optional<DistributionType> distributionType;
 
-    JoinMatcher(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> equiCriteria, Optional<Expression> filter)
+    JoinMatcher(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> equiCriteria, Optional<Expression> filter, Optional<DistributionType> distributionType)
     {
         this.joinType = requireNonNull(joinType, "joinType is null");
         this.equiCriteria = requireNonNull(equiCriteria, "equiCriteria is null");
         this.filter = requireNonNull(filter, "filter can not be null");
+        this.distributionType = requireNonNull(distributionType, "distributionType is null");
     }
 
     @Override
@@ -79,6 +82,10 @@ final class JoinMatcher
             if (joinNode.getFilter().isPresent()) {
                 return NO_MATCH;
             }
+        }
+
+        if (distributionType.isPresent() && !distributionType.equals(joinNode.getDistributionType())) {
+            return NO_MATCH;
         }
 
         /*

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -293,7 +293,12 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern semiJoin(String sourceSymbolAlias, String filteringSymbolAlias, String outputAlias, PlanMatchPattern source, PlanMatchPattern filtering)
     {
-        return node(SemiJoinNode.class, source, filtering).with(new SemiJoinMatcher(sourceSymbolAlias, filteringSymbolAlias, outputAlias));
+        return semiJoin(sourceSymbolAlias, filteringSymbolAlias, outputAlias, source, filtering, Optional.empty());
+    }
+
+    public static PlanMatchPattern semiJoin(String sourceSymbolAlias, String filteringSymbolAlias, String outputAlias, PlanMatchPattern source, PlanMatchPattern filtering, Optional<SemiJoinNode.DistributionType> distributionType)
+    {
+        return node(SemiJoinNode.class, source, filtering).with(new SemiJoinMatcher(sourceSymbolAlias, filteringSymbolAlias, outputAlias, distributionType));
     }
 
     public static PlanMatchPattern join(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> expectedEquiCriteria, PlanMatchPattern left, PlanMatchPattern right)
@@ -303,11 +308,17 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern join(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> expectedEquiCriteria, Optional<String> expectedFilter, PlanMatchPattern left, PlanMatchPattern right)
     {
+        return join(joinType, expectedEquiCriteria, expectedFilter, Optional.empty(), left, right);
+    }
+
+    public static PlanMatchPattern join(JoinNode.Type joinType, List<ExpectedValueProvider<JoinNode.EquiJoinClause>> expectedEquiCriteria, Optional<String> expectedFilter, Optional<JoinNode.DistributionType> expectedDistributionType, PlanMatchPattern left, PlanMatchPattern right)
+    {
         return node(JoinNode.class, left, right).with(
                 new JoinMatcher(
                         joinType,
                         expectedEquiCriteria,
-                        expectedFilter.map(predicate -> rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate)))));
+                        expectedFilter.map(predicate -> rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(predicate))),
+                        expectedDistributionType));
     }
 
     public static PlanMatchPattern exchange(PlanMatchPattern... sources)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SemiJoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SemiJoinMatcher.java
@@ -19,6 +19,8 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 
+import java.util.Optional;
+
 import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -31,12 +33,14 @@ final class SemiJoinMatcher
     private final String sourceSymbolAlias;
     private final String filteringSymbolAlias;
     private final String outputAlias;
+    private final Optional<SemiJoinNode.DistributionType> distributionType;
 
-    SemiJoinMatcher(String sourceSymbolAlias, String filteringSymbolAlias, String outputAlias)
+    SemiJoinMatcher(String sourceSymbolAlias, String filteringSymbolAlias, String outputAlias, Optional<SemiJoinNode.DistributionType> distributionType)
     {
         this.sourceSymbolAlias = requireNonNull(sourceSymbolAlias, "sourceSymbolAlias is null");
         this.filteringSymbolAlias = requireNonNull(filteringSymbolAlias, "filteringSymbolAlias is null");
         this.outputAlias = requireNonNull(outputAlias, "outputAlias is null");
+        this.distributionType = requireNonNull(distributionType, "distributiontype is null");
     }
 
     @Override
@@ -53,6 +57,10 @@ final class SemiJoinMatcher
         SemiJoinNode semiJoinNode = (SemiJoinNode) node;
         if (!(symbolAliases.get(sourceSymbolAlias).equals(semiJoinNode.getSourceJoinSymbol().toSymbolReference()) &&
                 symbolAliases.get(filteringSymbolAlias).equals(semiJoinNode.getFilteringSourceJoinSymbol().toSymbolReference()))) {
+            return NO_MATCH;
+        }
+
+        if (distributionType.isPresent() && !distributionType.equals(semiJoinNode.getDistributionType())) {
             return NO_MATCH;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.JoinNode.DistributionType;
+import com.facebook.presto.sql.planner.plan.JoinNode.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_JOIN;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+
+@Test(singleThreaded = true)
+public class TestDetermineJoinDistributionType
+        extends BaseRuleTest
+{
+    @Test
+    public void testDetermineDistributionType()
+    {
+        testDetermineDistributionType(true, INNER, PARTITIONED);
+        testDetermineDistributionType(false, INNER, REPLICATED);
+    }
+
+    @Test
+    public void testDetermineDistributionTypeForLeftOuter()
+    {
+        testDetermineDistributionType(true, LEFT, PARTITIONED);
+        testDetermineDistributionType(false, LEFT, REPLICATED);
+    }
+
+    private void testDetermineDistributionType(boolean sessionDistributedJoin, Type joinType, DistributionType expectedDistribution)
+    {
+        tester().assertThat(new DetermineJoinDistributionType())
+                .on(p ->
+                        p.join(
+                                joinType,
+                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(expressions("10"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(expressions("50"), expressions("11"))),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
+                                ImmutableList.of(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT)),
+                                Optional.empty()))
+                .setSystemProperty(DISTRIBUTED_JOIN, Boolean.toString(sessionDistributedJoin))
+                .matches(join(
+                        joinType,
+                        ImmutableList.of(equiJoinClause("B1", "A1")),
+                        Optional.empty(),
+                        Optional.of(expectedDistribution),
+                        values(ImmutableMap.of("B1", 0)),
+                        values(ImmutableMap.of("A1", 0))));
+    }
+
+    @Test
+    public void testRepartitionRightOuter()
+    {
+        testRepartitionRightOuter(true, FULL);
+        testRepartitionRightOuter(true, RIGHT);
+        testRepartitionRightOuter(false, FULL);
+        testRepartitionRightOuter(false, RIGHT);
+    }
+
+    private void testRepartitionRightOuter(boolean sessionDistributedJoin, Type joinType)
+    {
+        tester().assertThat(new DetermineJoinDistributionType())
+                .on(p ->
+                        p.join(
+                                joinType,
+                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(expressions("10"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(expressions("50"), expressions("11"))),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
+                                ImmutableList.of(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT)),
+                                Optional.empty()))
+                .setSystemProperty(DISTRIBUTED_JOIN, Boolean.toString(sessionDistributedJoin))
+                .matches(join(
+                        joinType,
+                        ImmutableList.of(equiJoinClause("A1", "B1")),
+                        Optional.empty(),
+                        Optional.of(PARTITIONED),
+                        values(ImmutableMap.of("A1", 0)),
+                        values(ImmutableMap.of("B1", 0))));
+    }
+
+    @Test
+    public void testRetainDistributionType()
+    {
+        tester().assertThat(new DetermineJoinDistributionType())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(ImmutableList.of(p.symbol("A1")), ImmutableList.of(expressions("10"), expressions("11"))),
+                                p.values(ImmutableList.of(p.symbol("B1")), ImmutableList.of(expressions("50"), expressions("11"))),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT))),
+                                ImmutableList.of(p.symbol("A1", BIGINT), p.symbol("B1", BIGINT)),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(REPLICATED)))
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode.DistributionType;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_JOIN;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.SemiJoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.SemiJoinNode.DistributionType.REPLICATED;
+
+@Test(singleThreaded = true)
+public class TestDetermineSemiJoinDistributionType
+        extends BaseRuleTest
+{
+    @Test
+    public void testDetermineDistributionType()
+    {
+        testDetermineDistributionType(true, PARTITIONED);
+        testDetermineDistributionType(false, REPLICATED);
+    }
+
+    private void testDetermineDistributionType(boolean sessionDistributedJoin, DistributionType expectedDistribution)
+    {
+        tester().assertThat(new DetermineSemiJoinDistributionType())
+                .on(p ->
+                        p.semiJoin(
+                                p.values(p.symbol("A1", BIGINT)),
+                                p.values(p.symbol("B1", BIGINT)),
+                                p.symbol("A1", BIGINT),
+                                p.symbol("B1", BIGINT),
+                                p.symbol("SJO", BIGINT),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .setSystemProperty(DISTRIBUTED_JOIN, Boolean.toString(sessionDistributedJoin))
+                .matches(semiJoin(
+                        "A1",
+                        "B1",
+                        "SJO",
+                        values(ImmutableMap.of("A1", 0)),
+                        values(ImmutableMap.of("B1", 0)),
+                        Optional.of(expectedDistribution)));
+    }
+
+    @Test
+    public void testRetainDistributionType()
+    {
+        tester().assertThat(new DetermineSemiJoinDistributionType())
+                .on(p ->
+                        p.semiJoin(
+                                p.values(p.symbol("A1", BIGINT)),
+                                p.values(p.symbol("B1", BIGINT)),
+                                p.symbol("A1", BIGINT),
+                                p.symbol("B1", BIGINT),
+                                p.symbol("SJO", BIGINT),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(REPLICATED)))
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -525,6 +525,11 @@ public class PlanBuilder
                 Optional.empty());
     }
 
+    public JoinNode join(JoinNode.Type type, PlanNode left, PlanNode right, List<JoinNode.EquiJoinClause> criteria, List<Symbol> outputSymbols, Optional<Expression> filter)
+    {
+        return join(type, left, right, criteria, outputSymbols, filter, Optional.empty(), Optional.empty());
+    }
+
     public JoinNode join(
             JoinNode.Type type,
             PlanNode left,
@@ -535,7 +540,21 @@ public class PlanBuilder
             Optional<Symbol> leftHashSymbol,
             Optional<Symbol> rightHashSymbol)
     {
-        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.empty());
+        return join(type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, Optional.empty());
+    }
+
+    public JoinNode join(
+            JoinNode.Type type,
+            PlanNode left,
+            PlanNode right,
+            List<JoinNode.EquiJoinClause> criteria,
+            List<Symbol> outputSymbols,
+            Optional<Expression> filter,
+            Optional<Symbol> leftHashSymbol,
+            Optional<Symbol> rightHashSymbol,
+            Optional<JoinNode.DistributionType> distributionType)
+    {
+        return new JoinNode(idAllocator.getNextId(), type, left, right, criteria, outputSymbols, filter, leftHashSymbol, rightHashSymbol, distributionType);
     }
 
     public PlanNode indexJoin(IndexJoinNode.Type type, TableScanNode probe, TableScanNode index)
@@ -548,6 +567,27 @@ public class PlanBuilder
                 emptyList(),
                 Optional.empty(),
                 Optional.empty());
+    }
+
+    public SemiJoinNode semiJoin(
+            PlanNode source,
+            PlanNode filteringSource,
+            Symbol sourceJoinSymbol,
+            Symbol filteringSourceJoinSymbol,
+            Symbol semiJoinOutput,
+            Optional<Symbol> sourceHashSymbol,
+            Optional<Symbol> filteringSourceHashSymbol,
+            Optional<SemiJoinNode.DistributionType> distributionType)
+    {
+        return new SemiJoinNode(idAllocator.getNextId(),
+                source,
+                filteringSource,
+                sourceJoinSymbol,
+                filteringSourceJoinSymbol,
+                semiJoinOutput,
+                sourceHashSymbol,
+                filteringSourceHashSymbol,
+                distributionType);
     }
 
     public UnionNode union(ListMultimap<Symbol, Symbol> outputsToInputs, List<PlanNode> sources)


### PR DESCRIPTION
This migrates `DetermineJoinDistributionType` legacy optimizer into iterative optimizer's rules.
Since semi-join requires special handling when in a `DELETE` query, there is a new legacy optimizer left that takes care just of this case. This one is due to be migrated when we have required infrastructure (traits).