### PR TITLE
Use specified schema in presto-memory's rename table

### DIFF
--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
@@ -165,11 +165,12 @@ public class MemoryMetadata
     @Override
     public synchronized void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
     {
+        checkSchemaExists(newTableName.getSchemaName());
         checkTableNotExists(newTableName);
         MemoryTableHandle oldTableHandle = (MemoryTableHandle) tableHandle;
         MemoryTableHandle newTableHandle = new MemoryTableHandle(
                 oldTableHandle.getConnectorId(),
-                oldTableHandle.getSchemaName(),
+                newTableName.getSchemaName(),
                 newTableName.getTableName(),
                 oldTableHandle.getTableId(),
                 oldTableHandle.getColumnHandles());

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
@@ -143,6 +143,19 @@ public class TestMemorySmoke
     }
 
     @Test
+    public void testRenameTable()
+    {
+        assertUpdate("CREATE TABLE test_table_to_be_renamed (a BIGINT)");
+        assertQueryFails("ALTER TABLE test_table_to_be_renamed RENAME TO memory.test_schema_not_exist.test_table_renamed", "Schema test_schema_not_exist not found");
+        assertUpdate("ALTER TABLE test_table_to_be_renamed RENAME TO test_table_renamed");
+        assertQueryResult("SELECT count(*) FROM test_table_renamed", 0L);
+
+        assertUpdate("CREATE SCHEMA test_different_schema");
+        assertUpdate("ALTER TABLE test_table_renamed RENAME TO test_different_schema.test_table_renamed");
+        assertQueryResult("SELECT count(*) FROM test_different_schema.test_table_renamed", 0L);
+    }
+
+    @Test
     public void testViews()
     {
         @Language("SQL") String query = "SELECT orderkey, orderstatus, totalprice / 2 half FROM orders";


### PR DESCRIPTION
Fix #9688 

Previously, RENAME TABLE in presto-memory always renames table to same schema even if the target schema is specified. 
This commit changes the behavior to use the specified schema. 
If the schema does not exist, throw SchemaNotFoundException.