### PR TITLE
Remove reorder_joins parameter from benchmarks

### DIFF
--- a/presto-benchto-benchmarks/src/main/resources/benchmarks/presto/tpcds.yaml
+++ b/presto-benchto-benchmarks/src/main/resources/benchmarks/presto/tpcds.yaml
@@ -2,7 +2,7 @@ datasource: presto
 query-names: presto/tpcds/${query}.sql
 runs: 6
 prewarm-runs: 2
-before-execution: sleep-4s, presto/session_set_reorder_joins.sql
+before-execution: sleep-4s
 frequency: 7
 database: hive
 tpcds_small: tpcds_10gb_orc
@@ -12,22 +12,9 @@ variables:
   1:
     query: q01,q06,q14_1,q39_1,q39_2,q47,q57,q67,q81
     schema: ${tpcds_small}
-    reorder_joins: true, false
   2:
-    query: q02,q03,q04,q05,q07,q09,q10,q11,q13,q14_2,q16,q17,q19,q22,q23_1,q23_2,q24_1,q24_2,q25,q28,q29,q30,q31,q32,q33,q35,q37,q38,q42,q43,q44,q46,q48,q49,q50,q51,q52,q53,q54,q55,q56,q58,q59,q60,q61,q63,q65,q66,q68,q69,q70,q71,q72,q74,q75,q77,q78,q80,q82,q88,q89,q94,q95
+    query: q02,q04,q05,q07,q09,q10,q11,q13,q14_2,q16,q17,q18,q19,q22,q23_1,q23_2,q24_1,q24_2,q25,q28,q29,q30,q31,q32,q33,q35,q38,q44,q46,q48,q49,q50,q51,q54,q55,q56,q58,q59,q60,q61,q63,q64,q65,q66,q68,q69,q70,q71,q72,q74,q75,q77,q78,q80,q82,q88,q89,q94,q95
     schema: ${tpcds_medium}
-    reorder_joins: true, false
   3:
-    # query not passing quick enough without reordering
-    query: q18,q64
-    schema: ${tpcds_medium}
-    reorder_joins: true
-  4:
-    query: q08,q12,q15,q20,q21,q26,q27,q34,q36,q40,q41,q45,q62,q73,q76,q79,q83,q84,q85,q86,q87,q90,q91,q92,q93,q96,q97,q98,q99
+    query: q03,q08,q12,q15,q20,q21,q26,q27,q34,q36,q37,q40,q41,q42,q43,q45,q52,q53,q62,q73,q76,q79,q83,q84,q85,q86,q87,q90,q91,q92,q93,q96,q97,q98,q99
     schema: ${tpcds_large}
-    reorder_joins: true, false
-  5:
-    # extra runs with reordering on 1tb schema (too slow without reordering on 1tb). For 100g we keep both runs, with and without reordering
-    query: q03,q37,q42,q43,q52,q53
-    schema: ${tpcds_large}
-    reorder_joins: true

--- a/presto-benchto-benchmarks/src/main/resources/benchmarks/presto/tpch.yaml
+++ b/presto-benchto-benchmarks/src/main/resources/benchmarks/presto/tpch.yaml
@@ -2,40 +2,17 @@ datasource: presto
 query-names: presto/tpch/${query}.sql
 runs: 6
 prewarm-runs: 2
-before-execution: sleep-4s, presto/session_set_reorder_joins.sql
+before-execution: sleep-4s
 frequency: 7
 database: hive
-tpch_small: tpch_10gb_orc
 tpch_medium: tpch_100gb_orc
 tpch_large: tpch_1tb_orc
 prefix: ""
 variables:
   1:
-    # queries too slow to run on 100gb without reordering
-    query: q2, q8, q9
-    schema: ${tpch_small}
-    reorder_joins: true, false
+    query: q3, q4, q5, q7, q8, q9, q17, q18, q21
+    schema: ${tpch_medium}
   2:
-    # queries too slow to run on 100gb without reordering
-    query: q8, q9
-    schema: ${tpch_medium}
-    reorder_joins: true
-  3:
-    # queries too slow to run on 100gb without reordering
-    query: q2
+    query: q1, q2, q6, q10, q11, q12, q13, q14, q15, q16, q19, q20, q22
     schema: ${tpch_large}
-    reorder_joins: true
-  4:
-    # queries too slow to run on 1tb
-    query: q3, q4, q5, q7, q17, q18, q21
-    schema: ${tpch_medium}
-    reorder_joins: true, false
-  5:
-    query: q10, q11, q12, q13, q14, q15, q16, q19, q20, q22
-    schema: ${tpch_large}
-    reorder_joins: true, false
-  6:
-    # queries without joins
-    query: q1, q6
-    schema: ${tpch_large}
-    reorder_joins: false
+

--- a/presto-benchto-benchmarks/src/main/resources/sql/presto/session_set_reorder_joins.sql
+++ b/presto-benchto-benchmarks/src/main/resources/sql/presto/session_set_reorder_joins.sql
@@ -1,1 +1,0 @@
-SET SESSION reorder_joins='${reorder_joins}'


### PR DESCRIPTION
reorder_joins is not true by default, therefore
it doesn't makes sense to benchmark legacy
reorder_joins=false setting.