### PR TITLE
Simplify Constraint construction in TableScanStatsRule

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/cost/TestOutputNodeStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestOutputNodeStats.java
@@ -26,7 +26,6 @@ public class TestOutputNodeStats
 {
     @Test
     public void testStatsForOutputNode()
-            throws Exception
     {
         PlanNodeStatsEstimate stats = PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(100)


### PR DESCRIPTION
Since `predicate` being added to `node.getCurrentConstraint()` is always
`TRUE_LITERAL`, the code constructing `DomainTranslator`, `TupleDomain`
and `TupleDomain`'s intersection was not doing anything useful.