### PR TITLE
Change StatsCalculator API and cache stats in Memo

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CachingStatsProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CachingStatsProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.GroupReference;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Memo;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.google.common.base.Suppliers;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+public final class CachingStatsProvider
+        implements StatsProvider
+{
+    private final StatsCalculator statsCalculator;
+    private final Optional<Memo> memo;
+    private final Lookup lookup;
+    private final Session session;
+    private final Supplier<Map<Symbol, Type>> types;
+
+    private final Map<PlanNode, PlanNodeStatsEstimate> cache = new IdentityHashMap<>();
+
+    public CachingStatsProvider(StatsCalculator statsCalculator, Session session, Map<Symbol, Type> types)
+    {
+        this(statsCalculator, Optional.empty(), noLookup(), session, Suppliers.ofInstance(requireNonNull(types, "types is null")));
+    }
+
+    public CachingStatsProvider(StatsCalculator statsCalculator, Optional<Memo> memo, Lookup lookup, Session session, Supplier<Map<Symbol, Type>> types)
+    {
+        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
+        this.memo = requireNonNull(memo, "memo is null");
+        this.lookup = requireNonNull(lookup, "lookup is null");
+        this.session = requireNonNull(session, "session is null");
+        this.types = requireNonNull(types, "types is null");
+    }
+
+    @Override
+    public PlanNodeStatsEstimate getStats(PlanNode node)
+    {
+        requireNonNull(node, "node is null");
+
+        if (node instanceof GroupReference) {
+            return getGroupStats((GroupReference) node);
+        }
+
+        PlanNodeStatsEstimate stats = cache.get(node);
+        if (stats != null) {
+            return stats;
+        }
+
+        stats = statsCalculator.calculateStats(node, this, lookup, session, types.get());
+        verify(cache.put(node, stats) == null, "Stats already set");
+        return stats;
+    }
+
+    private PlanNodeStatsEstimate getGroupStats(GroupReference groupReference)
+    {
+        int group = groupReference.getGroupId();
+        Memo memo = this.memo.orElseThrow(() -> new IllegalStateException("CachingStatsProvider without memo cannot handle GroupReferences"));
+
+        Optional<PlanNodeStatsEstimate> stats = memo.getStats(group);
+        if (stats.isPresent()) {
+            return stats.get();
+        }
+
+        PlanNodeStatsEstimate groupStats = statsCalculator.calculateStats(memo.getNode(group), this, lookup, session, types.get());
+        verify(!memo.getStats(group).isPresent(), "Group stats already set");
+        memo.storeStats(group, groupStats);
+        return groupStats;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculator.java
@@ -16,23 +16,25 @@ package com.facebook.presto.cost;
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
+import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.PlanNodeId;
 
 import java.util.Map;
 
-/**
- * Interface of cost calculator.
- * <p>
- * It's responsibility is to provide approximation of cost of execution of plan node.
- * Example implementations may be based on table statistics or data samples.
- */
 public interface StatsCalculator
 {
-    Map<PlanNodeId, PlanNodeStatsEstimate> calculateStatsForPlan(Session session, Map<Symbol, Type> types, PlanNode node);
-
-    default PlanNodeStatsEstimate calculateStatsForNode(Session session, Map<Symbol, Type> types, PlanNode node)
-    {
-        return calculateStatsForPlan(session, types, node).get(node.getId());
-    }
+    /**
+     * Calculate stats for the {@code node}.
+     *
+     * @param node The node to compute stats for.
+     * @param sourceStats The stats provider for any child nodes' stats, if needed to compute stats for the {@code node}
+     * @param lookup Lookup to be used when resolving source nodes, allowing stats calculation to work within {@link IterativeOptimizer}
+     */
+    PlanNodeStatsEstimate calculateStats(
+            PlanNode node,
+            StatsProvider sourceStats,
+            Lookup lookup,
+            Session session,
+            Map<Symbol, Type> types);
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+public interface StatsProvider
+{
+    PlanNodeStatsEstimate getStats(PlanNode node);
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -18,7 +18,6 @@ import com.facebook.presto.OutputBuffers.OutputBufferId;
 import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.connector.ConnectorId;
-import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.scheduler.ExecutionPolicy;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
@@ -133,7 +132,6 @@ public final class SqlQueryExecution
 
     private final QueryExplainer queryExplainer;
     private final PlanFlattener planFlattener;
-    private final StatsCalculator statsCalculator;
     private final AtomicReference<SqlQueryScheduler> queryScheduler = new AtomicReference<>();
     private final AtomicReference<Plan> queryPlan = new AtomicReference<>();
     private final NodeTaskMap nodeTaskMap;
@@ -153,7 +151,6 @@ public final class SqlQueryExecution
             SplitManager splitManager,
             NodePartitioningManager nodePartitioningManager,
             NodeScheduler nodeScheduler,
-            StatsCalculator statsCalculator,
             List<PlanOptimizer> planOptimizers,
             RemoteTaskFactory remoteTaskFactory,
             LocationFactory locationFactory,
@@ -176,7 +173,6 @@ public final class SqlQueryExecution
             this.splitManager = requireNonNull(splitManager, "splitManager is null");
             this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
             this.nodeScheduler = requireNonNull(nodeScheduler, "nodeScheduler is null");
-            this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
             this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null");
             this.locationFactory = requireNonNull(locationFactory, "locationFactory is null");
             this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
@@ -364,7 +360,7 @@ public final class SqlQueryExecution
 
         // plan query
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
-        LogicalPlanner logicalPlanner = new LogicalPlanner(stateMachine.getSession(), planOptimizers, idAllocator, metadata, sqlParser, statsCalculator);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(stateMachine.getSession(), planOptimizers, idAllocator, metadata, sqlParser);
         Plan plan = logicalPlanner.plan(analysis);
         queryPlan.set(plan);
 
@@ -632,7 +628,6 @@ public final class SqlQueryExecution
         private final SplitManager splitManager;
         private final NodePartitioningManager nodePartitioningManager;
         private final NodeScheduler nodeScheduler;
-        private final StatsCalculator statsCalculator;
         private final List<PlanOptimizer> planOptimizers;
         private final RemoteTaskFactory remoteTaskFactory;
         private final TransactionManager transactionManager;
@@ -655,7 +650,6 @@ public final class SqlQueryExecution
                 SplitManager splitManager,
                 NodePartitioningManager nodePartitioningManager,
                 NodeScheduler nodeScheduler,
-                StatsCalculator statsCalculator,
                 PlanOptimizers planOptimizers,
                 RemoteTaskFactory remoteTaskFactory,
                 TransactionManager transactionManager,
@@ -690,7 +684,6 @@ public final class SqlQueryExecution
             this.planFlattener = requireNonNull(planFlattener, "planFlattener is null");
 
             this.executionPolicies = requireNonNull(executionPolicies, "schedulerPolicies is null");
-            this.statsCalculator = requireNonNull(statsCalculator, "cost calculator is null");
             this.planOptimizers = planOptimizers.get();
         }
 
@@ -714,7 +707,6 @@ public final class SqlQueryExecution
                     splitManager,
                     nodePartitioningManager,
                     nodeScheduler,
-                    statsCalculator,
                     planOptimizers,
                     remoteTaskFactory,
                     locationFactory,

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -150,7 +150,7 @@ public class QueryExplainer
         PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
 
         // plan statement
-        LogicalPlanner logicalPlanner = new LogicalPlanner(session, planOptimizers, idAllocator, metadata, sqlParser, statsCalculator);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(session, planOptimizers, idAllocator, metadata, sqlParser);
         return logicalPlanner.plan(analysis);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -15,8 +15,6 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
-import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.NewTableLayout;
 import com.facebook.presto.metadata.QualifiedObjectName;
@@ -39,7 +37,6 @@ import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
@@ -93,28 +90,24 @@ public class LogicalPlanner
     private final SymbolAllocator symbolAllocator = new SymbolAllocator();
     private final Metadata metadata;
     private final SqlParser sqlParser;
-    private final StatsCalculator statsCalculator;
 
     public LogicalPlanner(Session session,
             List<PlanOptimizer> planOptimizers,
             PlanNodeIdAllocator idAllocator,
             Metadata metadata,
-            SqlParser sqlParser,
-            StatsCalculator statsCalculator)
+            SqlParser sqlParser)
     {
         requireNonNull(session, "session is null");
         requireNonNull(planOptimizers, "planOptimizers is null");
         requireNonNull(idAllocator, "idAllocator is null");
         requireNonNull(metadata, "metadata is null");
         requireNonNull(sqlParser, "sqlParser is null");
-        requireNonNull(statsCalculator, "statsCalculator is null");
 
         this.session = session;
         this.planOptimizers = planOptimizers;
         this.idAllocator = idAllocator;
         this.metadata = metadata;
         this.sqlParser = sqlParser;
-        this.statsCalculator = statsCalculator;
     }
 
     public Plan plan(Analysis analysis)
@@ -140,9 +133,7 @@ public class LogicalPlanner
             PlanSanityChecker.validateFinalPlan(root, session, metadata, sqlParser, symbolAllocator.getTypes());
         }
 
-        Map<PlanNodeId, PlanNodeStatsEstimate> planNodeStats = statsCalculator.calculateStatsForPlan(session, symbolAllocator.getTypes(), root);
-
-        return new Plan(root, symbolAllocator.getTypes(), planNodeStats);
+        return new Plan(root, symbolAllocator.getTypes());
     }
 
     public PlanNode planStatement(Analysis analysis, Statement statement)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Plan.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Plan.java
