### PR TITLE
User principal matching implementation into the file access control.

### DIFF
--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -61,23 +61,26 @@ contents:
    access-control.name=file
    security.config-file=etc/rules.json
 
-The config file consists of a list of access control rules in JSON format. The
-rules are matched in the order specified in the file. All
-regular expressions default to ``.*`` if not specified.
+The config file is specified in JSON format.
 
-This plugin currently only supports catalog access control rules. If you want
-to limit access on a system level in any other way, you must implement a custom
-SystemAccessControl plugin (see :doc:`/develop/system-access-control`).
+* It contains the rules defining which catalog can be accessed by which user (see Catalog Rules below).
+* User extraction rules specifying what principals can identify as what users (see Username Extraction below).
+
+This plugin currently only supports catalog access control rules and username
+extraction. If you want to limit access on a system level in any other way, you
+must implement a custom SystemAccessControl plugin
+(see :doc:`/develop/system-access-control`).
 
 Catalog Rules
 -------------
 
 These rules govern the catalogs particular users can access. The user is
-granted access to a catalog based on the first matching rule. If no rule
-matches, access is denied. Each rule is composed of the following fields:
+granted access to a catalog based on the first matching rule read from top to
+bottom. If no rule matches, access is denied. Each rule is composed of the
+following fields:
 
-* ``user`` (optional): regex to match against user name.
-* ``catalog`` (optional): regex to match against catalog name.
+* ``user`` (optional): regex to match against user name. Defaults to ``.*``.
+* ``catalog`` (optional): regex to match against catalog name. Defaults to ``.*``.
 * ``allowed`` (required): boolean indicating whether a user has access to the catalog
 
 .. note::
@@ -109,3 +112,29 @@ catalog, and deny all other access, you can use the following rules:
       ]
     }
 
+Username Extraction
+-------------------
+
+These rules serve to enforce a specific matching between a principal and a
+specified user name. It consists of a list of regular expressions which will
+perform group extraction and compare it with the provided user name.
+If a provided expression extracts the same user name, the user will have
+access to the database.
+If no expression are specified, no checks will be performed.
+
+The following implements an exact matching of the full principal name for LDAP
+and Kerberos authentication:
+
+.. code-block:: json
+
+    {
+      "catalog": [
+        {
+          "allow": true
+        }
+      ],
+      "user_patterns": [
+        "(.*)",
+        "([a-zA-Z]+)/?.*@.*"
+      ]
+    }

