### PR TITLE
Fix "Tuple domain handles must have assigned symbols" error

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneIndexSourceColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneIndexSourceColumns.java
@@ -48,7 +48,7 @@ public class PruneIndexSourceColumns
         Map<Symbol, ColumnHandle> prunedAssignments = Maps.filterEntries(
                 indexSourceNode.getAssignments(),
                 entry -> referencedOutputs.contains(entry.getKey()) ||
-                        tupleDomainReferencesColumnHandle(indexSourceNode.getEffectiveTupleDomain(), entry.getValue()));
+                        tupleDomainReferencesColumnHandle(indexSourceNode.getCurrentConstraint(), entry.getValue()));
 
         List<Symbol> prunedOutputList =
                 indexSourceNode.getOutputSymbols().stream()
@@ -64,7 +64,7 @@ public class PruneIndexSourceColumns
                         prunedLookupSymbols,
                         prunedOutputList,
                         prunedAssignments,
-                        indexSourceNode.getEffectiveTupleDomain()));
+                        indexSourceNode.getCurrentConstraint()));
     }
 
     private static boolean tupleDomainReferencesColumnHandle(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -65,7 +65,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
@@ -80,7 +79,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
-import static com.google.common.base.Predicates.in;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.concat;
@@ -386,20 +384,17 @@ public class PruneUnreferencedOutputs
         @Override
         public PlanNode visitTableScan(TableScanNode node, RewriteContext<Set<Symbol>> context)
         {
-            Set<Symbol> requiredTableScanOutputs = context.get().stream()
-                    .filter(node.getOutputSymbols()::contains)
-                    .collect(toImmutableSet());
-
-            List<Symbol> newOutputSymbols = node.getOutputSymbols().stream()
-                    .filter(requiredTableScanOutputs::contains)
+            List<Symbol> newOutputs = node.getOutputSymbols().stream()
+                    .filter(context.get()::contains)
                     .collect(toImmutableList());
 
-            Map<Symbol, ColumnHandle> newAssignments = Maps.filterKeys(node.getAssignments(), in(requiredTableScanOutputs));
+            Map<Symbol, ColumnHandle> newAssignments = newOutputs.stream()
+                    .collect(Collectors.toMap(Function.identity(), node.getAssignments()::get));
 
             return new TableScanNode(
                     node.getId(),
                     node.getTable(),
-                    newOutputSymbols,
+                    newOutputs,
                     newAssignments,
                     node.getLayout(),
                     node.getCurrentConstraint(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -290,13 +290,13 @@ public class PruneUnreferencedOutputs
                     .collect(toImmutableSet());
 
             Set<Symbol> requiredAssignmentSymbols = context.get();
-            if (!node.getEffectiveTupleDomain().isNone()) {
-                Set<Symbol> requiredSymbols = Maps.filterValues(node.getAssignments(), in(node.getEffectiveTupleDomain().getDomains().get().keySet())).keySet();
+            if (!node.getCurrentConstraint().isNone()) {
+                Set<Symbol> requiredSymbols = Maps.filterValues(node.getAssignments(), in(node.getCurrentConstraint().getDomains().get().keySet())).keySet();
                 requiredAssignmentSymbols = Sets.union(context.get(), requiredSymbols);
             }
             Map<Symbol, ColumnHandle> newAssignments = Maps.filterKeys(node.getAssignments(), in(requiredAssignmentSymbols));
 
-            return new IndexSourceNode(node.getId(), node.getIndexHandle(), node.getTableHandle(), node.getLayout(), newLookupSymbols, newOutputSymbols, newAssignments, node.getEffectiveTupleDomain());
+            return new IndexSourceNode(node.getId(), node.getIndexHandle(), node.getTableHandle(), node.getLayout(), newLookupSymbols, newOutputSymbols, newAssignments, node.getCurrentConstraint());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -521,7 +521,7 @@ public class UnaliasSymbolReferences
         @Override
         public PlanNode visitIndexSource(IndexSourceNode node, RewriteContext<Void> context)
         {
-            return new IndexSourceNode(node.getId(), node.getIndexHandle(), node.getTableHandle(), node.getLayout(), canonicalize(node.getLookupSymbols()), node.getOutputSymbols(), node.getAssignments(), node.getEffectiveTupleDomain());
+            return new IndexSourceNode(node.getId(), node.getIndexHandle(), node.getTableHandle(), node.getLayout(), canonicalize(node.getLookupSymbols()), node.getOutputSymbols(), node.getAssignments(), node.getCurrentConstraint());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexSourceNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexSourceNode.java
@@ -42,7 +42,7 @@ public class IndexSourceNode
     private final Set<Symbol> lookupSymbols;
     private final List<Symbol> outputSymbols;
     private final Map<Symbol, ColumnHandle> assignments; // symbol -> column
-    private final TupleDomain<ColumnHandle> effectiveTupleDomain; // general summary of how the output columns will be constrained
+    private final TupleDomain<ColumnHandle> currentConstraint; // constraint over the input data the operator will guarantee
 
     @JsonCreator
     public IndexSourceNode(
@@ -53,7 +53,7 @@ public class IndexSourceNode
             @JsonProperty("lookupSymbols") Set<Symbol> lookupSymbols,
             @JsonProperty("outputSymbols") List<Symbol> outputSymbols,
             @JsonProperty("assignments") Map<Symbol, ColumnHandle> assignments,
-            @JsonProperty("effectiveTupleDomain") TupleDomain<ColumnHandle> effectiveTupleDomain)
+            @JsonProperty("currentConstraint") TupleDomain<ColumnHandle> currentConstraint)
     {
         super(id);
         this.indexHandle = requireNonNull(indexHandle, "indexHandle is null");
@@ -62,13 +62,13 @@ public class IndexSourceNode
         this.lookupSymbols = ImmutableSet.copyOf(requireNonNull(lookupSymbols, "lookupSymbols is null"));
         this.outputSymbols = ImmutableList.copyOf(requireNonNull(outputSymbols, "outputSymbols is null"));
         this.assignments = ImmutableMap.copyOf(requireNonNull(assignments, "assignments is null"));
-        this.effectiveTupleDomain = requireNonNull(effectiveTupleDomain, "effectiveTupleDomain is null");
+        this.currentConstraint = requireNonNull(currentConstraint, "effectiveTupleDomain is null");
         checkArgument(!lookupSymbols.isEmpty(), "lookupSymbols is empty");
         checkArgument(!outputSymbols.isEmpty(), "outputSymbols is empty");
         checkArgument(assignments.keySet().containsAll(lookupSymbols), "Assignments do not include all lookup symbols");
         checkArgument(outputSymbols.containsAll(lookupSymbols), "Lookup symbols need to be part of the output symbols");
         Set<ColumnHandle> assignedColumnHandles = ImmutableSet.copyOf(assignments.values());
-        effectiveTupleDomain.getDomains().ifPresent(handleToDomain ->
+        currentConstraint.getDomains().ifPresent(handleToDomain ->
                 checkArgument(
                         assignedColumnHandles.containsAll(handleToDomain.keySet()),
                         "Tuple domain handles must have assigned symbols"));
@@ -112,9 +112,9 @@ public class IndexSourceNode
     }
 
     @JsonProperty
-    public TupleDomain<ColumnHandle> getEffectiveTupleDomain()
+    public TupleDomain<ColumnHandle> getCurrentConstraint()
     {
-        return effectiveTupleDomain;
+        return currentConstraint;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexSourceNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/IndexSourceNode.java
@@ -67,11 +67,6 @@ public class IndexSourceNode
         checkArgument(!outputSymbols.isEmpty(), "outputSymbols is empty");
         checkArgument(assignments.keySet().containsAll(lookupSymbols), "Assignments do not include all lookup symbols");
         checkArgument(outputSymbols.containsAll(lookupSymbols), "Lookup symbols need to be part of the output symbols");
-        Set<ColumnHandle> assignedColumnHandles = ImmutableSet.copyOf(assignments.values());
-        currentConstraint.getDomains().ifPresent(handleToDomain ->
-                checkArgument(
-                        assignedColumnHandles.containsAll(handleToDomain.keySet()),
-                        "Tuple domain handles must have assigned symbols"));
     }
 
     @JsonProperty

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/IndexSourceMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/IndexSourceMatcher.java
@@ -72,7 +72,7 @@ final class IndexSourceMatcher
         if (expectedConstraint.isPresent() &&
                 !domainsMatch(
                         expectedConstraint,
-                        indexSourceNode.getEffectiveTupleDomain(),
+                        indexSourceNode.getCurrentConstraint(),
                         indexSourceNode.getTableHandle(),
                         session,
                         metadata)) {


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/9800

No test for now. It requires a connector that supports predicate pushdown and index joins.