### PR TITLE
Make TPCH to support predicate pushdown form PART.container and type and apply Layout Constarint.predicate

### DIFF
--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -89,12 +89,11 @@ public class TpchMetadata
 
     public static final String ROW_NUMBER_COLUMN_NAME = "row_number";
 
-    private static final Set<String> ORDER_STATUS_VALUES = ImmutableSet.of("F", "O", "P");
-    private static final Set<Slice> ORDER_STATUS_VALUES_SLICES = ORDER_STATUS_VALUES.stream()
+    private static final Set<Slice> ORDER_STATUS_VALUES = ImmutableSet.of("F", "O", "P").stream()
             .map(Slices::utf8Slice)
             .collect(toImmutableSet());
     private static final Set<NullableValue> ORDER_STATUS_NULLABLE_VALUES = ORDER_STATUS_VALUES.stream()
-            .map(value -> new NullableValue(getPrestoType(OrderColumn.ORDER_STATUS), Slices.utf8Slice(value)))
+            .map(value -> new NullableValue(getPrestoType(OrderColumn.ORDER_STATUS), value))
             .collect(toSet());
 
     private final String connectorId;
@@ -295,7 +294,7 @@ public class TpchMetadata
             Map<ColumnHandle, Domain> domains = constraintSummary.getDomains().get();
             Optional<Domain> orderStatusDomain = Optional.ofNullable(domains.get(toColumnHandle(ORDER_STATUS)));
             Optional<Map<TpchColumn<?>, List<Object>>> allowedColumnValues = orderStatusDomain.map(domain -> {
-                List<Object> allowedValues = ORDER_STATUS_VALUES_SLICES.stream()
+                List<Object> allowedValues = ORDER_STATUS_VALUES.stream()
                         .filter(domain::includesNullableValue)
                         .collect(toList());
                 return avoidTrivialOrderStatusRestriction(allowedValues);
@@ -306,7 +305,7 @@ public class TpchMetadata
 
     private Map<TpchColumn<?>, List<Object>> avoidTrivialOrderStatusRestriction(List<Object> allowedValues)
     {
-        if (allowedValues.containsAll(ORDER_STATUS_VALUES_SLICES)) {
+        if (allowedValues.containsAll(ORDER_STATUS_VALUES)) {
             return emptyMap();
         }
         else {

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -233,6 +233,7 @@ public class TpchMetadata
     {
         return nullableValues.stream()
                 .filter(convertToPredicate(constraint.getSummary(), column))
+                .filter(value -> constraint.predicate().test(ImmutableMap.of(toColumnHandle(column), value)))
                 .collect(toSet());
     }
 

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchRecordSet.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchRecordSet.java
@@ -211,6 +211,10 @@ public class TpchRecordSet<E extends TpchEntity>
             if (predicate.isAll()) {
                 return true;
             }
+            if (predicate.isNone()) {
+                return false;
+            }
+
             Map<ColumnHandle, NullableValue> rowMap = predicate.getDomains().get().keySet().stream()
                     .collect(toImmutableMap(
                             column -> column,


### PR DESCRIPTION
This is based on https://github.com/prestodb/presto/pull/9823.

The aim is to provide coverage for `AddExchanges` for tables with multiple partitions so in future we could avoid regressions in planner. See related fix https://github.com/prestodb/presto/pull/9879.

Now TPCH connector support predicate pushdown for PART container (40 values) and type (150 values). #9879 is about case where table has thousands of partitions, here we have only 40 +150, but anyway it was possible to see the impact in `BenchmarkPlanner` where with this change applied:

```
Currently:
Benchmark                     Mode  Cnt     Score    Error  Units
BenchmarkPlanner.planQueries  avgt   20  2987.712 ± 89.916  ms/op

With PictTableLayout commented out from PlanOptimizers:
Benchmark                     Mode  Cnt    Score    Error  Units
BenchmarkPlanner.planQueries  avgt   20  634.585 ± 22.911  ms/op

With https://github.com/prestodb/presto/pull/9879:
Benchmark                     Mode  Cnt    Score    Error  Units
BenchmarkPlanner.planQueries  avgt   20  893.612 ± 35.967  ms/op
```

Notice that `BenchmarkPlanner` is not focused only to test the case of partition pruning. It could be seen as general planner impact.