### PR TITLE
Introduce FunctionReference (an FunctionCall alternative for planner) and use it in AggregationNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -115,6 +115,7 @@ import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.Serialization.ExpressionDeserializer;
 import com.facebook.presto.sql.Serialization.ExpressionSerializer;
 import com.facebook.presto.sql.Serialization.FunctionCallDeserializer;
+import com.facebook.presto.sql.Serialization.FunctionReferenceDeserializer;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
@@ -129,6 +130,7 @@ import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PlanOptimizers;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.transaction.ForTransactionManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.transaction.TransactionManagerConfig;
@@ -410,6 +412,7 @@ public class ServerMainModule
         jsonBinder(binder).addSerializerBinding(Expression.class).to(ExpressionSerializer.class);
         jsonBinder(binder).addDeserializerBinding(Expression.class).to(ExpressionDeserializer.class);
         jsonBinder(binder).addDeserializerBinding(FunctionCall.class).to(FunctionCallDeserializer.class);
+        jsonBinder(binder).addDeserializerBinding(FunctionReference.class).to(FunctionReferenceDeserializer.class);
 
         // query monitor
         configBinder(binder).bindConfig(QueryMonitorConfig.class);

--- a/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.google.common.base.Preconditions;
 
 import javax.inject.Inject;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
@@ -16,12 +16,14 @@ package com.facebook.presto.sql;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.common.base.Preconditions;
 
 import javax.inject.Inject;
 
