### PR TITLE
Prevent cyclic failure references in toFailure

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/Failures.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/Failures.java
@@ -25,12 +25,15 @@ import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.tree.NodeLocation;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.SYNTAX_ERROR;
@@ -38,8 +41,10 @@ import static com.google.common.base.Functions.toStringFunction;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Sets.newIdentityHashSet;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
 
 public final class Failures
 {
@@ -54,31 +59,7 @@ public final class Failures
 
     public static ExecutionFailureInfo toFailure(Throwable failure)
     {
-        if (failure == null) {
-            return null;
-        }
-        // todo prevent looping with suppressed cause loops and such
-        String type;
-        HostAddress remoteHost = null;
-        if (failure instanceof Failure) {
-            type = ((Failure) failure).getType();
-        }
-        else {
-            Class<?> clazz = failure.getClass();
-            type = firstNonNull(clazz.getCanonicalName(), clazz.getName());
-        }
-        if (failure instanceof PrestoTransportException) {
-            remoteHost = ((PrestoTransportException) failure).getRemoteHost();
-        }
-
-        return new ExecutionFailureInfo(type,
-                failure.getMessage(),
-                toFailure(failure.getCause()),
-                toFailures(asList(failure.getSuppressed())),
-                Lists.transform(asList(failure.getStackTrace()), toStringFunction()),
-                getErrorLocation(failure),
-                toErrorCode(failure),
-                remoteHost);
+        return toFailure(failure, newIdentityHashSet());
     }
 
     public static void checkCondition(boolean condition, ErrorCodeSupplier errorCode, String formatString, Object... args)
@@ -93,6 +74,54 @@ public final class Failures
         return failures.stream()
                 .map(Failures::toFailure)
                 .collect(toImmutableList());
+    }
+
+    private static ExecutionFailureInfo toFailure(Throwable throwable, Set<Throwable> seenFailures)
+    {
+        if (throwable == null) {
+            return null;
+        }
+
+        String type;
+        HostAddress remoteHost = null;
+        if (throwable instanceof Failure) {
+            type = ((Failure) throwable).getType();
+        }
+        else {
+            Class<?> clazz = throwable.getClass();
+            type = firstNonNull(clazz.getCanonicalName(), clazz.getName());
+        }
+        if (throwable instanceof PrestoTransportException) {
+            remoteHost = ((PrestoTransportException) throwable).getRemoteHost();
+        }
+
+        if (seenFailures.contains(throwable)) {
+            return new ExecutionFailureInfo(type, "[cyclic] " + throwable.getMessage(), null, ImmutableList.of(), ImmutableList.of(), null, GENERIC_INTERNAL_ERROR.toErrorCode(), remoteHost);
+        }
+        seenFailures.add(throwable);
+
+        ExecutionFailureInfo cause = toFailure(throwable.getCause(), seenFailures);
+        ErrorCode errorCode = toErrorCode(throwable);
+        if (errorCode == null) {
+            if (cause == null) {
+                errorCode = GENERIC_INTERNAL_ERROR.toErrorCode();
+            }
+            else {
+                errorCode = cause.getErrorCode();
+            }
+        }
+
+        return new ExecutionFailureInfo(
+                type,
+                throwable.getMessage(),
+                cause,
+                Arrays.stream(throwable.getSuppressed())
+                        .map(failure -> toFailure(failure, seenFailures))
+                        .collect(toImmutableList()),
+                Lists.transform(asList(throwable.getStackTrace()), toStringFunction()),
+                getErrorLocation(throwable),
+                errorCode,
+                remoteHost);
     }
 
     @Nullable
@@ -114,11 +143,9 @@ public final class Failures
     }
 
     @Nullable
-    private static ErrorCode toErrorCode(@Nullable Throwable throwable)
+    private static ErrorCode toErrorCode(Throwable throwable)
     {
-        if (throwable == null) {
-            return null;
-        }
+        requireNonNull(throwable);
 
         if (throwable instanceof PrestoException) {
             return ((PrestoException) throwable).getErrorCode();
@@ -129,10 +156,7 @@ public final class Failures
         if (throwable instanceof ParsingException || throwable instanceof SemanticException) {
             return SYNTAX_ERROR.toErrorCode();
         }
-        if (throwable.getCause() != null) {
-            return toErrorCode(throwable.getCause());
-        }
-        return GENERIC_INTERNAL_ERROR.toErrorCode();
+        return null;
     }
 
     public static PrestoException internalError(Throwable t)

--- a/presto-main/src/test/java/com/facebook/presto/util/TestFailures.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestFailures.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.spi.PrestoException;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
+import static com.facebook.presto.util.Failures.toFailure;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+public class TestFailures
+{
+    @Test
+    public void testToFailureLoop()
+    {
+        Throwable exception1 = new PrestoException(TOO_MANY_REQUESTS_FAILED, "fake exception 1");
+        Throwable exception2 = new RuntimeException("fake exception 2", exception1);
+        exception1.addSuppressed(exception2);
+
+        // add exception 1 --> add suppress (exception 2) --> add cause (exception 1)
+        ExecutionFailureInfo failure = toFailure(exception1);
+        assertEquals(failure.getMessage(), "fake exception 1");
+        assertNull(failure.getCause());
+        assertEquals(failure.getSuppressed().size(), 1);
+        assertEquals(failure.getSuppressed().get(0).getMessage(), "fake exception 2");
+        assertEquals(failure.getErrorCode(), TOO_MANY_REQUESTS_FAILED.toErrorCode());
+
+        // add exception 2 --> add cause (exception 2) --> add suppress (exception 1)
+        failure = toFailure(exception2);
+        assertEquals(failure.getMessage(), "fake exception 2");
+        assertNotNull(failure.getCause());
+        assertEquals(failure.getCause().getMessage(), "fake exception 1");
+        assertEquals(failure.getSuppressed().size(), 0);
+        assertEquals(failure.getErrorCode(), TOO_MANY_REQUESTS_FAILED.toErrorCode());
+
+        // add exception 1 --> add suppress (exception 2) --> add suppress (exception 1)
+        exception1 = new PrestoException(TOO_MANY_REQUESTS_FAILED, "fake exception 1");
+        exception2 = new RuntimeException("fake exception 2");
+        exception1.addSuppressed(exception2);
+        exception2.addSuppressed(exception1);
+        failure = toFailure(exception1);
+        assertEquals(failure.getMessage(), "fake exception 1");
+        assertNull(failure.getCause());
+        assertEquals(failure.getSuppressed().size(), 1);
+        assertEquals(failure.getSuppressed().get(0).getMessage(), "fake exception 2");
+        assertEquals(failure.getErrorCode(), TOO_MANY_REQUESTS_FAILED.toErrorCode());
+
+        // add exception 2 --> add cause (exception 1) --> add cause (exception 2)
+        exception1 = new RuntimeException("fake exception 1");
+        exception2 = new RuntimeException("fake exception 2", exception1);
+        exception1.initCause(exception2);
+        failure = toFailure(exception2);
+        assertEquals(failure.getMessage(), "fake exception 2");
+        assertNotNull(failure.getCause());
+        assertEquals(failure.getCause().getMessage(), "fake exception 1");
+        assertEquals(failure.getSuppressed().size(), 0);
+        assertEquals(failure.getErrorCode(), GENERIC_INTERNAL_ERROR.toErrorCode());
+    }
+}


### PR DESCRIPTION
toFailure(s) can create cyclic suppression given it is recursive. Use a
hash set to detect seen failures.