### PR TITLE
Add support for trace token in Thrift connector

### DIFF
--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.connector.thrift;
 
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceTokenHandler;
 import com.facebook.presto.connector.thrift.util.RebindSafeMBeanServer;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.connector.Connector;
@@ -23,6 +24,7 @@ import com.facebook.swift.codec.guice.ThriftCodecModule;
 import com.facebook.swift.service.guice.ThriftClientModule;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
 import org.weakref.jmx.guice.MBeanModule;
 
@@ -39,11 +41,13 @@ public class ThriftConnectorFactory
 {
     private final String name;
     private final Module locationModule;
+    private final Class<? extends ThriftTraceTokenHandler> traceTokenHandler;
 
-    public ThriftConnectorFactory(String name, Module locationModule)
+    public ThriftConnectorFactory(String name, Module locationModule, Class<? extends ThriftTraceTokenHandler> traceTokenHandler)
     {
         this.name = requireNonNull(name, "name is null");
         this.locationModule = requireNonNull(locationModule, "locationModule is null");
+        this.traceTokenHandler = requireNonNull(traceTokenHandler, "traceTokenHandler is null");
     }
 
     @Override
@@ -69,6 +73,7 @@ public class ThriftConnectorFactory
                     binder -> {
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(getPlatformMBeanServer()));
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(ThriftTraceTokenHandler.class).to(traceTokenHandler).in(Scopes.SINGLETON);
                     },
                     locationModule,
                     new ThriftModule(connectorId));

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorIndex.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorIndex.java
@@ -14,12 +14,14 @@
 package com.facebook.presto.connector.thrift;
 
 import com.facebook.presto.connector.thrift.clientproviders.PrestoThriftServiceProvider;
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceToken;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorIndex;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.RecordSet;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -34,6 +36,7 @@ public class ThriftConnectorIndex
     private final long maxBytesPerResponse;
     private final int lookupRequestsConcurrency;
     private final ThriftConnectorStats stats;
+    private final Optional<ThriftTraceToken> traceToken;
 
     public ThriftConnectorIndex(
             PrestoThriftServiceProvider clientProvider,
@@ -42,7 +45,8 @@ public class ThriftConnectorIndex
             List<ColumnHandle> lookupColumns,
             List<ColumnHandle> outputColumns,
             long maxBytesPerResponse,
-            int lookupRequestsConcurrency)
+            int lookupRequestsConcurrency,
+            Optional<ThriftTraceToken> traceToken)
     {
         this.clientProvider = requireNonNull(clientProvider, "clientProvider is null");
         this.stats = requireNonNull(stats, "stats is null");
@@ -51,12 +55,13 @@ public class ThriftConnectorIndex
         this.outputColumns = requireNonNull(outputColumns, "outputColumns is null");
         this.maxBytesPerResponse = maxBytesPerResponse;
         this.lookupRequestsConcurrency = lookupRequestsConcurrency;
+        this.traceToken = requireNonNull(traceToken, "traceToken is null");
     }
 
     @Override
     public ConnectorPageSource lookup(RecordSet recordSet)
     {
-        return new ThriftIndexPageSource(clientProvider, stats, indexHandle, lookupColumns, outputColumns, recordSet, maxBytesPerResponse, lookupRequestsConcurrency);
+        return new ThriftIndexPageSource(clientProvider, stats, indexHandle, lookupColumns, outputColumns, recordSet, maxBytesPerResponse, lookupRequestsConcurrency, traceToken);
     }
 
     @Override

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftIndexProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftIndexProvider.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 
+import static com.facebook.presto.connector.thrift.ThriftSessionProperties.getTraceToken;
 import static java.util.Objects.requireNonNull;
 
 public class ThriftIndexProvider
