### PR TITLE
Fix planning performance regression for tables with many partitions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -261,7 +261,7 @@ public class PlanOptimizers
                 new IterativeOptimizer(
                         stats,
                         statsCalculator,
-                        new PickTableLayout(metadata).rules()),
+                        new PickTableLayout(metadata, sqlParser).rules()),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(
                         stats,
@@ -303,7 +303,7 @@ public class PlanOptimizers
                 new IterativeOptimizer(
                         stats,
                         statsCalculator,
-                        new PickTableLayout(metadata).rules()),
+                        new PickTableLayout(metadata, sqlParser).rules()),
                 projectionPushDown);
 
         if (featuresConfig.isOptimizeSingleDistinct()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ConstraintEvaluator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ConstraintEvaluator.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.predicate.NullableValue;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.ExpressionInterpreter;
+import com.facebook.presto.sql.planner.LookupSymbolResolver;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolsExtractor;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.sql.tree.NullLiteral;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static java.util.Collections.emptyList;
+
+public class ConstraintEvaluator
+{
+    private final Session session;
+    private final Metadata metadata;
+    private final Map<NodeRef<Expression>, Type> expressionTypes;
+    private final List<Expression> conjuncts;
+
+    public ConstraintEvaluator(Session session, Metadata metadata, SqlParser parser, Map<Symbol, Type> types, Expression expression)
+    {
+        this.session = session;
+        this.metadata = metadata;
+
+        expressionTypes = getExpressionTypes(session, metadata, parser, types, expression, emptyList());
+        conjuncts = extractConjuncts(expression);
+    }
+
+    public boolean shouldPrune(Map<Symbol, ColumnHandle> assignments, Map<ColumnHandle, NullableValue> bindings, List<Symbol> correlations)
+    {
+        LookupSymbolResolver inputs = new LookupSymbolResolver(assignments, bindings);
+
+        // If any conjuncts evaluate to FALSE or null, then the whole predicate will never be true and so the partition should be pruned
+        for (Expression expression : conjuncts) {
+            if (SymbolsExtractor.extractUnique(expression).stream().anyMatch(correlations::contains)) {
+                // expression contains correlated symbol with outer query
+                continue;
+            }
+            ExpressionInterpreter optimizer = ExpressionInterpreter.expressionOptimizer(expression, metadata, session, expressionTypes);
+            Object optimized = optimizer.optimize(inputs);
+            if (Boolean.FALSE.equals(optimized) || optimized == null || optimized instanceof NullLiteral) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/BasePickTableLayoutTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/BasePickTableLayoutTest.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.TableLayoutHandle;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.testing.TestingTransactionHandle;
@@ -56,7 +57,7 @@ public abstract class BasePickTableLayoutTest
     @BeforeMethod
     public void setUpPerMethod()
     {
-        pickTableLayout = new PickTableLayout(tester().getMetadata());
+        pickTableLayout = new PickTableLayout(tester().getMetadata(), new SqlParser());
 
         connectorId = tester().getCurrentConnectorId();
         nationTableHandle = new TableHandle(


### PR DESCRIPTION
This fixes a performance regression due to a recent change to make
PickTableLayout run before AddExchanges (e6d963b1b32d3c5388a8f92ed4f04153b5570983).

For queries containing complex expression over partition keys, PickTableLayout was
not using this information when asking the connector for a layout. If a Hive
table has many partitions (several thousand), this causes the TableScan node to
contain a "current constraint" that enumerates all the possible values of the key.

Later, when AddExchanges.planTableScan executes, it builds an expression out of the
current constraint and any additional filters, which the Hive connector uses to prune
uninteresting partitions. Due to historical reasons, evaluating that expression can be
very expensive. It requires analyzing the expression, doing type inference, finding
function implementations, etc.

This change adds the ability for PickTableLayout to evaluate the full constraint in the
same manner AddExchanges used to do. Assuming the number of candidate partitions is small,
the resulting "current constraint" is smaller and cheaper to evaluate when AddExchanges
runs.