### PR TITLE
Fix deadlock in QueryContext::setMemoryPool

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -243,6 +243,16 @@ public class MemoryPool
         return reservedRevocableBytes;
     }
 
+    synchronized long getQueryUserMemoryReservation(QueryId queryId)
+    {
+        return queryMemoryReservations.getOrDefault(queryId, 0L);
+    }
+
+    synchronized long getQueryRevocableMemoryReservation(QueryId queryId)
+    {
+        return queryMemoryRevocableReservations.getOrDefault(queryId, 0L);
+    }
+
     @Override
     public synchronized String toString()
     {


### PR DESCRIPTION
    Previously when setMemoryPool is called while an operator is allocating memory
    it's possible that these two threads deadlock as they acquire the monitors in
    different orders. The thread calling setMemoryPool was acquiring the monitor of
    the QueryContext instance/this first and then the monitor of the user/revocable
    memory contexts in the queryMemoryContext. However, the driver threads reserving memory
    were acquiring the monitors of the user/revocable memory contexts first, and
    then the monitor of the QueryContext instance.

    This change solve the issue by preventing locking of the user/revocable memory contexts
    in the queryMemoryContext by getting the same information from the MemoryPool.