@@ -13,10 +13,8 @@
  */
 package com.facebook.presto.sql.planner;
 
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -27,17 +25,14 @@ public class Plan
 {
     private final PlanNode root;
     private final Map<Symbol, Type> types;
-    private final Map<PlanNodeId, PlanNodeStatsEstimate> planNodeStats;
 
-    public Plan(PlanNode root, Map<Symbol, Type> types, Map<PlanNodeId, PlanNodeStatsEstimate> planNodeStats)
+    public Plan(PlanNode root, Map<Symbol, Type> types)
     {
         requireNonNull(root, "root is null");
         requireNonNull(types, "types is null");
-        requireNonNull(planNodeStats, "planNodeStats is null");
 
         this.root = root;
         this.types = ImmutableMap.copyOf(types);
-        this.planNodeStats = planNodeStats;
     }
 
     public PlanNode getRoot()
@@ -48,10 +43,5 @@ public class Plan
     public Map<Symbol, Type> getTypes()
     {
         return types;
-    }
-
-    public Map<PlanNodeId, PlanNodeStatsEstimate> getPlanNodeStats()
-    {
-        return planNodeStats;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Memo.java
@@ -147,9 +147,7 @@ public class Memo
             checkState(childGroup.incomingReferences.remove(fromGroup), "Reference to remove not found");
 
             if (childGroup.incomingReferences.isEmpty()) {
-                PlanNode child = childGroup.membership;
                 deleteGroup(group);
-                decrementReferenceCounts(child, group);
             }
         }
     }
