### PR TITLE
Fix race condition when listing columns in MySQL connector

### DIFF
--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -60,6 +60,7 @@ public class MySqlClient
             throws SQLException
     {
         Properties connectionProperties = basicConnectionProperties(config);
+        connectionProperties.setProperty("useInformationSchema", "true");
         connectionProperties.setProperty("nullCatalogMeansCurrent", "false");
         connectionProperties.setProperty("useUnicode", "true");
         connectionProperties.setProperty("characterEncoding", "utf8");


### PR DESCRIPTION
The MySQL JDBC driver has a race condition where it lists all tables, then
fetches column metadata for each table, which throws a SQL exception if a
table is dropped during this process. This error does not occur if the
driver is set to use INFORMATION_SCHEMA for metadata.