### PR TITLE
Make local exchanger responsible for blocking writes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchanger.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchanger.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.exchange;
+
+import com.facebook.presto.spi.Page;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
+
+public interface LocalExchanger
+{
+    LocalExchanger FINISHED = new LocalExchanger()
+    {
+        @Override
+        public void accept(Page page) {}
+
+        @Override
+        public ListenableFuture<?> waitForWriting()
+        {
+            return NOT_BLOCKED;
+        }
+    };
+
+    void accept(Page page);
+
+    ListenableFuture<?> waitForWriting();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/PartitioningExchanger.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/PartitioningExchanger.java
@@ -21,34 +21,34 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.ListenableFuture;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.LongConsumer;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 class PartitioningExchanger
-        implements Consumer<Page>
+        implements LocalExchanger
 {
     private final List<Consumer<PageReference>> buffers;
-    private final LongConsumer memoryTracker;
+    private final LocalExchangeMemoryManager memoryManager;
     private final LocalPartitionGenerator partitionGenerator;
     private final IntArrayList[] partitionAssignments;
 
     public PartitioningExchanger(
             List<Consumer<PageReference>> partitions,
-            LongConsumer memoryTracker,
+            LocalExchangeMemoryManager memoryManager,
             List<? extends Type> types,
             List<Integer> partitionChannels,
             Optional<Integer> hashChannel)
     {
         this.buffers = ImmutableList.copyOf(requireNonNull(partitions, "partitions is null"));
-        this.memoryTracker = requireNonNull(memoryTracker, "memoryTracker is null");
+        this.memoryManager = requireNonNull(memoryManager, "memoryManager is null");
 
         HashGenerator hashGenerator;
         if (hashChannel.isPresent()) {
@@ -93,9 +93,15 @@ class PartitioningExchanger
                 }
 
                 Page pageSplit = new Page(positions.size(), outputBlocks);
-                memoryTracker.accept(pageSplit.getRetainedSizeInBytes());
-                buffers.get(partition).accept(new PageReference(pageSplit, 1, () -> memoryTracker.accept(-pageSplit.getRetainedSizeInBytes())));
+                memoryManager.updateMemoryUsage(pageSplit.getRetainedSizeInBytes());
+                buffers.get(partition).accept(new PageReference(pageSplit, 1, () -> memoryManager.updateMemoryUsage(-pageSplit.getRetainedSizeInBytes())));
             }
         }
+    }
+
+    @Override
+    public ListenableFuture<?> waitForWriting()
+    {
+        return memoryManager.getNotFullFuture();
     }
 }


### PR DESCRIPTION
It is more natural if local exchange is responsible for blocking writes. This allows to customize local exchangers even more (e.g: for distributed sort).

For distributed sort I will create an exchanger that manages memory pool slightly differently than other exchanges. It will give each source 1/N of total local exchange memory.