### PR TITLE
Short-circuit inner and right join when right side is empty

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinHash.java
@@ -49,6 +49,12 @@ public final class JoinHash
     }
 
     @Override
+    public boolean isEmpty()
+    {
+        return getJoinPositionCount() == 0;
+    }
+
+    @Override
     public final int getChannelCount()
     {
         return pagesHash.getChannelCount();

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -234,6 +234,13 @@ public class LookupJoinOperator
             }
             lookupSourceProvider = requireNonNull(getDone(lookupSourceProviderFuture));
             statisticsCounter.updateLookupSourcePositions(lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().getJoinPositionCount()));
+
+            // check if we can finish the join earlier
+            if (!probeOnOuterSide &&
+                    lookupSourceProvider.withLease(lookupSourceLease ->
+                            lookupSourceLease.getLookupSource().isEmpty())) {
+                finishing = true;
+            }
         }
         return true;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupSource.java
@@ -42,6 +42,8 @@ public interface LookupSource
 
     boolean isJoinPositionEligible(long currentJoinPosition, int probePosition, Page allProbeChannelsPage);
 
+    boolean isEmpty();
+
     @Override
     void close();
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/OuterLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OuterLookupSource.java
@@ -46,6 +46,12 @@ public final class OuterLookupSource
     }
 
     @Override
+    public boolean isEmpty()
+    {
+        return lookupSource.isEmpty();
+    }
+
+    @Override
     public int getChannelCount()
     {
         return lookupSource.getChannelCount();

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
@@ -104,6 +104,12 @@ public class PartitionedLookupSource
     }
 
     @Override
+    public boolean isEmpty()
+    {
+        return Arrays.stream(lookupSources).allMatch(LookupSource::isEmpty);
+    }
+
+    @Override
     public int getChannelCount()
     {
         return lookupSources[0].getChannelCount();

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -501,6 +501,12 @@ public final class PartitionedLookupSourceFactory
         }
 
         @Override
+        public boolean isEmpty()
+        {
+            return false;
+        }
+
+        @Override
         public int getChannelCount()
         {
             return channelCount;

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -381,6 +381,12 @@ public class IndexLoader
         }
 
         @Override
+        public boolean isEmpty()
+        {
+            return true;
+        }
+
+        @Override
         public int getChannelCount()
         {
             return channelCount;

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLookupSource.java
@@ -37,6 +37,13 @@ public class IndexLookupSource
     }
 
     @Override
+    public boolean isEmpty()
+    {
+        // since the data is not loaded, we don't know if it is empty
+        return false;
+    }
+
+    @Override
     public int getChannelCount()
     {
         return indexLoader.getChannelCount();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestLookupJoinPageBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestLookupJoinPageBuilder.java
@@ -188,6 +188,12 @@ public class TestLookupJoinPageBuilder
         }
 
         @Override
+        public boolean isEmpty()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public int getChannelCount()
         {
             throw new UnsupportedOperationException();

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8000,4 +8000,44 @@ public abstract class AbstractTestQueries
         assertEquals(doubleColumnResult.getTypes().get(0), DOUBLE);
         assertEquals(doubleColumnResult.getMaterializedRows().get(0).getField(0), 1.0);
     }
+
+    @Test
+    public void testInnerJoinWithEmptyBuildSide()
+    {
+        MaterializedResult actual = computeActual("" +
+                "WITH small_part AS (SELECT * FROM part WHERE name = 'a') " +
+                "SELECT lineitem.orderkey FROM lineitem INNER JOIN small_part ON lineitem.partkey = small_part.partkey");
+
+        assertEquals(actual.getRowCount(), 0);
+    }
+
+    @Test
+    public void testRightJoinWithEmptyBuildSide()
+    {
+        MaterializedResult actual = computeActual("" +
+                "WITH small_part AS (SELECT * FROM part WHERE name = 'a') " +
+                "SELECT lineitem.orderkey FROM lineitem RIGHT JOIN small_part ON lineitem.partkey = small_part.partkey");
+
+        assertEquals(actual.getRowCount(), 0);
+    }
+
+    @Test
+    public void testLeftJoinWithEmptyBuildSide()
+    {
+        MaterializedResult actual = computeActual("" +
+                "WITH small_part AS (SELECT * FROM part WHERE name = 'a') " +
+                "SELECT lineitem.orderkey FROM lineitem LEFT JOIN small_part ON lineitem.partkey = small_part.partkey");
+
+        assertEquals(actual.getRowCount(), 60175);
+    }
+
+    @Test
+    public void testFullJoinWithEmptyBuildSide()
+    {
+        MaterializedResult actual = computeActual("" +
+                "WITH small_part AS (SELECT * FROM part WHERE name = 'a') " +
+                "SELECT lineitem.orderkey FROM lineitem FULL OUTER JOIN small_part ON lineitem.partkey = small_part.partkey");
+
+        assertEquals(actual.getRowCount(), 60175);
+    }
 }


### PR DESCRIPTION
This is a fix for: #9769. After looking more at the problem, I don't think we can just do the check at planning (as in a large percentage of the cases, a table scan is involved). I discussed the issue with with @dain & @rongrong, they pointed me to an implementation of the fix, so that was my starting point (original PR: https://github.com/prestodb/presto/pull/7275).