### PR TITLE
Ensure tables initially not analyzed in TestHiveTableStatistics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dep.aws-sdk.version>1.11.165</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.0.0</dep.jdbi3.version>
-        <dep.tempto.version>1.42</dep.tempto.version>
+        <dep.tempto.version>1.45</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.nifty.version>0.15.1</dep.nifty.version>

--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -77,7 +77,7 @@ function docker_images_used() {
 function cleanup() {
   stop_application_runner_containers ${ENVIRONMENT}
 
-  if [[ "${LEAVE_CONTAINERS_ALIVE_ON_EXIT:-false}" = "true" ]]; then
+  if [[ "${LEAVE_CONTAINERS_ALIVE_ON_EXIT:-false}" != "true" ]]; then
     stop_docker_compose_containers ${ENVIRONMENT}
   fi
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -20,6 +20,7 @@ import io.prestodb.tempto.RequirementsProvider;
 import io.prestodb.tempto.Requires;
 import io.prestodb.tempto.configuration.Configuration;
 import io.prestodb.tempto.fulfillment.table.MutableTableRequirement;
+import io.prestodb.tempto.fulfillment.table.hive.HiveTableDefinition;
 import io.prestodb.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
@@ -45,7 +46,10 @@ public class TestHiveTableStatistics
         @Override
         public Requirement getRequirements(Configuration configuration)
         {
-            return mutableTable(NATION);
+            return mutableTable(
+                    HiveTableDefinition.from(NATION)
+                            .injectStats(false)
+                            .build());
         }
     }
 
@@ -55,7 +59,10 @@ public class TestHiveTableStatistics
         @Override
         public Requirement getRequirements(Configuration configuration)
         {
-            return mutableTable(NATION_PARTITIONED_BY_REGIONKEY);
+            return mutableTable(
+                    HiveTableDefinition.from(NATION_PARTITIONED_BY_REGIONKEY)
+                            .injectStats(false)
+                            .build());
         }
     }
 


### PR DESCRIPTION
`TestHiveTableStatistics` needs control over whether tables are
initially analyzed, because it tests both situations: analyzed and
non-analyzed tables (and deleting stats in Hive is not possible).