@@ -164,7 +162,9 @@ public class Memo
 
     private void deleteGroup(int group)
     {
-        groups.remove(group);
+        checkArgument(getGroup(group).incomingReferences.isEmpty(), "Cannot delete group that has incoming references");
+        PlanNode deletedNode = groups.remove(group).membership;
+        decrementReferenceCounts(deletedNode, group);
     }
 
     private PlanNode insertChildrenAndRewrite(PlanNode node)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/Rule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
@@ -47,6 +48,8 @@ public interface Rule<T>
         SymbolAllocator getSymbolAllocator();
 
         Session getSession();
+
+        StatsProvider getStatsProvider();
     }
 
     final class Result

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -744,7 +744,7 @@ public class LocalQueryRunner
         FeaturesConfig featuresConfig = new FeaturesConfig()
                 .setDistributedIndexJoinsEnabled(false)
                 .setOptimizeHashGeneration(true);
-        return new PlanOptimizers(metadata, sqlParser, featuresConfig, forceSingleNode, new MBeanExporter(new TestingMBeanServer())).get();
+        return new PlanOptimizers(metadata, sqlParser, featuresConfig, forceSingleNode, new MBeanExporter(new TestingMBeanServer()), statsCalculator).get();
     }
 
     public Plan createPlan(Session session, @Language("SQL") String sql, List<PlanOptimizer> optimizers)
@@ -777,7 +777,7 @@ public class LocalQueryRunner
                 dataDefinitionTask);
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.of(queryExplainer), parameters);
 
