### PR TITLE
Skip reserved hash slot in ORC dictionary builder

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryBuilder.java
@@ -138,6 +138,11 @@ public class DictionaryBuilder
         int length = block.getSliceLength(position);
         long hashPosition = getMaskedHash(block.hash(position, 0, length));
         while (true) {
+            if (hashPosition == NULL_POSITION) {
+                // Need to skip the reserved null slot
+                hashPosition = getMaskedHash(hashPosition + 1);
+            }
+
             int blockPosition = blockPositionByHash.get(hashPosition);
             if (blockPosition == EMPTY_SLOT) {
                 // Doesn't have this element

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.writer.DictionaryBuilder;
+import com.facebook.presto.spi.block.VariableWidthBlock;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.testng.Assert.assertEquals;
+
+public class TestDictionaryBuilder
+{
+    @Test
+    public void testSkipReservedSlots()
+    {
+        Set<Integer> positions = new HashSet<>();
+        DictionaryBuilder dictionaryBuilder = new DictionaryBuilder(64);
+        for (int i = 0; i < 64; i++) {
+            positions.add(dictionaryBuilder.putIfAbsent(new TestHashCollisionBlock(1, wrappedBuffer(new byte[]{1}), new int[]{0, 1}, new boolean[]{false}), 0));
+            positions.add(dictionaryBuilder.putIfAbsent(new TestHashCollisionBlock(1, wrappedBuffer(new byte[]{2}), new int[]{0, 1}, new boolean[]{false}), 0));
+        }
+        assertEquals(positions, ImmutableSet.of(1, 2));
+    }
+
+    private class TestHashCollisionBlock
+            extends VariableWidthBlock
+    {
+        public TestHashCollisionBlock(int positionCount, Slice slice, int[] offsets, boolean[] valueIsNull)
+        {
+            super(positionCount, slice, offsets, valueIsNull);
+        }
+
+        @Override
+        public long hash(int position, int offset, int length)
+        {
+            // return 0 to hash to the reserved null position which is zero
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
ORC dictionary builder by default uses position 0 to denote null values.
However, hash function of the builder can return 0 as a legit empty
position. Need to skip the reserved slot for null.