@@ -53,6 +54,14 @@ public class ThriftIndexProvider
             List<ColumnHandle> lookupSchema,
             List<ColumnHandle> outputSchema)
     {
-        return new ThriftConnectorIndex(clientProvider, stats, (ThriftIndexHandle) indexHandle, lookupSchema, outputSchema, maxBytesPerResponse, lookupRequestsConcurrency);
+        return new ThriftConnectorIndex(
+                clientProvider,
+                stats,
+                (ThriftIndexHandle) indexHandle,
+                lookupSchema,
+                outputSchema,
+                maxBytesPerResponse,
+                lookupRequestsConcurrency,
+                getTraceToken(session));
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSource.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftNullableToken;
 import com.facebook.presto.connector.thrift.api.PrestoThriftPageResult;
 import com.facebook.presto.connector.thrift.api.PrestoThriftService;
 import com.facebook.presto.connector.thrift.clientproviders.PrestoThriftServiceProvider;
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceToken;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.Page;
@@ -26,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -57,7 +59,8 @@ public class ThriftPageSource
             ThriftConnectorSplit split,
             List<ColumnHandle> columns,
             ThriftConnectorStats stats,
-            long maxBytesPerResponse)
+            long maxBytesPerResponse,
+            Optional<ThriftTraceToken> traceToken)
     {
         // init columns
         requireNonNull(columns, "columns is null");
@@ -83,11 +86,12 @@ public class ThriftPageSource
 
         // init client
         requireNonNull(clientProvider, "clientProvider is null");
+        requireNonNull(traceToken, "traceToken is null");
         if (split.getAddresses().isEmpty()) {
-            this.client = clientProvider.anyHostClient();
+            this.client = clientProvider.anyHostClient(traceToken);
         }
         else {
-            this.client = clientProvider.selectedHostClient(split.getAddresses());
+            this.client = clientProvider.selectedHostClient(split.getAddresses(), traceToken);
         }
     }
 

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSourceProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSourceProvider.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 
+import static com.facebook.presto.connector.thrift.ThriftSessionProperties.getTraceToken;
 import static java.util.Objects.requireNonNull;
 
 public class ThriftPageSourceProvider