-        LogicalPlanner logicalPlanner = new LogicalPlanner(session, optimizers, idAllocator, metadata, sqlParser, statsCalculator);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(session, optimizers, idAllocator, metadata, sqlParser);
 
         Analysis analysis = analyzer.analyze(statement);
         return logicalPlanner.plan(analysis, stage);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
@@ -18,7 +18,6 @@ import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
-import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.UnaliasSymbolReferences;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.google.common.collect.ImmutableList;
@@ -26,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
@@ -42,10 +40,6 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 public class TestCanonicalize
         extends BasePlanTest
 {
-    private static final List<PlanOptimizer> OPTIMIZERS = ImmutableList.of(
-            new UnaliasSymbolReferences(),
-            new IterativeOptimizer(new StatsRecorder(), ImmutableSet.of(new RemoveRedundantIdentityProjections())));
-
     @Test
     public void testJoin()
     {
@@ -80,6 +74,11 @@ public class TestCanonicalize
                                         .specification(specification)
                                         .addFunction(functionCall("row_number", Optional.empty(), ImmutableList.of())),
                                 values("A"))),
-                OPTIMIZERS);
+                ImmutableList.of(
+                        new UnaliasSymbolReferences(),
+                        new IterativeOptimizer(
+                                new StatsRecorder(),
+                                getQueryRunner().getStatsCalculator(),
+                                ImmutableSet.of(new RemoveRedundantIdentityProjections()))));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
@@ -56,7 +56,7 @@ public class AggregationMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         AggregationNode aggregationNode = (AggregationNode) node;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AliasMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AliasMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -52,7 +52,7 @@ public class AliasMatcher
      *    higher up the tree.
      */
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         Optional<Symbol> symbol = matcher.getAssignedSymbol(node, session, metadata, symbolAliases);
         if (symbol.isPresent() && alias.isPresent()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
@@ -125,7 +125,10 @@ public class BasePlanTest
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(),
                 new PruneUnreferencedOutputs(),
-                new IterativeOptimizer(new StatsRecorder(), ImmutableSet.of(new RemoveRedundantIdentityProjections())));
+                new IterativeOptimizer(
+                        new StatsRecorder(),
+                        queryRunner.getStatsCalculator(),
+                        ImmutableSet.of(new RemoveRedundantIdentityProjections())));
 
         assertPlan(sql, LogicalPlanner.Stage.OPTIMIZED, pattern, optimizers);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BaseStrictSymbolsMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BaseStrictSymbolsMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -48,7 +48,7 @@ public abstract class BaseStrictSymbolsMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         return new MatchResult(getActual.apply(node).equals(getExpectedSymbols(node, session, metadata, symbolAliases)));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CorrelationMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/CorrelationMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
@@ -46,7 +46,7 @@ public class CorrelationMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(
                 shapeMatches(node),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExchangeMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExchangeMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -46,7 +46,7 @@ final class ExchangeMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/FilterMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/FilterMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -41,7 +41,7 @@ final class FilterMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/GroupIdMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/GroupIdMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
@@ -49,7 +49,7 @@ public class GroupIdMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/IndexSourceMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/IndexSourceMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableMetadata;
 import com.facebook.presto.spi.predicate.Domain;
@@ -57,7 +57,7 @@ final class IndexSourceMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate planNodeStatsEstimate, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.JoinNode.DistributionType;
@@ -60,7 +60,7 @@ final class JoinMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/LimitMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/LimitMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -43,7 +43,7 @@ public class LimitMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node));
         return MatchResult.match();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/MarkDistinctMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/MarkDistinctMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -52,7 +52,7 @@ public class MarkDistinctMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         MarkDistinctNode markDistinctNode = (MarkDistinctNode) node;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/Matcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/Matcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
@@ -63,11 +63,11 @@ public interface Matcher
      * node if shapeMatches didn't return true for the same node.
      *
      * @param node The node to apply the matching tests to
-     * @param stats The computed stats of plan node
+     * @param stats Provider of stats for
      * @param session The session information for the query
      * @param metadata The metadata for the query
      * @param symbolAliases The SymbolAliases containing aliases from the nodes sources
      * @return a MatchResult with information about the success of the match
      */
