### PR TITLE
Fix predicate push-down in TPCH connector

### DIFF
--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -408,7 +408,9 @@ public class TpchMetadata
 
     private Predicate<NullableValue> convertToPredicate(TupleDomain<ColumnHandle> predicate, TpchColumn column)
     {
-        return nullableValue -> predicate.contains(TupleDomain.fromFixedValues(ImmutableMap.of(toColumnHandle(column), nullableValue)));
+        TpchColumnHandle columnHandle = toColumnHandle(column);
+        TupleDomain<ColumnHandle> columnPredicate = filterColumns(predicate, columnHandle::equals);
+        return nullableValue -> columnPredicate.contains(TupleDomain.fromFixedValues(ImmutableMap.of(columnHandle, nullableValue)));
     }
 
     private TupleDomain<ColumnHandle> filterOutColumnFromPredicate(TupleDomain<ColumnHandle> predicate, TpchColumn column)


### PR DESCRIPTION
Previously, for `TupleDomain` on column other than `orderstatus`, it
would incorrectly conclude no `orderstatus` value matches and return
empty `TupleDomain`.