@@ -49,6 +50,6 @@ public class ThriftPageSourceProvider
             ConnectorSplit split,
             List<ColumnHandle> columns)
     {
-        return new ThriftPageSource(clientProvider, (ThriftConnectorSplit) split, columns, stats, maxBytesPerResponse);
+        return new ThriftPageSource(clientProvider, (ThriftConnectorSplit) split, columns, stats, maxBytesPerResponse, getTraceToken(session));
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPlugin.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPlugin.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.connector.thrift;
 
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceTokenHandler;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.google.common.collect.ImmutableList;
@@ -31,6 +32,7 @@ public class ThriftPlugin
 {
     private final String name;
     private final Module locationModule;
+    private final Class<? extends ThriftTraceTokenHandler> traceTokenHandler;
 
     public ThriftPlugin()
     {
@@ -39,20 +41,21 @@ public class ThriftPlugin
 
     private ThriftPlugin(ThriftPluginInfo info)
     {
-        this(info.getName(), info.getLocationModule());
+        this(info.getName(), info.getLocationModule(), info.getTraceTokenHandler());
     }
 
-    public ThriftPlugin(String name, Module locationModule)
+    public ThriftPlugin(String name, Module locationModule, Class<? extends ThriftTraceTokenHandler> traceTokenHandler)
     {
         checkArgument(!isNullOrEmpty(name), "name is null or empty");
         this.name = name;
         this.locationModule = requireNonNull(locationModule, "locationModule is null");
+        this.traceTokenHandler = requireNonNull(traceTokenHandler, "traceTokenHandler is null");
     }
 
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new ThriftConnectorFactory(name, locationModule));
+        return ImmutableList.of(new ThriftConnectorFactory(name, locationModule, traceTokenHandler));
     }
 
     private static ThriftPluginInfo getPluginInfo()

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPluginInfo.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPluginInfo.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.connector.thrift;
 
 import com.facebook.presto.connector.thrift.location.StaticLocationModule;
+import com.facebook.presto.connector.thrift.tracetoken.DefaultTraceTokenHandler;
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceTokenHandler;
 import com.google.inject.Module;
 
 public class ThriftPluginInfo
@@ -26,5 +28,10 @@ public class ThriftPluginInfo
     public Module getLocationModule()
     {
         return new StaticLocationModule();
+    }
+
+    public Class<? extends ThriftTraceTokenHandler> getTraceTokenHandler()
+    {
+        return DefaultTraceTokenHandler.class;
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSessionProperties.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSessionProperties.java
@@ -13,12 +13,17 @@
  */
 package com.facebook.presto.connector.thrift;
 
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceToken;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 
 /**
  * Internal session properties are those defined by the connector itself.
@@ -26,16 +31,32 @@ import java.util.List;
  */
 public final class ThriftSessionProperties
 {
+    private static final String TRACE_TOKEN = "trace_token";
+
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
     public ThriftSessionProperties(ThriftConnectorConfig config)
     {
-        sessionProperties = ImmutableList.of();
+        sessionProperties = ImmutableList.of(
+                new PropertyMetadata<>(
+                        TRACE_TOKEN,
+                        "Trace token value",
+                        VARCHAR,
+                        ThriftTraceToken.class,
+                        null,
+                        false,
+                        object -> ThriftTraceToken.valueOf((String) object),
+                        traceToken -> traceToken == null ? null : traceToken.getValue()));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    public static Optional<ThriftTraceToken> getTraceToken(ConnectorSession session)
+    {
+        return Optional.ofNullable(session.getProperty(TRACE_TOKEN, ThriftTraceToken.class));
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSplitManager.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSplitManager.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.facebook.presto.connector.thrift.ThriftSessionProperties.getTraceToken;
 import static com.facebook.presto.connector.thrift.util.TupleDomainConversion.tupleDomainToThriftTupleDomain;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -69,7 +70,7 @@ public class ThriftSplitManager
     {
         ThriftTableLayoutHandle layoutHandle = (ThriftTableLayoutHandle) layout;
         return new ThriftSplitSource(
-                clientProvider.anyHostClient(),
+                clientProvider.anyHostClient(getTraceToken(session)),
                 new PrestoThriftSchemaTableName(layoutHandle.getSchemaName(), layoutHandle.getTableName()),
                 layoutHandle.getColumns().map(ThriftSplitManager::columnNames),
                 tupleDomainToThriftTupleDomain(layoutHandle.getConstraint()));

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/clientproviders/PrestoThriftServiceProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/clientproviders/PrestoThriftServiceProvider.java
@@ -14,20 +14,22 @@
 package com.facebook.presto.connector.thrift.clientproviders;
 
 import com.facebook.presto.connector.thrift.api.PrestoThriftService;
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceToken;
 import com.facebook.presto.spi.HostAddress;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 public interface PrestoThriftServiceProvider
 {
-    PrestoThriftService anyHostClient();
+    PrestoThriftService anyHostClient(Optional<ThriftTraceToken> traceToken);
 
-    PrestoThriftService selectedHostClient(List<HostAddress> hosts);
+    PrestoThriftService selectedHostClient(List<HostAddress> hosts, Optional<ThriftTraceToken> traceToken);
 
     default <V> V runOnAnyHost(Function<PrestoThriftService, V> call)
     {
-        try (PrestoThriftService client = anyHostClient()) {
+        try (PrestoThriftService client = anyHostClient(Optional.empty())) {
             return call.apply(client);
         }
     }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/clientproviders/RetryingPrestoThriftServiceProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/clientproviders/RetryingPrestoThriftServiceProvider.java
@@ -26,6 +26,7 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftService;
 import com.facebook.presto.connector.thrift.api.PrestoThriftServiceException;
 import com.facebook.presto.connector.thrift.api.PrestoThriftSplitBatch;
 import com.facebook.presto.connector.thrift.api.PrestoThriftTupleDomain;
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceToken;
 import com.facebook.presto.connector.thrift.util.RetryDriver;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
@@ -42,6 +43,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.connector.thrift.ThriftErrorCode.THRIFT_SERVICE_GENERIC_REMOTE_ERROR;
@@ -85,15 +87,15 @@ public class RetryingPrestoThriftServiceProvider
     }
 
     @Override
-    public PrestoThriftService anyHostClient()
+    public PrestoThriftService anyHostClient(Optional<ThriftTraceToken> traceToken)
     {
-        return new RetryingService(original::anyHostClient, retry, stats);
+        return new RetryingService(() -> original.anyHostClient(traceToken), retry, stats);
     }
 
     @Override
-    public PrestoThriftService selectedHostClient(List<HostAddress> hosts)
+    public PrestoThriftService selectedHostClient(List<HostAddress> hosts, Optional<ThriftTraceToken> traceToken)
     {
-        return new RetryingService(() -> original.selectedHostClient(hosts), retry, stats);
+        return new RetryingService(() -> original.selectedHostClient(hosts, traceToken), retry, stats);
     }
 
     @NotThreadSafe

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/tracetoken/DefaultTraceTokenHandler.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/tracetoken/DefaultTraceTokenHandler.java
@@ -11,20 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.connector.thrift.clientproviders;
+package com.facebook.presto.connector.thrift.tracetoken;
 
-import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceToken;
-import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.connector.thrift.api.PrestoThriftService;
 
-import java.util.List;
-import java.util.Optional;
-
-public interface ConnectedThriftServiceProvider
-        extends PrestoThriftServiceProvider
+public class DefaultTraceTokenHandler
+        implements ThriftTraceTokenHandler
 {
     @Override
-    ConnectedThriftService anyHostClient(Optional<ThriftTraceToken> traceToken);
-
-    @Override
-    ConnectedThriftService selectedHostClient(List<HostAddress> hosts, Optional<ThriftTraceToken> traceToken);
+    public PrestoThriftService applyTraceToken(PrestoThriftService client, ThriftTraceToken traceToken)
+    {
+        return client;
+    }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/tracetoken/ThriftTraceToken.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/tracetoken/ThriftTraceToken.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.tracetoken;
+
+import com.google.common.base.Strings;
+
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class ThriftTraceToken
+{
+    private final String value;
+
+    public ThriftTraceToken(String value)
+    {
+        requireNonNull(value, "value is null");
+        checkArgument(Strings.isNullOrEmpty(value), "value is null or empty");
+        checkArgument(value.length() <= 22, "value must have <= 22 characters");
+        this.value = value;
+    }
+
+    public String getValue()
+    {
+        return value;
+    }
+
+    @Nullable
+    public static ThriftTraceToken valueOf(String value)
+    {
+        return value == null ? null : new ThriftTraceToken(value);
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/tracetoken/ThriftTraceTokenHandler.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/tracetoken/ThriftTraceTokenHandler.java
@@ -11,20 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.connector.thrift.clientproviders;
+package com.facebook.presto.connector.thrift.tracetoken;
 
-import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceToken;
-import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.connector.thrift.api.PrestoThriftService;
 
-import java.util.List;
-import java.util.Optional;
-
-public interface ConnectedThriftServiceProvider
-        extends PrestoThriftServiceProvider
+public interface ThriftTraceTokenHandler
 {
-    @Override
-    ConnectedThriftService anyHostClient(Optional<ThriftTraceToken> traceToken);
-
-    @Override
-    ConnectedThriftService selectedHostClient(List<HostAddress> hosts, Optional<ThriftTraceToken> traceToken);
+    PrestoThriftService applyTraceToken(PrestoThriftService client, ThriftTraceToken traceToken);
 }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
@@ -27,6 +27,7 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftSplitBatch;
 import com.facebook.presto.connector.thrift.api.PrestoThriftTupleDomain;
 import com.facebook.presto.connector.thrift.api.datatypes.PrestoThriftInteger;
 import com.facebook.presto.connector.thrift.clientproviders.PrestoThriftServiceProvider;
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceToken;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.InMemoryRecordSet;
 import com.facebook.presto.spi.Page;
@@ -43,6 +44,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -100,7 +102,8 @@ public class TestThriftIndexPageSource
                 ImmutableList.of(column("b", INTEGER)),
                 new InMemoryRecordSet(ImmutableList.of(INTEGER), generateKeys(0, splits)),
                 MAX_BYTES_PER_RESPONSE,
-                lookupRequestsConcurrency);
+                lookupRequestsConcurrency,
+                Optional.empty());
 
         assertNull(pageSource.getNextPage());
         assertEquals((long) stats.getIndexPageSize().getAllTime().getTotal(), 0);
@@ -206,7 +209,8 @@ public class TestThriftIndexPageSource
                 ImmutableList.of(column("b", INTEGER)),
                 new InMemoryRecordSet(ImmutableList.of(INTEGER), generateKeys(1, splits + 1)),
                 MAX_BYTES_PER_RESPONSE,
-                lookupRequestsConcurrency);
+                lookupRequestsConcurrency,
+                Optional.empty());
 
         List<Integer> actual = new ArrayList<>();
         while (!pageSource.isFinished()) {
@@ -359,13 +363,13 @@ public class TestThriftIndexPageSource
         }
 
         @Override
-        public PrestoThriftService anyHostClient()
+        public PrestoThriftService anyHostClient(Optional<ThriftTraceToken> traceToken)
         {
             return client;
         }
 
         @Override
-        public PrestoThriftService selectedHostClient(List<HostAddress> hosts)
+        public PrestoThriftService selectedHostClient(List<HostAddress> hosts, Optional<ThriftTraceToken> traceToken)
         {
             return client;
         }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/clientproviders/TestRetryingPrestoThriftServiceProvider.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/clientproviders/TestRetryingPrestoThriftServiceProvider.java
@@ -27,6 +27,7 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftSplitBatch;
 import com.facebook.presto.connector.thrift.api.PrestoThriftTupleDomain;
 import com.facebook.presto.connector.thrift.location.HostLocationHandle;
 import com.facebook.presto.connector.thrift.location.SimpleHostLocationHandle;
+import com.facebook.presto.connector.thrift.tracetoken.ThriftTraceToken;
 import com.facebook.presto.spi.HostAddress;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -37,6 +38,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.spi.HostAddress.fromParts;
@@ -112,14 +114,14 @@ public class TestRetryingPrestoThriftServiceProvider
         }
 
         @Override
-        public ConnectedThriftService anyHostClient()
+        public ConnectedThriftService anyHostClient(Optional<ThriftTraceToken> traceToken)
         {
             openServiceCount.getAndIncrement();
             return new TestingConnectedThriftService();
         }
 
         @Override
-        public ConnectedThriftService selectedHostClient(List<HostAddress> hosts)
+        public ConnectedThriftService selectedHostClient(List<HostAddress> hosts, Optional<ThriftTraceToken> traceToken)
         {
             openServiceCount.getAndIncrement();
             return new TestingConnectedThriftService();


### PR DESCRIPTION
Trace token needs to be set as a session property named "trace_token".
Usage of this value is up to the handler implementation.