-    MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases);
+    MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases);
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/NotPlanNodeMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/NotPlanNodeMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
@@ -40,7 +40,7 @@ final class NotPlanNodeMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         return match();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OutputMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OutputMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -45,7 +45,7 @@ public class OutputMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         int i = 0;
         for (String alias : aliases) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanAssert.java
@@ -14,12 +14,15 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.cost.CachingStatsProvider;
 import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
+import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
 import static com.facebook.presto.sql.planner.iterative.Plans.resolveGroupReferences;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textLogicalPlan;
 import static java.lang.String.format;
@@ -30,12 +33,13 @@ public final class PlanAssert
 
     public static void assertPlan(Session session, Metadata metadata, StatsCalculator statsCalculator, Plan actual, PlanMatchPattern pattern)
     {
-        assertPlan(session, metadata, statsCalculator, actual, Lookup.noLookup(), pattern);
+        assertPlan(session, metadata, statsCalculator, actual, noLookup(), pattern);
     }
 
     public static void assertPlan(Session session, Metadata metadata, StatsCalculator statsCalculator, Plan actual, Lookup lookup, PlanMatchPattern pattern)
     {
-        MatchResult matches = actual.getRoot().accept(new PlanMatchingVisitor(session, metadata, actual.getPlanNodeStats(), lookup), pattern);
+        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, actual.getTypes());
+        MatchResult matches = actual.getRoot().accept(new PlanMatchingVisitor(session, metadata, statsProvider, lookup), pattern);
         if (!matches.isMatch()) {
             String formattedPlan = textLogicalPlan(actual.getRoot(), actual.getTypes(), metadata, statsCalculator, session);
             PlanNode resolvedPlan = resolveGroupReferences(actual.getRoot(), lookup);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.predicate.Domain;
@@ -461,7 +462,7 @@ public final class PlanMatchPattern
         return states.build();
     }
 
-    MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         SymbolAliases.Builder newAliases = SymbolAliases.builder();
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingVisitor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingVisitor.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
@@ -22,12 +22,10 @@ import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 
 import java.util.List;
-import java.util.Map;
 
 import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
