### PR TITLE
Add set_ugi method to Hive Metastore

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -121,6 +121,9 @@ Property Name                                      Description                  
                                                    Example: ``thrift://192.0.2.3:9083`` or
                                                    ``thrift://192.0.2.3:9083,thrift://192.0.2.4:9083``
 
+``hive.metastore.username``                        Which user is used to access Hive Metastore.
+                                                   Send users to Metastore like Hive clients.
+
 ``hive.config.resources``                          An optional comma-separated list of HDFS
                                                    configuration files. These files must exist on the
                                                    machines running Presto. Only specify this if

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
@@ -112,4 +112,11 @@ public interface HiveMetastoreClient
 
     boolean revokePrivileges(PrivilegeBag privilegeBag)
             throws TException;
+
+    /**
+     * send UGI(UserGroupInformation , abbreviated in hadoop) to Hive Metastore,
+     * tell Hive Metastore who am i
+     */
+    void setUGI(String userName)
+            throws TException;
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/StaticMetastoreConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/StaticMetastoreConfig.java
@@ -30,6 +30,7 @@ public class StaticMetastoreConfig
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private List<URI> metastoreUris;
+    private String metastoreUsername;
 
     @NotNull
     public List<URI> getMetastoreUris()
@@ -48,5 +49,18 @@ public class StaticMetastoreConfig
 
         this.metastoreUris = ImmutableList.copyOf(transform(SPLITTER.split(uris), URI::create));
         return this;
+    }
+
+    @Config("hive.metastore.username")
+    @ConfigDescription("Optional username for accessing the Hive metastore")
+    public StaticMetastoreConfig setMetastoreUsername(String metastoreUsername)
+    {
+        this.metastoreUsername = metastoreUsername;
+        return this;
+    }
+
+    public String getMetastoreUsername()
+    {
+        return metastoreUsername;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -31,6 +31,7 @@ import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TTransport;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -242,5 +243,12 @@ public class ThriftHiveMetastoreClient
             throws TException
     {
         return client.revoke_privileges(privilegeBag);
+    }
+
+    @Override
+    public void setUGI(String userName)
+            throws TException
+    {
+        client.set_ugi(userName, new ArrayList<String>());
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
@@ -306,4 +306,10 @@ public class MockHiveMetastoreClient
     {
         // No-op
     }
+
+    @Override
+    public void setUGI(String userName)
+    {
+        // No-op
+    }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestStaticHiveCluster.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestStaticHiveCluster.java
@@ -38,6 +38,14 @@ public class TestStaticHiveCluster
     private static final StaticMetastoreConfig CONFIG_WITHOUT_FALLBACK = new StaticMetastoreConfig()
             .setMetastoreUris("thrift://default:8080");
 
+    private static final StaticMetastoreConfig CONFIG_WITH_FALLBACK_WITH_HIVE_USER = new StaticMetastoreConfig()
+            .setMetastoreUris("thrift://default:8080,thrift://fallback:8090,thrift://fallback2:8090")
+            .setMetastoreUsername("presto");
+
+    private static final StaticMetastoreConfig CONFIG_WITHOUT_FALLBACK_WITH_HIVE_USER = new StaticMetastoreConfig()
+            .setMetastoreUris("thrift://default:8080")
+            .setMetastoreUsername("presto");
+
     @Test
     public void testDefaultHiveMetastore()
     {
@@ -63,6 +71,20 @@ public class TestStaticHiveCluster
     public void testMetastoreFailedWithoutFallback()
     {
         HiveCluster cluster = createHiveCluster(CONFIG_WITHOUT_FALLBACK, singletonList(null));
+        assertCreateClientFails(cluster, "Failed connecting to Hive metastore: [default:8080]");
+    }
+
+    @Test
+    public void testFallbackHiveMetastoreWithHiveUser()
+    {
+        HiveCluster cluster = createHiveCluster(CONFIG_WITH_FALLBACK_WITH_HIVE_USER, asList(null, null, FALLBACK_CLIENT));
+        assertEquals(cluster.createMetastoreClient(), FALLBACK_CLIENT);
+    }
+
+    @Test
+    public void testMetastoreFailedWithoutFallbackWithHiveUser()
+    {
+        HiveCluster cluster = createHiveCluster(CONFIG_WITHOUT_FALLBACK_WITH_HIVE_USER, singletonList(null));
         assertCreateClientFails(cluster, "Failed connecting to Hive metastore: [default:8080]");
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestStaticMetastoreConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestStaticMetastoreConfig.java
@@ -31,7 +31,8 @@ public class TestStaticMetastoreConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(StaticMetastoreConfig.class)
-                .setMetastoreUris(null));
+                .setMetastoreUris(null)
+                .setMetastoreUsername(null));
     }
 
     @Test
@@ -39,13 +40,16 @@ public class TestStaticMetastoreConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("hive.metastore.uri", "thrift://localhost:9083")
+                .put("hive.metastore.username", "presto")
                 .build();
 
         StaticMetastoreConfig expected = new StaticMetastoreConfig()
-                .setMetastoreUris("thrift://localhost:9083");
+                .setMetastoreUris("thrift://localhost:9083")
+                .setMetastoreUsername("presto");
 
         assertFullMapping(properties, expected);
         assertEquals(expected.getMetastoreUris(), ImmutableList.of(URI.create("thrift://localhost:9083")));
+        assertEquals(expected.getMetastoreUsername(), "presto");
     }
 
     @Test
@@ -53,14 +57,17 @@ public class TestStaticMetastoreConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("hive.metastore.uri", "thrift://localhost:9083,thrift://192.0.2.3:8932")
+                .put("hive.metastore.username", "presto")
                 .build();
 
         StaticMetastoreConfig expected = new StaticMetastoreConfig()
-                .setMetastoreUris("thrift://localhost:9083,thrift://192.0.2.3:8932");
+                .setMetastoreUris("thrift://localhost:9083,thrift://192.0.2.3:8932")
+                .setMetastoreUsername("presto");
 
         assertFullMapping(properties, expected);
         assertEquals(expected.getMetastoreUris(), ImmutableList.of(
                 URI.create("thrift://localhost:9083"),
                 URI.create("thrift://192.0.2.3:8932")));
+        assertEquals(expected.getMetastoreUsername(), "presto");
     }
 }


### PR DESCRIPTION
When Presto connects to the Hive Metastore, if the user information is set, the user information is sent to the Hive Metastore. Hive Metastore can do something with user information, such as permission checking.