### PR TITLE
Improve state tracking in StatementClient

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkQueryRunner.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.benchmark.driver.BenchmarkQueryResult.passResu
 import static com.facebook.presto.client.OkHttpUtil.setupCookieJar;
 import static com.facebook.presto.client.OkHttpUtil.setupSocksProxy;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
 import static io.airlift.http.client.Request.Builder.prepareGet;
@@ -200,19 +201,24 @@ public class BenchmarkQueryRunner
         // start query
         try (StatementClient client = new StatementClient(okHttpClient, session, query)) {
             // read query output
-            while (client.isValid() && client.advance()) {
+            while (client.isRunning()) {
                 queryDataConsumer.accept(client.currentData());
+
+                if (!client.advance()) {
+                    break;
+                }
             }
 
             // verify final state
-            if (client.isClosed()) {
+            if (client.isClientAborted()) {
                 throw new IllegalStateException("Query aborted by user");
             }
 
-            if (client.isGone()) {
+            if (client.isClientError()) {
                 throw new IllegalStateException("Query is gone (server restarted?)");
             }
 
+            verify(client.isFinished());
             QueryError resultsError = client.finalStatusInfo().getError();
             if (resultsError != null) {
                 queryErrorConsumer.accept(resultsError);

--- a/presto-cli/src/main/java/com/facebook/presto/cli/OutputHandler.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/OutputHandler.java
@@ -70,7 +70,7 @@ public final class OutputHandler
     public void processRows(StatementClient client)
             throws IOException
     {
-        while (client.isValid()) {
+        while (client.isRunning()) {
             Iterable<List<Object>> data = client.currentData().getData();
             if (data != null) {
                 for (List<Object> row : data) {

--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -86,7 +86,7 @@ Parallelism: 2.5
     {
         long lastPrint = System.nanoTime();
         try {
-            while (client.isValid()) {
+            while (client.isRunning()) {
                 try {
                     // exit status loop if there is pending output
                     if (client.currentData().getData() != null) {

--- a/presto-cli/src/main/java/com/facebook/presto/cli/TableNameCompleter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/TableNameCompleter.java
@@ -71,7 +71,7 @@ public class TableNameCompleter
     {
         ImmutableList.Builder<String> cache = ImmutableList.builder();
         try (StatementClient client = queryRunner.startInternalQuery(query)) {
-            while (client.isValid() && !Thread.currentThread().isInterrupted()) {
+            while (client.isRunning() && !Thread.currentThread().isInterrupted()) {
                 QueryData results = client.currentData();
                 if (results.getData() != null) {
                     for (List<Object> row : results.getData()) {

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.airlift.json.JsonCodec;
+import io.airlift.units.Duration;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -74,7 +75,6 @@ import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 @ThreadSafe
 public class StatementClient
@@ -99,12 +99,11 @@ public class StatementClient
     private final Set<String> deallocatedPreparedStatements = Sets.newConcurrentHashSet();
     private final AtomicReference<String> startedTransactionId = new AtomicReference<>();
     private final AtomicBoolean clearTransactionId = new AtomicBoolean();
-    private final AtomicBoolean closed = new AtomicBoolean();
-    private final AtomicBoolean gone = new AtomicBoolean();
-    private final AtomicBoolean valid = new AtomicBoolean(true);
     private final TimeZoneKey timeZone;
-    private final long requestTimeoutNanos;
+    private final Duration requestTimeoutNanos;
     private final String user;
+
+    private final AtomicReference<State> state = new AtomicReference<>(State.RUNNING);
 
     public StatementClient(OkHttpClient httpClient, ClientSession session, String query)
     {
@@ -115,13 +114,14 @@ public class StatementClient
         this.httpClient = httpClient;
         this.timeZone = session.getTimeZone();
         this.query = query;
-        this.requestTimeoutNanos = session.getClientRequestTimeout().roundTo(NANOSECONDS);
+        this.requestTimeoutNanos = session.getClientRequestTimeout();
         this.user = session.getUser();
 
         Request request = buildQueryRequest(session, query);
 
         JsonResponse<QueryResults> response = JsonResponse.execute(QUERY_RESULTS_CODEC, httpClient, request);
         if ((response.getStatusCode() != HTTP_OK) || !response.hasValue()) {
+            state.compareAndSet(State.RUNNING, State.CLIENT_ERROR);
             throw requestFailedException("starting query", request, response);
         }
 
@@ -184,19 +184,24 @@ public class StatementClient
         return timeZone;
     }
 
-    public boolean isClosed()
+    public boolean isRunning()
     {
-        return closed.get();
+        return state.get() == State.RUNNING;
     }
 
-    public boolean isGone()
+    public boolean isClientAborted()
     {
-        return gone.get();
+        return state.get() == State.CLIENT_ABORTED;
     }
 
-    public boolean isFailed()
+    public boolean isClientError()
     {
-        return currentResults.get().getError() != null;
+        return state.get() == State.CLIENT_ERROR;
+    }
+
+    public boolean isFinished()
+    {
+        return state.get() == State.FINISHED;
     }
 
     public StatementStats getStats()
@@ -204,21 +209,21 @@ public class StatementClient
         return currentResults.get().getStats();
     }
 
-    public QueryStatusInfo currentStatusInfo()
+    public QueryData currentData()
     {
-        checkState(isValid(), "current position is not valid (cursor past end)");
+        checkState(isRunning(), "current position is not valid (cursor past end)");
         return currentResults.get();
     }
 
-    public QueryData currentData()
+    public QueryStatusInfo currentStatusInfo()
     {
-        checkState(isValid(), "current position is not valid (cursor past end)");
+        checkState(isRunning(), "current position is not valid (cursor past end)");
         return currentResults.get();
     }
 
     public QueryStatusInfo finalStatusInfo()
     {
-        checkState((!isValid()) || isFailed(), "current position is still valid");
+        checkState(!isRunning(), "current position is still valid");
         return currentResults.get();
     }
 
@@ -263,11 +268,6 @@ public class StatementClient
         return clearTransactionId.get();
     }
 
-    public boolean isValid()
-    {
-        return valid.get() && (!isGone()) && (!isClosed());
-    }
-
     private Request.Builder prepareRequest(HttpUrl url)
     {
         return new Request.Builder()
@@ -278,9 +278,13 @@ public class StatementClient
 
     public boolean advance()
     {
+        if (!isRunning()) {
+            return false;
+        }
+
         URI nextUri = currentStatusInfo().getNextUri();
-        if (isClosed() || (nextUri == null)) {
-            valid.set(false);
+        if (nextUri == null) {
+            state.compareAndSet(State.RUNNING, State.FINISHED);
             return false;
         }
 
@@ -290,7 +294,7 @@ public class StatementClient
         long start = System.nanoTime();
         long attempts = 0;
 
-        do {
+        while (true) {
             // back-off on retry
             if (attempts > 0) {
                 try {
@@ -303,6 +307,7 @@ public class StatementClient
                     finally {
                         Thread.currentThread().interrupt();
                     }
+                    state.compareAndSet(State.RUNNING, State.CLIENT_ERROR);
                     throw new RuntimeException("StatementClient thread was interrupted");
                 }
             }
@@ -323,13 +328,19 @@ public class StatementClient
             }
 
             if (response.getStatusCode() != HTTP_UNAVAILABLE) {
+                state.compareAndSet(State.RUNNING, State.CLIENT_ERROR);
                 throw requestFailedException("fetching next", request, response);
             }
-        }
-        while (((System.nanoTime() - start) < requestTimeoutNanos) && !isClosed());
 
-        gone.set(true);
-        throw new RuntimeException("Error fetching next", cause);
+            if (Duration.nanosSince(start).compareTo(requestTimeoutNanos) > 0) {
+                state.compareAndSet(State.RUNNING, State.CLIENT_ERROR);
+                throw new RuntimeException("Error fetching next", cause);
+            }
+
+            if (isClientAborted()) {
+                return false;
+            }
+        }
     }
 
     private void processResponse(Headers headers, QueryResults results)
@@ -370,7 +381,6 @@ public class StatementClient
 
     private RuntimeException requestFailedException(String task, Request request, JsonResponse<QueryResults> response)
     {
-        gone.set(true);
         if (!response.hasValue()) {
             if (response.getStatusCode() == HTTP_UNAUTHORIZED) {
                 return new ClientException("Authentication failed" +
@@ -387,7 +397,7 @@ public class StatementClient
 
     public void cancelLeafStage()
     {
-        checkState(!isClosed(), "client is closed");
+        checkState(!isClientAborted(), "client is closed");
 
         URI uri = currentStatusInfo().getPartialCancelUri();
         if (uri != null) {
@@ -398,7 +408,8 @@ public class StatementClient
     @Override
     public void close()
     {
-        if (!closed.getAndSet(true)) {
+        // If the query is not done, abort the query.
+        if (state.compareAndSet(State.RUNNING, State.CLIENT_ABORTED)) {
             URI uri = currentResults.get().getNextUri();
             if (uri != null) {
                 httpDelete(uri);
@@ -432,5 +443,19 @@ public class StatementClient
         catch (UnsupportedEncodingException e) {
             throw new AssertionError(e);
         }
+    }
+
+    private enum State
+    {
+        /**
+         * submitted to server, not in terminal state (including planning, queued, running, etc)
+         */
+        RUNNING,
+        CLIENT_ERROR,
+        CLIENT_ABORTED,
+        /**
+         * finished on remote Presto server (including failed and successfully completed)
+         */
+        FINISHED,
     }
 }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.jdbc;
 
 import com.facebook.presto.client.ClientException;
+import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.client.StatementClient;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
@@ -234,8 +235,11 @@ public class PrestoStatement
         ResultSet resultSet = null;
         try {
             client = connection().startQuery(sql, getStatementSessionProperties());
-            if (client.isFailed()) {
-                throw resultsException(client.finalStatusInfo());
+            if (client.isFinished()) {
+                QueryStatusInfo finalStatusInfo = client.finalStatusInfo();
+                if (finalStatusInfo.getError() != null) {
+                    throw resultsException(finalStatusInfo);
+                }
             }
             executingClient.set(client);
 


### PR DESCRIPTION
StatementClient previously use 3 booleans to track 4 possible states.
This redundancy introduced confusion and bugs.
For example, a completed query may still be aborted.
An enum is used instead.

StatementClient previously had isValid and isClosed.
isClosed is confusingly named because it represents whether the client
is aborted instead of whether the client can potentially produce more data.
It is renamed to isAborted.