### PR TITLE
Remove test suppression for PostgreSQL

### DIFF
--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -56,5 +56,5 @@ public class TestPostgreSqlDistributedQueries
         // https://github.com/prestodb/presto/issues/5752
     }
 
-    // PostgreSQL specific tests should normally go in TestPostgreSqlDistributedQueries
+    // PostgreSQL specific tests should normally go in TestPostgreSqlIntegrationSmokeTest
 }

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -48,13 +48,5 @@ public class TestPostgreSqlDistributedQueries
         postgreSqlServer.close();
     }
 
-    @Override
-    public void testLargeIn()
-    {
-        // the PostgreSQL query fails with "stack depth limit exceeded"
-        // TODO: fix QueryBuilder not to generate such a large query
-        // https://github.com/prestodb/presto/issues/5752
-    }
-
     // PostgreSQL specific tests should normally go in TestPostgreSqlIntegrationSmokeTest
 }


### PR DESCRIPTION
`testLargeIn` passes for PostgreSQL when run locally on Mac, no need to
disable it.

If this gets merged, https://github.com/prestodb/presto/issues/5752 should be closed.
