### PR TITLE
Support lambda function for regex replacement

### DIFF
--- a/presto-docs/src/main/sphinx/functions/regexp.rst
+++ b/presto-docs/src/main/sphinx/functions/regexp.rst
@@ -99,6 +99,16 @@ with a few notable exceptions:
 
         SELECT regexp_replace('1a 2b 14m', '(\d+)([ab]) ', '3c$2 '); -- '3ca 3cb 14m'
 
+.. function:: regexp_replace(string, pattern, function) -> varchar
+
+    Replaces every instance of the substring matched by the regular expression
+    ``pattern`` in ``string`` using ``function``. The :doc:`lambda expression <lambda>`
+    ``function`` is invoked for each match with the `capturing groups`_ passed as an
+    array. Capturing group numbers start at one; there is no group for the entire match
+    (if you need this, surround the entire expression with parenthesis). ::
+
+        SELECT regexp_replace('new york', '(\w)(\w*)', x -> upper(x[1]) || lower(x[2])); --'New York'
+
 .. function:: regexp_split(string, pattern) -> array<varchar>
 
     Splits ``string`` using the regular expression ``pattern`` and returns an

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -91,6 +91,7 @@ import com.facebook.presto.operator.scalar.FailureFunction;
 import com.facebook.presto.operator.scalar.HyperLogLogFunctions;
 import com.facebook.presto.operator.scalar.JoniRegexpCasts;
 import com.facebook.presto.operator.scalar.JoniRegexpFunctions;
+import com.facebook.presto.operator.scalar.JoniRegexpReplaceLambdaFunction;
 import com.facebook.presto.operator.scalar.JsonFunctions;
 import com.facebook.presto.operator.scalar.JsonOperators;
 import com.facebook.presto.operator.scalar.MapCardinalityFunction;
@@ -105,6 +106,7 @@ import com.facebook.presto.operator.scalar.MapToMapCast;
 import com.facebook.presto.operator.scalar.MapValues;
 import com.facebook.presto.operator.scalar.MathFunctions;
 import com.facebook.presto.operator.scalar.Re2JRegexpFunctions;
+import com.facebook.presto.operator.scalar.Re2JRegexpReplaceLambdaFunction;
 import com.facebook.presto.operator.scalar.RepeatFunction;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.operator.scalar.SequenceFunction;
