### PR TITLE
Add support for Glue Hive metastore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dep.airlift.version>0.164</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.33</dep.slice.version>
-        <dep.aws-sdk.version>1.11.165</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.11.293</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.0.0</dep.jdbi3.version>
         <dep.tempto.version>1.45</dep.tempto.version>
@@ -846,6 +846,26 @@
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>joda-time</groupId>
+                        <artifactId>joda-time</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-glue</artifactId>
+                <version>${dep.aws-sdk.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>joda-time</groupId>
+                        <artifactId>joda-time</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -857,6 +877,10 @@
                     <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>joda-time</groupId>
+                        <artifactId>joda-time</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -147,23 +147,16 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>joda-time</groupId>
-                    <artifactId>joda-time</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-glue</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>joda-time</groupId>
-                    <artifactId>joda-time</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -290,4 +283,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!-- Exclude tests against Glue from build -->
+                        <exclude>**/TestHiveClientGlueMetastore.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreModule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.metastore;
 
 import com.facebook.presto.hive.metastore.file.FileMetastoreModule;
+import com.facebook.presto.hive.metastore.glue.GlueMetastoreModule;
 import com.facebook.presto.hive.metastore.thrift.ThriftMetastoreModule;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -44,6 +45,7 @@ public class HiveMetastoreModule
         else {
             bindMetastoreModule("thrift", new ThriftMetastoreModule(connectorId));
             bindMetastoreModule("file", new FileMetastoreModule(connectorId));
+            bindMetastoreModule("glue", new GlueMetastoreModule(connectorId));
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueExpressionUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueExpressionUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import com.amazonaws.services.glue.model.GetPartitionsRequest;
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
+
+public class GlueExpressionUtil
+{
+    private static final Joiner JOINER = Joiner.on(" AND ");
+    private static final Set<String> QUOTED_TYPES = ImmutableSet.of("string", "char", "varchar", "date", "timestamp", "binary", "varbinary");
+
+    private GlueExpressionUtil() {}
+
+    /**
+     * <pre>
+     * Build an expression string used for partition filtering in {@link GetPartitionsRequest}
+     *
+     * Ex: partition keys: ['a', 'b']
+     *     partition values: ['1', '2']
+     *     expression: (a='1') AND (b='2')
+     *
+     * Partial specification ex:
+     *      partition values: ['', '2']
+     *      expression: (b='2')
+     * </pre>
+     * @param partitionKeys
+     * @param partitionValues Full or partial list of partition values to filter on. Keys without filter should be empty string.
+     */
+    public static String buildExpression(List<Column> partitionKeys, List<String> partitionValues)
+    {
+        if (partitionValues == null || partitionValues.isEmpty()) {
+            return null;
+        }
+
+        if (partitionKeys == null || partitionValues.size() != partitionKeys.size()) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, "Incorrect number of partition values: " + partitionValues);
+        }
+
+        List<String> predicates = new LinkedList<>();
+        for (int i = 0; i < partitionValues.size(); i++) {
+            if (!Strings.isNullOrEmpty(partitionValues.get(i))) {
+                predicates.add(buildPredicate(partitionKeys.get(i), partitionValues.get(i)));
+            }
+        }
+
+        return JOINER.join(predicates);
+    }
+
+    private static String buildPredicate(Column partitionKey, String value)
+    {
+        if (isQuotedType(partitionKey.getType())) {
+            return String.format("(%s='%s')", partitionKey.getName(), value);
+        }
+        return String.format("(%s=%s)", partitionKey.getName(), value);
+    }
+
+    private static boolean isQuotedType(HiveType type)
+    {
+        return QUOTED_TYPES.contains(type.getTypeSignature().getBase());
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -1,0 +1,734 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.glue.AWSGlueAsync;
+import com.amazonaws.services.glue.AWSGlueAsyncClientBuilder;
+import com.amazonaws.services.glue.model.AlreadyExistsException;
+import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
+import com.amazonaws.services.glue.model.BatchCreatePartitionResult;
+import com.amazonaws.services.glue.model.BatchGetPartitionRequest;
+import com.amazonaws.services.glue.model.BatchGetPartitionResult;
+import com.amazonaws.services.glue.model.CreateDatabaseRequest;
+import com.amazonaws.services.glue.model.CreateTableRequest;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
+import com.amazonaws.services.glue.model.DeletePartitionRequest;
+import com.amazonaws.services.glue.model.DeleteTableRequest;
+import com.amazonaws.services.glue.model.EntityNotFoundException;
+import com.amazonaws.services.glue.model.ErrorDetail;
+import com.amazonaws.services.glue.model.GetDatabaseRequest;
+import com.amazonaws.services.glue.model.GetDatabaseResult;
+import com.amazonaws.services.glue.model.GetDatabasesRequest;
+import com.amazonaws.services.glue.model.GetDatabasesResult;
+import com.amazonaws.services.glue.model.GetPartitionRequest;
+import com.amazonaws.services.glue.model.GetPartitionResult;
+import com.amazonaws.services.glue.model.GetPartitionsRequest;
+import com.amazonaws.services.glue.model.GetPartitionsResult;
+import com.amazonaws.services.glue.model.GetTableRequest;
+import com.amazonaws.services.glue.model.GetTableResult;
+import com.amazonaws.services.glue.model.GetTablesRequest;
+import com.amazonaws.services.glue.model.GetTablesResult;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UpdateDatabaseRequest;
+import com.amazonaws.services.glue.model.UpdatePartitionRequest;
+import com.amazonaws.services.glue.model.UpdateTableRequest;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.HiveUtil;
+import com.facebook.presto.hive.HiveWriteUtils;
+import com.facebook.presto.hive.PartitionNotFoundException;
+import com.facebook.presto.hive.SchemaAlreadyExistsException;
+import com.facebook.presto.hive.TableAlreadyExistsException;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HiveColumnStatistics;
+import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.PrincipalPrivileges;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hive.metastore.glue.converter.GlueInputConverter;
+import com.facebook.presto.hive.metastore.glue.converter.GlueToPrestoConverter;
+import com.facebook.presto.spi.ColumnNotFoundException;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaNotFoundException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.security.Identity;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import io.airlift.log.Logger;
+import org.apache.hadoop.fs.Path;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
+import static com.facebook.presto.hive.HiveUtil.toPartitionValues;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.makePartName;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyCanDropColumn;
+import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.UnaryOperator.identity;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
+import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
+
+public class GlueHiveMetastore
+        implements ExtendedHiveMetastore
+{
+    private static final Logger log = Logger.get(GlueHiveMetastore.class);
+
+    private static final String PUBLIC_ROLE_NAME = "public";
+    private static final String DEFAULT_METASTORE_USER = "presto";
+    private static final String WILDCARD_EXPRESSION = "";
+    private static final int BATCH_GET_PARTITION_MAX_PAGE_SIZE = 1000;
+    private static final int BATCH_CREATE_PARTITION_MAX_PAGE_SIZE = 100;
+
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HdfsContext hdfsContext;
+    private final AWSGlueAsync glueClient;
+    private final Optional<String> defaultDir;
+
+    @Inject
+    public GlueHiveMetastore(HdfsEnvironment hdfsEnvironment, GlueHiveMetastoreConfig glueConfig)
+    {
+        this(hdfsEnvironment, glueConfig, createAsyncGlueClient(glueConfig));
+    }
+
+    public GlueHiveMetastore(HdfsEnvironment hdfsEnvironment, GlueHiveMetastoreConfig glueConfig, AWSGlueAsync glueClient)
+    {
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.hdfsContext = new HdfsContext(new Identity(DEFAULT_METASTORE_USER, Optional.empty()));
+        this.glueClient = requireNonNull(glueClient, "glueClient is null");
+        this.defaultDir = glueConfig.getDefaultWarehouseDir();
+    }
+
+    private static AWSGlueAsync createAsyncGlueClient(GlueHiveMetastoreConfig config)
+    {
+        ClientConfiguration clientConfig = new ClientConfiguration().withMaxConnections(config.getMaxGlueConnections());
+        AWSGlueAsyncClientBuilder asyncGlueClientBuilder = AWSGlueAsyncClientBuilder.standard()
+                .withClientConfiguration(clientConfig);
+
+        if (config.getGlueRegion().isPresent()) {
+            asyncGlueClientBuilder.setRegion(config.getGlueRegion().get());
+        }
+        else if (config.getPinGlueClientToCurrentRegion()) {
+            Region currentRegion = Regions.getCurrentRegion();
+            if (currentRegion != null) {
+                asyncGlueClientBuilder.setRegion(currentRegion.getName());
+            }
+        }
+
+        return asyncGlueClientBuilder.build();
+    }
+
+    @Override
+    public Optional<Database> getDatabase(String databaseName)
+    {
+        try {
+            GetDatabaseResult result = glueClient.getDatabase(new GetDatabaseRequest().withName(databaseName));
+            return Optional.of(GlueToPrestoConverter.convertDatabase(result.getDatabase()));
+        }
+        catch (EntityNotFoundException e) {
+            return Optional.empty();
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public List<String> getAllDatabases()
+    {
+        try {
+            List<String> databaseNames = new ArrayList<>();
+            String nextToken = null;
+
+            do {
+                GetDatabasesResult result = glueClient.getDatabases(new GetDatabasesRequest().withNextToken(nextToken));
+                nextToken = result.getNextToken();
+                result.getDatabaseList().stream().forEach(database -> databaseNames.add(database.getName()));
+            }
+            while (nextToken != null);
+
+            return databaseNames;
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public Optional<Table> getTable(String databaseName, String tableName)
+    {
+        try {
+            GetTableResult result = glueClient.getTable(new GetTableRequest()
+                    .withDatabaseName(databaseName)
+                    .withName(tableName));
+            return Optional.of(GlueToPrestoConverter.convertTable(result.getTable(), databaseName));
+        }
+        catch (EntityNotFoundException e) {
+            return Optional.empty();
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    private Table getTableOrElseThrow(String databaseName, String tableName)
+    {
+        return getTable(databaseName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
+    }
+
+    @Override
+    public Optional<Map<String, HiveColumnStatistics>> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
+    {
+        return Optional.of(ImmutableMap.of());
+    }
+
+    @Override
+    public Optional<Map<String, Map<String, HiveColumnStatistics>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
+    {
+        return Optional.of(ImmutableMap.of());
+    }
+
+    @Override
+    public Optional<List<String>> getAllTables(String databaseName)
+    {
+        try {
+            List<String> tableNames = new ArrayList<>();
+            String nextToken = null;
+
+            do {
+                GetTablesResult result = glueClient.getTables(new GetTablesRequest()
+                        .withDatabaseName(databaseName)
+                        .withNextToken(nextToken));
+                result.getTableList().stream().forEach(table -> tableNames.add(table.getName()));
+                nextToken = result.getNextToken();
+            }
+            while (nextToken != null);
+
+            return Optional.of(tableNames);
+        }
+        catch (EntityNotFoundException e) {
+            // database does not exist
+            return Optional.empty();
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public Optional<List<String>> getAllViews(String databaseName)
+    {
+        try {
+            List<String> views = new ArrayList<>();
+            String nextToken = null;
+
+            do {
+                GetTablesResult result = glueClient.getTables(new GetTablesRequest()
+                        .withDatabaseName(databaseName)
+                        .withNextToken(nextToken));
+                result.getTableList().stream()
+                        .filter(table -> VIRTUAL_VIEW.name().equals(table.getTableType()))
+                        .forEach(table -> views.add(table.getName()));
+                nextToken = result.getNextToken();
+            }
+            while (nextToken != null);
+
+            return Optional.of(views);
+        }
+        catch (EntityNotFoundException e) {
+            // database does not exist
+            return Optional.empty();
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public void createDatabase(Database database)
+    {
+        if (!database.getLocation().isPresent() && defaultDir.isPresent()) {
+            String databaseLocation = new Path(defaultDir.get(), database.getDatabaseName()).toString();
+            database = Database.builder(database)
+                    .setLocation(Optional.of(databaseLocation))
+                    .build();
+        }
+
+        try {
+            DatabaseInput databaseInput = GlueInputConverter.convertDatabase(database);
+            glueClient.createDatabase(new CreateDatabaseRequest().withDatabaseInput(databaseInput));
+        }
+        catch (AlreadyExistsException e) {
+            throw new SchemaAlreadyExistsException(database.getDatabaseName());
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+
+        if (database.getLocation().isPresent()) {
+            HiveWriteUtils.createDirectory(hdfsContext, hdfsEnvironment, new Path(database.getLocation().get()));
+        }
+    }
+
+    @Override
+    public void dropDatabase(String databaseName)
+    {
+        try {
+            glueClient.deleteDatabase(new DeleteDatabaseRequest().withName(databaseName));
+        }
+        catch (EntityNotFoundException e) {
+            throw new SchemaNotFoundException(databaseName);
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public void renameDatabase(String databaseName, String newDatabaseName)
+    {
+        try {
+            Database database = getDatabase(databaseName).orElseThrow(() -> new SchemaNotFoundException(databaseName));
+            DatabaseInput renamedDatabase = GlueInputConverter.convertDatabase(database).withName(newDatabaseName);
+            glueClient.updateDatabase(new UpdateDatabaseRequest()
+                    .withName(databaseName)
+                    .withDatabaseInput(renamedDatabase));
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public void createTable(Table table, PrincipalPrivileges principalPrivileges)
+    {
+        try {
+            TableInput input = GlueInputConverter.convertTable(table);
+            glueClient.createTable(new CreateTableRequest()
+                    .withDatabaseName(table.getDatabaseName())
+                    .withTableInput(input));
+        }
+        catch (AlreadyExistsException e) {
+            throw new TableAlreadyExistsException(new SchemaTableName(table.getDatabaseName(), table.getTableName()));
+        }
+        catch (EntityNotFoundException e) {
+            throw new SchemaNotFoundException(table.getDatabaseName());
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    {
+        Table table = getTableOrElseThrow(databaseName, tableName);
+
+        try {
+            glueClient.deleteTable(new DeleteTableRequest()
+                    .withDatabaseName(databaseName)
+                    .withName(tableName));
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+
+        String tableLocation = table.getStorage().getLocation();
+        if (deleteData && isManagedTable(table) && !isNullOrEmpty(tableLocation)) {
+            deleteDir(hdfsContext, hdfsEnvironment, new Path(tableLocation), true);
+        }
+    }
+
+    private static boolean isManagedTable(Table table)
+    {
+        return table.getTableType().equals(MANAGED_TABLE.name());
+    }
+
+    private static void deleteDir(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path, boolean recursive)
+    {
+        try {
+            hdfsEnvironment.getFileSystem(context, path).delete(path, recursive);
+        }
+        catch (Exception e) {
+            // don't fail if unable to delete path
+            log.warn(e, "Failed to delete path: " + path.toString());
+        }
+    }
+
+    @Override
+    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    {
+        try {
+            TableInput newTableInput = GlueInputConverter.convertTable(newTable);
+            glueClient.updateTable(new UpdateTableRequest()
+                    .withDatabaseName(databaseName)
+                    .withTableInput(newTableInput));
+        }
+        catch (EntityNotFoundException e) {
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public void renameTable(String databaseName, String tableName, String newDatabaseName, String newTableName)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "Table rename is not yet supported by Glue service");
+    }
+
+    @Override
+    public void addColumn(String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    {
+        Table oldTable = getTableOrElseThrow(databaseName, tableName);
+        Table newTable = Table.builder(oldTable)
+                .addDataColumn(new Column(columnName, columnType, Optional.ofNullable(columnComment)))
+                .build();
+        replaceTable(databaseName, tableName, newTable, null);
+    }
+
+    @Override
+    public void renameColumn(String databaseName, String tableName, String oldColumnName, String newColumnName)
+    {
+        Table oldTable = getTableOrElseThrow(databaseName, tableName);
+        if (oldTable.getPartitionColumns().stream().anyMatch(c -> c.getName().equals(oldColumnName))) {
+            throw new PrestoException(NOT_SUPPORTED, "Renaming partition columns is not supported");
+        }
+
+        ImmutableList.Builder<Column> newDataColumns = ImmutableList.builder();
+        for (Column column : oldTable.getDataColumns()) {
+            if (column.getName().equals(oldColumnName)) {
+                newDataColumns.add(new Column(newColumnName, column.getType(), column.getComment()));
+            }
+            else {
+                newDataColumns.add(column);
+            }
+        }
+
+        Table newTable = Table.builder(oldTable)
+                .setDataColumns(newDataColumns.build())
+                .build();
+        replaceTable(databaseName, tableName, newTable, null);
+    }
+
+    @Override
+    public void dropColumn(String databaseName, String tableName, String columnName)
+    {
+        verifyCanDropColumn(this, databaseName, tableName, columnName);
+        Table oldTable = getTableOrElseThrow(databaseName, tableName);
+
+        if (!oldTable.getColumn(columnName).isPresent()) {
+            SchemaTableName name = new SchemaTableName(databaseName, tableName);
+            throw new ColumnNotFoundException(name, columnName);
+        }
+
+        ImmutableList.Builder<Column> newDataColumns = ImmutableList.builder();
+        oldTable.getDataColumns().stream()
+                .filter(fieldSchema -> !fieldSchema.getName().equals(columnName))
+                .forEach(fieldSchema -> newDataColumns.add(fieldSchema));
+
+        Table newTable = Table.builder(oldTable)
+                .setDataColumns(newDataColumns.build())
+                .build();
+        replaceTable(databaseName, tableName, newTable, null);
+    }
+
+    @Override
+    public Optional<Partition> getPartition(String databaseName, String tableName, List<String> partitionValues)
+    {
+        try {
+            GetPartitionResult result = glueClient.getPartition(new GetPartitionRequest()
+                    .withDatabaseName(databaseName)
+                    .withTableName(tableName)
+                    .withPartitionValues(partitionValues));
+            return Optional.of(GlueToPrestoConverter.convertPartition(result.getPartition()));
+        }
+        catch (EntityNotFoundException e) {
+            return Optional.empty();
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public Optional<List<String>> getPartitionNames(String databaseName, String tableName)
+    {
+        Table table = getTableOrElseThrow(databaseName, tableName);
+        List<Partition> partitions = getPartitions(databaseName, tableName, WILDCARD_EXPRESSION);
+        return Optional.of(buildPartitionNames(table.getPartitionColumns(), partitions));
+    }
+
+    /**
+     * <pre>
+     * Ex: Partition keys = ['a', 'b', 'c']
+     *     Valid partition values:
+     *     ['1','2','3'] or
+     *     ['', '2', '']
+     * </pre>
+     * @param parts Full or partial list of partition values to filter on. Keys without filter will be empty strings.
+     * @return a list of partition names.
+     */
+    @Override
+    public Optional<List<String>> getPartitionNamesByParts(String databaseName, String tableName, List<String> parts)
+    {
+        Table table = getTableOrElseThrow(databaseName, tableName);
+        String expression = GlueExpressionUtil.buildExpression(table.getPartitionColumns(), parts);
+        List<Partition> partitions = getPartitions(databaseName, tableName, expression);
+        return Optional.of(buildPartitionNames(table.getPartitionColumns(), partitions));
+    }
+
+    private List<Partition> getPartitions(String databaseName, String tableName, String expression)
+    {
+        try {
+            List<Partition> partitions = new ArrayList<>();
+            String nextToken = null;
+
+            do {
+                GetPartitionsResult result = glueClient.getPartitions(new GetPartitionsRequest()
+                        .withDatabaseName(databaseName)
+                        .withTableName(tableName)
+                        .withExpression(expression)
+                        .withNextToken(nextToken));
+                result.getPartitions().stream()
+                        .forEach(partition -> partitions.add(GlueToPrestoConverter.convertPartition(partition)));
+                nextToken = result.getNextToken();
+            }
+            while (nextToken != null);
+
+            return partitions;
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    private List<String> buildPartitionNames(List<Column> partitionColumns, List<Partition> partitions)
+    {
+        List<String> partitionNames = new ArrayList<>();
+        partitions.stream().forEach(partition -> partitionNames.add(makePartName(partitionColumns, partition.getValues())));
+        return partitionNames;
+    }
+
+    /**
+     * <pre>
+     * Ex: Partition keys = ['a', 'b']
+     *     Partition names = ['a=1/b=2', 'a=2/b=2']
+     * </pre>
+     * @param partitionNames List of full partition names
+     * @return Mapping of partition name to partition object
+     */
+    @Override
+    public Map<String, Optional<Partition>> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
+    {
+        requireNonNull(partitionNames, "partitionNames is null");
+        if (partitionNames.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        List<Partition> partitions = batchGetPartition(databaseName, tableName, partitionNames);
+
+        Map<String, List<String>> partitionNameToPartitionValuesMap = partitionNames.stream()
+                .collect(toMap(identity(), HiveUtil::toPartitionValues));
+        Map<List<String>, Partition> partitionValuesToPartitionMap = partitions.stream()
+                .collect(toMap(Partition::getValues, identity()));
+
+        ImmutableMap.Builder<String, Optional<Partition>> resultBuilder = ImmutableMap.builder();
+        for (Map.Entry<String, List<String>> entry : partitionNameToPartitionValuesMap.entrySet()) {
+            Partition partition = partitionValuesToPartitionMap.get(entry.getValue());
+            resultBuilder.put(entry.getKey(), Optional.ofNullable(partition));
+        }
+        return resultBuilder.build();
+    }
+
+    private List<Partition> batchGetPartition(String databaseName, String tableName, List<String> partitionNames)
+    {
+        try {
+            List<PartitionValueList> partitionValueLists = partitionNames.stream()
+                    .map(partitionName -> new PartitionValueList().withValues(toPartitionValues(partitionName))).collect(toList());
+
+            List<List<PartitionValueList>> batchedPartitionValueLists = Lists.partition(partitionValueLists, BATCH_GET_PARTITION_MAX_PAGE_SIZE);
+            List<Future<BatchGetPartitionResult>> batchGetPartitionFutures = new ArrayList<>();
+            List<Partition> result = new ArrayList<>();
+
+            for (List<PartitionValueList> partitions : batchedPartitionValueLists) {
+                batchGetPartitionFutures.add(glueClient.batchGetPartitionAsync(new BatchGetPartitionRequest()
+                        .withDatabaseName(databaseName)
+                        .withTableName(tableName)
+                        .withPartitionsToGet(partitions)));
+            }
+
+            for (Future<BatchGetPartitionResult> future : batchGetPartitionFutures) {
+                BatchGetPartitionResult batchResult = future.get();
+                batchResult.getPartitions().stream().forEach(partition -> result.add(GlueToPrestoConverter.convertPartition(partition)));
+            }
+
+            return result;
+        }
+        catch (AmazonServiceException | InterruptedException | ExecutionException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public void addPartitions(String databaseName, String tableName, List<Partition> partitions)
+    {
+        try {
+            List<List<Partition>> batchedPartitions = Lists.partition(partitions, BATCH_CREATE_PARTITION_MAX_PAGE_SIZE);
+            List<Future<BatchCreatePartitionResult>> futures = new ArrayList<>();
+
+            for (List<Partition> partitionBatch : batchedPartitions) {
+                List<PartitionInput> partitionInputs = partitionBatch.stream().map(GlueInputConverter::convertPartition).collect(toList());
+                futures.add(glueClient.batchCreatePartitionAsync(new BatchCreatePartitionRequest()
+                        .withDatabaseName(databaseName)
+                        .withTableName(tableName)
+                        .withPartitionInputList(partitionInputs)));
+            }
+
+            for (Future<BatchCreatePartitionResult> future : futures) {
+                BatchCreatePartitionResult result = future.get();
+                propagatePartitionErrorToPrestoException(databaseName, tableName, result.getErrors());
+            }
+        }
+        catch (AmazonServiceException | InterruptedException | ExecutionException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    private void propagatePartitionErrorToPrestoException(String databaseName, String tableName, List<PartitionError> partitionErrors)
+    {
+        if (partitionErrors != null && !partitionErrors.isEmpty()) {
+            ErrorDetail errorDetail = partitionErrors.get(0).getErrorDetail();
+            String glueExceptionCode = errorDetail.getErrorCode();
+
+            switch (glueExceptionCode) {
+                case "AlreadyExistsException":
+                    throw new PrestoException(ALREADY_EXISTS, errorDetail.getErrorMessage());
+                case "EntityNotFoundException":
+                    throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), errorDetail.getErrorMessage());
+                default:
+                    throw new PrestoException(HIVE_METASTORE_ERROR, errorDetail.getErrorCode() + ": " + errorDetail.getErrorMessage());
+            }
+        }
+    }
+
+    @Override
+    public void dropPartition(String databaseName, String tableName, List<String> parts, boolean deleteData)
+    {
+        Table table = getTableOrElseThrow(databaseName, tableName);
+        Partition partition = getPartition(databaseName, tableName, parts)
+                .orElseThrow(() -> new PartitionNotFoundException(new SchemaTableName(databaseName, tableName), parts));
+
+        try {
+            glueClient.deletePartition(new DeletePartitionRequest()
+                    .withDatabaseName(databaseName)
+                    .withTableName(tableName)
+                    .withPartitionValues(parts));
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+
+        String partLocation = partition.getStorage().getLocation();
+        if (deleteData && isManagedTable(table) && !isNullOrEmpty(partLocation)) {
+            deleteDir(hdfsContext, hdfsEnvironment, new Path(partLocation), true);
+        }
+    }
+
+    @Override
+    public void alterPartition(String databaseName, String tableName, Partition partition)
+    {
+        try {
+            PartitionInput newPartition = GlueInputConverter.convertPartition(partition);
+            glueClient.updatePartition(new UpdatePartitionRequest()
+                    .withDatabaseName(databaseName)
+                    .withTableName(tableName)
+                    .withPartitionInput(newPartition)
+                    .withPartitionValueList(partition.getValues()));
+        }
+        catch (EntityNotFoundException e) {
+            throw new PartitionNotFoundException(new SchemaTableName(databaseName, tableName), partition.getValues());
+        }
+        catch (AmazonServiceException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public Set<String> getRoles(String user)
+    {
+        // all users belong to public role implicitly
+        return ImmutableSet.<String>builder()
+                .add(PUBLIC_ROLE_NAME)
+                .build();
+    }
+
+    @Override
+    public Set<HivePrivilegeInfo> getDatabasePrivileges(String user, String databaseName)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "getDatabasePrivileges is not supported by Glue");
+    }
+
+    @Override
+    public Set<HivePrivilegeInfo> getTablePrivileges(String user, String databaseName, String tableName)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "getTablePrivileges is not supported by Glue");
+    }
+
+    @Override
+    public void grantTablePrivileges(String databaseName, String tableName, String grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "grantTablePrivileges is not supported by Glue");
+    }
+
+    @Override
+    public void revokeTablePrivileges(String databaseName, String tableName, String grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "revokeTablePrivileges is not supported by Glue");
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.Min;
+
+import java.util.Optional;
+
+public class GlueHiveMetastoreConfig
+{
+    private Optional<String> glueRegion = Optional.empty();
+    private boolean pinGlueClientToCurrentRegion;
+    private int maxGlueConnections = 5;
+    private Optional<String> defaultWarehouseDir = Optional.empty();
+
+    public Optional<String> getGlueRegion()
+    {
+        return glueRegion;
+    }
+
+    @Config("hive.metastore.glue.region")
+    @ConfigDescription("AWS Region for Glue Data Catalog")
+    public GlueHiveMetastoreConfig setGlueRegion(String region)
+    {
+        this.glueRegion = Optional.ofNullable(region);
+        return this;
+    }
+
+    public boolean getPinGlueClientToCurrentRegion()
+    {
+        return pinGlueClientToCurrentRegion;
+    }
+
+    @Config("hive.metastore.glue.pin-client-to-current-region")
+    @ConfigDescription("Should the Glue client be pinned to the current EC2 region")
+    public GlueHiveMetastoreConfig setPinGlueClientToCurrentRegion(boolean pinGlueClientToCurrentRegion)
+    {
+        this.pinGlueClientToCurrentRegion = pinGlueClientToCurrentRegion;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxGlueConnections()
+    {
+        return maxGlueConnections;
+    }
+
+    @Config("hive.metastore.glue.max-connections")
+    @ConfigDescription("Max number of concurrent connections to Glue")
+    public GlueHiveMetastoreConfig setMaxGlueConnections(int maxGlueConnections)
+    {
+        this.maxGlueConnections = maxGlueConnections;
+        return this;
+    }
+
+    public Optional<String> getDefaultWarehouseDir()
+    {
+        return defaultWarehouseDir;
+    }
+
+    @Config("hive.metastore.glue.default-warehouse-dir")
+    @ConfigDescription("Hive Glue metastore default warehouse directory")
+    public GlueHiveMetastoreConfig setDefaultWarehouseDir(String defaultWarehouseDir)
+    {
+        this.defaultWarehouseDir = Optional.ofNullable(defaultWarehouseDir);
+        return this;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueMetastoreModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueMetastoreModule.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class GlueMetastoreModule
+        implements Module
+{
+    private final String connectorId;
+
+    public GlueMetastoreModule(String connectorId)
+    {
+        this.connectorId = requireNonNull(connectorId, "connectorId is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
+        binder.bind(ExtendedHiveMetastore.class).to(GlueHiveMetastore.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(ExtendedHiveMetastore.class)
+                .as(generatedNameOf(GlueHiveMetastore.class, connectorId));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueInputConverter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueInputConverter.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue.converter;
+
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.SerDeInfo;
+import com.amazonaws.services.glue.model.StorageDescriptor;
+import com.amazonaws.services.glue.model.TableInput;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.Table;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public final class GlueInputConverter
+{
+    private GlueInputConverter() {}
+
+    public static DatabaseInput convertDatabase(Database database)
+    {
+        DatabaseInput input = new DatabaseInput();
+        input.setName(database.getDatabaseName());
+        input.setParameters(database.getParameters());
+        database.getComment().ifPresent(input::setDescription);
+        database.getLocation().ifPresent(input::setLocationUri);
+        return input;
+    }
+
+    public static TableInput convertTable(Table table)
+    {
+        TableInput input = new TableInput();
+        input.setName(table.getTableName());
+        input.setOwner(table.getOwner());
+        input.setTableType(table.getTableType());
+        input.setStorageDescriptor(convertStorage(table.getStorage(), table.getDataColumns()));
+        input.setPartitionKeys(table.getPartitionColumns().stream().map(GlueInputConverter::convertColumn).collect(toList()));
+        input.setParameters(table.getParameters());
+        table.getViewOriginalText().ifPresent(input::setViewOriginalText);
+        table.getViewExpandedText().ifPresent(input::setViewExpandedText);
+        return input;
+    }
+
+    public static PartitionInput convertPartition(Partition partition)
+    {
+        PartitionInput input = new PartitionInput();
+        input.setValues(partition.getValues());
+        input.setStorageDescriptor(convertStorage(partition.getStorage(), partition.getColumns()));
+        input.setParameters(partition.getParameters());
+        return input;
+    }
+
+    private static StorageDescriptor convertStorage(Storage storage, List<Column> columns)
+    {
+        if (storage.isSorted() || storage.isSkewed()) {
+            throw new IllegalArgumentException("Writing to sorted and/or skewed table/partition is not supported");
+        }
+        SerDeInfo serdeInfo = new SerDeInfo()
+                .withSerializationLibrary(storage.getStorageFormat().getSerDeNullable())
+                .withParameters(storage.getSerdeParameters());
+
+        StorageDescriptor sd = new StorageDescriptor();
+        sd.setLocation(storage.getLocation());
+        sd.setColumns(columns.stream().map(GlueInputConverter::convertColumn).collect(toList()));
+        sd.setSerdeInfo(serdeInfo);
+        sd.setInputFormat(storage.getStorageFormat().getInputFormatNullable());
+        sd.setOutputFormat(storage.getStorageFormat().getOutputFormatNullable());
+        sd.setParameters(ImmutableMap.of());
+
+        if (storage.getBucketProperty().isPresent()) {
+            sd.setNumberOfBuckets(storage.getBucketProperty().get().getBucketCount());
+            sd.setBucketColumns(storage.getBucketProperty().get().getBucketedBy());
+        }
+
+        return sd;
+    }
+
+    private static com.amazonaws.services.glue.model.Column convertColumn(Column prestoColumn)
+    {
+        return new com.amazonaws.services.glue.model.Column()
+                .withName(prestoColumn.getName())
+                .withType(prestoColumn.getType().toString())
+                .withComment(prestoColumn.getComment().orElse(null));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueToPrestoConverter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueToPrestoConverter.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue.converter;
+
+import com.amazonaws.services.glue.model.SerDeInfo;
+import com.amazonaws.services.glue.model.StorageDescriptor;
+import com.facebook.presto.hive.HiveBucketProperty;
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.PrincipalType;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.StorageFormat;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.nullToEmpty;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public final class GlueToPrestoConverter
+{
+    private static final String PUBLIC_OWNER = "PUBLIC";
+
+    private GlueToPrestoConverter() {}
+
+    public static Database convertDatabase(com.amazonaws.services.glue.model.Database glueDb)
+    {
+        return Database.builder()
+                .setDatabaseName(glueDb.getName())
+                .setLocation(Optional.ofNullable(glueDb.getLocationUri()))
+                .setComment(Optional.ofNullable(glueDb.getDescription()))
+                .setParameters(glueDb.getParameters())
+                .setOwnerName(PUBLIC_OWNER)
+                .setOwnerType(PrincipalType.ROLE)
+                .build();
+    }
+
+    public static Table convertTable(com.amazonaws.services.glue.model.Table glueTable, String dbName)
+    {
+        requireNonNull(glueTable.getStorageDescriptor(), "Table StorageDescriptor is null");
+        StorageDescriptor sd = glueTable.getStorageDescriptor();
+
+        Table.Builder tableBuilder = Table.builder()
+                .setDatabaseName(dbName)
+                .setTableName(glueTable.getName())
+                .setOwner(nullToEmpty(glueTable.getOwner()))
+                .setTableType(glueTable.getTableType())
+                .setDataColumns(sd.getColumns().stream()
+                        .map(GlueToPrestoConverter::convertColumn)
+                        .collect(toList()))
+                .setParameters(glueTable.getParameters())
+                .setViewOriginalText(Optional.ofNullable(glueTable.getViewOriginalText()))
+                .setViewExpandedText(Optional.ofNullable(glueTable.getViewExpandedText()));
+
+        if (glueTable.getPartitionKeys() != null) {
+            tableBuilder.setPartitionColumns(glueTable.getPartitionKeys().stream()
+                    .map(GlueToPrestoConverter::convertColumn)
+                    .collect(toList()));
+        }
+        else {
+            tableBuilder.setPartitionColumns(new ArrayList<>());
+        }
+
+        setStorageBuilder(sd, tableBuilder.getStorageBuilder());
+        return tableBuilder.build();
+    }
+
+    private static void setStorageBuilder(StorageDescriptor sd, Storage.Builder storageBuilder)
+    {
+        requireNonNull(sd.getSerdeInfo(), "StorageDescriptor SerDeInfo is null");
+        SerDeInfo serdeInfo = sd.getSerdeInfo();
+
+        Optional<HiveBucketProperty> bucketProperty = Optional.empty();
+        if (sd.getNumberOfBuckets() > 0) {
+            if (isNullOrEmpty(sd.getBucketColumns())) {
+                throw new PrestoException(HIVE_INVALID_METADATA, "Table/partition metadata has 'numBuckets' set, but 'bucketCols' is not set");
+            }
+            bucketProperty = Optional.of(new HiveBucketProperty(sd.getBucketColumns(), sd.getNumberOfBuckets()));
+        }
+
+        storageBuilder.setStorageFormat(StorageFormat.createNullable(serdeInfo.getSerializationLibrary(), sd.getInputFormat(), sd.getOutputFormat()))
+                .setLocation(nullToEmpty(sd.getLocation()))
+                .setBucketProperty(bucketProperty)
+                .setSorted(!isNullOrEmpty(sd.getSortColumns()))
+                .setSkewed(sd.getSkewedInfo() != null && !isNullOrEmpty(sd.getSkewedInfo().getSkewedColumnNames()))
+                .setSerdeParameters(firstNonNull(serdeInfo.getParameters(), ImmutableMap.of()))
+                .build();
+    }
+
+    private static Column convertColumn(com.amazonaws.services.glue.model.Column glueColumn)
+    {
+        return new Column(glueColumn.getName(), HiveType.valueOf(glueColumn.getType().toLowerCase()), Optional.ofNullable(glueColumn.getComment()));
+    }
+
+    public static Partition convertPartition(com.amazonaws.services.glue.model.Partition gluePartition)
+    {
+        requireNonNull(gluePartition.getStorageDescriptor(), "Partition StorageDescriptor is null");
+        StorageDescriptor sd = gluePartition.getStorageDescriptor();
+
+        Partition.Builder partitionBuilder = Partition.builder()
+                .setDatabaseName(gluePartition.getDatabaseName())
+                .setTableName(gluePartition.getTableName())
+                .setValues(gluePartition.getValues())
+                .setColumns(sd.getColumns().stream()
+                        .map(GlueToPrestoConverter::convertColumn)
+                        .collect(toList()))
+                .setParameters(gluePartition.getParameters());
+
+        setStorageBuilder(sd, partitionBuilder.getStorageBuilder());
+        return partitionBuilder.build();
+    }
+
+    private static boolean isNullOrEmpty(List list)
+    {
+        return list == null || list.isEmpty();
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
@@ -33,6 +33,7 @@ import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 public abstract class AbstractTestHiveClientLocal
         extends AbstractTestHiveClient
 {
+    private static final String TEST_DB_NAME = "test";
     private File tempDir;
 
     protected abstract ExtendedHiveMetastore createMetastore(File tempDir);
@@ -45,7 +46,7 @@ public abstract class AbstractTestHiveClientLocal
         ExtendedHiveMetastore metastore = createMetastore(tempDir);
 
         metastore.createDatabase(Database.builder()
-                .setDatabaseName("test")
+                .setDatabaseName(TEST_DB_NAME)
                 .setOwnerName("public")
                 .setOwnerType(PrincipalType.ROLE)
                 .build());
@@ -53,14 +54,19 @@ public abstract class AbstractTestHiveClientLocal
         HiveClientConfig hiveConfig = new HiveClientConfig()
                 .setTimeZone("America/Los_Angeles");
 
-        setup("test", hiveConfig, metastore);
+        setup(TEST_DB_NAME, hiveConfig, metastore);
     }
 
     @AfterClass(alwaysRun = true)
     public void cleanup()
             throws IOException
     {
-        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+        try {
+            getMetastoreClient(TEST_DB_NAME).dropDatabase(TEST_DB_NAME);
+        }
+        finally {
+            deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+        }
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueExpressionUtil.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueExpressionUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestGlueExpressionUtil
+{
+    private static final List<Column> partitionKeys = ImmutableList.of(
+            getColumn("name", "string"),
+            getColumn("birthday", "date"),
+            getColumn("age", "int"));
+
+    private static Column getColumn(String name, String type)
+    {
+        return new Column(name, HiveType.valueOf(type), Optional.empty());
+    }
+
+    @Test
+    public void testBuildExpression()
+    {
+        List<String> partitionValues = ImmutableList.of("foo", "2018-01-02", "99");
+        String expression = GlueExpressionUtil.buildExpression(partitionKeys, partitionValues);
+        assertEquals(expression, "(name='foo') AND (birthday='2018-01-02') AND (age=99)");
+
+        partitionValues = ImmutableList.of("foo", "2018-01-02", "");
+        expression = GlueExpressionUtil.buildExpression(partitionKeys, partitionValues);
+        assertEquals(expression, "(name='foo') AND (birthday='2018-01-02')");
+    }
+
+    @Test
+    public void testBuildExpressionFromPartialSpecification()
+    {
+        List<String> partitionValues = ImmutableList.of("", "2018-01-02", "");
+        String expression = GlueExpressionUtil.buildExpression(partitionKeys, partitionValues);
+        assertEquals(expression, "(birthday='2018-01-02')");
+
+        partitionValues = ImmutableList.of("foo", "", "99");
+        expression = GlueExpressionUtil.buildExpression(partitionKeys, partitionValues);
+        assertEquals(expression, "(name='foo') AND (age=99)");
+    }
+
+    @Test
+    public void testBuildExpressionNullOrEmptyValues()
+    {
+        assertNull(GlueExpressionUtil.buildExpression(partitionKeys, ImmutableList.of()));
+        assertNull(GlueExpressionUtil.buildExpression(partitionKeys, null));
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testBuildExpressionInvalidPartitionValueListSize()
+    {
+        List<String> partitionValues = ImmutableList.of("foo", "2017-01-02", "99", "extra");
+        GlueExpressionUtil.buildExpression(partitionKeys, partitionValues);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testBuildExpressionNullPartitionKeys()
+    {
+        List<String> partitionValues = ImmutableList.of("foo", "2018-01-02", "99");
+        GlueExpressionUtil.buildExpression(null, partitionValues);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestGlueHiveMetastoreConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(GlueHiveMetastoreConfig.class)
+                .setGlueRegion(null)
+                .setPinGlueClientToCurrentRegion(false)
+                .setMaxGlueConnections(5)
+                .setDefaultWarehouseDir(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMapping()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.metastore.glue.region", "us-east-1")
+                .put("hive.metastore.glue.pin-client-to-current-region", "true")
+                .put("hive.metastore.glue.max-connections", "10")
+                .put("hive.metastore.glue.default-warehouse-dir", "/location")
+                .build();
+
+        GlueHiveMetastoreConfig expected = new GlueHiveMetastoreConfig()
+                .setGlueRegion("us-east-1")
+                .setPinGlueClientToCurrentRegion(true)
+                .setMaxGlueConnections(10)
+                .setDefaultWarehouseDir("/location");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueInputConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueInputConverter.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.StorageDescriptor;
+import com.amazonaws.services.glue.model.TableInput;
+import com.facebook.presto.hive.HiveBucketProperty;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hive.metastore.glue.converter.GlueInputConverter;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestGlueInputConverter
+{
+    private Database testDb;
+    private Table testTbl;
+    private Partition testPartition;
+
+    @BeforeClass
+    public void setup()
+    {
+        testDb = TestMetastoreObjects.getPrestoTestDatabase();
+        testTbl = TestMetastoreObjects.getPrestoTestTable(testDb.getDatabaseName());
+        testPartition = TestMetastoreObjects.getPrestoTestPartition(testDb.getDatabaseName(), testTbl.getTableName(), ImmutableList.of("val1"));
+    }
+
+    @Test
+    public void testConvertDatabase()
+    {
+        DatabaseInput dbInput = GlueInputConverter.convertDatabase(testDb);
+
+        assertEquals(dbInput.getName(), testDb.getDatabaseName());
+        assertEquals(dbInput.getDescription(), testDb.getComment().get());
+        assertEquals(dbInput.getLocationUri(), testDb.getLocation().get());
+        assertEquals(dbInput.getParameters(), testDb.getParameters());
+    }
+
+    @Test
+    public void testConvertTable()
+    {
+        TableInput tblInput = GlueInputConverter.convertTable(testTbl);
+
+        assertEquals(tblInput.getName(), testTbl.getTableName());
+        assertEquals(tblInput.getOwner(), testTbl.getOwner());
+        assertEquals(tblInput.getTableType(), testTbl.getTableType());
+        assertEquals(tblInput.getParameters(), testTbl.getParameters());
+        assertColumnList(tblInput.getStorageDescriptor().getColumns(), testTbl.getDataColumns());
+        assertColumnList(tblInput.getPartitionKeys(), testTbl.getPartitionColumns());
+        assertStorage(tblInput.getStorageDescriptor(), testTbl.getStorage());
+        assertEquals(tblInput.getViewExpandedText(), testTbl.getViewExpandedText().get());
+        assertEquals(tblInput.getViewOriginalText(), testTbl.getViewOriginalText().get());
+    }
+
+    @Test
+    public void testConvertPartition()
+    {
+        PartitionInput partitionInput = GlueInputConverter.convertPartition(testPartition);
+
+        assertEquals(partitionInput.getParameters(), testPartition.getParameters());
+        assertStorage(partitionInput.getStorageDescriptor(), testPartition.getStorage());
+        assertEquals(partitionInput.getValues(), testPartition.getValues());
+    }
+
+    private static void assertColumnList(List<com.amazonaws.services.glue.model.Column> actual, List<Column> expected)
+    {
+        if (expected == null) {
+            assertNull(actual);
+        }
+        assertEquals(actual.size(), expected.size());
+
+        for (int i = 0; i < expected.size(); i++) {
+            assertColumn(actual.get(i), expected.get(i));
+        }
+    }
+
+    private static void assertColumn(com.amazonaws.services.glue.model.Column actual, Column expected)
+    {
+        assertEquals(actual.getName(), expected.getName());
+        assertEquals(actual.getType(), expected.getType().getHiveTypeName().toString());
+        assertEquals(actual.getComment(), expected.getComment().get());
+    }
+
+    private static void assertStorage(StorageDescriptor actual, Storage expected)
+    {
+        assertEquals(actual.getLocation(), expected.getLocation());
+        assertEquals(actual.getSerdeInfo().getSerializationLibrary(), expected.getStorageFormat().getSerDe());
+        assertEquals(actual.getInputFormat(), expected.getStorageFormat().getInputFormat());
+        assertEquals(actual.getOutputFormat(), expected.getStorageFormat().getOutputFormat());
+
+        if (expected.getBucketProperty().isPresent()) {
+            HiveBucketProperty bucketProperty = expected.getBucketProperty().get();
+            assertEquals(actual.getBucketColumns(), bucketProperty.getBucketedBy());
+            assertEquals(actual.getNumberOfBuckets().intValue(), bucketProperty.getBucketCount());
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueToPrestoConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueToPrestoConverter.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.StorageDescriptor;
+import com.amazonaws.services.glue.model.Table;
+import com.facebook.presto.hive.HiveBucketProperty;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.PrincipalType;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.glue.converter.GlueToPrestoConverter;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.amazonaws.util.CollectionUtils.isNullOrEmpty;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestGlueToPrestoConverter
+{
+    private static final String PUBLIC_OWNER = "PUBLIC";
+
+    private Database testDb;
+    private Table testTbl;
+    private Partition testPartition;
+
+    @BeforeClass
+    public void setup()
+    {
+        testDb = TestMetastoreObjects.getGlueTestDatabase();
+        testTbl = TestMetastoreObjects.getGlueTestTable(testDb.getName());
+        testPartition = TestMetastoreObjects.getGlueTestPartition(testDb.getName(), testTbl.getName(), ImmutableList.of("val1"));
+    }
+
+    @Test
+    public void testConvertDatabase()
+    {
+        com.facebook.presto.hive.metastore.Database prestoDb = GlueToPrestoConverter.convertDatabase(testDb);
+        assertEquals(prestoDb.getDatabaseName(), testDb.getName());
+        assertEquals(prestoDb.getLocation().get(), testDb.getLocationUri());
+        assertEquals(prestoDb.getComment().get(), testDb.getDescription());
+        assertEquals(prestoDb.getParameters(), testDb.getParameters());
+        assertEquals(prestoDb.getOwnerName(), PUBLIC_OWNER);
+        assertEquals(prestoDb.getOwnerType(), PrincipalType.ROLE);
+    }
+
+    @Test
+    public void testConvertTable()
+    {
+        com.facebook.presto.hive.metastore.Table prestoTbl = GlueToPrestoConverter.convertTable(testTbl, testDb.getName());
+        assertEquals(prestoTbl.getTableName(), testTbl.getName());
+        assertEquals(prestoTbl.getDatabaseName(), testDb.getName());
+        assertEquals(prestoTbl.getTableType(), testTbl.getTableType());
+        assertEquals(prestoTbl.getOwner(), testTbl.getOwner());
+        assertEquals(prestoTbl.getParameters(), testTbl.getParameters());
+        assertColumnList(prestoTbl.getDataColumns(), testTbl.getStorageDescriptor().getColumns());
+        assertColumnList(prestoTbl.getPartitionColumns(), testTbl.getPartitionKeys());
+        assertStorage(prestoTbl.getStorage(), testTbl.getStorageDescriptor());
+        assertEquals(prestoTbl.getViewOriginalText().get(), testTbl.getViewOriginalText());
+        assertEquals(prestoTbl.getViewExpandedText().get(), testTbl.getViewExpandedText());
+    }
+
+    @Test
+    public void testConvertTableNullPartitions()
+    {
+        testTbl.setPartitionKeys(null);
+        com.facebook.presto.hive.metastore.Table prestoTbl = GlueToPrestoConverter.convertTable(testTbl, testDb.getName());
+        assertTrue(prestoTbl.getPartitionColumns().isEmpty());
+    }
+
+    @Test
+    public void testConvertTableUppercaseColumnType()
+    {
+        com.amazonaws.services.glue.model.Column uppercaseCol = TestMetastoreObjects.getGlueTestColumn().withType("String");
+        testTbl.getStorageDescriptor().setColumns(ImmutableList.of(uppercaseCol));
+        GlueToPrestoConverter.convertTable(testTbl, testDb.getName());
+    }
+
+    @Test
+    public void testConvertPartition()
+    {
+        com.facebook.presto.hive.metastore.Partition prestoPartition = GlueToPrestoConverter.convertPartition(testPartition);
+        assertEquals(prestoPartition.getDatabaseName(), testPartition.getDatabaseName());
+        assertEquals(prestoPartition.getTableName(), testPartition.getTableName());
+        assertColumnList(prestoPartition.getColumns(), testPartition.getStorageDescriptor().getColumns());
+        assertEquals(prestoPartition.getValues(), testPartition.getValues());
+        assertStorage(prestoPartition.getStorage(), testPartition.getStorageDescriptor());
+        assertEquals(prestoPartition.getParameters(), testPartition.getParameters());
+    }
+
+    private static void assertColumnList(List<Column> actual, List<com.amazonaws.services.glue.model.Column> expected)
+    {
+        if (expected == null) {
+            assertNull(actual);
+        }
+        assertEquals(actual.size(), expected.size());
+
+        for (int i = 0; i < expected.size(); i++) {
+            assertColumn(actual.get(i), expected.get(i));
+        }
+    }
+
+    private static void assertColumn(Column actual, com.amazonaws.services.glue.model.Column expected)
+    {
+        assertEquals(actual.getName(), expected.getName());
+        assertEquals(actual.getType().getHiveTypeName().toString(), expected.getType());
+        assertEquals(actual.getComment().get(), expected.getComment());
+    }
+
+    private static void assertStorage(Storage actual, StorageDescriptor expected)
+    {
+        assertEquals(actual.getLocation(), expected.getLocation());
+        assertEquals(actual.getStorageFormat().getSerDe(), expected.getSerdeInfo().getSerializationLibrary());
+        assertEquals(actual.getStorageFormat().getInputFormat(), expected.getInputFormat());
+        assertEquals(actual.getStorageFormat().getOutputFormat(), expected.getOutputFormat());
+        if (!isNullOrEmpty(expected.getBucketColumns())) {
+            HiveBucketProperty bucketProperty = actual.getBucketProperty().get();
+            assertEquals(bucketProperty.getBucketedBy(), expected.getBucketColumns());
+            assertEquals(bucketProperty.getBucketCount(), expected.getNumberOfBuckets().intValue());
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import com.facebook.presto.hive.AbstractTestHiveClientLocal;
+import com.facebook.presto.hive.HdfsConfiguration;
+import com.facebook.presto.hive.HdfsConfigurationUpdater;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+
+import java.io.File;
+
+public class TestHiveClientGlueMetastore
+        extends AbstractTestHiveClientLocal
+{
+    /**
+     * GlueHiveMetastore currently uses AWS Default Credential Provider Chain,
+     * See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+     * on ways to set your AWS credentials which will be needed to run this test.
+     */
+    @Override
+    protected ExtendedHiveMetastore createMetastore(File tempDir)
+    {
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig));
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
+        GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig();
+        glueConfig.setDefaultWarehouseDir(tempDir.toURI().toString());
+
+        return new GlueHiveMetastore(hdfsEnvironment, glueConfig);
+    }
+
+    @Override
+    public void testRenameTable()
+    {
+        // rename table is not yet supported by Glue
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestMetastoreObjects.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestMetastoreObjects.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.glue;
+
+import com.amazonaws.services.glue.model.Column;
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.SerDeInfo;
+import com.amazonaws.services.glue.model.StorageDescriptor;
+import com.amazonaws.services.glue.model.Table;
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.metastore.PrincipalType;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.StorageFormat;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.hive.metastore.TableType;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+
+public class TestMetastoreObjects
+{
+    private TestMetastoreObjects() {}
+
+    // --------------- Glue Objects ---------------
+
+    public static Database getGlueTestDatabase()
+    {
+        return new Database()
+                .withName("test-db" + generateRandom())
+                .withDescription("database desc")
+                .withLocationUri("/db")
+                .withParameters(ImmutableMap.of());
+    }
+
+    public static Table getGlueTestTable(String dbName)
+    {
+        return new Table()
+                .withDatabaseName(dbName)
+                .withName("test-tbl" + generateRandom())
+                .withOwner("owner")
+                .withParameters(ImmutableMap.of())
+                .withPartitionKeys(ImmutableList.of(getGlueTestColumn()))
+                .withStorageDescriptor(getGlueTestStorageDescriptor())
+                .withTableType(TableType.EXTERNAL_TABLE.name())
+                .withViewOriginalText("originalText")
+                .withViewExpandedText("expandedText");
+    }
+
+    public static Column getGlueTestColumn()
+    {
+        return new Column()
+                .withName("test-col" + generateRandom())
+                .withType("string")
+                .withComment("column comment");
+    }
+
+    public static StorageDescriptor getGlueTestStorageDescriptor()
+    {
+        return new StorageDescriptor()
+                .withBucketColumns(ImmutableList.of("test-bucket-col"))
+                .withColumns(ImmutableList.of(getGlueTestColumn()))
+                .withParameters(ImmutableMap.of())
+                .withSerdeInfo(new SerDeInfo()
+                        .withSerializationLibrary("SerdeLib")
+                        .withParameters(ImmutableMap.of()))
+                .withInputFormat("InputFormat")
+                .withOutputFormat("OutputFormat")
+                .withLocation("/test-tbl")
+                .withNumberOfBuckets(1);
+    }
+
+    public static Partition getGlueTestPartition(String dbName, String tblName, List<String> values)
+    {
+        return new Partition()
+                .withDatabaseName(dbName)
+                .withTableName(tblName)
+                .withValues(values)
+                .withParameters(ImmutableMap.of())
+                .withStorageDescriptor(getGlueTestStorageDescriptor());
+    }
+
+    // --------------- Presto Objects ---------------
+
+    public static com.facebook.presto.hive.metastore.Database getPrestoTestDatabase()
+    {
+        return com.facebook.presto.hive.metastore.Database.builder()
+                .setDatabaseName("test-db" + generateRandom())
+                .setComment(Optional.of("database desc"))
+                .setLocation(Optional.of("/db"))
+                .setParameters(ImmutableMap.of())
+                .setOwnerName("PUBLIC")
+                .setOwnerType(PrincipalType.ROLE).build();
+    }
+
+    public static com.facebook.presto.hive.metastore.Table getPrestoTestTable(String dbName)
+    {
+        return com.facebook.presto.hive.metastore.Table.builder()
+                .setDatabaseName(dbName)
+                .setTableName("test-tbl" + generateRandom())
+                .setOwner("owner")
+                .setParameters(ImmutableMap.of())
+                .setTableType(TableType.EXTERNAL_TABLE.name())
+                .setDataColumns(ImmutableList.of(getPrestoTestColumn()))
+                .setPartitionColumns(ImmutableList.of(getPrestoTestColumn()))
+                .setViewOriginalText(Optional.of("originalText"))
+                .setViewExpandedText(Optional.of("expandedText"))
+                .withStorage(STORAGE_CONSUMER).build();
+    }
+
+    public static com.facebook.presto.hive.metastore.Partition getPrestoTestPartition(String dbName, String tblName, List<String> values)
+    {
+        return com.facebook.presto.hive.metastore.Partition.builder()
+                .setDatabaseName(dbName)
+                .setTableName(tblName)
+                .setValues(values)
+                .setColumns(ImmutableList.of(getPrestoTestColumn()))
+                .setParameters(ImmutableMap.of())
+                .withStorage(STORAGE_CONSUMER).build();
+    }
+
+    public static com.facebook.presto.hive.metastore.Column getPrestoTestColumn()
+    {
+        return new com.facebook.presto.hive.metastore.Column("test-col" + generateRandom(), HiveType.HIVE_STRING, Optional.of("column comment"));
+    }
+
+    private static final Consumer<Storage.Builder> STORAGE_CONSUMER = storage ->
+    {
+        storage.setStorageFormat(StorageFormat.create("SerdeLib", "InputFormat", "OutputFormat"))
+            .setLocation("/test-tbl")
+            .setBucketProperty(Optional.empty())
+            .setSerdeParameters(ImmutableMap.of());
+    };
+
+    private static String generateRandom()
+    {
+        return String.format("%04x", ThreadLocalRandom.current().nextInt());
+    }
+}


### PR DESCRIPTION
Allows users to use AWS Glue Data Catalog as metastore in Hive connector