### PR TITLE
Fix peak memory in query details UI

### DIFF
--- a/presto-main/src/main/resources/webapp/assets/query.js
+++ b/presto-main/src/main/resources/webapp/assets/query.js
@@ -1205,7 +1205,7 @@ let QueryDetail = React.createClass({
                                                 Peak Memory
                                             </td>
                                             <td className="info-text">
-                                                { query.queryStats.peakMemoryReservation }
+                                                { query.queryStats.peakUserMemoryReservation }
                                             </td>
                                         </tr>
                                         <tr>


### PR DESCRIPTION
The name of this field changed in the QueryStats json causing it to be empty
in the query details UI.