@@ -585,9 +587,11 @@ public class FunctionRegistry
         switch (featuresConfig.getRegexLibrary()) {
             case JONI:
                 builder.scalars(JoniRegexpFunctions.class);
+                builder.scalar(JoniRegexpReplaceLambdaFunction.class);
                 break;
             case RE2J:
                 builder.scalars(Re2JRegexpFunctions.class);
+                builder.scalar(Re2JRegexpReplaceLambdaFunction.class);
                 break;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpReplaceLambdaFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpReplaceLambdaFunction.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.LiteralParameters;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.sql.gen.lambda.UnaryFunctionInterface;
+import com.facebook.presto.type.JoniRegexpType;
+import com.google.common.collect.ImmutableList;
+import io.airlift.joni.Matcher;
+import io.airlift.joni.Option;
+import io.airlift.joni.Regex;
+import io.airlift.joni.Region;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+@ScalarFunction("regexp_replace")
+@Description("replaces substrings matching a regular expression using a lambda function")
+public final class JoniRegexpReplaceLambdaFunction
+{
+    private final PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(VARCHAR));
+
+    @LiteralParameters("x")
+    @SqlType("varchar")
+    @SqlNullable
+    public Slice regexpReplace(
+            @SqlType("varchar") Slice source,
+            @SqlType(JoniRegexpType.NAME) Regex pattern,
+            @SqlType("function(array(varchar), varchar(x))") UnaryFunctionInterface replaceFunction)
+    {
+        // If there is no match we can simply return the original source without doing copy.
+        Matcher matcher = pattern.matcher(source.getBytes());
+        if (matcher.search(0, source.length(), Option.DEFAULT) == -1) {
+            return source;
+        }
+
+        SliceOutput output = new DynamicSliceOutput(source.length());
+
+        // Prepare a BlockBuilder that will be used to create the target block
+        // that will be passed to the lambda function.
+        if (pageBuilder.isFull()) {
+            pageBuilder.reset();
+        }
+        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+
+        int groupCount = pattern.numberOfCaptures();
+        int appendPosition = 0;
+        int nextStart = 0;
+
+        do {
+            // nextStart is the same as the last appendPosition, unless the last match was zero-width.
+            // In such case, nextStart is last appendPosition + 1.
+            if (matcher.getEnd() == matcher.getBegin()) {
+                nextStart = matcher.getEnd() + 1;
+            }
+            else {
+                nextStart = matcher.getEnd();
+            }
+
+            // Append the un-matched part
+            Slice unmatched = source.slice(appendPosition, matcher.getBegin() - appendPosition);
+            appendPosition = matcher.getEnd();
+            output.appendBytes(unmatched);
+
+            // Append the capturing groups to the target block that will be passed to lambda
+            Region matchedRegion = matcher.getEagerRegion();
+            for (int i = 1; i <= groupCount; i++) {
+                // Add to the block builder if the matched region is not null. In Joni null is represented as [-1, -1]
+                if (matchedRegion.beg[i] >= 0 && matchedRegion.end[i] >= 0) {
+                    VARCHAR.writeSlice(blockBuilder, source, matchedRegion.beg[i], matchedRegion.end[i] - matchedRegion.beg[i]);
+                }
+                else {
+                    blockBuilder.appendNull();
+                }
+            }
+            pageBuilder.declarePositions(groupCount);
+            Block target = blockBuilder.getRegion(blockBuilder.getPositionCount() - groupCount, groupCount);
+
+            // Call the lambda function to replace the block, and append the result to output
+            Slice replaced = (Slice) replaceFunction.apply(target);
+            if (replaced == null) {
+                // replacing a substring with null (unknown) makes the entire string null
+                return null;
+            }
+            output.appendBytes(replaced);
+        }
+        while (matcher.search(nextStart, source.length(), Option.DEFAULT) != -1);
+
+        // Append the last un-matched part
+        output.writeBytes(source, appendPosition, source.length() - appendPosition);
+        return output.slice();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/Re2JRegexpReplaceLambdaFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/Re2JRegexpReplaceLambdaFunction.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.LiteralParameters;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.sql.gen.lambda.UnaryFunctionInterface;
+import com.facebook.presto.type.Re2JRegexp;
+import com.facebook.presto.type.Re2JRegexpType;
+import com.google.common.collect.ImmutableList;
+import com.google.re2j.Matcher;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+@ScalarFunction("regexp_replace")
+@Description("replaces substrings matching a regular expression using a lambda function")
+public final class Re2JRegexpReplaceLambdaFunction
+{
+    private final PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(VARCHAR));
+
+    @LiteralParameters("x")
+    @SqlType("varchar")
+    @SqlNullable
+    public Slice regexpReplace(
+            @SqlType("varchar") Slice source,
+            @SqlType(Re2JRegexpType.NAME) Re2JRegexp pattern,
+            @SqlType("function(array(varchar), varchar(x))") UnaryFunctionInterface replaceFunction)
+    {
+        // If there is no match we can simply return the original source without doing copy.
+        Matcher matcher = pattern.re2jPattern.matcher(source);
+        if (!matcher.find()) {
+            return source;
+        }
+
+        SliceOutput output = new DynamicSliceOutput(source.length());
+
+        // Prepare a BlockBuilder that will be used to create the target block
+        // that will be passed to the lambda function.
+        if (pageBuilder.isFull()) {
+            pageBuilder.reset();
+        }
+        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+
+        int groupCount = matcher.groupCount();
+        int appendPosition = 0;
+
+        do {
+            int start = matcher.start();
+            int end = matcher.end();
+
+            // Append the un-matched part
+            if (appendPosition < start) {
+                output.writeBytes(source, appendPosition, start - appendPosition);
+            }
+            appendPosition = end;
+
+            // Append the capturing groups to the target block that will be passed to lambda
+            for (int i = 1; i <= groupCount; i++) {
+                Slice matchedGroupSlice = matcher.group(i);
+                if (matchedGroupSlice != null) {
+                    VARCHAR.writeSlice(blockBuilder, matchedGroupSlice);
+                }
+                else {
+                    blockBuilder.appendNull();
+                }
+            }
+            pageBuilder.declarePositions(groupCount);
+            Block target = blockBuilder.getRegion(blockBuilder.getPositionCount() - groupCount, groupCount);
+
+            // Call the lambda function to replace the block, and append the result to output
+            Slice replaced = (Slice) replaceFunction.apply(target);
+            if (replaced == null) {
+                // replacing a substring with null (unknown) makes the entire string null
+                return null;
+            }
+            output.appendBytes(replaced);
+        }
+        while (matcher.find());
+
+        // Append the rest of un-matched
+        output.writeBytes(source, appendPosition, source.length() - appendPosition);
+        return output.slice();
+    }
+}


### PR DESCRIPTION
There are some uses cases of string manipulation that can be efficiently supported if regexp_replace can take a lamdba function to define the replacement. The lambda function will take an array of match groups. For example, INITCAP in Oracle could be written as regexp_replace(string, '(\w)(\w*)', x -> upper(x[1]) || lower(x[2]))

Update:
The document description for this new regexp_replace() function is put into regexp.rst. The function is still named as regexp_replace().

When lambda returns null, the whole replace string becomes null. This is because in SQL the null represents "not known". If we replace a matched group with unknown value, the whole result becomes unknown. The current presto regexp_replace follows the same way:
select REGEXP_REPLACE('abc', 'b', null);
Result is null.

The first capturing group(the entire match) for each match is not passed to lambda. There are two main reasons for this decision:
  1) performance considerations: Since the entire match can always be passed if the user uses () for the whole pattern, we don't need to pass the whole match when it's not necessary. Passing it always incurs extra cost.
 2) To follow the current numbering convention in existing regexp_replace function: $1 represents the first match, $2 the second. E.g.
    SELECT regexp_replace('1a 2b 14m', '(\d+)([ab]) ', '3c$2 '); -- '3ca 3cb 14m'
So the INITCAP example would be regexp_replace('new york', '(\w)(\w*)', x -> upper(x[1]) || lower(x[2])) = 'New York'

https://github.com/prestodb/presto/issues/9772