### PR TITLE
Use actual query elapsed time in HTTP backoff

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -80,6 +80,7 @@ import static io.airlift.http.client.StatusResponseHandler.createStatusResponseH
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -88,6 +89,7 @@ public final class HttpPageBufferClient
         implements Closeable
 {
     private static final Logger log = Logger.get(HttpPageBufferClient.class);
+    private static final Duration ZERO_EXECUTION_ELAPSED_TIME = new Duration(0, MILLISECONDS);
 
     /**
      * For each request, the addPage method will be called zero or more times,
@@ -175,7 +177,9 @@ public final class HttpPageBufferClient
         requireNonNull(minErrorDuration, "minErrorDuration is null");
         requireNonNull(maxErrorDuration, "maxErrorDuration is null");
         requireNonNull(ticker, "ticker is null");
-        this.backoff = new Backoff(minErrorDuration, maxErrorDuration, ticker);
+        // The exchange buffer is typically on another machine, so calculating elapsed time requires some form of
+        // clock synchronization.  For now, we just assume there is no elapsed time.
+        this.backoff = new Backoff(ZERO_EXECUTION_ELAPSED_TIME, minErrorDuration, maxErrorDuration, ticker);
     }
 
     public synchronized PageBufferClientStatus getStatus()

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpPageBufferClient.java
@@ -80,7 +80,6 @@ import static io.airlift.http.client.StatusResponseHandler.createStatusResponseH
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -176,15 +175,7 @@ public final class HttpPageBufferClient
         requireNonNull(minErrorDuration, "minErrorDuration is null");
         requireNonNull(maxErrorDuration, "maxErrorDuration is null");
         requireNonNull(ticker, "ticker is null");
-        this.backoff = new Backoff(
-                minErrorDuration,
-                maxErrorDuration,
-                ticker,
-                new Duration(0, MILLISECONDS),
-                new Duration(50, MILLISECONDS),
-                new Duration(100, MILLISECONDS),
-                new Duration(200, MILLISECONDS),
-                new Duration(500, MILLISECONDS));
+        this.backoff = new Backoff(minErrorDuration, maxErrorDuration, ticker);
     }
 
     public synchronized PageBufferClientStatus getStatus()

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/Backoff.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/Backoff.java
@@ -49,19 +49,20 @@ public class Backoff
     private long lastFailureTime;
     private long failureCount;
 
-    public Backoff(Duration minFailureInterval, Duration maxFailureInterval)
+    public Backoff(Duration executionElapsedTime, Duration minFailureInterval, Duration maxFailureInterval)
     {
-        this(minFailureInterval, maxFailureInterval, Ticker.systemTicker(), DEFAULT_BACKOFF_DELAY_INTERVALS);
+        this(executionElapsedTime, minFailureInterval, maxFailureInterval, Ticker.systemTicker());
     }
 
-    public Backoff(Duration minFailureInterval, Duration maxFailureInterval, Ticker ticker)
+    public Backoff(Duration executionElapsedTime, Duration minFailureInterval, Duration maxFailureInterval, Ticker ticker)
     {
-        this(minFailureInterval, maxFailureInterval, ticker, DEFAULT_BACKOFF_DELAY_INTERVALS);
+        this(executionElapsedTime, minFailureInterval, maxFailureInterval, ticker, DEFAULT_BACKOFF_DELAY_INTERVALS);
     }
 
     @VisibleForTesting
-    public Backoff(Duration minFailureInterval, Duration maxFailureInterval, Ticker ticker, List<Duration> backoffDelayIntervals)
+    public Backoff(Duration executionElapsedTime, Duration minFailureInterval, Duration maxFailureInterval, Ticker ticker, List<Duration> backoffDelayIntervals)
     {
+        requireNonNull(executionElapsedTime, "executionElapsedTime is null");
         requireNonNull(minFailureInterval, "minFailureInterval is null");
         requireNonNull(maxFailureInterval, "maxFailureInterval is null");
         requireNonNull(ticker, "ticker is null");
@@ -78,7 +79,7 @@ public class Backoff
 
         this.lastSuccessTime = this.ticker.read();
         this.firstRequestAfterSuccessTime = Long.MIN_VALUE;
-        this.createTime = this.ticker.read();
+        this.createTime = ticker.read() - executionElapsedTime.roundTo(NANOSECONDS);
     }
 
     public synchronized long getFailureCount()

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -81,9 +81,7 @@ class ContinuousTaskStatusFetcher
             JsonCodec<TaskStatus> taskStatusCodec,
             Executor executor,
             HttpClient httpClient,
-            Duration executionElapsedTime,
-            Duration minErrorDuration,
-            Duration maxErrorDuration,
+            Backoff backoff,
             ScheduledExecutorService errorScheduledExecutor,
             RemoteTaskStats stats)
     {
@@ -99,14 +97,7 @@ class ContinuousTaskStatusFetcher
         this.executor = requireNonNull(executor, "executor is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
 
-        this.errorTracker = new RequestErrorTracker(
-                taskId,
-                initialTaskStatus.getSelf(),
-                executionElapsedTime,
-                minErrorDuration,
-                maxErrorDuration,
-                errorScheduledExecutor,
-                "getting task status");
+        this.errorTracker = new RequestErrorTracker(taskId, initialTaskStatus.getSelf(), backoff, errorScheduledExecutor, "getting task status");
         this.stats = requireNonNull(stats, "stats is null");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -81,6 +81,7 @@ class ContinuousTaskStatusFetcher
             JsonCodec<TaskStatus> taskStatusCodec,
             Executor executor,
             HttpClient httpClient,
+            Duration executionElapsedTime,
             Duration minErrorDuration,
             Duration maxErrorDuration,
             ScheduledExecutorService errorScheduledExecutor,
@@ -98,7 +99,14 @@ class ContinuousTaskStatusFetcher
         this.executor = requireNonNull(executor, "executor is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
 
-        this.errorTracker = new RequestErrorTracker(taskId, initialTaskStatus.getSelf(), minErrorDuration, maxErrorDuration, errorScheduledExecutor, "getting task status");
+        this.errorTracker = new RequestErrorTracker(
+                taskId,
+                initialTaskStatus.getSelf(),
+                executionElapsedTime,
+                minErrorDuration,
+                maxErrorDuration,
+                errorScheduledExecutor,
+                "getting task status");
         this.stats = requireNonNull(stats, "stats is null");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -98,7 +98,7 @@ public final class HttpRemoteTask
         implements RemoteTask
 {
     private static final Logger log = Logger.get(HttpRemoteTask.class);
-    private static final Duration MAX_CLEANUP_RETRY_TIME = new Duration(2, TimeUnit.MINUTES);
+    private static final Duration MAX_CLEANUP_RETRY_TIME = new Duration(10, TimeUnit.MINUTES);
     private static final int MIN_RETRIES = 3;
 
     private final TaskId taskId;

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -656,9 +656,8 @@ public final class HttpRemoteTask
             @Override
             public void onFailure(Throwable t)
             {
-                if (t instanceof RejectedExecutionException) {
-                    // TODO: we should only give up retrying when the client has been shutdown
-                    logError(t, "Unable to %s task at %s. Got RejectedExecutionException.", action, request.getUri());
+                if (t instanceof RejectedExecutionException && httpClient.isClosed()) {
+                    logError(t, "Unable to %s task at %s. HTTP client is closed.", action, request.getUri());
                     cleanUpLocally();
                     return;
                 }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -204,9 +204,7 @@ public final class HttpRemoteTask
             this.updateErrorTracker = new RequestErrorTracker(
                     taskId,
                     location,
-                    getQueryElapsedTime(),
-                    minErrorDuration,
-                    maxErrorDuration,
+                    new Backoff(getQueryElapsedTime(), minErrorDuration, maxErrorDuration),
                     errorScheduledExecutor,
                     "updating task");
             this.partitionedSplitCountTracker = requireNonNull(partitionedSplitCountTracker, "partitionedSplitCountTracker is null");
@@ -235,9 +233,7 @@ public final class HttpRemoteTask
                     taskStatusCodec,
                     executor,
                     httpClient,
-                    getQueryElapsedTime(),
-                    minErrorDuration,
-                    maxErrorDuration,
+                    new Backoff(getQueryElapsedTime(), minErrorDuration, maxErrorDuration),
                     errorScheduledExecutor,
                     stats);
 
@@ -247,9 +243,7 @@ public final class HttpRemoteTask
                     httpClient,
                     taskInfoUpdateInterval,
                     taskInfoCodec,
-                    getQueryElapsedTime(),
-                    minErrorDuration,
-                    maxErrorDuration,
+                    new Backoff(getQueryElapsedTime(), minErrorDuration, maxErrorDuration),
                     summarizeTaskInfo,
                     executor,
                     updateScheduledExecutor,

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/RequestErrorTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/RequestErrorTracker.java
@@ -58,12 +58,19 @@ class RequestErrorTracker
 
     private final Queue<Throwable> errorsSinceLastSuccess = new ConcurrentLinkedQueue<>();
 
-    public RequestErrorTracker(TaskId taskId, URI taskUri, Duration minErrorDuration, Duration maxErrorDuration, ScheduledExecutorService scheduledExecutor, String jobDescription)
+    public RequestErrorTracker(
+            TaskId taskId,
+            URI taskUri,
+            Duration executionElapsedTime,
+            Duration minErrorDuration,
+            Duration maxErrorDuration,
+            ScheduledExecutorService scheduledExecutor,
+            String jobDescription)
     {
         this.taskId = taskId;
         this.taskUri = taskUri;
         this.scheduledExecutor = scheduledExecutor;
-        this.backoff = new Backoff(minErrorDuration, maxErrorDuration);
+        this.backoff = new Backoff(executionElapsedTime, minErrorDuration, maxErrorDuration);
         this.jobDescription = jobDescription;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/RequestErrorTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/RequestErrorTracker.java
@@ -22,7 +22,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
 import io.airlift.event.client.ServiceUnavailableException;
 import io.airlift.log.Logger;
-import io.airlift.units.Duration;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -42,6 +41,7 @@ import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
 import static com.facebook.presto.util.Failures.WORKER_NODE_ERROR;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -61,17 +61,15 @@ class RequestErrorTracker
     public RequestErrorTracker(
             TaskId taskId,
             URI taskUri,
-            Duration executionElapsedTime,
-            Duration minErrorDuration,
-            Duration maxErrorDuration,
+            Backoff backoff,
             ScheduledExecutorService scheduledExecutor,
             String jobDescription)
     {
-        this.taskId = taskId;
-        this.taskUri = taskUri;
-        this.scheduledExecutor = scheduledExecutor;
-        this.backoff = new Backoff(executionElapsedTime, minErrorDuration, maxErrorDuration);
-        this.jobDescription = jobDescription;
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.taskUri = requireNonNull(taskUri, "taskUri is null");
+        this.scheduledExecutor = requireNonNull(scheduledExecutor, "scheduledExecutor is null");
+        this.backoff = requireNonNull(backoff, "backoff is null");
+        this.jobDescription = requireNonNull(jobDescription, "jobDescription is null");
     }
 
     public ListenableFuture<?> acquireRequestPermit()

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
@@ -83,9 +83,7 @@ public class TaskInfoFetcher
             HttpClient httpClient,
             Duration updateInterval,
             JsonCodec<TaskInfo> taskInfoCodec,
-            Duration executionElapsedTime,
-            Duration minErrorDuration,
-            Duration maxErrorDuration,
+            Backoff backoff,
             boolean summarizeTaskInfo,
             Executor executor,
             ScheduledExecutorService updateScheduledExecutor,
@@ -93,9 +91,6 @@ public class TaskInfoFetcher
             RemoteTaskStats stats)
     {
         requireNonNull(initialTask, "initialTask is null");
-        requireNonNull(executionElapsedTime, "executionElapsedTime is null");
-        requireNonNull(minErrorDuration, "minErrorDuration is null");
-        requireNonNull(maxErrorDuration, "maxErrorDuration is null");
         requireNonNull(errorScheduledExecutor, "errorScheduledExecutor is null");
 
         this.taskId = initialTask.getTaskStatus().getTaskId();
@@ -105,14 +100,7 @@ public class TaskInfoFetcher
 
         this.updateIntervalMillis = requireNonNull(updateInterval, "updateInterval is null").toMillis();
         this.updateScheduledExecutor = requireNonNull(updateScheduledExecutor, "updateScheduledExecutor is null");
-        this.errorTracker = new RequestErrorTracker(
-                taskId,
-                initialTask.getTaskStatus().getSelf(),
-                executionElapsedTime,
-                minErrorDuration,
-                maxErrorDuration,
-                errorScheduledExecutor,
-                "getting info for task");
+        this.errorTracker = new RequestErrorTracker(taskId, initialTask.getTaskStatus().getSelf(), backoff, errorScheduledExecutor, "getting info for task");
 
         this.summarizeTaskInfo = summarizeTaskInfo;
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
@@ -83,6 +83,7 @@ public class TaskInfoFetcher
             HttpClient httpClient,
             Duration updateInterval,
             JsonCodec<TaskInfo> taskInfoCodec,
+            Duration executionElapsedTime,
             Duration minErrorDuration,
             Duration maxErrorDuration,
             boolean summarizeTaskInfo,
@@ -92,7 +93,9 @@ public class TaskInfoFetcher
             RemoteTaskStats stats)
     {
         requireNonNull(initialTask, "initialTask is null");
+        requireNonNull(executionElapsedTime, "executionElapsedTime is null");
         requireNonNull(minErrorDuration, "minErrorDuration is null");
+        requireNonNull(maxErrorDuration, "maxErrorDuration is null");
         requireNonNull(errorScheduledExecutor, "errorScheduledExecutor is null");
 
         this.taskId = initialTask.getTaskStatus().getTaskId();
@@ -102,7 +105,14 @@ public class TaskInfoFetcher
 
         this.updateIntervalMillis = requireNonNull(updateInterval, "updateInterval is null").toMillis();
         this.updateScheduledExecutor = requireNonNull(updateScheduledExecutor, "updateScheduledExecutor is null");
-        this.errorTracker = new RequestErrorTracker(taskId, initialTask.getTaskStatus().getSelf(), minErrorDuration, maxErrorDuration, errorScheduledExecutor, "getting info for task");
+        this.errorTracker = new RequestErrorTracker(
+                taskId,
+                initialTask.getTaskStatus().getSelf(),
+                executionElapsedTime,
+                minErrorDuration,
+                maxErrorDuration,
+                errorScheduledExecutor,
+                "getting info for task");
 
         this.summarizeTaskInfo = summarizeTaskInfo;
 

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestBackoff.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestBackoff.java
@@ -28,11 +28,13 @@ import static org.testng.Assert.assertTrue;
 
 public class TestBackoff
 {
+    private static final Duration ZERO_ELAPSED_TIME = new Duration(0, MILLISECONDS);
+
     @Test
     public void testFailureInterval()
     {
         TestingTicker ticker = new TestingTicker();
-        Backoff backoff = new Backoff(new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(new Duration(10, MILLISECONDS)));
+        Backoff backoff = new Backoff(ZERO_ELAPSED_TIME, new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(new Duration(10, MILLISECONDS)));
         ticker.increment(10, MICROSECONDS);
 
         assertEquals(backoff.getFailureCount(), 0);
@@ -55,7 +57,7 @@ public class TestBackoff
     public void testStartRequest()
     {
         TestingTicker ticker = new TestingTicker();
-        Backoff backoff = new Backoff(new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(new Duration(10, MILLISECONDS)));
+        Backoff backoff = new Backoff(ZERO_ELAPSED_TIME, new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(new Duration(10, MILLISECONDS)));
         ticker.increment(10, MICROSECONDS);
 
         assertEquals(backoff.getFailureCount(), 0);
@@ -80,7 +82,7 @@ public class TestBackoff
     public void testMaxFailureInterval()
     {
         TestingTicker ticker = new TestingTicker();
-        Backoff backoff = new Backoff(new Duration(5, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(new Duration(10, MILLISECONDS)));
+        Backoff backoff = new Backoff(ZERO_ELAPSED_TIME, new Duration(5, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(new Duration(10, MILLISECONDS)));
         ticker.increment(10, MICROSECONDS);
         ticker.increment(6, SECONDS);
 
@@ -118,7 +120,7 @@ public class TestBackoff
     {
         // 1, 2, 4, 8
         TestingTicker ticker = new TestingTicker();
-        Backoff backoff = new Backoff(new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(
+        Backoff backoff = new Backoff(ZERO_ELAPSED_TIME, new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(
                 new Duration(0, SECONDS),
                 new Duration(1, SECONDS),
                 new Duration(2, SECONDS),

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestBackoff.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestBackoff.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server.remotetask;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.testing.TestingTicker;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
@@ -31,7 +32,7 @@ public class TestBackoff
     public void testFailureInterval()
     {
         TestingTicker ticker = new TestingTicker();
-        Backoff backoff = new Backoff(new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, new Duration(10, MILLISECONDS));
+        Backoff backoff = new Backoff(new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(new Duration(10, MILLISECONDS)));
         ticker.increment(10, MICROSECONDS);
 
         assertEquals(backoff.getFailureCount(), 0);
@@ -54,7 +55,7 @@ public class TestBackoff
     public void testStartRequest()
     {
         TestingTicker ticker = new TestingTicker();
-        Backoff backoff = new Backoff(new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, new Duration(10, MILLISECONDS));
+        Backoff backoff = new Backoff(new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(new Duration(10, MILLISECONDS)));
         ticker.increment(10, MICROSECONDS);
 
         assertEquals(backoff.getFailureCount(), 0);
@@ -79,7 +80,7 @@ public class TestBackoff
     public void testMaxFailureInterval()
     {
         TestingTicker ticker = new TestingTicker();
-        Backoff backoff = new Backoff(new Duration(5, SECONDS), new Duration(15, SECONDS), ticker, new Duration(10, MILLISECONDS));
+        Backoff backoff = new Backoff(new Duration(5, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(new Duration(10, MILLISECONDS)));
         ticker.increment(10, MICROSECONDS);
         ticker.increment(6, SECONDS);
 
@@ -117,12 +118,12 @@ public class TestBackoff
     {
         // 1, 2, 4, 8
         TestingTicker ticker = new TestingTicker();
-        Backoff backoff = new Backoff(new Duration(15, SECONDS), new Duration(15, SECONDS), ticker,
+        Backoff backoff = new Backoff(new Duration(15, SECONDS), new Duration(15, SECONDS), ticker, ImmutableList.of(
                 new Duration(0, SECONDS),
                 new Duration(1, SECONDS),
                 new Duration(2, SECONDS),
                 new Duration(4, SECONDS),
-                new Duration(8, SECONDS));
+                new Duration(8, SECONDS)));
 
         assertEquals(backoff.getFailureCount(), 0);
         assertEquals(backoff.getTimeSinceLastSuccess().roundTo(SECONDS), 0);

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -71,6 +71,7 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.OutputBuffers.createInitialEmptyOutputBuffers;
@@ -156,15 +157,16 @@ public class TestHttpRemoteTask
 
         httpRemoteTaskFactory.stop();
         assertTrue(remoteTask.getTaskStatus().getState().isDone(), format("TaskStatus is not in a done state: %s", remoteTask.getTaskStatus()));
-        assertTrue(remoteTask.getTaskInfo().getTaskStatus().getState().isDone(), format("TaskInfo is not in a done state: %s", remoteTask.getTaskInfo()));
 
         ErrorCode actualErrorCode = getOnlyElement(remoteTask.getTaskStatus().getFailures()).getErrorCode();
         switch (testCase) {
             case TASK_MISMATCH:
             case TASK_MISMATCH_WHEN_VERSION_IS_HIGH:
+                assertTrue(remoteTask.getTaskInfo().getTaskStatus().getState().isDone(), format("TaskInfo is not in a done state: %s", remoteTask.getTaskInfo()));
                 assertEquals(actualErrorCode, REMOTE_TASK_MISMATCH.toErrorCode());
                 break;
             case REJECTED_EXECUTION:
+                // for a rejection to occur, the http client must be shutdown, which means we will not be able to ge the final task info
                 assertEquals(actualErrorCode, REMOTE_TASK_ERROR.toErrorCode());
                 break;
             default:
@@ -203,6 +205,7 @@ public class TestHttpRemoteTask
                     {
                         JaxrsTestingHttpProcessor jaxrsTestingHttpProcessor = new JaxrsTestingHttpProcessor(URI.create("http://fake.invalid/"), testingTaskResource, jsonMapper);
                         TestingHttpClient testingHttpClient = new TestingHttpClient(jaxrsTestingHttpProcessor.setTrace(TRACE_HTTP));
+                        testingTaskResource.setHttpClient(testingHttpClient);
                         return new HttpRemoteTaskFactory(
                                 new QueryManagerConfig(),
                                 TASK_MANAGER_CONFIG,
@@ -268,6 +271,8 @@ public class TestHttpRemoteTask
         private final AtomicLong lastActivityNanos;
         private final TestCase testCase;
 
+        private AtomicReference<TestingHttpClient> httpClient = new AtomicReference<>();
+
         private TaskInfo initialTaskInfo;
         private TaskStatus initialTaskStatus;
         private long version;
@@ -280,6 +285,11 @@ public class TestHttpRemoteTask
         {
             this.lastActivityNanos = requireNonNull(lastActivityNanos, "lastActivityNanos is null");
             this.testCase = requireNonNull(testCase, "testCase is null");
+        }
+
+        public void setHttpClient(TestingHttpClient newValue)
+        {
+            httpClient.set(newValue);
         }
 
         @GET
@@ -384,6 +394,7 @@ public class TestHttpRemoteTask
                     break;
                 case REJECTED_EXECUTION:
                     if (statusFetchCounter >= 10) {
+                        httpClient.get().close();
                         throw new RejectedExecutionException();
                     }
                     break;


### PR DESCRIPTION
The backoff calculation in HTTP requests uses a sliding scale based on how
long the execution has been running, but the execution time was calculated
incorrectly. Not the execution time is based on query start time.