### PR TITLE
Refactor getQueryMaxMemory session property getter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.String.format;
 
 public final class SystemSessionProperties
@@ -221,12 +222,16 @@ public final class SystemSessionProperties
                         Duration::toString),
                 new PropertyMetadata<>(
                         QUERY_MAX_MEMORY,
-                        "Maximum amount of distributed memory a query can use",
+                        "Maximum amount of distributed memory a query can use (will be capped by global config property)",
                         VARCHAR,
                         DataSize.class,
                         memoryManagerConfig.getMaxQueryMemory(),
                         true,
-                        value -> DataSize.valueOf((String) value),
+                        value -> {
+                            long sessionValue = DataSize.valueOf((String) value).toBytes();
+                            long configValue = memoryManagerConfig.getMaxQueryMemory().toBytes();
+                            return succinctBytes(Math.min(configValue, sessionValue));
+                        },
                         DataSize::toString),
                 booleanSessionProperty(
                         RESOURCE_OVERCOMMIT,

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -156,8 +156,7 @@ public class ClusterMemoryManager
         long totalBytes = 0;
         for (QueryExecution query : queries) {
             long bytes = query.getTotalMemoryReservation();
-            DataSize sessionMaxQueryMemory = getQueryMaxMemory(query.getSession());
-            long queryMemoryLimit = Math.min(maxQueryMemory.toBytes(), sessionMaxQueryMemory.toBytes());
+            long queryMemoryLimit = getQueryMaxMemory(query.getSession()).toBytes();
             totalBytes += bytes;
             if (resourceOvercommit(query.getSession()) && outOfMemory) {
                 // If a query has requested resource overcommit, only kill it if the cluster has run out of memory


### PR DESCRIPTION
Capping of limit set by sesion manger was moved from
ClusterMemoryManager.java to SystemSessionProperties.java