### PR TITLE
Set UGI when connecting to a Hive Metastore

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -121,6 +121,9 @@ Property Name                                      Description                  
                                                    Example: ``thrift://192.0.2.3:9083`` or
                                                    ``thrift://192.0.2.3:9083,thrift://192.0.2.4:9083``
 
+``hive.username``                                  Which user is used to access Hive Metastore.
+                                                   Send users to Metastore like Hive clients.                   ``NONE``
+
 ``hive.config.resources``                          An optional comma-separated list of HDFS
                                                    configuration files. These files must exist on the
                                                    machines running Presto. Only specify this if

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
@@ -112,4 +112,11 @@ public interface HiveMetastoreClient
 
     boolean revokePrivileges(PrivilegeBag privilegeBag)
             throws TException;
+
+    /**
+     * send UGI(UserGroupInformation , abbreviated in hadoop) to Hive Metastore,
+     * tell Hive Metastore who am i
+     */
+    List<String> setUGI(String userName, List<String> groupNames)
+            throws TException;
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/StaticMetastoreConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/StaticMetastoreConfig.java
@@ -30,6 +30,7 @@ public class StaticMetastoreConfig
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private List<URI> metastoreUris;
+    private String hiveUserName;
 
     @NotNull
     public List<URI> getMetastoreUris()
@@ -48,5 +49,18 @@ public class StaticMetastoreConfig
 
         this.metastoreUris = ImmutableList.copyOf(transform(SPLITTER.split(uris), URI::create));
         return this;
+    }
+
+    @Config("hive.username")
+    @ConfigDescription("Which user is used to access Hive Metastore. Optional")
+    public StaticMetastoreConfig setHiveUserName(String hiveUserName)
+    {
+        this.hiveUserName = hiveUserName;
+        return this;
+    }
+
+    public String getHiveUserName()
+    {
+        return hiveUserName;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -243,4 +243,11 @@ public class ThriftHiveMetastoreClient
     {
         return client.revoke_privileges(privilegeBag);
     }
+
+    @Override
+    public List<String> setUGI(String userName, List<String> groupNames)
+            throws TException
+    {
+        return client.set_ugi(userName, groupNames);
+    }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -305,5 +306,13 @@ public class MockHiveMetastoreClient
     public void close()
     {
         // No-op
+    }
+
+    @Override
+    public List<String> setUGI(String userName, List<String> groupNames)
+    {
+        List<String> result = new ArrayList(groupNames);
+        result.add(userName);
+        return result;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestStaticHiveCluster.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestStaticHiveCluster.java
@@ -38,6 +38,14 @@ public class TestStaticHiveCluster
     private static final StaticMetastoreConfig CONFIG_WITHOUT_FALLBACK = new StaticMetastoreConfig()
             .setMetastoreUris("thrift://default:8080");
 
+    private static final StaticMetastoreConfig CONFIG_WITH_FALLBACK_WITH_HIVE_USER = new StaticMetastoreConfig()
+            .setMetastoreUris("thrift://default:8080,thrift://fallback:8090,thrift://fallback2:8090")
+            .setHiveUserName("presto");
+
+    private static final StaticMetastoreConfig CONFIG_WITHOUT_FALLBACK_WITH_HIVE_USER = new StaticMetastoreConfig()
+            .setMetastoreUris("thrift://default:8080")
+            .setHiveUserName("presto");
+
     @Test
     public void testDefaultHiveMetastore()
     {
@@ -64,6 +72,20 @@ public class TestStaticHiveCluster
     {
         HiveCluster cluster = createHiveCluster(CONFIG_WITHOUT_FALLBACK, singletonList(null));
         assertCreateClientFails(cluster, "Failed connecting to Hive metastore: [default:8080]");
+    }
+
+    @Test
+    public void testFallbackHiveMetastoreWithHiveUser()
+    {
+        HiveCluster cluster = createHiveCluster(CONFIG_WITH_FALLBACK_WITH_HIVE_USER, asList(null, null, FALLBACK_CLIENT));
+        assertEquals(cluster.createMetastoreClient(), FALLBACK_CLIENT);
+    }
+
+    @Test
+    public void testMetastoreFailedWithoutFallbackWithHiveUser()
+    {
+        HiveCluster cluster = createHiveCluster(CONFIG_WITHOUT_FALLBACK_WITH_HIVE_USER, singletonList(null));
+        assertCreateClientFails(cluster, "Failed connecting to Hive metastore: [default:8080] , HiveUserName is presto");
     }
 
     private static void assertCreateClientFails(HiveCluster cluster, String message)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestStaticMetastoreConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestStaticMetastoreConfig.java
@@ -31,7 +31,7 @@ public class TestStaticMetastoreConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(StaticMetastoreConfig.class)
-                .setMetastoreUris(null));
+                .setMetastoreUris(null).setHiveUserName(null));
     }
 
     @Test
@@ -39,13 +39,16 @@ public class TestStaticMetastoreConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("hive.metastore.uri", "thrift://localhost:9083")
+                .put("hive.username", "presto")
                 .build();
 
         StaticMetastoreConfig expected = new StaticMetastoreConfig()
-                .setMetastoreUris("thrift://localhost:9083");
+                .setMetastoreUris("thrift://localhost:9083")
+                .setHiveUserName("presto");
 
         assertFullMapping(properties, expected);
         assertEquals(expected.getMetastoreUris(), ImmutableList.of(URI.create("thrift://localhost:9083")));
+        assertEquals(expected.getHiveUserName(), "presto");
     }
 
     @Test
@@ -53,14 +56,17 @@ public class TestStaticMetastoreConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("hive.metastore.uri", "thrift://localhost:9083,thrift://192.0.2.3:8932")
+                .put("hive.username", "presto")
                 .build();
 
         StaticMetastoreConfig expected = new StaticMetastoreConfig()
-                .setMetastoreUris("thrift://localhost:9083,thrift://192.0.2.3:8932");
+                .setMetastoreUris("thrift://localhost:9083,thrift://192.0.2.3:8932")
+                .setHiveUserName("presto");
 
         assertFullMapping(properties, expected);
         assertEquals(expected.getMetastoreUris(), ImmutableList.of(
                 URI.create("thrift://localhost:9083"),
                 URI.create("thrift://192.0.2.3:8932")));
+        assertEquals(expected.getHiveUserName(), "presto");
     }
 }


### PR DESCRIPTION
When Presto connects to the Hive Metastore, if the user information is set, the user information is sent to the Hive Metastore. Hive Metastore can do something with user information, such as permission checking.

Fixes https://github.com/prestodb/presto/issues/9785