### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ cache:
 services:
   - docker
 
+before_install:
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
+
 install:
   - ./mvnw -v
   - |
@@ -137,6 +142,17 @@ deploy:
   acl: public_read
 
 after_script:
+- if [[ -v MAVEN_CHECKS ]]; then
+    testspace **/target/checkstyle-result.xml;
+  elif [[ -v PRODUCT_TESTS_BASIC_ENVIRONMENT ]]; then
+    testspace "[Product Tests - BASIC]**/target/test-reports/tempto-tests/all.xml{presto-product-tests}";
+  elif [[ -v PRODUCT_TESTS_SPECIFIC_ENVIRONMENT ]]; then
+    testspace "[Product Tests - SPECIFIC]**/target/test-reports/tempto-tests/all.xml{presto-product-tests}";
+  elif [[ -v HIVE_TESTS ]]; then
+    testspace "[Hive Tests]**/target/surefire-reports/TEST-*.xml";
+  else
+    testspace "[Modules Tests]**/target/surefire-reports/TEST-*.xml{.}";
+  fi
 - |
   if [[ -v DEPLOY_S3_ACCESS_KEY ]]; then
     sudo pip install awscli


### PR DESCRIPTION
Hi, `presto` team. We’ve made a few minor changes to your `.travis.yml` file to demonstrate how you can add a Results Dashboard for Travis CI using [Testspace.com](https://www.testspace.com/). 

We have a short blog article [here](https://blog.testspace.com/testspace-and-open-source/) on some of the benefits for open source.

---
 
Check out YOUR RESULTS at https://open.testspace.com/projects/TryTestspace:presto from our fork.

You can customize how you organize your test results. We choose to group based on test types (at least our understanding): 
 * `Module Tests`
 * `Hive Tests`
 * `Product Tests - SPECIFIC`
 * `Product Tests - BASIC`

We think the team will like the **simplicity of finding failing tests**, versus using the Travis logs .. especially because the volume of your test cases. 

 ----

**Give Testspace a try**:

1. Create **Open** (free) account: https://testspace.com/pricing. 
2. Add a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
