### PR TITLE
Create distributed plans in BenchmarkPlanner

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/BenchmarkPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/BenchmarkPlanner.java
@@ -116,7 +116,7 @@ public class BenchmarkPlanner
         return benchmarkData.queryRunner.inTransaction(transactionSession -> {
             LogicalPlanner.Stage stage = LogicalPlanner.Stage.valueOf(benchmarkData.stage.toUpperCase());
             return benchmarkData.queries.stream()
-                    .map(query -> benchmarkData.queryRunner.createPlan(transactionSession, query, stage))
+                    .map(query -> benchmarkData.queryRunner.createPlan(transactionSession, query, stage, false))
                     .collect(toImmutableList());
         });
     }


### PR DESCRIPTION
`BenchmarkPlanner` runs both iterative optimizer enabled and disabled.
Without iterative optimizer, and with `forceSingleNode=true`, the
created plan is invalid and eventually fails.

This disables `forceSingleNode` so that we always produce a plan without
failure.