### PR TITLE
Limit the number of values for min/max n functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxNAggregationFunction.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.operator.aggregation.AggregationUtils.generate
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Failures.checkCondition;
 import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Math.toIntExact;
@@ -54,6 +55,7 @@ public abstract class AbstractMinMaxNAggregationFunction
     private static final MethodHandle INPUT_FUNCTION = methodHandle(AbstractMinMaxNAggregationFunction.class, "input", BlockComparator.class, Type.class, MinMaxNState.class, Block.class, long.class, int.class);
     private static final MethodHandle COMBINE_FUNCTION = methodHandle(AbstractMinMaxNAggregationFunction.class, "combine", MinMaxNState.class, MinMaxNState.class);
     private static final MethodHandle OUTPUT_FUNCTION = methodHandle(AbstractMinMaxNAggregationFunction.class, "output", ArrayType.class, MinMaxNState.class, BlockBuilder.class);
+    private static final long MAX_NUMBER_OF_VALUES = 10_000;
 
     private final Function<Type, BlockComparator> typeToComparator;
 
@@ -113,6 +115,7 @@ public abstract class AbstractMinMaxNAggregationFunction
             if (n <= 0) {
                 throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "second argument of max_n/min_n must be positive");
             }
+            checkCondition(n <= MAX_NUMBER_OF_VALUES, INVALID_FUNCTION_ARGUMENT, "second argument of max_n/min_n must be less than or equal to %s; found %s", MAX_NUMBER_OF_VALUES, n);
             heap = new TypedHeap(comparator, type, toIntExact(n));
             state.setTypedHeap(heap);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayMaxNAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayMaxNAggregation.java
@@ -94,6 +94,7 @@ public class TestArrayMaxNAggregation
         testCustomAggregation(new Long[] {1L, 2L, null, 3L}, 5);
         testInvalidAggregation(new Long[] {1L, 2L, 3L}, 0);
         testInvalidAggregation(new Long[] {1L, 2L, 3L}, -1);
+        testInvalidAggregation(new Long[] {1L, 2L, 3L}, 10001);
     }
 
     private void testInvalidAggregation(Long[] x, int n)

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongMaxNAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongMaxNAggregation.java
@@ -68,6 +68,7 @@ public class TestLongMaxNAggregation
         testCustomAggregation(new Long[] {1L, 2L, null, 3L}, 5);
         testInvalidAggregation(new Long[] {1L, 2L, 3L}, 0);
         testInvalidAggregation(new Long[] {1L, 2L, 3L}, -1);
+        testInvalidAggregation(new Long[] {1L, 2L, 3L}, 10001);
     }
 
     private void testInvalidAggregation(Long[] x, int n)


### PR DESCRIPTION
min_n/max_n or min_by_n/max_by_n functions do not check the value of n
before creating the corresponding heaps for the states. This led to
production failure due to OOM when n is big enough. This patch enforces
n to be no greater than 10000.