--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControlRules.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControlRules.java
@@ -19,19 +19,29 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 public class FileBasedSystemAccessControlRules
 {
     private final List<CatalogAccessControlRule> catalogRules;
+    private final List<Pattern> userPatterns;
 
     @JsonCreator
-    public FileBasedSystemAccessControlRules(@JsonProperty("catalogs") Optional<List<CatalogAccessControlRule>> catalogRules)
+    public FileBasedSystemAccessControlRules(
+            @JsonProperty("catalogs") Optional<List<CatalogAccessControlRule>> catalogRules,
+            @JsonProperty("user_patterns") Optional<List<Pattern>> userPatterns)
     {
         this.catalogRules = catalogRules.map(ImmutableList::copyOf).orElse(ImmutableList.of());
+        this.userPatterns = userPatterns.map(ImmutableList::copyOf).orElse(ImmutableList.of());
     }
 
     public List<CatalogAccessControlRule> getCatalogRules()
     {
         return catalogRules;
+    }
+
+    public List<Pattern> getUserPatterns()
+    {
+        return userPatterns;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import javax.security.auth.kerberos.KerberosPrincipal;
+
 import java.util.Optional;
 import java.util.Set;
 
@@ -35,6 +37,8 @@ import static org.testng.Assert.assertThrows;
 public class TestFileBasedSystemAccessControl
 {
     private static final Identity alice = new Identity("alice", Optional.empty());
+    private static final Identity kerberosValidAlice = new Identity("alice", Optional.of(new KerberosPrincipal("alice/example.com@EXAMPLE.COM")));
+    private static final Identity kerberosInvalidAlice = new Identity("alice", Optional.of(new KerberosPrincipal("mallory/example.com@EXAMPLE.COM")));
     private static final Identity bob = new Identity("bob", Optional.empty());
     private static final Identity admin = new Identity("admin", Optional.empty());
     private static final Identity nonAsciiUser = new Identity("\u0194\u0194\u0194", Optional.empty());
@@ -44,10 +48,36 @@ public class TestFileBasedSystemAccessControl
     private static final CatalogSchemaName aliceSchema = new CatalogSchemaName("alice-catalog", "schema");
 
     @Test
+    public void testCanSetUserOperations()
+    {
+        TransactionManager transactionManager = createTestTransactionManager();
+        AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog_user_patterns.json");
+
+        try {
+            accessControlManager.checkCanSetUser(null, alice.getUser());
+            throw new AssertionError("expected AccessDeniedExeption");
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        accessControlManager.checkCanSetUser(kerberosValidAlice.getPrincipal().get(), kerberosValidAlice.getUser());
+        try {
+            accessControlManager.checkCanSetUser(kerberosInvalidAlice.getPrincipal().get(), kerberosInvalidAlice.getUser());
+            throw new AssertionError("expected AccessDeniedExeption");
+        }
+        catch (AccessDeniedException expected) {
+        }
+
+        TransactionManager transactionManagerNoPatterns = createTestTransactionManager();
+        AccessControlManager accessControlManagerNoPatterns = newAccessControlManager(transactionManager, "catalog.json");
+        accessControlManagerNoPatterns.checkCanSetUser(kerberosValidAlice.getPrincipal().get(), kerberosValidAlice.getUser());
+    }
+
+    @Test
     public void testCatalogOperations()
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControlManager accessControlManager = newAccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog.json");
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
@@ -65,7 +95,7 @@ public class TestFileBasedSystemAccessControl
     public void testSchemaOperations()
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControlManager accessControlManager = newAccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog.json");
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
@@ -87,7 +117,7 @@ public class TestFileBasedSystemAccessControl
     public void testTableOperations()
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControlManager accessControlManager = newAccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog.json");
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
@@ -112,7 +142,7 @@ public class TestFileBasedSystemAccessControl
     public void testViewOperations()
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControlManager accessControlManager = newAccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog.json");
 
         transaction(transactionManager, accessControlManager)
                 .execute(transactionId -> {
@@ -130,11 +160,11 @@ public class TestFileBasedSystemAccessControl
         }));
     }
 
-    private AccessControlManager newAccessControlManager(TransactionManager transactionManager)
+    private AccessControlManager newAccessControlManager(TransactionManager transactionManager, String resourceName)
     {
         AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
 
-        String path = this.getClass().getClassLoader().getResource("catalog.json").getPath();
+        String path = this.getClass().getClassLoader().getResource(resourceName).getPath();
         accessControlManager.setSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of("security.config-file", path));
 
         return accessControlManager;

--- a/presto-main/src/test/resources/catalog_user_patterns.json
+++ b/presto-main/src/test/resources/catalog_user_patterns.json
@@ -1,0 +1,11 @@
+{
+  "catalog": [
+    {
+      "allow": true
+    }
+  ],
+  "user_patterns": [
+    "(.*)",
+    "([a-zA-Z]+)/?.*@.*"
+  ]
+}


### PR DESCRIPTION
Following #9908, I did give a shot to implement a similar mechanism over file access control as @dain suggested. I went with regexes and catching groups since the proposed approach over auth_to_local rules would add an extra - unwanted (imho) - dependency. It only differs from @dain's approach on the fact that I check all catching groups, not only the first one.

It is still distinct from the catalog object in the config file for the simple reason that checkCanSetUser does not specify a catalog, so I cannot really spot the right catalog object in the array, and I don't want to perform this check out of this function or call it from somewhere else. I can change the API, but I'm a bit reluctant to break the API.

Any suggestions?