### PR TITLE
Fix testNormalCdf unit test

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1327,7 +1327,7 @@ public class TestMathFunctions
         assertFunction("normal_cdf(nan(), 1, 0)", DOUBLE, Double.NaN);
         assertFunction("normal_cdf(0, 1, nan())", DOUBLE, Double.NaN);
 
-        assertInvalidFunction("normal_cdf(0, 0, 0.1985)", "sd must > 0");
-        assertInvalidFunction("normal_cdf(0, nan(), 0.1985)", "sd must > 0");
+        assertInvalidFunction("normal_cdf(0, 0, 0.1985)", "standardDeviation must > 0");
+        assertInvalidFunction("normal_cdf(0, nan(), 0.1985)", "standardDeviation must > 0");
     }
 }


### PR DESCRIPTION
```
[ERROR] Tests run: 3643, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 692.581 s <<< FAILURE! - in TestSuite
[ERROR] testNormalCdf(com.facebook.presto.operator.scalar.TestMathFunctions)  Time elapsed: 0.335 s  <<< FAILURE!
java.lang.AssertionError: expected [true] but found [false]
	at com.facebook.presto.operator.scalar.TestMathFunctions.testNormalCdf(TestMathFunctions.java:1330)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   TestMathFunctions.testNormalCdf:1330->AbstractTestFunctions.assertInvalidFunction:129 expected [true] but found [false]
[INFO] 
[ERROR] Tests run: 3643, Failures: 1, Errors: 0, Skipped: 0
```