### PR TITLE
Improve split assignment performance by avoiding future cancellation 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -14,11 +14,11 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.OutputBuffers;
+import com.facebook.presto.execution.FutureStateChange.StateChangeFuture;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
-import com.google.common.util.concurrent.ListenableFuture;
 
 public interface RemoteTask
 {
@@ -42,7 +42,11 @@ public interface RemoteTask
 
     void addStateChangeListener(StateChangeListener<TaskStatus> stateChangeListener);
 
-    ListenableFuture<?> whenSplitQueueHasSpace(int threshold);
+    /**
+     * If split queue is full, returns a listener that will fire when space in split queue becomes available,
+     * otherwise returns empty.
+     */
+    StateChangeFuture<?> whenSplitQueueHasSpace(int threshold);
 
     void cancel();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StateMachine.java
@@ -242,7 +242,7 @@ public class StateMachine<T>
                 return immediateFuture(state);
             }
 
-            return futureStateChange.get().createNewListener();
+            return futureStateChange.get().newListenableFuture();
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestFutureStateChange.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestFutureStateChange.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.execution.FutureStateChange.StateChangeFuture.getFirstCompleteAndCancelOthers;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestFutureStateChange
+{
+    public void testComplete()
+    {
+
+
+    }
+
+    @Test
+    public void testGetFirstCompleteAndCancelOthers()
+            throws Exception
+    {
+        FutureStateChange<Integer> stateChange1 = new FutureStateChange<>();
+        FutureStateChange<Integer> stateChange2 = new FutureStateChange<>();
+        FutureStateChange<Integer> stateChange3 = new FutureStateChange<>();
+
+        ListenableFuture<Integer> future = getFirstCompleteAndCancelOthers(
+                ImmutableList.of(stateChange1.newStateChangeFuture(), stateChange2.newStateChangeFuture(), stateChange3.newStateChangeFuture()));
+
+        assertEquals(stateChange1.getListenerCount(), 1);
+        assertEquals(stateChange2.getListenerCount(), 1);
+        assertEquals(stateChange3.getListenerCount(), 1);
+
+        assertFalse(future.isDone());
+        stateChange2.complete(100);
+        assertEquals((int) future.get(), 100);
+
+        assertEquals(stateChange1.getListenerCount(), 0);
+        assertEquals(stateChange2.getListenerCount(), 0);
+        assertEquals(stateChange3.getListenerCount(), 0);
+    }
+
+    @Test
+    public void testGetFirstCompleteAndCancelOthersWithCompletedListener()
+            throws Exception
+    {
+        FutureStateChange<Integer> stateChange1 = new FutureStateChange<>();
+        FutureStateChange<Integer> stateChange2 = new FutureStateChange<>();
+        FutureStateChange<Integer> stateChange3 = new FutureStateChange<>();
+
+        FutureStateChange.StateChangeFuture<Integer> listener1 = stateChange1.newStateChangeFuture();
+        FutureStateChange.StateChangeFuture<Integer> listener2 = stateChange2.newStateChangeFuture();
+        FutureStateChange.StateChangeFuture<Integer> listener3 = stateChange3.newStateChangeFuture();
+
+        stateChange2.complete(100);
+
+        ListenableFuture<Integer> future = getFirstCompleteAndCancelOthers(
+                ImmutableList.of(listener1, listener2, listener3));
+
+        assertEquals((int) future.get(), 100);
+
+        assertEquals(stateChange1.getListenerCount(), 0);
+        assertEquals(stateChange2.getListenerCount(), 0);
+        assertEquals(stateChange3.getListenerCount(), 0);
+    }
+}


### PR DESCRIPTION
One of the responsibilities of Presto coordinator is assigning splits to tasks. The split assignment implementation involves cancelling a lot of futures. Cancelling future is expensive because it involves filling in stack traces. It can take more than 10% of overall CPU on a coordinator, causing a performance bottleneck.

7a7bb28 attempted to fix this problem. Unfortunately, it only solved half of the problem, and didn't
resolve the performance bottleneck.

The cancellation cause no longer has a stacktrace with this fix. However, when invoked, `AbstractFuture.getDoneValue` would wrap the cause with either `CancellationException` or `ExecutionException`, and populates stacktrace on the wrapper exception. For any useful `Future`, someone is directly or indirectly calling `get` on it (even with `Futures.addCallback` for example).