@@ -40,14 +38,14 @@ final class PlanMatchingVisitor
 {
     private final Metadata metadata;
     private final Session session;
-    private final Map<PlanNodeId, PlanNodeStatsEstimate> planStats;
+    private final StatsProvider statsProvider;
     private final Lookup lookup;
 
-    PlanMatchingVisitor(Session session, Metadata metadata, Map<PlanNodeId, PlanNodeStatsEstimate> planStats, Lookup lookup)
+    PlanMatchingVisitor(Session session, Metadata metadata, StatsProvider statsProvider, Lookup lookup)
     {
         this.session = requireNonNull(session, "session is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.planStats = requireNonNull(planStats, "planStats is null");
+        this.statsProvider = requireNonNull(statsProvider, "statsProvider is null");
         this.lookup = requireNonNull(lookup, "lookup is null");
     }
 
@@ -123,7 +121,7 @@ final class PlanMatchingVisitor
 
             // Try upMatching this node with the the aliases gathered from the source nodes.
             SymbolAliases allSourceAliases = sourcesMatch.getAliases();
-            MatchResult matchResult = pattern.detailMatches(node, planStats.get(node.getId()), session, metadata, allSourceAliases);
+            MatchResult matchResult = pattern.detailMatches(node, statsProvider, session, metadata, allSourceAliases);
             if (matchResult.isMatch()) {
                 checkState(result == NO_MATCH, format("Ambiguous match on node %s", node));
                 result = match(allSourceAliases.withNewAliases(matchResult.getAliases()));
@@ -148,7 +146,7 @@ final class PlanMatchingVisitor
                  * 2) Collect the aliases from the source nodes so we can add them to
                  *    SymbolAliases. They'll be needed further up.
                  */
-            MatchResult matchResult = pattern.detailMatches(node, planStats.get(node.getId()), session, metadata, new SymbolAliases());
+            MatchResult matchResult = pattern.detailMatches(node, statsProvider, session, metadata, new SymbolAliases());
             if (matchResult.isMatch()) {
                 checkState(result == NO_MATCH, format("Ambiguous match on leaf node %s", node));
                 result = matchResult;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanNodeMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanNodeMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
@@ -40,7 +40,7 @@ final class PlanNodeMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         return match();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanStatsMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanStatsMatcher.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
@@ -37,9 +38,9 @@ public class PlanStatsMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
-        return new MatchResult(expectedStats.equals(stats));
+        return new MatchResult(expectedStats.equals(stats.getStats(node)));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SemiJoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SemiJoinMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
@@ -46,7 +46,7 @@ final class SemiJoinMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolCardinalityMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolCardinalityMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
@@ -37,7 +37,7 @@ final class SymbolCardinalityMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         return new MatchResult(node.getOutputSymbols().size() == numberOfSymbols);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TableScanMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TableScanMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableMetadata;
 import com.facebook.presto.spi.predicate.Domain;
@@ -57,7 +57,7 @@ final class TableScanMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TableWriterMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TableWriterMatcher.java
@@ -15,7 +15,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -48,7 +48,7 @@ public class TableWriterMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate planNodeStatsEstimate, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TopNMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TopNMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.sql.planner.Symbol;
@@ -52,7 +52,7 @@ public class TopNMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate planNodeStatsEstimate, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         TopNNode topNNode = (TopNNode) node;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ValuesMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ValuesMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
@@ -57,7 +57,7 @@ public class ValuesMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
         ValuesNode valuesNode = (ValuesNode) node;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.block.SortOrder;
@@ -66,7 +66,7 @@ public final class WindowMatcher
     }
 
     @Override
-    public MatchResult detailMatches(PlanNode node, PlanNodeStatsEstimate stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestIterativeOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestIterativeOptimizer.java
@@ -69,7 +69,10 @@ public class TestIterativeOptimizer
     @Test(timeOut = 1000)
     public void optimizerTimeoutsOnNonConvergingPlan()
     {
-        PlanOptimizer optimizer = new IterativeOptimizer(new StatsRecorder(), ImmutableSet.of(new NonConvergingRule()));
+        PlanOptimizer optimizer = new IterativeOptimizer(
+                new StatsRecorder(),
+                queryRunner.getStatsCalculator(),
+                ImmutableSet.of(new NonConvergingRule()));
 
         try {
             queryRunner.inTransaction(transactionSession -> {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.testng.Assert.assertEquals;
 
 public class TestMemo
@@ -55,6 +56,29 @@ public class TestMemo
         memo.replace(getChildGroup(memo, memo.getRootGroup()), transformed, "rule");
         assertEquals(memo.getGroupCount(), 3);
         assertMatchesStructure(memo.extract(), node(plan.getId(), transformed));
+    }
+
+    /*
+      From: X -> Y  -> Z
+      To:   X -> Y' -> Z
+     */
+    @Test
+    public void testReplaceNode()
+    {
+        PlanNode z = node();
+        PlanNode y = node(z);
+        PlanNode x = node(y);
+
+        Memo memo = new Memo(idAllocator, x);
+        assertEquals(memo.getGroupCount(), 3);
+
+        // replace child of root node with another node, retaining child's child
+        int yGroup = getChildGroup(memo, memo.getRootGroup());
+        GroupReference zRef = (GroupReference) getOnlyElement(memo.getNode(yGroup).getSources());
+        PlanNode transformed = node(zRef);
+        memo.replace(yGroup, transformed, "rule");
+        assertEquals(memo.getGroupCount(), 3);
+        assertMatchesStructure(memo.extract(), node(x.getId(), node(transformed.getId(), z)));
     }
 
     /*

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -90,7 +90,10 @@ public class TestEliminateSorts
                 new UnaliasSymbolReferences(),
                 new AddExchanges(getQueryRunner().getMetadata(), new SqlParser()),
                 new PruneUnreferencedOutputs(),
-                new IterativeOptimizer(new StatsRecorder(), ImmutableSet.of(new RemoveRedundantIdentityProjections())));
+                new IterativeOptimizer(
+                        new StatsRecorder(),
+                        getQueryRunner().getStatsCalculator(),
+                        ImmutableSet.of(new RemoveRedundantIdentityProjections())));
 
         assertPlan(sql, pattern, optimizers);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
@@ -556,6 +556,7 @@ public class TestMergeWindows
                 new UnaliasSymbolReferences(),
                 new IterativeOptimizer(
                         new StatsRecorder(),
+                        getQueryRunner().getStatsCalculator(),
                         ImmutableSet.<Rule<?>>builder()
                                 .add(new RemoveRedundantIdentityProjections())
                                 .addAll(GatherAndMergeWindows.rules())

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMixedDistinctAggregationOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMixedDistinctAggregationOptimizer.java
@@ -112,7 +112,10 @@ public class TestMixedDistinctAggregationOptimizer
     {
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(),
-                new IterativeOptimizer(new StatsRecorder(), ImmutableSet.of(new RemoveRedundantIdentityProjections())),
+                new IterativeOptimizer(
+                        new StatsRecorder(),
+                        getQueryRunner().getStatsCalculator(),
+                        ImmutableSet.of(new RemoveRedundantIdentityProjections())),
                 new OptimizeMixedDistinctAggregations(getQueryRunner().getMetadata()),
                 new PruneUnreferencedOutputs());
         assertPlan(sql, pattern, optimizers);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
@@ -297,7 +297,9 @@ public class TestReorderWindows
     {
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(),
-                new IterativeOptimizer(new StatsRecorder(),
+                new IterativeOptimizer(
+                        new StatsRecorder(),
+                        getQueryRunner().getStatsCalculator(),
                         ImmutableSet.of(
                                 new RemoveRedundantIdentityProjections(),
                                 new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSetFlatteningOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestSetFlatteningOptimizer.java
@@ -128,7 +128,10 @@ public class TestSetFlatteningOptimizer
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(),
                 new PruneUnreferencedOutputs(),
-                new IterativeOptimizer(new StatsRecorder(), ImmutableSet.of(new RemoveRedundantIdentityProjections())),
+                new IterativeOptimizer(
+                        new StatsRecorder(),
+                        getQueryRunner().getStatsCalculator(),
+                        ImmutableSet.of(new RemoveRedundantIdentityProjections())),
                 new SetFlatteningOptimizer());
         assertPlan(sql, pattern, optimizers);
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -302,7 +302,13 @@ public abstract class AbstractTestQueryFramework
         Metadata metadata = queryRunner.getMetadata();
         FeaturesConfig featuresConfig = new FeaturesConfig().setOptimizeHashGeneration(true);
         boolean forceSingleNode = queryRunner.getNodeCount() == 1;
-        List<PlanOptimizer> optimizers = new PlanOptimizers(metadata, sqlParser, featuresConfig, forceSingleNode, new MBeanExporter(new TestingMBeanServer())).get();
+        List<PlanOptimizer> optimizers = new PlanOptimizers(
+                metadata,
+                sqlParser,
+                featuresConfig,
+                forceSingleNode,
+                new MBeanExporter(new TestingMBeanServer()),
+                queryRunner.getStatsCalculator()).get();
         return new QueryExplainer(
                 optimizers,
                 metadata,

--- a/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/statistics/MetricComparator.java
@@ -37,10 +37,9 @@ public final class MetricComparator
 {
     private MetricComparator() {}
 
-    public static List<MetricComparison> createMetricComparisons(Plan queryPlan, StageInfo outputStageInfo)
+    public static List<MetricComparison> createMetricComparisons(Plan queryPlan, Map<PlanNodeId, PlanNodeStatsEstimate> estimates, StageInfo outputStageInfo)
     {
         return Stream.of(Metric.values()).flatMap(metric -> {
-            Map<PlanNodeId, PlanNodeStatsEstimate> estimates = queryPlan.getPlanNodeStats();
             Map<PlanNodeId, PlanNodeStatsEstimate> actuals = extractActualStats(outputStageInfo);
             return estimates.entrySet().stream().map(entry -> {
                 // todo refactor to stay in PlanNodeId domain ????


### PR DESCRIPTION
This introduces support for on-demand Stats calculation in Rules, keeping calculated stats in Memo.

Initial commits (`Reorder fields to match constructor arguments`, `Remove Filter above TableScan logic from CoefficientBasedStatsCalculator`, `Use doubles instead Estimates in PlanNodeStatsEstimate`) were already reviewed in https://github.com/prestodb/presto/pull/9812, https://github.com/prestodb/presto/pull/9831.