### PR TITLE
Optimize ST_Envelope

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -60,6 +60,7 @@ import static java.lang.String.format;
 public final class GeoFunctions
 {
     private static final Joiner OR_JOINER = Joiner.on(" or ");
+    private static final Slice EMPTY_POLYGON = serialize(createFromEsriGeometry(new Polygon(), null));
 
     private GeoFunctions() {}
 
@@ -392,10 +393,11 @@ public final class GeoFunctions
     @SqlType(GEOMETRY_TYPE_NAME)
     public static Slice stEnvelope(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
-        OGCGeometry geometry = deserialize(input);
-        SpatialReference reference = geometry.getEsriSpatialReference();
-        Envelope envelope = getEnvelope(geometry);
-        return serialize(createFromEsriGeometry(envelope, reference));
+        Envelope envelope = deserializeEnvelope(input);
+        if (envelope == null) {
+            return EMPTY_POLYGON;
+        }
+        return serialize(createFromEsriGeometry(envelope, null));
     }
 
     @Description("Returns the Geometry value that represents the point set difference of two geometries")

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkSTContains.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkSTContains.java
@@ -35,11 +35,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.plugin.geospatial.GeometryBenchmarkUtils.loadPolygon;
 
 @State(Scope.Thread)
 @Fork(2)
@@ -144,12 +142,7 @@ public class BenchmarkSTContains
         public void setup()
                 throws IOException
         {
-            Path filePath = Paths.get(this.getClass().getClassLoader().getResource("large_polygon.txt").getPath());
-            List<String> lines = Files.readAllLines(filePath);
-            String line = lines.get(0);
-            String[] parts = line.split("\\|");
-            String wkt = parts[0];
-            geometry = GeoFunctions.stGeometryFromText(Slices.utf8Slice(wkt));
+            geometry = GeoFunctions.stGeometryFromText(Slices.utf8Slice(loadPolygon("large_polygon.txt")));
             simpleGeometry = GeoFunctions.stGeometryFromText(Slices.utf8Slice("POLYGON ((16.5 54, 16.5 54.1, 16.8 54.1, 16.8 54))"));
             innerPoint = GeoFunctions.stPoint(16.6, 54.0167);
             outerPointInEnvelope = GeoFunctions.stPoint(16.6667, 54.05);

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkSTEnvelope.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkSTEnvelope.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.io.IOException;
+
+import static com.facebook.presto.plugin.geospatial.GeometryBenchmarkUtils.loadPolygon;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@OutputTimeUnit(NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkSTEnvelope
+{
+    @Benchmark
+    public Slice simpleGeometry(BenchmarkData data)
+    {
+        return GeoFunctions.stEnvelope(data.simpleGeometry);
+    }
+
+    @Benchmark
+    public Slice complexGeometry(BenchmarkData data)
+    {
+        return GeoFunctions.stEnvelope(data.complexGeometry);
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private Slice complexGeometry;
+        private Slice simpleGeometry;
+
+        @Setup
+        public void setup()
+                throws IOException
+        {
+            complexGeometry = GeoFunctions.stGeometryFromText(Slices.utf8Slice(loadPolygon("large_polygon.txt")));
+            simpleGeometry = GeoFunctions.stGeometryFromText(Slices.utf8Slice("POLYGON ((1 1, 4 1, 1 4))"));
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkSTEnvelope.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/GeometryBenchmarkUtils.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/GeometryBenchmarkUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class GeometryBenchmarkUtils
+{
+    private GeometryBenchmarkUtils() {}
+
+    public static String loadPolygon(String fileName)
+            throws IOException
+    {
+        Path filePath = Paths.get(GeometryBenchmarkUtils.class.getClassLoader().getResource(fileName).getPath());
+        List<String> lines = Files.readAllLines(filePath);
+        String line = lines.get(0);
+        String[] parts = line.split("\\|");
+        return parts[0];
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoQueries.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoQueries.java
@@ -276,6 +276,7 @@ public class TestGeoQueries
         assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))')))", VARCHAR, "POLYGON ((1 1, 5 1, 5 4, 1 4, 1 1))");
         assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('POLYGON ((1 1, 4 1, 1 4))')))", VARCHAR, "POLYGON ((1 1, 4 1, 4 4, 1 4, 1 1))");
         assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1)), ((0 0, 0 2, 2 2, 2 0)))')))", VARCHAR, "POLYGON ((0 0, 3 0, 3 3, 0 3, 0 0))");
+        assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('GEOMETRYCOLLECTION (POINT (5 1), LINESTRING (3 4, 4 4))')))", VARCHAR, "POLYGON ((3 1, 5 1, 5 4, 3 4, 3 1))");
     }
 
     @Test


### PR DESCRIPTION
Similar to #9798, ST_Envelope spent most of the time deserializing geometry from Slice. This PR updates ST_Envelope to limit deserialization to just the envelope.

Benchmark results before the change:

```
Benchmark                                      Mode  Cnt       Score       Error  Units
BenchmarkSTEnvelope.complexGeometry  avgt   20  173054.303 ± 24902.172  ns/op
BenchmarkSTEnvelope.simpleGeometry   avgt   20    1866.689 ±   388.987  ns/op
```

and after:

```
Benchmark                                      Mode  Cnt     Score    Error  Units
BenchmarkSTEnvelope.complexGeometry  avgt   20   977.294 ± 55.636  ns/op
BenchmarkSTEnvelope.simpleGeometry   avgt   20  1016.174 ± 57.284  ns/op
```

Also, fixes #9814 