### PR TITLE
Add missing 'alwaysRun' in @AfterClass

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/util/TestAsyncQueue.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/util/TestAsyncQueue.java
@@ -46,7 +46,7 @@ public class TestAsyncQueue
         executor = Executors.newFixedThreadPool(8, Threads.daemonThreadsNamed("test-async-queue-%s"));
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDownClass()
     {
         executor.shutdownNow();

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
@@ -45,7 +45,7 @@ public class TestTpchDistributedStats
         statisticsAssertion = new StatisticsAssertion(runner);
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDown()
     {
         statisticsAssertion.close();


### PR DESCRIPTION
We do always `@AfterClass(alwaysRun = true)` except for two cases. I updated those two.