### PR TITLE
PartitioningExchanger doesn't have to synchronize on accept

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/PartitioningExchanger.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/PartitioningExchanger.java
@@ -69,7 +69,7 @@ class PartitioningExchanger
     }
 
     @Override
-    public synchronized void accept(Page page)
+    public void accept(Page page)
     {
         // reset the assignment lists
         for (IntList partitionAssignment : partitionAssignments) {


### PR DESCRIPTION
PartitioningExchange#accept is only called by LocalExchangeSink#addPage
which is only called from LocalExchangeSinkOperator#addInput