### PR TITLE
Remove LocalExchangeMemoryManager#setNoBlockOnFull

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
@@ -245,7 +245,6 @@ public class LocalExchange
         }
 
         sources.forEach(LocalExchangeSource::finish);
-        memoryManager.setNoBlockOnFull();
     }
 
     private static void checkNotHoldsLock(Object lock)


### PR DESCRIPTION
This methods is not needed as pages are drained
from LocalExchangeSink in LocalExchangeSource#close.
This causes LocalExchangeMemoryManager#notFullFuture
to unblock.