@@ -29,6 +31,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public final class Serialization
 {
@@ -80,6 +83,30 @@ public final class Serialization
                 throws IOException
         {
             return (FunctionCall) rewriteIdentifiersToSymbolReferences(sqlParser.createExpression(jsonParser.readValueAs(String.class)));
+        }
+    }
+
+    public static class FunctionReferenceDeserializer
+            extends JsonDeserializer<FunctionReference>
+    {
+        private final SqlParser sqlParser;
+
+        @Inject
+        public FunctionReferenceDeserializer(SqlParser sqlParser)
+        {
+            this.sqlParser = sqlParser;
+        }
+
+        @Override
+        public FunctionReference deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException
+        {
+            FunctionCall functionCall = (FunctionCall) rewriteIdentifiersToSymbolReferences(sqlParser.createExpression(jsonParser.readValueAs(String.class)));
+            checkArgument(!functionCall.getOrderBy().isPresent(), "Unexpected ORDER BY in function call");
+            checkArgument(!functionCall.getWindow().isPresent(), "Unexpected window information in function call");
+            checkArgument(!functionCall.getFilter().isPresent(), "Unexpected FILTER in function call");
+            checkArgument(!functionCall.isDistinct(), "Unexpected DISTINCT in function call");
+            return new FunctionReference(functionCall.getName(), functionCall.getArguments());
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.tree.ExistsPredicate;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.GroupingOperation;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.InPredicate;
@@ -101,6 +102,7 @@ public class Analysis
     private final Set<NodeRef<Expression>> typeOnlyCoercions = new LinkedHashSet<>();
     private final Map<NodeRef<Relation>, List<Type>> relationCoercions = new LinkedHashMap<>();
     private final Map<NodeRef<FunctionCall>, Signature> functionSignature = new LinkedHashMap<>();
+    private final Map<NodeRef<FunctionReference>, Signature> functionReferenceSignature = new LinkedHashMap<>();
     private final Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences = new LinkedHashMap<>();
 
     private final Map<Field, ColumnHandle> columns = new LinkedHashMap<>();
@@ -427,6 +429,11 @@ public class Analysis
     public void addFunctionSignatures(Map<NodeRef<FunctionCall>, Signature> infos)
     {
         functionSignature.putAll(infos);
+    }
+
+    public void addFunctionReferenceSignatures(Map<NodeRef<FunctionReference>, Signature> infos)
+    {
+        functionReferenceSignature.putAll(infos);
     }
 
     public Set<NodeRef<Expression>> getColumnReferences()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
@@ -90,7 +90,10 @@ public class ExpressionExtractor
         public Void visitAggregation(AggregationNode node, ImmutableList.Builder<Expression> context)
         {
             node.getAggregations().values()
-                    .forEach(aggregation -> context.add(aggregation.getCall()));
+                    .forEach(aggregation -> {
+                        context.add(aggregation.getCall());
+                        aggregation.getPredicate().ifPresent(context::add);
+                    });
             return super.visitAggregation(node, context);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -150,8 +150,6 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.OrderBy;
-import com.facebook.presto.sql.tree.SortItem;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -2010,17 +2008,9 @@ public class LocalExecutionPlanner
 
             List<SortOrder> sortOrders = ImmutableList.of();
             List<Symbol> sortKeys = ImmutableList.of();
-            if (aggregation.getCall().getOrderBy().isPresent()) {
-                OrderBy orderBy = aggregation.getCall().getOrderBy().get();
-
-                sortKeys = orderBy.getSortItems().stream()
-                        .map(SortItem::getSortKey)
-                        .map(Symbol::from)
-                        .collect(toImmutableList());
-
-                sortOrders = orderBy.getSortItems().stream()
-                        .map(QueryPlanner::toSortOrder)
-                        .collect(toImmutableList());
+            if (aggregation.getOrderingScheme().isPresent()) {
+                sortKeys = aggregation.getOrderingScheme().get().getOrderBy();
+                sortOrders = aggregation.getOrderingScheme().get().getOrderingList();
             }
 
             return metadata

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanBuilder.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 class PlanBuilder
@@ -78,6 +79,13 @@ class PlanBuilder
     public Symbol translate(Expression expression)
     {
         return translations.get(expression);
+    }
+
+    public List<Expression> rewrite(List<Expression> expressions)
+    {
+        return expressions.stream()
+                .map(this::rewrite)
+                .collect(toImmutableList());
     }
 
     public Expression rewrite(Expression expression)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
@@ -28,7 +28,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
-import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -177,11 +177,14 @@ public class AddIntermediateAggregations
         for (Map.Entry<Symbol, AggregationNode.Aggregation> entry : assignments.entrySet()) {
             Symbol output = entry.getKey();
             AggregationNode.Aggregation aggregation = entry.getValue();
-            checkState(!aggregation.getCall().getOrderBy().isPresent(), "Intermediate aggregation does not support ORDER BY");
+            checkState(!aggregation.getOrderingScheme().isPresent(), "Intermediate aggregation does not support ORDER BY");
             builder.put(
                     output,
                     new AggregationNode.Aggregation(
-                            new FunctionCall(QualifiedName.of(aggregation.getSignature().getName()), ImmutableList.of(output.toSymbolReference())),
+                            new FunctionReference(QualifiedName.of(aggregation.getSignature().getName()), ImmutableList.of(output.toSymbolReference())),
+                            aggregation.getOrderingScheme(),
+                            aggregation.getPredicate(),
+                            aggregation.isDistinct(),
                             aggregation.getSignature(),
                             Optional.empty()));  // No mask for INTERMEDIATE
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -155,12 +155,13 @@ public class ExpressionRewriteRuleSet
         {
             boolean anyRewritten = false;
             ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
-            for (Map.Entry<Symbol, Aggregation> aggregation : aggregationNode.getAggregations().entrySet()) {
-                FunctionCall call = (FunctionCall) rewriter.rewrite(aggregation.getValue().getCall(), context);
+            for (Map.Entry<Symbol, Aggregation> entry : aggregationNode.getAggregations().entrySet()) {
+                Aggregation aggregation = entry.getValue();
+                FunctionCall call = (FunctionCall) rewriter.rewrite(aggregation.getCall(), context);
                 aggregations.put(
-                        aggregation.getKey(),
-                        new Aggregation(call, aggregation.getValue().getSignature(), aggregation.getValue().getMask()));
-                if (!aggregation.getValue().getCall().equals(call)) {
+                        entry.getKey(),
+                        new Aggregation(call, aggregation.getSignature(), aggregation.getMask()));
+                if (!aggregation.getCall().equals(call)) {
                     anyRewritten = true;
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -27,7 +27,6 @@ import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -157,11 +156,17 @@ public class ExpressionRewriteRuleSet
             ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
             for (Map.Entry<Symbol, Aggregation> entry : aggregationNode.getAggregations().entrySet()) {
                 Aggregation aggregation = entry.getValue();
-                FunctionCall call = (FunctionCall) rewriter.rewrite(aggregation.getCall(), context);
+                Optional<Expression> rewrittenPredicate = aggregation.getPredicate().map(predicate -> rewriter.rewrite(predicate, context));
                 aggregations.put(
                         entry.getKey(),
-                        new Aggregation(call, aggregation.getSignature(), aggregation.getMask()));
-                if (!aggregation.getCall().equals(call)) {
+                        new Aggregation(
+                                aggregation.getCall(),
+                                aggregation.getOrderingScheme(),
+                                rewrittenPredicate,
+                                aggregation.isDistinct(),
+                                aggregation.getSignature(),
+                                aggregation.getMask()));
+                if (!aggregation.getPredicate().equals(rewrittenPredicate)) {
                     anyRewritten = true;
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.ExpressionUtils;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
@@ -87,6 +88,9 @@ public class ImplementFilteredAggregations
             if (call.getFilter().isPresent()) {
                 Expression filter = call.getFilter().get();
                 Symbol symbol = context.getSymbolAllocator().newSymbol(filter, BOOLEAN);
+                if (mask.isPresent()) {
+                    filter = ExpressionUtils.and(filter, mask.get().toSymbolReference());
+                }
                 newAssignments.put(symbol, filter);
                 mask = Optional.of(symbol);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
@@ -58,6 +58,8 @@ public class PruneAggregationSourceColumns
     {
         return Streams.concat(
                 SymbolsExtractor.extractUnique(aggregation.getCall()).stream(),
-                aggregation.getMask().map(Stream::of).orElse(Stream.empty()));
+                aggregation.getMask().map(Stream::of).orElse(Stream.empty()),
+                aggregation.getOrderingScheme().map(orderingScheme -> orderingScheme.getOrderBy().stream()).orElse(Stream.empty()),
+                aggregation.getPredicate().map(predicate -> SymbolsExtractor.extractUnique(predicate).stream()).orElse(Stream.empty()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
@@ -20,7 +20,7 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
-import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.google.common.collect.ImmutableList;
 
@@ -56,7 +56,7 @@ public class PruneCountAggregationOverScalar
             AggregationNode.Aggregation aggregation = entry.getValue();
             requireNonNull(aggregation, "aggregation is null");
             Signature signature = aggregation.getSignature();
-            FunctionCall functionCall = aggregation.getCall();
+            FunctionReference functionCall = aggregation.getCall();
             if (!"count".equals(signature.getName()) || !functionCall.getArguments().isEmpty()) {
                 return Result.empty();
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
@@ -19,10 +19,10 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
-import com.facebook.presto.sql.tree.FunctionCall;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
@@ -56,7 +56,7 @@ public class PruneOrderByInAggregation
         ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
         for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
             Aggregation aggregation = entry.getValue();
-            if (!aggregation.getCall().getOrderBy().isPresent()) {
+            if (!aggregation.getOrderingScheme().isPresent()) {
                 aggregations.put(entry);
             }
             // getAggregateFunctionImplementation can be expensive, so check it last.
@@ -65,13 +65,13 @@ public class PruneOrderByInAggregation
             }
             else {
                 anyRewritten = true;
-                FunctionCall rewritten = new FunctionCall(
-                        aggregation.getCall().getName(),
-                        aggregation.getCall().isDistinct(),
-                        aggregation.getCall().getArguments(),
-                        aggregation.getCall().getFilter());
-
-                aggregations.put(entry.getKey(), new Aggregation(rewritten, aggregation.getSignature(), aggregation.getMask()));
+                aggregations.put(entry.getKey(), new Aggregation(
+                        aggregation.getCall(),
+                        Optional.empty(),
+                        aggregation.getPredicate(),
+                        aggregation.isDistinct(),
+                        aggregation.getSignature(),
+                        aggregation.getMask()));
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -30,7 +30,7 @@ import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
@@ -272,7 +272,10 @@ public class PushAggregationThroughOuterJoin
             Symbol aggregationSymbol = entry.getKey();
             AggregationNode.Aggregation aggregation = entry.getValue();
             AggregationNode.Aggregation overNullAggregation = new AggregationNode.Aggregation(
-                    (FunctionCall) inlineSymbols(sourcesSymbolMapping, aggregation.getCall()),
+                    (FunctionReference) inlineSymbols(sourcesSymbolMapping, aggregation.getCall()),
+                    aggregation.getOrderingScheme(),
+                    aggregation.getPredicate(),
+                    aggregation.isDistinct(),
                     aggregation.getSignature(),
                     aggregation.getMask().map(x -> Symbol.from(sourcesSymbolMapping.get(x))));
             Symbol overNullSymbol = symbolAllocator.newSymbol(overNullAggregation.getCall(), symbolAllocator.getTypes().get(aggregationSymbol));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -24,7 +24,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.Literal;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -71,7 +71,10 @@ public class SimplifyCountOverConstant
             if (isCountOverConstant(aggregation, child.getAssignments())) {
                 changed = true;
                 aggregations.put(symbol, new AggregationNode.Aggregation(
-                        new FunctionCall(QualifiedName.of("count"), ImmutableList.of()),
+                        new FunctionReference(QualifiedName.of("count"), ImmutableList.of()),
+                        aggregation.getOrderingScheme(),
+                        aggregation.getPredicate(),
+                        aggregation.isDistinct(),
                         new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT)),
                         aggregation.getMask()));
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -37,7 +37,7 @@ import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.ComparisonExpressionType;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.IsNotNullPredicate;
 import com.facebook.presto.sql.tree.IsNullPredicate;
@@ -48,7 +48,6 @@ import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SearchedCaseExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.WhenClause;
-import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.util.AstUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -243,16 +242,11 @@ public class TransformCorrelatedInPredicateToJoin
 
     private static AggregationNode.Aggregation countWithFilter(Expression condition)
     {
-        FunctionCall countCall = new FunctionCall(
-                QualifiedName.of("count"),
-                Optional.<Window>empty(),
-                Optional.of(condition),
-                Optional.empty(),
-                false,
-                ImmutableList.<Expression>of()); /* arguments */
-
         return new AggregationNode.Aggregation(
-                countCall,
+                new FunctionReference(QualifiedName.of("count"), ImmutableList.of()),
+                Optional.empty(), /* ordering schema */
+                Optional.of(condition),
+                false,
                 new Signature("count", FunctionKind.AGGREGATE, BIGINT.getTypeSignature()),
                 Optional.<Symbol>empty()); /* mask */
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
@@ -29,7 +29,7 @@ import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.ExistsPredicate;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;
@@ -59,7 +59,7 @@ public class TransformExistsApplyToLateralNode
     private static final Pattern<ApplyNode> PATTERN = applyNode();
 
     private static final QualifiedName COUNT = QualifiedName.of("count");
-    private static final FunctionCall COUNT_CALL = new FunctionCall(COUNT, ImmutableList.of());
+    private static final FunctionReference COUNT_CALL = new FunctionReference(COUNT, ImmutableList.of());
     private final Signature countSignature;
 
     public TransformExistsApplyToLateralNode(FunctionRegistry functionRegistry)
@@ -98,7 +98,7 @@ public class TransformExistsApplyToLateralNode
                                 new AggregationNode(
                                         context.getIdAllocator().getNextId(),
                                         parent.getSubquery(),
-                                        ImmutableMap.of(count, new Aggregation(COUNT_CALL, countSignature, Optional.empty())),
+                                        ImmutableMap.of(count, new Aggregation(COUNT_CALL, Optional.empty(), Optional.empty(), false, countSignature, Optional.empty())),
                                         ImmutableList.of(ImmutableList.of()),
                                         AggregationNode.Step.SINGLE,
                                         Optional.empty(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DesugaringOptimizer.java
@@ -35,7 +35,6 @@ import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
 
 import java.util.Map;
 import java.util.Optional;
@@ -101,7 +100,13 @@ public class DesugaringOptimizer
             Map<Symbol, Aggregation> aggregations = node.getAggregations().entrySet().stream()
                     .collect(toImmutableMap(Map.Entry::getKey, entry -> {
                         Aggregation aggregation = entry.getValue();
-                        return new Aggregation((FunctionCall) desugar(aggregation.getCall()), aggregation.getSignature(), aggregation.getMask());
+                        return new Aggregation(
+                                aggregation.getCall(),
+                                aggregation.getOrderingScheme(),
+                                aggregation.getPredicate().map(this::desugar),
+                                aggregation.isDistinct(),
+                                aggregation.getSignature(),
+                                aggregation.getMask());
                     }));
             return new AggregationNode(
                     node.getId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -35,7 +35,7 @@ import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -233,7 +233,10 @@ public class ImplementIntersectAndExceptAsUnion
             for (int i = 0; i < markers.size(); i++) {
                 Symbol output = aggregationOutputs.get(i);
                 aggregations.put(output, new Aggregation(
-                        new FunctionCall(QualifiedName.of("count"), ImmutableList.of(markers.get(i).toSymbolReference())),
+                        new FunctionReference(QualifiedName.of("count"), ImmutableList.of(markers.get(i).toSymbolReference())),
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
                         COUNT_AGGREGATION,
                         Optional.empty()));
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -101,7 +101,7 @@ public class MetadataQueryOptimizer
         {
             // supported functions are only MIN/MAX/APPROX_DISTINCT or distinct aggregates
             for (Aggregation aggregation : node.getAggregations().values()) {
-                if (!ALLOWED_FUNCTIONS.contains(aggregation.getCall().getName().toString()) && !aggregation.getCall().isDistinct()) {
+                if (!ALLOWED_FUNCTIONS.contains(aggregation.getCall().getName().toString()) && !aggregation.isDistinct()) {
                     return context.defaultRewrite(node);
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -311,10 +311,8 @@ public class PruneUnreferencedOutputs
                     Aggregation aggregation = entry.getValue();
                     FunctionCall call = aggregation.getCall();
                     expectedInputs.addAll(SymbolsExtractor.extractUnique(call));
-                    if (aggregation.getMask().isPresent()) {
-                        expectedInputs.add(aggregation.getMask().get());
-                    }
-                    aggregations.put(symbol, new Aggregation(call, aggregation.getSignature(), aggregation.getMask()));
+                    aggregation.getMask().ifPresent(expectedInputs::add);
+                    aggregations.put(symbol, aggregation);
                 }
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoIdentifierLeftChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoIdentifierLeftChecker.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.ExpressionExtractor;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Identifier;
+
+import java.util.Map;
+
+import static java.lang.String.format;
+
+public final class NoIdentifierLeftChecker
+        implements PlanSanityChecker.Checker
+{
+    @Override
+    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
+    {
+        for (Expression expression : ExpressionExtractor.extractExpressions(plan)) {
+            new DefaultTraversalVisitor<Void, Void>()
+            {
+                @Override
+                protected Void visitIdentifier(Identifier node, Void context)
+                {
+                    throw new IllegalStateException(format("Unexpected identifier in logical plan: %s", node));
+                }
+            }.process(expression, null);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
@@ -36,6 +36,7 @@ public final class PlanSanityChecker
                     new NoDuplicatePlanNodeIdsChecker(),
                     new TypeValidator(),
                     new NoSubqueryExpressionLeftChecker(),
+                    new NoIdentifierLeftChecker(),
                     new VerifyOnlyOneOutputNode())
             .putAll(
                     Stage.FINAL,
@@ -43,6 +44,7 @@ public final class PlanSanityChecker
                     new NoDuplicatePlanNodeIdsChecker(),
                     new TypeValidator(),
                     new NoSubqueryExpressionLeftChecker(),
+                    new NoIdentifierLeftChecker(),
                     new VerifyOnlyOneOutputNode(),
                     new VerifyNoFilteredAggregations())
             .build();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
@@ -30,6 +30,7 @@ import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ListMultimap;
@@ -159,6 +160,14 @@ public final class TypeValidator
         }
 
         private void checkCall(Symbol symbol, FunctionCall call)
+        {
+            Type expectedType = types.get(symbol);
+            Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, types, call, emptyList() /*parameters already replaced */);
+            Type actualType = expressionTypes.get(NodeRef.<Expression>of(call));
+            verifyTypeSignature(symbol, expectedType.getTypeSignature(), actualType.getTypeSignature());
+        }
+
+        private void checkCall(Symbol symbol, FunctionReference call)
         {
             Type expectedType = types.get(symbol);
             Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, types, call, emptyList() /*parameters already replaced */);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -120,6 +120,9 @@ public final class ValidateDependenciesChecker
             for (Aggregation aggregation : node.getAggregations().values()) {
                 Set<Symbol> dependencies = SymbolsExtractor.extractUnique(aggregation.getCall());
                 checkDependencies(inputs, dependencies, "Invalid node. Aggregation dependencies (%s) not in source plan output (%s)", dependencies, node.getSource().getOutputSymbols());
+                aggregation.getMask().ifPresent(mask -> {
+                    checkDependencies(inputs, ImmutableSet.of(mask), "Invalid node. Aggregation mask symbol (%s) not in source plan output (%s)", mask, node.getSource().getOutputSymbols());
+                });
             }
 
             return null;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -120,6 +120,14 @@ public final class ValidateDependenciesChecker
             for (Aggregation aggregation : node.getAggregations().values()) {
                 Set<Symbol> dependencies = SymbolsExtractor.extractUnique(aggregation.getCall());
                 checkDependencies(inputs, dependencies, "Invalid node. Aggregation dependencies (%s) not in source plan output (%s)", dependencies, node.getSource().getOutputSymbols());
+                aggregation.getPredicate().ifPresent(predicate -> {
+                    Set<Symbol> predicateDependencies = SymbolsExtractor.extractUnique(predicate);
+                    checkDependencies(inputs, predicateDependencies, "Invalid node. Aggregation predicate dependencies (%s) not in source plan output (%s)", predicateDependencies, node.getSource().getOutputSymbols());
+                });
+                aggregation.getOrderingScheme().ifPresent(orderingScheme -> {
+                    Set<Symbol> orderingDependencies = ImmutableSet.copyOf(orderingScheme.getOrderBy());
+                    checkDependencies(inputs, orderingDependencies, "Invalid node. Aggregation ordering dependencies (%s) not in source plan output (%s)", orderingDependencies, node.getSource().getOutputSymbols());
+                });
                 aggregation.getMask().ifPresent(mask -> {
                     checkDependencies(inputs, ImmutableSet.of(mask), "Invalid node. Aggregation mask symbol (%s) not in source plan output (%s)", mask, node.getSource().getOutputSymbols());
                 });

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoFilteredAggregations.java
@@ -35,8 +35,7 @@ public final class VerifyNoFilteredAggregations
                 .where(AggregationNode.class::isInstance)
                 .<AggregationNode>findAll()
                 .stream()
-                .flatMap(node -> node.getAggregations().values().stream())
-                .filter(aggregation -> aggregation.getCall().getFilter().isPresent())
+                .filter(AggregationNode::hasPredicate)
                 .forEach(ignored -> {
                     throw new IllegalStateException("Generated plan contains unimplemented filtered aggregations");
                 });

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -44,6 +44,7 @@ import com.facebook.presto.sql.tree.ComparisonExpressionType;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LongLiteral;
@@ -150,8 +151,8 @@ public class TestEffectivePredicateExtractor
                                 greaterThan(AE, bigintLiteral(2)),
                                 equals(EE, FE))),
                 ImmutableMap.of(
-                        C, new Aggregation(fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty()),
-                        D, new Aggregation(fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty())),
+                        C, new Aggregation(fakeFunction(), Optional.empty(), Optional.empty(), false, fakeFunctionHandle("test", AGGREGATE), Optional.empty()),
+                        D, new Aggregation(fakeFunction(), Optional.empty(), Optional.empty(), false, fakeFunctionHandle("test", AGGREGATE), Optional.empty())),
                 ImmutableList.of(ImmutableList.of(A, B, C)),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
@@ -748,9 +749,9 @@ public class TestEffectivePredicateExtractor
         return new IsNullPredicate(expression);
     }
 
-    private static FunctionCall fakeFunction()
+    private static FunctionReference fakeFunction()
     {
-        return new FunctionCall(QualifiedName.of("test"), ImmutableList.of());
+        return new FunctionReference(QualifiedName.of("test"), ImmutableList.of());
     }
 
     private static Signature fakeFunctionHandle(String name, FunctionKind kind)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -36,6 +36,7 @@ import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.FunctionReference;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.facebook.presto.testing.TestingMetadata.TestingColumnHandle;
@@ -185,7 +186,10 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 ImmutableMap.of(aggregationSymbol, new Aggregation(
-                        new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())),
+                        new FunctionReference(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())),
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
                         new Signature(
                                 "sum",
                                 FunctionKind.AGGREGATE,
@@ -242,7 +246,10 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 ImmutableMap.of(aggregationSymbol, new Aggregation(
-                        new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference())),
+                        new FunctionReference(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference())),
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
                         new Signature(
                                 "sum",
                                 FunctionKind.AGGREGATE,
@@ -269,7 +276,10 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 ImmutableMap.of(aggregationSymbol, new Aggregation(
-                        new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())),
+                        new FunctionReference(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())),
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
                         new Signature(
                                 "sum",
                                 FunctionKind.AGGREGATE,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
@@ -72,7 +72,7 @@ public class AggregationMatcher
         List<Symbol> aggregationsWithMask = aggregationNode.getAggregations()
                 .entrySet()
                 .stream()
-                .filter(entry -> entry.getValue().getCall().isDistinct())
+                .filter(entry -> entry.getValue().isDistinct())
                 .map(entry -> entry.getKey())
                 .collect(Collectors.toList());
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -701,4 +701,9 @@ public abstract class AstVisitor<R, C>
     {
         return visitExpression(node, context);
     }
+
+    protected R visitFunctionReference(FunctionReference node, C context)
+    {
+        return visitExpression(node, context);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -185,6 +185,16 @@ public abstract class DefaultTraversalVisitor<R, C>
     }
 
     @Override
+    protected R visitFunctionReference(FunctionReference node, C context)
+    {
+        for (Expression argument : node.getArguments()) {
+            process(argument, context);
+        }
+
+        return null;
+    }
+
+    @Override
     protected R visitGroupingOperation(GroupingOperation node, C context)
     {
         for (Expression columnArgument : node.getGroupingColumns()) {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionRewriter.java
@@ -105,6 +105,11 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
+    public Expression rewriteFunctionReference(FunctionReference node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
+
     public Expression rewriteLambdaExpression(LambdaExpression node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -43,6 +43,15 @@ public final class ExpressionTreeRewriter<C>
         this.visitor = new RewritingVisitor();
     }
 
+    public List<Expression> rewrite(List<Expression> items, Context<C> context)
+    {
+        ImmutableList.Builder<Expression> builder = ImmutableList.builder();
+        for (Expression expression : items) {
+            builder.add(rewrite(expression, context.get()));
+        }
+        return builder.build();
+    }
+
     @SuppressWarnings("unchecked")
     public <T extends Expression> T rewrite(T node, C context)
     {
@@ -84,13 +93,10 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
-            ImmutableList.Builder<Expression> builder = ImmutableList.builder();
-            for (Expression expression : node.getItems()) {
-                builder.add(rewrite(expression, context.get()));
-            }
+            List<Expression> items = rewrite(node.getItems(), context);
 
-            if (!sameElements(node.getItems(), builder.build())) {
-                return new Row(builder.build());
+            if (!sameElements(node.getItems(), items)) {
+                return new Row(items);
             }
 
             return node;
@@ -144,13 +150,10 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
-            ImmutableList.Builder<Expression> builder = ImmutableList.builder();
-            for (Expression expression : node.getValues()) {
-                builder.add(rewrite(expression, context.get()));
-            }
+            List<Expression> values = rewrite(node.getValues(), context);
 
-            if (!sameElements(node.getValues(), builder.build())) {
-                return new ArrayConstructor(builder.build());
+            if (!sameElements(node.getValues(), values)) {
+                return new ArrayConstructor(values);
             }
 
             return node;
@@ -441,13 +444,10 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
-            ImmutableList.Builder<Expression> builder = ImmutableList.builder();
-            for (Expression expression : node.getOperands()) {
-                builder.add(rewrite(expression, context.get()));
-            }
+            List<Expression> operands = rewrite(node.getOperands(), context);
 
-            if (!sameElements(node.getOperands(), builder.build())) {
-                return new CoalesceExpression(builder.build());
+            if (!sameElements(node.getOperands(), operands)) {
+                return new CoalesceExpression(operands);
             }
 
             return node;
@@ -493,10 +493,7 @@ public final class ExpressionTreeRewriter<C>
             if (node.getWindow().isPresent()) {
                 Window window = node.getWindow().get();
 
-                ImmutableList.Builder<Expression> partitionBy = ImmutableList.builder();
-                for (Expression expression : window.getPartitionBy()) {
-                    partitionBy.add(rewrite(expression, context.get()));
-                }
+                List<Expression> partitionBy = rewrite(window.getPartitionBy(), context);
 
                 Optional<OrderBy> orderBy = Optional.empty();
                 if (window.getOrderBy().isPresent()) {
@@ -532,21 +529,18 @@ public final class ExpressionTreeRewriter<C>
                     }
                 }
 
-                if (!sameElements(window.getPartitionBy(), partitionBy.build()) ||
+                if (!sameElements(window.getPartitionBy(), partitionBy) ||
                         !sameElements(window.getOrderBy(), orderBy) ||
                         !sameElements(window.getFrame(), rewrittenFrame)) {
-                    rewrittenWindow = Optional.of(new Window(partitionBy.build(), orderBy, rewrittenFrame));
+                    rewrittenWindow = Optional.of(new Window(partitionBy, orderBy, rewrittenFrame));
                 }
             }
 
-            ImmutableList.Builder<Expression> arguments = ImmutableList.builder();
-            for (Expression expression : node.getArguments()) {
-                arguments.add(rewrite(expression, context.get()));
-            }
+            List<Expression> arguments = rewrite(node.getArguments(), context);
 
-            if (!sameElements(node.getArguments(), arguments.build()) || !sameElements(rewrittenWindow, node.getWindow())
+            if (!sameElements(node.getArguments(), arguments) || !sameElements(rewrittenWindow, node.getWindow())
                     || !sameElements(filter, node.getFilter())) {
-                return new FunctionCall(node.getName(), rewrittenWindow, filter, node.getOrderBy().map(orderBy -> rewriteOrderBy(orderBy, context)), node.isDistinct(), arguments.build());
+                return new FunctionCall(node.getName(), rewrittenWindow, filter, node.getOrderBy().map(orderBy -> rewriteOrderBy(orderBy, context)), node.isDistinct(), arguments);
             }
             return node;
         }
@@ -670,13 +664,10 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
-            ImmutableList.Builder<Expression> builder = ImmutableList.builder();
-            for (Expression expression : node.getValues()) {
-                builder.add(rewrite(expression, context.get()));
-            }
+            List<Expression> values = rewrite(node.getValues(), context);
 
-            if (!sameElements(node.getValues(), builder.build())) {
-                return new InListExpression(builder.build());
+            if (!sameElements(node.getValues(), values)) {
+                return new InListExpression(values);
             }
 
             return node;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -572,6 +572,23 @@ public final class ExpressionTreeRewriter<C>
         }
 
         @Override
+        protected Expression visitFunctionReference(FunctionReference node, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                Expression result = rewriter.rewriteFunctionReference(node, context.get(), ExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            List<Expression> arguments = rewrite(node.getArguments(), context);
+            if (!sameElements(node.getArguments(), arguments)) {
+                return new FunctionReference(node.getName(), arguments);
+            }
+            return node;
+        }
+
+        @Override
         protected Expression visitLambdaExpression(LambdaExpression node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionReference.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionReference.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class FunctionReference
+        extends Expression
+{
+    private final QualifiedName name;
+    private final List<Expression> arguments;
+
+    public FunctionReference(QualifiedName name, List<Expression> arguments)
+    {
+        super(Optional.empty());
+        this.name = requireNonNull(name, "name is null");
+        this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return arguments;
+    }
+
+    public QualifiedName getName()
+    {
+        return name;
+    }
+
+    public List<Expression> getArguments()
+    {
+        return arguments;
+    }
+
+    @Override
+    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitFunctionReference(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FunctionReference that = (FunctionReference) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(arguments, that.arguments);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, arguments);
+    }
+}


### PR DESCRIPTION
`FunctionCall` is a analyzer object, using it in planner is cumbersome. In different places it may mean different things and different information you need to use from this class. 

This PR introduces `FunctionReference` and uses it in `AggregationNode`. Thanks to that all required information from `FunctionCall` are captured by `AggregationNode.Aggregation` class.