### PR TITLE
Allow multiple LDAP user bind patterns in config

### DIFF
--- a/presto-main/etc/log.properties
+++ b/presto-main/etc/log.properties
@@ -9,3 +9,4 @@ com.facebook.presto=INFO
 com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory=WARN
 com.ning.http.client=WARN
 com.facebook.presto.server.PluginManager=DEBUG
+com.facebook.presto.server.security.LdapAuthenticator=DEBUG

--- a/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationException.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationException.java
@@ -32,6 +32,12 @@ public class AuthenticationException
         this.authenticateHeader = Optional.of(authenticateHeader);
     }
 
+    public AuthenticationException(String message, Throwable cause)
+    {
+        super(message, cause);
+        this.authenticateHeader = Optional.empty();
+    }
+
     public Optional<String> getAuthenticateHeader()
     {
         return authenticateHeader;

--- a/presto-main/src/main/java/com/facebook/presto/server/security/LdapConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/LdapConfig.java
@@ -27,19 +27,23 @@
  */
 package com.facebook.presto.server.security;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class LdapConfig
 {
     private String ldapUrl;
-    private String userBindSearchPattern;
+    private List<String> userBindSearchPatterns = ImmutableList.of();
     private String groupAuthorizationSearchPattern;
     private String userBaseDistinguishedName;
     private Duration ldapCacheTtl = new Duration(1, TimeUnit.HOURS);
@@ -60,16 +64,17 @@ public class LdapConfig
     }
 
     @NotNull
-    public String getUserBindSearchPattern()
+    @Size(min = 1)
+    public List<String> getUserBindSearchPatterns()
     {
-        return userBindSearchPattern;
+        return userBindSearchPatterns;
     }
 
     @Config("authentication.ldap.user-bind-pattern")
-    @ConfigDescription("Custom user bind pattern. Example: ${USER}@example.com")
-    public LdapConfig setUserBindSearchPattern(String userBindSearchPattern)
+    @ConfigDescription("Custom user bind patterns. Example: ${USER}@example.com. You may specify multiple bind patterns separated by a semicolon.")
+    public LdapConfig setUserBindSearchPatterns(String bindPatterns)
     {
-        this.userBindSearchPattern = userBindSearchPattern;
+        this.userBindSearchPatterns = ImmutableList.copyOf(Splitter.on(";").trimResults().omitEmptyStrings().split(bindPatterns));
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestLdapConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestLdapConfig.java
@@ -20,6 +20,7 @@ import org.testng.annotations.Test;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +37,7 @@ public class TestLdapConfig
     {
         assertRecordedDefaults(ConfigAssertions.recordDefaults(LdapConfig.class)
                 .setLdapUrl(null)
-                .setUserBindSearchPattern(null)
+                .setUserBindSearchPatterns("")
                 .setUserBaseDistinguishedName(null)
                 .setGroupAuthorizationSearchPattern(null)
                 .setLdapCacheTtl(new Duration(1, TimeUnit.HOURS)));
@@ -47,7 +48,7 @@ public class TestLdapConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("authentication.ldap.url", "ldaps://localhost:636")
-                .put("authentication.ldap.user-bind-pattern", "uid=${USER},ou=org,dc=test,dc=com")
+                .put("authentication.ldap.user-bind-pattern", "uid=${USER},ou=org,dc=test,dc=com;uid=${USER},ou=com,dc=test,dc=com")
                 .put("authentication.ldap.user-base-dn", "dc=test,dc=com")
                 .put("authentication.ldap.group-auth-pattern", "&(objectClass=user)(memberOf=cn=group)(user=username)")
                 .put("authentication.ldap.cache-ttl", "2m")
@@ -55,7 +56,7 @@ public class TestLdapConfig
 
         LdapConfig expected = new LdapConfig()
                 .setLdapUrl("ldaps://localhost:636")
-                .setUserBindSearchPattern("uid=${USER},ou=org,dc=test,dc=com")
+                .setUserBindSearchPatterns("uid=${USER},ou=org,dc=test,dc=com;uid=${USER},ou=com,dc=test,dc=com")
                 .setUserBaseDistinguishedName("dc=test,dc=com")
                 .setGroupAuthorizationSearchPattern("&(objectClass=user)(memberOf=cn=group)(user=username)")
                 .setLdapCacheTtl(new Duration(2, TimeUnit.MINUTES));
@@ -68,7 +69,7 @@ public class TestLdapConfig
     {
         assertValidates(new LdapConfig()
                 .setLdapUrl("ldaps://localhost")
-                .setUserBindSearchPattern("uid=${USER},ou=org,dc=test,dc=com")
+                .setUserBindSearchPatterns("uid=${USER},ou=org,dc=test,dc=com;uid=${USER},ou=com,dc=test,dc=com")
                 .setUserBaseDistinguishedName("dc=test,dc=com")
                 .setGroupAuthorizationSearchPattern("&(objectClass=user)(memberOf=cn=group)(user=username)"));
 
@@ -77,6 +78,6 @@ public class TestLdapConfig
         assertFailsValidation(new LdapConfig().setLdapUrl("ldaps:/localhost"), "ldapUrl", "LDAP without SSL/TLS unsupported. Expected ldaps://", Pattern.class);
 
         assertFailsValidation(new LdapConfig(), "ldapUrl", "may not be null", NotNull.class);
-        assertFailsValidation(new LdapConfig(), "userBindSearchPattern", "may not be null", NotNull.class);
+        assertFailsValidation(new LdapConfig(), "userBindSearchPatterns", "size must be between 1 and 2147483647", Size.class);
     }
 }


### PR DESCRIPTION
Hi, at our company we have a need to try multiple bind patterns as we have accounts with different DN hierarchies. Is this a feature you would be interested in taking? Thanks!