### PR TITLE
Remove unnecessary SQLException from TestBlackHoleSmoke

### DIFF
--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
@@ -26,7 +26,6 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
-import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -67,7 +66,6 @@ public class TestBlackHoleSmoke
 
     @Test
     public void testCreateSchema()
-            throws SQLException
     {
         assertEquals(queryRunner.execute("SHOW SCHEMAS FROM blackhole").getRowCount(), 2);
         queryRunner.execute("CREATE SCHEMA blackhole.test");
@@ -76,7 +74,6 @@ public class TestBlackHoleSmoke
 
     @Test
     public void createTableWhenTableIsAlreadyCreated()
-            throws SQLException
     {
         String createTableSql = "CREATE TABLE nation as SELECT * FROM tpch.tiny.nation";
         queryRunner.execute(createTableSql);
@@ -94,7 +91,6 @@ public class TestBlackHoleSmoke
 
     @Test
     public void blackHoleConnectorUsage()
-            throws SQLException
     {
         assertThatQueryReturnsValue("CREATE TABLE nation as SELECT * FROM tpch.tiny.nation", 25L);
 


### PR DESCRIPTION
This causes compilation failures with `MAVEN_CHECKS=true` in travis.

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/travis/build/prestodb/presto/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java:[69,20] cannot find symbol
  symbol:   class SQLException
  location: class com.facebook.presto.plugin.blackhole.TestBlackHoleSmoke
```