### PR TITLE
Filter scan constraint to use only accessible columns

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TupleDomains.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TupleDomains.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+public final class TupleDomains
+{
+    private TupleDomains() {}
+
+    public static <T> TupleDomain<T> filter(TupleDomain<T> tupleDomain, Collection<T> columns)
+    {
+        if (tupleDomain.isNone()) {
+            return tupleDomain;
+        }
+        Set<T> columnsSet = ImmutableSet.copyOf(columns);
+        Map<T, Domain> domains = tupleDomain.getDomains().get().entrySet().stream()
+                .filter(entry -> columnsSet.contains(entry.getKey()))
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        return TupleDomain.withColumnDomains(domains);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.DomainTranslator;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.iterative.rule.TupleDomains;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.FilterNode;
@@ -276,6 +277,7 @@ public class IndexJoinOptimizer
             TupleDomain<ColumnHandle> simplifiedConstraint = decomposedPredicate.getTupleDomain()
                     .transform(node.getAssignments()::get)
                     .intersect(node.getCurrentConstraint());
+            simplifiedConstraint = TupleDomains.filter(simplifiedConstraint, node.getAssignments().values());
 
             checkState(node.getOutputSymbols().containsAll(context.getLookupSymbols()));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -84,6 +84,7 @@ import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.primitives.Primitives;
 
 import java.util.Comparator;
 import java.util.List;
@@ -536,7 +537,7 @@ final class ShowQueriesRewrite
                     }
 
                     PropertyMetadata<?> property = allTableProperties.get(propertyName);
-                    if (!property.getJavaType().isInstance(value)) {
+                    if (!Primitives.wrap(property.getJavaType()).isInstance(value)) {
                         throw new PrestoException(INVALID_TABLE_PROPERTY, format(
                                 "Property %s for table %s should have value of type %s, not %s",
                                 propertyName,

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
@@ -118,6 +118,12 @@ public abstract class AbstractTestIndexedQueries
     }
 
     @Test
+    public void testJoinWithNonJoinExpression()
+    {
+        assertQuery("SELECT COUNT(*) FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.custkey = 1");
+    }
+
+    @Test
     public void testPredicateDerivedKey()
     {
         assertQuery("" +

--- a/presto-tests/src/main/java/com/facebook/presto/tests/tpch/AppendingRecordSet.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/tpch/AppendingRecordSet.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Primitives;
 import io.airlift.slice.Slice;
 
 import java.util.ArrayList;
@@ -42,7 +43,7 @@ class AppendingRecordSet
         for (int i = 0; i < appendedValues.size(); i++) {
             Object value = appendedValues.get(i);
             if (value != null) {
-                checkArgument(appendedTypes.get(i).getJavaType().isInstance(value), "Object value does not match declared type");
+                checkArgument(Primitives.wrap(appendedTypes.get(i).getJavaType()).isInstance(value), "Object value does not match declared type");
             }
         }
     }


### PR DESCRIPTION
Filter scan constraint to use only accessible columns

In case when predicate, in layout returned from connector, contains
extra TupleDomains, for columns not accessible with
TableScan#assignemnts. Such predicates (domains) have to be filtered out
before creating IndexSourceNode.
