### PR TITLE
 Fix static import of format method

### DIFF
--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
@@ -81,7 +81,7 @@ public class BlackHoleMetadata
     public synchronized void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
     {
         if (schemas.contains(schemaName)) {
-            throw new PrestoException(ALREADY_EXISTS, String.format("Schema [%s] already exists", schemaName));
+            throw new PrestoException(ALREADY_EXISTS, format("Schema [%s] already exists", schemaName));
         }
         schemas.add(schemaName);
     }

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
@@ -53,7 +53,7 @@ import static com.facebook.presto.plugin.blackhole.BlackHoleConnector.ROWS_PER_P
 import static com.facebook.presto.plugin.blackhole.BlackHoleConnector.SPLIT_COUNT_PROPERTY;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
-import static java.text.MessageFormat.format;
+import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;


### PR DESCRIPTION
With `MessageFormat.format` being imported instead of `String.format`,
the code would produce exception with `%s` not being replaced:

```
   Query failed: All properties [%s, %s, %s] must be set if any are set
```