### PR TITLE
Approximate object references for ReferenceCountMap

### DIFF
--- a/presto-array/pom.xml
+++ b/presto-array/pom.xml
@@ -42,5 +42,17 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
@@ -13,30 +13,36 @@
  */
 package com.facebook.presto.array;
 
+import com.facebook.presto.spi.block.Block;
 import io.airlift.slice.SizeOf;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenCustomHashMap;
+import io.airlift.slice.Slice;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import org.openjdk.jol.info.ClassLayout;
 
+import static java.lang.String.format;
+import static java.lang.reflect.Array.getLength;
+
+// This class tracks how many times an objects have been referenced
+// in order not to over count memory in complex objects such as SliceBigArray or BlockBigArray.
+// Ideally the key set should be the object references themselves.
+// But it turns out such implementation can lead to long concurrent marking time with G1GC.
+// With several attempts including breaking down the object arrays into object big arrays,
+// the problem can be solved but tracking overhead is still high.
+// Benchmark results show using hash maps with primitive arrays perform way better than object arrays.
+// Therefore, we use concatenation of identity hash code and size of the object to identify an object.
+// This may lead to hash collision, in which case we will under count memory usage.
+// But we believe the performance boost is worth the cost.
 public final class ReferenceCountMap
-        extends Object2IntOpenCustomHashMap<Object>
+        extends Long2IntOpenHashMap
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ReferenceCountMap.class).instanceSize();
-
-    /**
-     * Two different blocks can share the same underlying data
-     * Use the map to avoid memory over counting
-     */
-    public ReferenceCountMap()
-    {
-        super(new ObjectStrategy());
-    }
 
     /**
      * Increments the reference count of an object by 1 and returns the updated reference count
      */
     public int incrementAndGet(Object key)
     {
-        return addTo(key, 1) + 1;
+        return addTo(getHashCode(key), 1) + 1;
     }
 
     /**
@@ -44,9 +50,10 @@ public final class ReferenceCountMap
      */
     public int decrementAndGet(Object key)
     {
-        int previousCount = addTo(key, -1);
+        long hashCode = getHashCode(key);
+        int previousCount = addTo(hashCode, -1);
         if (previousCount == 1) {
-            remove(key);
+            remove(hashCode);
         }
         return previousCount - 1;
     }
@@ -59,19 +66,33 @@ public final class ReferenceCountMap
         return INSTANCE_SIZE + SizeOf.sizeOf(key) + SizeOf.sizeOf(value) + SizeOf.sizeOf(used);
     }
 
-    private static final class ObjectStrategy
-            implements Strategy<Object>
+    /**
+     * Get the 64-bit hash code for an object
+     */
+    private static long getHashCode(Object key)
     {
-        @Override
-        public int hashCode(Object object)
-        {
-            return System.identityHashCode(object);
+        // identityHashCode of two objects are not guaranteed to be different.
+        // Any additional identity information can reduce collisions.
+        // In the most cases below, we use size of an object to be the extra identity.
+        // Experiments show that with 100 million objects created, using identityHashCode has a collision rate around 2.5%.
+        // However, if these 100 million objects are combined with 10 different sizes, the collision rate is around 0.1%.
+        // The collision rate can be lower than 0.001% if there are 1000 different sizes.
+        int extraIdentity;
+        if (key == null) {
+            extraIdentity = 0;
         }
-
-        @Override
-        public boolean equals(Object left, Object right)
-        {
-            return left == right;
+        else if (key instanceof Block) {
+            extraIdentity = (int) ((Block) key).getRetainedSizeInBytes();
         }
+        else if (key instanceof Slice) {
+            extraIdentity = (int) ((Slice) key).getRetainedSize();
+        }
+        else if (key.getClass().isArray()) {
+            extraIdentity = getLength(key);
+        }
+        else {
+            throw new IllegalArgumentException(format("Unsupported type for %s", key));
+        }
+        return (((long) System.identityHashCode(key)) << Integer.SIZE) + extraIdentity;
     }
 }

--- a/presto-array/src/test/java/com/facebook/presto/array/BenchmarkReferenceCountMap.java
+++ b/presto-array/src/test/java/com/facebook/presto/array/BenchmarkReferenceCountMap.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.array;
+
+import io.airlift.slice.Slice;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.runner.options.WarmupMode;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.airlift.slice.Slices.wrappedDoubleArray;
+import static io.airlift.slice.Slices.wrappedIntArray;
+import static io.airlift.slice.Slices.wrappedLongArray;
+
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(4)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class BenchmarkReferenceCountMap
+{
+    private static final int NUMBER_OF_ENTRIES = 1_000_000;
+    private static final int NUMBER_OF_BASES = 100;
+
+    @State(Scope.Thread)
+    public static class Data
+    {
+        @Param({"int", "double", "long", "byte"})
+        private String arrayType = "int";
+        private Object[] bases = new Object[NUMBER_OF_BASES];
+        private Slice[] slices = new Slice[NUMBER_OF_ENTRIES];
+
+        @Setup
+        public void setup()
+        {
+            for (int i = 0; i < NUMBER_OF_BASES; i++) {
+                switch (arrayType) {
+                    case "int":
+                        bases[i] = new int[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
+                        break;
+                    case "double":
+                        bases[i] = new double[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
+                        break;
+                    case "long":
+                        bases[i] = new long[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
+                        break;
+                    case "byte":
+                        bases[i] = new byte[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
+                        break;
+                    default:
+                        throw new UnsupportedOperationException();
+                }
+            }
+
+            for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
+                Object base = bases[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
+                switch (arrayType) {
+                    case "int":
+                        int[] intBase = (int[]) base;
+                        slices[i] = wrappedIntArray(intBase, 0, intBase.length);
+                        break;
+                    case "double":
+                        double[] doubleBase = (double[]) base;
+                        slices[i] = wrappedDoubleArray(doubleBase, 0, doubleBase.length);
+                        break;
+                    case "long":
+                        long[] longBase = (long[]) base;
+                        slices[i] = wrappedLongArray(longBase, 0, longBase.length);
+                        break;
+                    case "byte":
+                        byte[] byteBase = (byte[]) base;
+                        slices[i] = wrappedBuffer(byteBase, 0, byteBase.length);
+                        break;
+                    default:
+                        throw new UnsupportedOperationException();
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(NUMBER_OF_ENTRIES)
+    public ReferenceCountMap benchmarkInserts(Data data)
+    {
+        ReferenceCountMap map = new ReferenceCountMap();
+        for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
+            map.incrementAndGet(data.slices[i]);
+            map.incrementAndGet(data.slices[i].getBase());
+        }
+        return map;
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .warmupMode(WarmupMode.BULK)
+                .include(".*" + BenchmarkReferenceCountMap.class.getSimpleName() + ".*")
+                .addProfiler(GCProfiler.class)
+                .jvmArgs("-XX:+UseG1GC")
+                .build();
+
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
ReferenceCountMap maps from objects to reference counts. Its keys are
stored in a single object array. In some extreme cases, the array grows
to hundreds of millions of objects. This can cause G1GC to push huge
amounts of object pointers to a task queue, which can both lead to GC
overhead as well as queue overflow. The problem can be solved by using
big arrays to store objects. However, the performance overhead (other than
GC) can still be high. This patch combines both identity hash code and
the size of the objects as the key to identity an object. Collision can
happen but according to benchmark is neglectable.