### PR TITLE
Extract aggregation tests to a separate class

### DIFF
--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -45,18 +45,6 @@ public class TestCassandraDistributed
     }
 
     @Override
-    public void testGroupingSetMixedExpressionAndColumn()
-    {
-        // Cassandra does not support DATE
-    }
-
-    @Override
-    public void testGroupingSetMixedExpressionAndOrdinal()
-    {
-        // Cassandra does not support DATE
-    }
-
-    @Override
     public void testRenameTable()
     {
         // Cassandra does not support renaming tables

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedAggregations.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedAggregations.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.tests.AbstractTestAggregations;
+
+import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
+import static io.airlift.tpch.TpchTable.getTables;
+
+public class TestHiveDistributedAggregations
+        extends AbstractTestAggregations
+{
+    public TestHiveDistributedAggregations()
+    {
+        super(() -> createQueryRunner(getTables()));
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -1,0 +1,1181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.testing.MaterializedResult;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
+
+public abstract class AbstractTestAggregations
+        extends AbstractTestQueryFramework
+{
+    public AbstractTestAggregations(QueryRunnerSupplier supplier)
+    {
+        super(supplier);
+    }
+
+    @Test
+    public void testCountBoolean()
+    {
+        assertQuery("SELECT COUNT(true) FROM orders");
+    }
+
+    @Test
+    public void testCountAllWithComparison()
+    {
+        assertQuery("SELECT COUNT(*) FROM lineitem WHERE tax < discount");
+    }
+
+    @Test
+    public void testCountWithNotPredicate()
+    {
+        assertQuery("SELECT COUNT(*) FROM lineitem WHERE NOT tax < discount");
+    }
+
+    @Test
+    public void testCountWithNullPredicate()
+    {
+        assertQuery("SELECT COUNT(*) FROM lineitem WHERE NULL");
+    }
+
+    @Test
+    public void testCountWithIsNullPredicate()
+    {
+        assertQuery(
+                "SELECT COUNT(*) FROM orders WHERE NULLIF(orderstatus, 'F') IS NULL",
+                "SELECT COUNT(*) FROM orders WHERE orderstatus = 'F' ");
+    }
+
+    @Test
+    public void testCountWithIsNotNullPredicate()
+    {
+        assertQuery(
+                "SELECT COUNT(*) FROM orders WHERE NULLIF(orderstatus, 'F') IS NOT NULL",
+                "SELECT COUNT(*) FROM orders WHERE orderstatus <> 'F' ");
+    }
+
+    @Test
+    public void testCountWithNullIfPredicate()
+    {
+        assertQuery("SELECT COUNT(*) FROM orders WHERE NULLIF(orderstatus, 'F') = orderstatus ");
+    }
+
+    @Test
+    public void testCountWithCoalescePredicate()
+    {
+        assertQuery(
+                "SELECT COUNT(*) FROM orders WHERE COALESCE(NULLIF(orderstatus, 'F'), 'bar') = 'bar'",
+                "SELECT COUNT(*) FROM orders WHERE orderstatus = 'F'");
+    }
+
+    @Test
+    public void testCountWithAndPredicate()
+    {
+        assertQuery("SELECT COUNT(*) FROM lineitem WHERE tax < discount AND tax > 0.01 AND discount < 0.05");
+    }
+
+    @Test
+    public void testCountWithOrPredicate()
+    {
+        assertQuery("SELECT COUNT(*) FROM lineitem WHERE tax < 0.01 OR discount > 0.05");
+    }
+
+    @Test
+    public void testCountWithInlineView()
+    {
+        assertQuery("SELECT COUNT(*) FROM (SELECT orderkey FROM lineitem) x");
+    }
+
+    @Test
+    public void testNestedCount()
+    {
+        assertQuery("SELECT COUNT(*) FROM (SELECT orderkey, COUNT(*) FROM lineitem GROUP BY orderkey) x");
+    }
+
+    @Test
+    public void testGroupByOnSupersetOfPartitioning()
+    {
+        assertQuery("SELECT orderdate, c, count(*) FROM (SELECT orderdate, count(*) c FROM orders GROUP BY orderdate) GROUP BY orderdate, c");
+    }
+
+    @Test
+    public void testSumOfNulls()
+    {
+        assertQuery("SELECT orderstatus, sum(CAST(NULL AS BIGINT)) FROM orders GROUP BY orderstatus");
+    }
+
+    @Test
+    public void testCountAllWithPredicate()
+    {
+        assertQuery("SELECT COUNT(*) FROM orders WHERE orderstatus = 'F'");
+    }
+
+    @Test
+    public void testGroupByArray()
+    {
+        assertQuery("SELECT col[1], count FROM (SELECT ARRAY[custkey] col, COUNT(*) count FROM orders GROUP BY 1 ORDER BY 1)", "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey ORDER BY custkey");
+    }
+
+    @Test
+    public void testGroupByMap()
+    {
+        assertQuery("SELECT col[1], count FROM (SELECT MAP(ARRAY[1], ARRAY[custkey]) col, COUNT(*) count FROM orders GROUP BY 1)", "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey");
+    }
+
+    @Test
+    public void testGroupByComplexMap()
+    {
+        assertQuery("SELECT MAP_KEYS(x)[1] FROM (VALUES MAP(ARRAY['a'], ARRAY[ARRAY[1]]), MAP(ARRAY['b'], ARRAY[ARRAY[2]])) t(x) GROUP BY x", "VALUES 'a', 'b'");
+    }
+
+    @Test
+    public void testGroupByRow()
+    {
+        assertQuery("SELECT col.col1, count FROM (SELECT CAST(row(custkey, custkey) AS row(col0 bigint, col1 bigint)) col, COUNT(*) count FROM orders GROUP BY 1)", "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey");
+    }
+
+    @Test
+    public void testGroupByWithoutAggregation()
+    {
+        assertQuery("SELECT orderstatus FROM orders GROUP BY orderstatus");
+    }
+
+    @Test
+    public void testNestedGroupByWithSameKey()
+    {
+        assertQuery("SELECT custkey, sum(t) FROM (SELECT custkey, count(*) t FROM orders GROUP BY custkey) GROUP BY custkey");
+    }
+
+    @Test
+    public void testGroupByWithNulls()
+    {
+        assertQuery("SELECT key, COUNT(*) FROM (" +
+                "SELECT CASE " +
+                "  WHEN orderkey % 3 = 0 THEN NULL " +
+                "  WHEN orderkey % 5 = 0 THEN 0 " +
+                "  ELSE orderkey " +
+                "  END AS key " +
+                "FROM lineitem) " +
+                "GROUP BY key");
+    }
+
+    @Test
+    public void testHistogram()
+    {
+        assertQuery("SELECT lines, COUNT(*) FROM (SELECT orderkey, COUNT(*) lines FROM lineitem GROUP BY orderkey) U GROUP BY lines");
+    }
+
+    @Test
+    public void testCountDistinct()
+    {
+        assertQuery("SELECT COUNT(DISTINCT custkey + 1) FROM orders", "SELECT COUNT(*) FROM (SELECT DISTINCT custkey + 1 FROM orders) t");
+    }
+
+    @Test
+    public void testDistinctGroupBy()
+    {
+        assertQuery("SELECT COUNT(DISTINCT clerk) AS count, orderdate FROM orders GROUP BY orderdate ORDER BY count, orderdate");
+    }
+
+    @Test
+    public void testSingleDistinctOptimizer()
+    {
+        assertQuery("SELECT custkey, orderstatus, COUNT(DISTINCT orderkey) FROM orders GROUP BY custkey, orderstatus");
+        assertQuery("SELECT custkey, orderstatus, COUNT(DISTINCT orderkey), SUM(DISTINCT orderkey) FROM orders GROUP BY custkey, orderstatus");
+        assertQuery("" +
+                "SELECT custkey, COUNT(DISTINCT orderstatus) FROM (" +
+                "   SELECT orders.custkey AS custkey, orders.orderstatus AS orderstatus " +
+                "   FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = lineitem.partkey " +
+                "   GROUP BY orders.custkey, orders.orderstatus" +
+                ") " +
+                "GROUP BY custkey");
+        assertQuery("SELECT custkey, COUNT(DISTINCT orderkey), COUNT(DISTINCT orderstatus) FROM orders GROUP BY custkey");
+
+        assertQuery("SELECT SUM(DISTINCT x) FROM (SELECT custkey, COUNT(DISTINCT orderstatus) x FROM orders GROUP BY custkey) t");
+    }
+
+    @Test
+    public void testExtractDistinctAggregationOptimizer()
+    {
+        assertQuery("SELECT max(orderstatus), COUNT(orderkey), sum(DISTINCT orderkey) FROM orders");
+
+        assertQuery("SELECT custkey, orderstatus, avg(shippriority), SUM(DISTINCT orderkey) FROM orders GROUP BY custkey, orderstatus");
+
+        assertQuery("SELECT s, MAX(custkey), SUM(a) FROM (" +
+                "    SELECT custkey, avg(shippriority) AS a, SUM(DISTINCT orderkey) AS s FROM orders GROUP BY custkey, orderstatus" +
+                ") " +
+                "GROUP BY s");
+
+        assertQuery("SELECT max(orderstatus), COUNT(DISTINCT orderkey), sum(DISTINCT orderkey) FROM orders");
+
+        assertQuery("SELECT max(orderstatus), COUNT(DISTINCT shippriority), sum(DISTINCT orderkey) FROM orders");
+
+        assertQuery("SELECT COUNT(tan(shippriority)), sum(DISTINCT orderkey) FROM orders");
+
+        assertQuery("SELECT count(DISTINCT a), max(b) FROM (VALUES (row(1, 2), 3)) t(a, b)", "VALUES (1, 3)");
+
+        // Test overlap between GroupBy columns and aggregation columns
+        assertQuery("SELECT shippriority, MAX(orderstatus), SUM(DISTINCT shippriority) FROM orders GROUP BY shippriority");
+
+        assertQuery("SELECT shippriority, COUNT(shippriority), SUM(DISTINCT orderkey) FROM orders GROUP BY shippriority");
+
+        assertQuery("SELECT shippriority, COUNT(shippriority), SUM(DISTINCT shippriority) FROM orders GROUP BY shippriority");
+
+        assertQuery("SELECT clerk, shippriority, MAX(orderstatus), SUM(DISTINCT shippriority) FROM orders GROUP BY clerk, shippriority");
+
+        assertQuery("SELECT clerk, shippriority, COUNT(shippriority), SUM(DISTINCT orderkey) FROM orders GROUP BY clerk, shippriority");
+
+        assertQuery("SELECT clerk, shippriority, COUNT(shippriority), SUM(DISTINCT shippriority) FROM orders GROUP BY clerk, shippriority");
+    }
+
+    @Test
+    public void testDistinctWhere()
+    {
+        assertQuery("SELECT COUNT(DISTINCT clerk) FROM orders WHERE LENGTH(clerk) > 5");
+    }
+
+    @Test
+    public void testMultipleDifferentDistinct()
+    {
+        assertQuery("SELECT COUNT(DISTINCT orderstatus), SUM(DISTINCT custkey) FROM orders");
+    }
+
+    @Test
+    public void testMultipleDistinct()
+    {
+        assertQuery(
+                "SELECT COUNT(DISTINCT custkey), SUM(DISTINCT custkey) FROM orders",
+                "SELECT COUNT(*), SUM(custkey) FROM (SELECT DISTINCT custkey FROM orders) t");
+    }
+
+    @Test
+    public void testComplexDistinct()
+    {
+        assertQuery(
+                "SELECT COUNT(DISTINCT custkey), " +
+                        "SUM(DISTINCT custkey), " +
+                        "SUM(DISTINCT custkey + 1.0E0), " +
+                        "AVG(DISTINCT custkey), " +
+                        "VARIANCE(DISTINCT custkey) FROM orders",
+                "SELECT COUNT(*), " +
+                        "SUM(custkey), " +
+                        "SUM(custkey + 1.0), " +
+                        "AVG(custkey), " +
+                        "VARIANCE(custkey) FROM (SELECT DISTINCT custkey FROM orders) t");
+    }
+
+    @Test
+    public void testAggregationFilter()
+    {
+        assertQuery("SELECT sum(x) FILTER (WHERE y > 4) FROM (VALUES (1, 3), (2, 4), (2, 4), (4, 5)) t (x, y)", "SELECT 4");
+        assertQuery("SELECT sum(x) FILTER (WHERE x > 1), sum(y) FILTER (WHERE y > 4) FROM (VALUES (1, 3), (2, 4), (2, 4), (4, 5)) t (x, y)", "SELECT 8, 5");
+        assertQuery("SELECT sum(x) FILTER (WHERE x > 1), sum(x) FROM (VALUES (1), (2), (2), (4)) t (x)", "SELECT 8, 9");
+        assertQuery("SELECT count(*) FILTER (WHERE x > 1), sum(x) FROM (VALUES (1, 3), (2, 4), (2, 4), (4, 5)) t (x, y)", "SELECT 3, 9");
+        assertQuery("SELECT count(*) FILTER (WHERE x > 1), count(DISTINCT y) FROM (VALUES (1, 10), (2, 10), (3, 10), (4, 20)) t (x, y)", "SELECT 3, 2");
+
+        assertQuery("" +
+                        "SELECT sum(b) FILTER (WHERE true) " +
+                        "FROM (SELECT count(*) FILTER (WHERE true) AS b)",
+                "SELECT 1");
+
+        assertQuery("SELECT count(1) FILTER (WHERE orderstatus = 'O') FROM orders", "SELECT count(*) FROM orders WHERE orderstatus = 'O'");
+
+        // TODO: enable when DISTINCT is allowed with filtered aggregations
+        // assertQuery("SELECT count(DISTINCT x) FILTER (where y = 1) FROM (VALUES (2, 1), (1, 2), (1,1)) t(x, y)", "SELECT 2");
+        // assertQuery("SELECT sum(DISTINCT x) FILTER (WHERE x > 1) AS x FROM (VALUES (1), (2), (2), (4)) t (x)", "SELECT 6");
+        // assertQuery("SELECT sum(DISTINCT x) FILTER (WHERE y > 3), sum(DISTINCT y) FILTER (WHERE x > 1) FROM (VALUES (1, 3), (2, 4), (2, 4), (4, 5)) t (x, y)", "SELECT 6, 9");
+        // assertQuery("SELECT sum(x) FILTER (WHERE x > 1) AS x, sum(DISTINCT x) FROM (VALUES (1), (2), (2), (4)) t (x)", "SELECT 8, 9");
+    }
+
+    @Test
+    public void testAggregationWithProjection()
+    {
+        assertQuery("SELECT sum(totalprice * 2) - sum(totalprice) FROM orders");
+        assertQuery("SELECT sum(totalprice * 2) + sum(totalprice * 2) FROM orders");
+    }
+
+    @Test
+    public void testSameInputToAggregates()
+    {
+        assertQuery("SELECT max(a), max(b) FROM (SELECT custkey a, custkey b FROM orders) x");
+    }
+
+    @Test
+    public void testAggregationImplicitCoercion()
+    {
+        assertQuery("SELECT 1.0 / COUNT(*) FROM orders");
+        assertQuery("SELECT custkey, 1.0 / COUNT(*) FROM orders GROUP BY custkey");
+    }
+
+    @Test
+    public void testAggregationOverRightJoinOverSingleStreamProbe()
+    {
+        // this should return one row since value is always 'value'
+        // this test verifies that the two streams produced by the right join
+        // are handled gathered for the aggregation operator
+        assertQueryOrdered("" +
+                        "SELECT\n" +
+                        "  value\n" +
+                        "FROM\n" +
+                        "(\n" +
+                        "    SELECT\n" +
+                        "        key\n" +
+                        "    FROM\n" +
+                        "        (VALUES 'match') AS a(key)\n" +
+                        "        LEFT JOIN (SELECT * FROM (VALUES (0)) LIMIT 0) AS x(ignored)\n" +
+                        "        ON TRUE\n" +
+                        "    GROUP BY 1\n" +
+                        ") a\n" +
+                        "RIGHT JOIN\n" +
+                        "(\n" +
+                        "    VALUES\n" +
+                        "    ('match', 'value'),\n" +
+                        "    ('no-match', 'value')\n" +
+                        ") AS b(key, value)\n" +
+                        "ON a.key = b.key\n" +
+                        "GROUP BY 1\n",
+                "VALUES 'value'");
+    }
+
+    @Test
+    public void testAggregationPushedBelowOuterJoin()
+    {
+        assertQuery(
+                "SELECT * " +
+                        "FROM nation n1 " +
+                        "WHERE (n1.nationkey > ( " +
+                        "SELECT avg(nationkey) " +
+                        "FROM nation n2 " +
+                        "WHERE n1.regionkey=n2.regionkey))");
+        assertQuery(
+                "SELECT max(name), min(name), count(nationkey) + 1, count(nationkey) " +
+                        "FROM (SELECT DISTINCT regionkey FROM region) AS r1 " +
+                        "LEFT JOIN " +
+                        "nation " +
+                        "ON r1.regionkey = nation.regionkey " +
+                        "GROUP BY r1.regionkey " +
+                        "HAVING sum(nationkey) < 20");
+
+        assertQuery(
+                "SELECT DISTINCT r1.regionkey " +
+                        "FROM (SELECT regionkey FROM region INTERSECT SELECT regionkey FROM region WHERE regionkey < 4) AS r1 " +
+                        "LEFT JOIN " +
+                        "nation " +
+                        "ON r1.regionkey = nation.regionkey");
+
+        assertQuery(
+                "SELECT max(nationkey) " +
+                        "FROM (SELECT regionkey FROM region EXCEPT SELECT regionkey FROM region WHERE regionkey < 4) AS r1 " +
+                        "LEFT JOIN " +
+                        "nation " +
+                        "ON r1.regionkey = nation.regionkey " +
+                        "GROUP BY r1.regionkey");
+
+        assertQuery(
+                "SELECT max(nationkey) " +
+                        "FROM (VALUES CAST (1 AS BIGINT)) v1(col1) " +
+                        "LEFT JOIN " +
+                        "nation " +
+                        "ON v1.col1 = nation.regionkey " +
+                        "GROUP BY v1.col1",
+                "VALUES 24");
+    }
+
+    @Test
+    public void testAggregationWithSomeArgumentCasts()
+    {
+        assertQuery("SELECT APPROX_PERCENTILE(0.1E0, x), AVG(x), MIN(x) FROM (values 1, 1, 1) t(x)", "SELECT 0.1, 1.0, 1");
+    }
+
+    @Test
+    public void testAggregationWithHaving()
+    {
+        assertQuery("SELECT a, count(1) FROM (VALUES 1, 2, 3, 2) t(a) GROUP BY a HAVING count(1) > 1", "SELECT 2, 2");
+    }
+
+    @Test
+    public void testAggregationWithOrderBy()
+    {
+        assertQuery(
+                "SELECT sum(x ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
+                "VALUES (8)");
+        assertQuery(
+                "SELECT array_agg(x ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
+                "VALUES ((4, 1, 3))");
+
+        assertQuery(
+                "SELECT array_agg(x ORDER BY y DESC) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
+                "VALUES ((3, 1, 4))");
+
+        assertQuery(
+                "SELECT array_agg(x ORDER BY x DESC) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
+                "VALUES ((4, 3, 1))");
+
+        assertQuery(
+                "SELECT array_agg(x ORDER BY x) FROM (VALUES ('a', 2), ('bcd', 5), ('abcd', 1)) t(x, y)",
+                "VALUES (('a', 'abcd', 'bcd'))");
+
+        assertQuery(
+                "SELECT array_agg(y ORDER BY x) FROM (VALUES ('a', 2), ('bcd', 5), ('abcd', 1)) t(x, y)",
+                "VALUES ((2, 1, 5))");
+
+        assertQuery(
+                "SELECT array_agg(y ORDER BY x) FROM (VALUES ((1, 2), 2), ((3, 4), 5), ((1, 1), 1)) t(x, y)",
+                "VALUES ((1, 2, 5))");
+
+        assertQuery(
+                "SELECT array_agg(z ORDER BY x, y DESC) FROM (VALUES (1, 2, 2), (2, 2, 3), (2, 4, 5), (3, 4, 4), (1, 1, 1)) t(x, y, z)",
+                "VALUES ((2, 1, 5, 3, 4))");
+
+        assertQuery(
+                "SELECT x, array_agg(z ORDER BY y + z DESC) FROM (VALUES (1, 2, 2), (2, 2, 3), (2, 4, 5), (3, 4, 4), (3, 2, 1), (1, 1, 1)) t(x, y, z) GROUP BY x",
+                "VALUES (1, (2, 1)), (2, (5, 3)), (3, (4, 1))");
+
+        assertQuery(
+                "SELECT array_agg(y ORDER BY x.a DESC) FROM (VALUES (CAST(ROW(1) AS ROW(a BIGINT)), 1), (CAST(ROW(2) AS ROW(a BIGINT)), 2)) t(x, y)",
+                "VALUES ((2, 1))");
+
+        assertQuery(
+                "SELECT x, y, array_agg(z ORDER BY z DESC NULLS FIRST) FROM (VALUES (1, 2, NULL), (1, 2, 1), (1, 2, 2), (2, 1, 3), (2, 1, 4), (2, 1, NULL)) t(x, y, z) GROUP BY x, y",
+                "VALUES (1, 2, (NULL, 2, 1)), (2, 1, (NULL, 4, 3))");
+
+        assertQuery(
+                "SELECT x, y, array_agg(z ORDER BY z DESC NULLS LAST) FROM (VALUES (1, 2, 3), (1, 2, 1), (1, 2, 2), (2, 1, 3), (2, 1, 4), (2, 1, NULL)) t(x, y, z) GROUP BY GROUPING SETS ((x), (x, y))",
+                "VALUES (1, 2, (3, 2, 1)), (1, NULL, (3, 2, 1)), (2, 1, (4, 3, NULL)), (2, NULL, (4, 3, NULL))");
+
+        assertQuery(
+                "SELECT x, y, array_agg(z ORDER BY z DESC NULLS LAST) FROM (VALUES (1, 2, 3), (1, 2, 1), (1, 2, 2), (2, 1, 3), (2, 1, 4), (2, 1, NULL)) t(x, y, z) GROUP BY GROUPING SETS ((x), (x, y))",
+                "VALUES (1, 2, (3, 2, 1)), (1, NULL, (3, 2, 1)), (2, 1, (4, 3, NULL)), (2, NULL, (4, 3, NULL))");
+
+        assertQuery(
+                "SELECT x, array_agg(DISTINCT z + y ORDER BY z + y DESC) FROM (VALUES (1, 2, 2), (2, 2, 3), (2, 4, 5), (3, 4, 4), (3, 2, 1), (1, 1, 1)) t(x, y, z) GROUP BY x",
+                "VALUES (1, (4, 2)), (2, (9, 5)), (3, (8, 3))");
+
+        assertQuery(
+                "SELECT x, sum(cast(x AS double))\n" +
+                        "FROM (VALUES '1.0') t(x)\n" +
+                        "GROUP BY x\n" +
+                        "ORDER BY sum(cast(t.x AS double) ORDER BY t.x)",
+                "VALUES ('1.0', 1.0)");
+
+        assertQuery(
+                "SELECT x, y, array_agg(z ORDER BY z) FROM (VALUES (1, 2, 3), (1, 2, 1), (2, 1, 3), (2, 1, 4)) t(x, y, z) GROUP BY GROUPING SETS ((x), (x, y))",
+                "VALUES (1, NULL, (1, 3)), (2, NULL, (3, 4)), (1, 2, (1, 3)), (2, 1, (3, 4))");
+
+        assertQueryFails(
+                "SELECT x, array_agg(z ORDER BY z) FROM (VALUES (1, 2, 3), (1, 2, 1), (2, 1, 3), (2, 1, 4)) t(x, y, z) GROUP BY ROLLUP (x)",
+                ".* ORDER BY in aggregate function with at least one empty grouping set and at least one non-empty grouping set is not supported");
+
+        assertQueryFails(
+                "SELECT x, y, array_agg(z ORDER BY z) FROM (VALUES (1, 2, 3), (1, 2, 1), (2, 1, 3), (2, 1, 4)) t(x, y, z) GROUP BY CUBE (x, y)",
+                ".* ORDER BY in aggregate function with at least one empty grouping set and at least one non-empty grouping set is not supported");
+
+        assertQueryFails(
+                "SELECT array_agg(z ORDER BY z) OVER (PARTITION BY x) FROM (VALUES (1, 2, 3), (1, 2, 1), (2, 1, 3), (2, 1, 4)) t(x, y, z) GROUP BY x, z",
+                ".* Window function with ORDER BY is not supported");
+
+        assertQueryFails(
+                "SELECT array_agg(DISTINCT x ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
+                ".* For aggregate function with DISTINCT, ORDER BY expressions must appear in arguments");
+
+        assertQueryFails(
+                "SELECT array_agg(DISTINCT x+y ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
+                ".* For aggregate function with DISTINCT, ORDER BY expressions must appear in arguments");
+
+        assertQueryFails(
+                "SELECT x, array_agg(DISTINCT y ORDER BY z + y DESC) FROM (VALUES (1, 2, 2), (2, 2, 3), (2, 4, 5), (3, 4, 4), (3, 2, 1), (1, 1, 1)) t(x, y, z) GROUP BY x",
+                ".* For aggregate function with DISTINCT, ORDER BY expressions must appear in arguments");
+    }
+
+    @Test
+    public void testGroupByRepeatedField()
+    {
+        assertQuery("SELECT sum(custkey) FROM orders GROUP BY orderstatus, orderstatus");
+        assertQuery("SELECT count(*) FROM (SELECT orderstatus a, orderstatus b FROM orders) GROUP BY a, b");
+    }
+
+    @Test
+    public void testGroupByMultipleFieldsWithPredicateOnAggregationArgument()
+    {
+        assertQuery("SELECT custkey, orderstatus, MAX(orderkey) FROM orders WHERE orderkey = 1 GROUP BY custkey, orderstatus");
+    }
+
+    @Test
+    public void testReorderOutputsOfGroupByAggregation()
+    {
+        assertQuery(
+                "SELECT orderstatus, a, custkey, b FROM (SELECT custkey, orderstatus, -COUNT(*) a, MAX(orderkey) b FROM orders WHERE orderkey = 1 GROUP BY custkey, orderstatus) T");
+    }
+
+    @Test
+    public void testGroupAggregationOverNestedGroupByAggregation()
+    {
+        assertQuery("SELECT sum(custkey), max(orderstatus), min(c) FROM (SELECT orderstatus, custkey, COUNT(*) c FROM orders GROUP BY orderstatus, custkey) T");
+    }
+
+    @Test
+    public void testGroupByBetween()
+    {
+        // whole expression in group by
+        assertQuery("SELECT orderkey BETWEEN 1 AND 100 FROM orders GROUP BY orderkey BETWEEN 1 AND 100 ");
+
+        // expression in group by
+        assertQuery("SELECT CAST(orderkey BETWEEN 1 AND 100 AS BIGINT) FROM orders GROUP BY orderkey");
+
+        // min in group by
+        assertQuery("SELECT CAST(50 BETWEEN orderkey AND 100 AS BIGINT) FROM orders GROUP BY orderkey");
+
+        // max in group by
+        assertQuery("SELECT CAST(50 BETWEEN 1 AND orderkey AS BIGINT) FROM orders GROUP BY orderkey");
+    }
+
+    @Test
+    public void testGroupByOrdinal()
+    {
+        assertQuery(
+                "SELECT orderstatus, sum(totalprice) FROM orders GROUP BY 1",
+                "SELECT orderstatus, sum(totalprice) FROM orders GROUP BY orderstatus");
+    }
+
+    @Test
+    public void testGroupBySearchedCase()
+    {
+        assertQuery("SELECT CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END");
+
+        assertQuery(
+                "SELECT CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
+                        "FROM orders\n" +
+                        "GROUP BY 1",
+                "SELECT CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
+                        "FROM orders\n" +
+                        "GROUP BY CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END");
+    }
+
+    @Test
+    public void testGroupBySearchedCaseNoElse()
+    {
+        // whole CASE in GROUP BY clause
+        assertQuery("SELECT CASE WHEN orderstatus = 'O' THEN 'a' END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY CASE WHEN orderstatus = 'O' THEN 'a' END");
+
+        assertQuery(
+                "SELECT CASE WHEN orderstatus = 'O' THEN 'a' END, count(*)\n" +
+                        "FROM orders\n" +
+                        "GROUP BY 1",
+                "SELECT CASE WHEN orderstatus = 'O' THEN 'a' END, count(*)\n" +
+                        "FROM orders\n" +
+                        "GROUP BY CASE WHEN orderstatus = 'O' THEN 'a' END");
+
+        assertQuery("SELECT CASE WHEN true THEN orderstatus END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY orderstatus");
+    }
+
+    @Test
+    public void testGroupByIf()
+    {
+        assertQuery(
+                "SELECT IF(orderkey between 1 and 5, 'orders', 'others'), sum(totalprice) FROM orders GROUP BY 1",
+                "SELECT CASE WHEN orderkey BETWEEN 1 AND 5 THEN 'orders' ELSE 'others' END, sum(totalprice)\n" +
+                        "FROM orders\n" +
+                        "GROUP BY CASE WHEN orderkey BETWEEN 1 AND 5 THEN 'orders' ELSE 'others' END");
+    }
+
+    @Test
+    public void testGroupByCase()
+    {
+        // whole CASE in GROUP BY clause
+        assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END");
+
+        assertQuery(
+                "SELECT CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
+                        "FROM orders\n" +
+                        "GROUP BY 1",
+                "SELECT CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
+                        "FROM orders\n" +
+                        "GROUP BY CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END");
+
+        // operand in GROUP BY clause
+        assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY orderstatus");
+
+        // condition in GROUP BY clause
+        assertQuery("SELECT CASE 'O' WHEN orderstatus THEN 'a' ELSE 'b' END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY orderstatus");
+
+        // 'then' in GROUP BY clause
+        assertQuery("SELECT CASE 1 WHEN 1 THEN orderstatus ELSE 'x' END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY orderstatus");
+
+        // 'else' in GROUP BY clause
+        assertQuery("SELECT CASE 1 WHEN 1 THEN 'x' ELSE orderstatus END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY orderstatus");
+    }
+
+    @Test
+    public void testGroupByCaseNoElse()
+    {
+        // whole CASE in GROUP BY clause
+        assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY CASE orderstatus WHEN 'O' THEN 'a' END");
+
+        // operand in GROUP BY clause
+        assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY orderstatus");
+
+        // condition in GROUP BY clause
+        assertQuery("SELECT CASE 'O' WHEN orderstatus THEN 'a' END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY orderstatus");
+
+        // 'then' in GROUP BY clause
+        assertQuery("SELECT CASE 1 WHEN 1 THEN orderstatus END, count(*)\n" +
+                "FROM orders\n" +
+                "GROUP BY orderstatus");
+    }
+
+    @Test
+    public void testGroupByCast()
+    {
+        // whole CAST in GROUP BY expression
+        assertQuery("SELECT CAST(orderkey AS VARCHAR), count(*) FROM orders GROUP BY CAST(orderkey AS VARCHAR)");
+
+        assertQuery(
+                "SELECT CAST(orderkey AS VARCHAR), count(*) FROM orders GROUP BY 1",
+                "SELECT CAST(orderkey AS VARCHAR), count(*) FROM orders GROUP BY CAST(orderkey AS VARCHAR)");
+
+        // argument in GROUP BY expression
+        assertQuery("SELECT CAST(orderkey AS VARCHAR), count(*) FROM orders GROUP BY orderkey");
+    }
+
+    @Test
+    public void testGroupByCoalesce()
+    {
+        // whole COALESCE in group by
+        assertQuery("SELECT COALESCE(orderkey, custkey), count(*) FROM orders GROUP BY COALESCE(orderkey, custkey)");
+
+        assertQuery(
+                "SELECT COALESCE(orderkey, custkey), count(*) FROM orders GROUP BY 1",
+                "SELECT COALESCE(orderkey, custkey), count(*) FROM orders GROUP BY COALESCE(orderkey, custkey)");
+
+        // operands in group by
+        assertQuery("SELECT COALESCE(orderkey, 1), count(*) FROM orders GROUP BY orderkey");
+
+        // operands in group by
+        assertQuery("SELECT COALESCE(1, orderkey), count(*) FROM orders GROUP BY orderkey");
+    }
+
+    @Test
+    public void testGroupByNullIf()
+    {
+        // whole NULLIF in group by
+        assertQuery("SELECT NULLIF(orderkey, custkey), count(*) FROM orders GROUP BY NULLIF(orderkey, custkey)");
+
+        assertQuery(
+                "SELECT NULLIF(orderkey, custkey), count(*) FROM orders GROUP BY 1",
+                "SELECT NULLIF(orderkey, custkey), count(*) FROM orders GROUP BY NULLIF(orderkey, custkey)");
+
+        // first operand in group by
+        assertQuery("SELECT NULLIF(orderkey, 1), count(*) FROM orders GROUP BY orderkey");
+
+        // second operand in group by
+        assertQuery("SELECT NULLIF(1, orderkey), count(*) FROM orders GROUP BY orderkey");
+    }
+
+    @Test
+    public void testGroupByExtract()
+    {
+        // whole expression in group by
+        assertQuery("SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY EXTRACT(YEAR FROM now())");
+
+        assertQuery(
+                "SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY 1",
+                "SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY EXTRACT(YEAR FROM now())");
+
+        // argument in group by
+        assertQuery("SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY now()");
+    }
+
+    @Test
+    public void testGroupByNullConstant()
+    {
+        assertQuery("" +
+                "SELECT count(*)\n" +
+                "FROM (\n" +
+                "  SELECT CAST(null AS VARCHAR) constant, orderdate\n" +
+                "  FROM orders\n" +
+                ") a\n" +
+                "group by constant, orderdate\n");
+    }
+
+    @Test
+    public void test15WayGroupBy()
+    {
+        // Among other things, this test verifies we are not getting for overflow in the distributed HashPagePartitionFunction
+        assertQuery("" +
+                "SELECT " +
+                "    orderkey + 1, orderkey + 2, orderkey + 3, orderkey + 4, orderkey + 5, " +
+                "    orderkey + 6, orderkey + 7, orderkey + 8, orderkey + 9, orderkey + 10, " +
+                "    count(*) " +
+                "FROM orders " +
+                "GROUP BY " +
+                "    orderkey + 1, orderkey + 2, orderkey + 3, orderkey + 4, orderkey + 5, " +
+                "    orderkey + 6, orderkey + 7, orderkey + 8, orderkey + 9, orderkey + 10");
+    }
+
+    @Test
+    public void testApproximateCountDistinct()
+    {
+        assertQuery("SELECT approx_distinct(custkey) FROM orders", "SELECT 996");
+        assertQuery("SELECT approx_distinct(custkey, 0.023) FROM orders", "SELECT 996");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE)) FROM orders", "SELECT 1031");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE), 0.023) FROM orders", "SELECT 1031");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR)) FROM orders", "SELECT 1011");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR), 0.023) FROM orders", "SELECT 1011");
+        assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR))) FROM orders", "SELECT 1011");
+        assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR)), 0.023) FROM orders", "SELECT 1011");
+    }
+
+    @Test
+    public void testApproximateCountDistinctGroupBy()
+    {
+        MaterializedResult actual = computeActual("SELECT orderstatus, approx_distinct(custkey) FROM orders GROUP BY orderstatus");
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                .row("O", 995L)
+                .row("F", 993L)
+                .row("P", 303L)
+                .build();
+
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testApproximateCountDistinctGroupByWithStandardError()
+    {
+        MaterializedResult actual = computeActual("SELECT orderstatus, approx_distinct(custkey, 0.023) FROM orders GROUP BY orderstatus");
+        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
+                .row("O", 995L)
+                .row("F", 993L)
+                .row("P", 303L)
+                .build();
+
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testGroupByNoAggregations()
+    {
+        assertQuery("SELECT custkey FROM orders GROUP BY custkey");
+    }
+
+    @Test
+    public void testGroupByCount()
+    {
+        assertQuery(
+                "SELECT orderstatus, COUNT(*) FROM orders GROUP BY orderstatus",
+                "SELECT orderstatus, CAST(COUNT(*) AS INTEGER) FROM orders GROUP BY orderstatus");
+    }
+
+    @Test
+    public void testGroupByMultipleFields()
+    {
+        assertQuery("SELECT custkey, orderstatus, COUNT(*) FROM orders GROUP BY custkey, orderstatus");
+    }
+
+    @Test
+    public void testGroupByWithAlias()
+    {
+        assertQuery(
+                "SELECT orderdate x, COUNT(*) FROM orders GROUP BY orderdate",
+                "SELECT orderdate x, CAST(COUNT(*) AS INTEGER) FROM orders GROUP BY orderdate");
+    }
+
+    @Test
+    public void testGroupBySum()
+    {
+        assertQuery("SELECT suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY suppkey");
+    }
+
+    @Test
+    public void testGroupByRequireIntegerCoercion()
+    {
+        assertQuery("SELECT partkey, COUNT(DISTINCT shipdate), SUM(linenumber) FROM lineitem GROUP BY partkey");
+    }
+
+    @Test
+    public void testGroupByEmptyGroupingSet()
+    {
+        assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY ()",
+                "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupByWithWildcard()
+    {
+        assertQuery("SELECT * FROM (SELECT orderkey FROM orders) t GROUP BY orderkey");
+    }
+
+    @Test
+    public void testSingleGroupingSet()
+    {
+        assertQuery(
+                "SELECT linenumber, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "GROUP BY GROUPING SETS (linenumber)",
+                "SELECT linenumber, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "GROUP BY linenumber");
+    }
+
+    @Test
+    public void testGroupingSets()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY suppkey");
+    }
+
+    @Test
+    public void testGroupingSetsNoInput()
+    {
+        assertQuery(
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY linenumber, suppkey " +
+                        "UNION " +
+                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY suppkey");
+    }
+
+    @Test
+    public void testGroupingSetsWithGlobalAggregationNoInput()
+    {
+        assertQuery(
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey), ())",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY linenumber, suppkey " +
+                        "UNION " +
+                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY suppkey " +
+                        "UNION " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0");
+    }
+
+    @Test
+    public void testGroupingSetsWithSingleDistinct()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
+                "SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)) FROM lineitem GROUP BY suppkey");
+    }
+
+    @Test
+    public void testGroupingSetsWithMultipleDistinct()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
+                "SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) FROM lineitem GROUP BY suppkey");
+    }
+
+    @Test
+    public void testGroupingSetsWithMultipleDistinctNoInput()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
+                "SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY linenumber, suppkey " +
+                        "UNION " +
+                        "SELECT NULL, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY suppkey");
+    }
+
+    @Test
+    public void testGroupingSetsGrandTotalSet()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsRepeatedSetsAll()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((), (linenumber, suppkey), (), (linenumber, suppkey))",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem UNION ALL " +
+                        "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsRepeatedSetsAllNoInput()
+    {
+        assertQuery(
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY GROUPING SETS ((), (linenumber, suppkey), (), (linenumber, suppkey))",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY linenumber, suppkey " +
+                        "UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "UNION ALL " +
+                        "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0 " +
+                        "GROUP BY linenumber, suppkey " +
+                        "UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) " +
+                        "FROM lineitem " +
+                        "WHERE quantity < 0");
+    }
+
+    @Test
+    public void testGroupingSetsRepeatedSetsDistinct()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY DISTINCT GROUPING SETS ((), (linenumber, suppkey), (), (linenumber, suppkey))",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsGrandTotalSetFirst()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((), (linenumber), (linenumber, suppkey))",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
+                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsOnlyGrandTotalSet()
+    {
+        assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS (())",
+                "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsMultipleGrandTotalSets()
+    {
+        assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((), ())",
+                "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem UNION ALL " +
+                        "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsMultipleGrandTotalSetsNoInput()
+    {
+        assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY GROUPING SETS ((), ())",
+                "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 UNION ALL " +
+                        "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0");
+    }
+
+    @Test
+    public void testGroupingSetsAliasedGroupingColumns()
+    {
+        assertQuery("SELECT lna, lnb, SUM(quantity) " +
+                        "FROM (SELECT linenumber lna, linenumber lnb, CAST(quantity AS BIGINT) quantity FROM lineitem) " +
+                        "GROUP BY GROUPING SETS ((lna, lnb), (lna), (lnb), ())",
+                "SELECT linenumber, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT NULL, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetMixedExpressionAndColumn()
+    {
+        assertQuery("SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate), ROLLUP(suppkey)",
+                "SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate), suppkey UNION ALL " +
+                        "SELECT NULL, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate)");
+    }
+
+    @Test
+    public void testGroupingSetMixedExpressionAndOrdinal()
+    {
+        assertQuery("SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY 2, ROLLUP(suppkey)",
+                "SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate), suppkey UNION ALL " +
+                        "SELECT NULL, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate)");
+    }
+
+    @Test
+    public void testGroupingSetSubsetAndPartitioning()
+    {
+        assertQuery("SELECT COUNT_IF(x IS NULL) FROM (" +
+                        "SELECT x, y, COUNT(z) FROM (SELECT CAST(lineitem.orderkey AS BIGINT) x, lineitem.linestatus y, SUM(lineitem.quantity) z FROM lineitem " +
+                        "JOIN orders ON lineitem.orderkey = orders.orderkey GROUP BY 1, 2) GROUP BY GROUPING SETS ((x, y), ()))",
+                "SELECT 1");
+    }
+
+    @Test
+    public void testGroupingSetPredicatePushdown()
+    {
+        assertQuery("SELECT * FROM (" +
+                        "SELECT COALESCE(orderpriority, 'ALL'), COALESCE(shippriority, -1) sp FROM (" +
+                        "SELECT orderpriority, shippriority, COUNT(1) FROM orders GROUP BY GROUPING SETS ((orderpriority), (shippriority)))) WHERE sp=-1",
+                "SELECT orderpriority, -1 FROM orders GROUP BY orderpriority");
+    }
+
+    @Test
+    public void testGroupingSetsAggregateOnGroupedColumn()
+    {
+        assertQuery("SELECT orderpriority, COUNT(orderpriority) FROM orders GROUP BY ROLLUP (orderpriority)",
+                "SELECT orderpriority, COUNT(orderpriority) FROM orders GROUP BY orderpriority UNION " +
+                        "SELECT NULL, COUNT(orderpriority) FROM orders");
+    }
+
+    @Test
+    public void testGroupingSetsMultipleAggregatesOnGroupedColumn()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
+                "SELECT linenumber, suppkey, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, NULL, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsMultipleAggregatesOnUngroupedColumn()
+    {
+        assertQuery("SELECT linenumber, suppkey, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
+                "SELECT linenumber, suppkey, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, NULL, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsMultipleAggregatesWithGroupedColumns()
+    {
+        assertQuery("SELECT linenumber, suppkey, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
+                "SELECT linenumber, suppkey, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
+                        "SELECT NULL, NULL, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsWithSingleDistinctAndUnion()
+    {
+        assertQuery("SELECT suppkey, COUNT(DISTINCT linenumber) FROM " +
+                        "(SELECT * FROM lineitem WHERE linenumber%2 = 0 UNION ALL SELECT * FROM lineitem WHERE linenumber%2 = 1) " +
+                        "GROUP BY GROUPING SETS ((suppkey), ())",
+                "SELECT suppkey, COUNT(DISTINCT linenumber) FROM lineitem GROUP BY suppkey UNION ALL " +
+                        "SELECT NULL, COUNT(DISTINCT linenumber) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsWithSingleDistinctAndUnionGroupedArguments()
+    {
+        assertQuery("SELECT linenumber, COUNT(DISTINCT linenumber) FROM " +
+                        "(SELECT * FROM lineitem WHERE linenumber%2 = 0 UNION ALL SELECT * FROM lineitem WHERE linenumber%2 = 1) " +
+                        "GROUP BY GROUPING SETS ((linenumber), ())",
+                "SELECT DISTINCT linenumber, 1 FROM lineitem UNION ALL " +
+                        "SELECT NULL, COUNT(DISTINCT linenumber) FROM lineitem");
+    }
+
+    @Test
+    public void testGroupingSetsWithMultipleDistinctAndUnion()
+    {
+        assertQuery("SELECT linenumber, COUNT(DISTINCT linenumber), SUM(DISTINCT suppkey) FROM " +
+                        "(SELECT * FROM lineitem WHERE linenumber%2 = 0 UNION ALL SELECT * FROM lineitem WHERE linenumber%2 = 1) " +
+                        "GROUP BY GROUPING SETS ((linenumber), ())",
+                "SELECT linenumber, 1, SUM(DISTINCT suppkey) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT NULL, COUNT(DISTINCT linenumber), SUM(DISTINCT suppkey) FROM lineitem");
+    }
+
+    @Test
+    public void testRollup()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY ROLLUP (linenumber, suppkey)",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
+                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testCube()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY CUBE (linenumber, suppkey)",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
+                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
+                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY suppkey UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
+    }
+
+    @Test
+    public void testCubeNoInput()
+    {
+        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY CUBE (linenumber, suppkey)",
+                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY linenumber, suppkey UNION ALL " +
+                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY linenumber UNION ALL " +
+                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY suppkey UNION ALL " +
+                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0");
+    }
+
+    @Test
+    public void testGroupingCombinationsAll()
+    {
+        assertQuery("SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, ROLLUP (suppkey, linenumber), CUBE (linenumber)",
+                "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, suppkey, linenumber UNION ALL " +
+                        "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, suppkey, linenumber UNION ALL " +
+                        "SELECT orderkey, partkey, NULL, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, linenumber UNION ALL " +
+                        "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, suppkey, linenumber UNION ALL " +
+                        "SELECT orderkey, partkey, suppkey, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, suppkey UNION ALL " +
+                        "SELECT orderkey, partkey, NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey");
+    }
+
+    @Test
+    public void testGroupingCombinationsDistinct()
+    {
+        assertQuery("SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY DISTINCT orderkey, partkey, ROLLUP (suppkey, linenumber), CUBE (linenumber)",
+                "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, suppkey, linenumber UNION ALL " +
+                        "SELECT orderkey, partkey, NULL, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, linenumber UNION ALL " +
+                        "SELECT orderkey, partkey, suppkey, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, suppkey UNION ALL " +
+                        "SELECT orderkey, partkey, NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey");
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -776,118 +776,9 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testSumOfNulls()
-    {
-        assertQuery("SELECT orderstatus, sum(CAST(NULL AS BIGINT)) FROM orders GROUP BY orderstatus");
-    }
-
-    @Test
-    public void testAggregationWithSomeArgumentCasts()
-    {
-        assertQuery("SELECT APPROX_PERCENTILE(0.1E0, x), AVG(x), MIN(x) FROM (values 1, 1, 1) t(x)", "SELECT 0.1, 1.0, 1");
-    }
-
-    @Test
-    public void testAggregationWithHaving()
-    {
-        assertQuery("SELECT a, count(1) FROM (VALUES 1, 2, 3, 2) t(a) GROUP BY a HAVING count(1) > 1", "SELECT 2, 2");
-    }
-
-    @Test
-    public void testApproximateCountDistinct()
-    {
-        assertQuery("SELECT approx_distinct(custkey) FROM orders", "SELECT 996");
-        assertQuery("SELECT approx_distinct(custkey, 0.023) FROM orders", "SELECT 996");
-        assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE)) FROM orders", "SELECT 1031");
-        assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE), 0.023) FROM orders", "SELECT 1031");
-        assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR)) FROM orders", "SELECT 1011");
-        assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR), 0.023) FROM orders", "SELECT 1011");
-        assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR))) FROM orders", "SELECT 1011");
-        assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR)), 0.023) FROM orders", "SELECT 1011");
-    }
-
-    @Test
-    public void testApproximateCountDistinctGroupBy()
-    {
-        MaterializedResult actual = computeActual("SELECT orderstatus, approx_distinct(custkey) FROM orders GROUP BY orderstatus");
-        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
-                .row("O", 995L)
-                .row("F", 993L)
-                .row("P", 303L)
-                .build();
-
-        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
-    }
-
-    @Test
-    public void testApproximateCountDistinctGroupByWithStandardError()
-    {
-        MaterializedResult actual = computeActual("SELECT orderstatus, approx_distinct(custkey, 0.023) FROM orders GROUP BY orderstatus");
-        MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
-                .row("O", 995L)
-                .row("F", 993L)
-                .row("P", 303L)
-                .build();
-
-        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
-    }
-
-    @Test
-    public void testCountBoolean()
-    {
-        assertQuery("SELECT COUNT(true) FROM orders");
-    }
-
-    @Test
     public void testJoinWithMultiFieldGroupBy()
     {
         assertQuery("SELECT orderstatus FROM lineitem JOIN (SELECT DISTINCT orderkey, orderstatus FROM orders) T on lineitem.orderkey = T.orderkey");
-    }
-
-    @Test
-    public void testGroupByRepeatedField()
-    {
-        assertQuery("SELECT sum(custkey) FROM orders GROUP BY orderstatus, orderstatus");
-    }
-
-    @Test
-    public void testGroupByRepeatedField2()
-    {
-        assertQuery("SELECT count(*) FROM (SELECT orderstatus a, orderstatus b FROM orders) GROUP BY a, b");
-    }
-
-    @Test
-    public void testGroupByMultipleFieldsWithPredicateOnAggregationArgument()
-    {
-        assertQuery("SELECT custkey, orderstatus, MAX(orderkey) FROM orders WHERE orderkey = 1 GROUP BY custkey, orderstatus");
-    }
-
-    @Test
-    public void testReorderOutputsOfGroupByAggregation()
-    {
-        assertQuery(
-                "SELECT orderstatus, a, custkey, b FROM (SELECT custkey, orderstatus, -COUNT(*) a, MAX(orderkey) b FROM orders WHERE orderkey = 1 GROUP BY custkey, orderstatus) T");
-    }
-
-    @Test
-    public void testGroupAggregationOverNestedGroupByAggregation()
-    {
-        assertQuery("SELECT sum(custkey), max(orderstatus), min(c) FROM (SELECT orderstatus, custkey, COUNT(*) c FROM orders GROUP BY orderstatus, custkey) T");
-    }
-
-    @Test
-    public void test15WayGroupBy()
-    {
-        // Among other things, this test verifies we are not getting for overflow in the distributed HashPagePartitionFunction
-        assertQuery("" +
-                "SELECT " +
-                "    orderkey + 1, orderkey + 2, orderkey + 3, orderkey + 4, orderkey + 5, " +
-                "    orderkey + 6, orderkey + 7, orderkey + 8, orderkey + 9, orderkey + 10, " +
-                "    count(*) " +
-                "FROM orders " +
-                "GROUP BY " +
-                "    orderkey + 1, orderkey + 2, orderkey + 3, orderkey + 4, orderkey + 5, " +
-                "    orderkey + 6, orderkey + 7, orderkey + 8, orderkey + 9, orderkey + 10");
     }
 
     @Test
@@ -919,92 +810,12 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testDistinctGroupBy()
-    {
-        assertQuery("SELECT COUNT(DISTINCT clerk) AS count, orderdate FROM orders GROUP BY orderdate ORDER BY count, orderdate");
-    }
-
-    @Test
-    public void testSingleDistinctOptimizer()
-    {
-        assertQuery("SELECT custkey, orderstatus, COUNT(DISTINCT orderkey) FROM orders GROUP BY custkey, orderstatus");
-        assertQuery("SELECT custkey, orderstatus, COUNT(DISTINCT orderkey), SUM(DISTINCT orderkey) FROM orders GROUP BY custkey, orderstatus");
-        assertQuery("" +
-                "SELECT custkey, COUNT(DISTINCT orderstatus) FROM (" +
-                "   SELECT orders.custkey AS custkey, orders.orderstatus AS orderstatus " +
-                "   FROM lineitem JOIN orders ON lineitem.orderkey = orders.orderkey AND orders.orderkey = lineitem.partkey " +
-                "   GROUP BY orders.custkey, orders.orderstatus" +
-                ") " +
-                "GROUP BY custkey");
-        assertQuery("SELECT custkey, COUNT(DISTINCT orderkey), COUNT(DISTINCT orderstatus) FROM orders GROUP BY custkey");
-
-        assertQuery("SELECT SUM(DISTINCT x) FROM (SELECT custkey, COUNT(DISTINCT orderstatus) x FROM orders GROUP BY custkey) t");
-    }
-
-    @Test
-    public void testExtractDistinctAggregationOptimizer()
-    {
-        assertQuery("SELECT max(orderstatus), COUNT(orderkey), sum(DISTINCT orderkey) FROM orders");
-
-        assertQuery("SELECT custkey, orderstatus, avg(shippriority), SUM(DISTINCT orderkey) FROM orders GROUP BY custkey, orderstatus");
-
-        assertQuery("SELECT s, MAX(custkey), SUM(a) FROM (" +
-                "    SELECT custkey, avg(shippriority) AS a, SUM(DISTINCT orderkey) AS s FROM orders GROUP BY custkey, orderstatus" +
-                ") " +
-                "GROUP BY s");
-
-        assertQuery("SELECT max(orderstatus), COUNT(DISTINCT orderkey), sum(DISTINCT orderkey) FROM orders");
-
-        assertQuery("SELECT max(orderstatus), COUNT(DISTINCT shippriority), sum(DISTINCT orderkey) FROM orders");
-
-        assertQuery("SELECT COUNT(tan(shippriority)), sum(DISTINCT orderkey) FROM orders");
-
-        assertQuery("SELECT count(DISTINCT a), max(b) FROM (VALUES (row(1, 2), 3)) t(a, b)", "VALUES (1, 3)");
-
-        // Test overlap between GroupBy columns and aggregation columns
-        assertQuery("SELECT shippriority, MAX(orderstatus), SUM(DISTINCT shippriority) FROM orders GROUP BY shippriority");
-
-        assertQuery("SELECT shippriority, COUNT(shippriority), SUM(DISTINCT orderkey) FROM orders GROUP BY shippriority");
-
-        assertQuery("SELECT shippriority, COUNT(shippriority), SUM(DISTINCT shippriority) FROM orders GROUP BY shippriority");
-
-        assertQuery("SELECT clerk, shippriority, MAX(orderstatus), SUM(DISTINCT shippriority) FROM orders GROUP BY clerk, shippriority");
-
-        assertQuery("SELECT clerk, shippriority, COUNT(shippriority), SUM(DISTINCT orderkey) FROM orders GROUP BY clerk, shippriority");
-
-        assertQuery("SELECT clerk, shippriority, COUNT(shippriority), SUM(DISTINCT shippriority) FROM orders GROUP BY clerk, shippriority");
-    }
-
-    @Test
     public void testDistinctHaving()
     {
         assertQuery("SELECT COUNT(DISTINCT clerk) AS count " +
                 "FROM orders " +
                 "GROUP BY orderdate " +
                 "HAVING COUNT(DISTINCT clerk) > 1");
-    }
-
-    @Test
-    public void testAggregationFilter()
-    {
-        assertQuery("SELECT sum(x) FILTER (WHERE y > 4) FROM (VALUES (1, 3), (2, 4), (2, 4), (4, 5)) t (x, y)", "SELECT 4");
-        assertQuery("SELECT sum(x) FILTER (WHERE x > 1), sum(y) FILTER (WHERE y > 4) FROM (VALUES (1, 3), (2, 4), (2, 4), (4, 5)) t (x, y)", "SELECT 8, 5");
-        assertQuery("SELECT sum(x) FILTER (WHERE x > 1), sum(x) FROM (VALUES (1), (2), (2), (4)) t (x)", "SELECT 8, 9");
-        assertQuery("SELECT count(*) FILTER (WHERE x > 1), sum(x) FROM (VALUES (1, 3), (2, 4), (2, 4), (4, 5)) t (x, y)", "SELECT 3, 9");
-        assertQuery("SELECT count(*) FILTER (WHERE x > 1), count(DISTINCT y) FROM (VALUES (1, 10), (2, 10), (3, 10), (4, 20)) t (x, y)", "SELECT 3, 2");
-
-        assertQuery("" +
-                        "SELECT sum(b) FILTER (WHERE true) " +
-                        "FROM (SELECT count(*) FILTER (WHERE true) AS b)",
-                "SELECT 1");
-
-        assertQuery("SELECT count(1) FILTER (WHERE orderstatus = 'O') FROM orders", "SELECT count(*) FROM orders WHERE orderstatus = 'O'");
-
-        // TODO: enable when DISTINCT is allowed with filtered aggregations
-        // assertQuery("SELECT count(DISTINCT x) FILTER (where y = 1) FROM (VALUES (2, 1), (1, 2), (1,1)) t(x, y)", "SELECT 2");
-        // assertQuery("SELECT sum(DISTINCT x) FILTER (WHERE x > 1) AS x FROM (VALUES (1), (2), (2), (4)) t (x)", "SELECT 6");
-        // assertQuery("SELECT sum(DISTINCT x) FILTER (WHERE y > 3), sum(DISTINCT y) FILTER (WHERE x > 1) FROM (VALUES (1, 3), (2, 4), (2, 4), (4, 5)) t (x, y)", "SELECT 6, 9");
-        // assertQuery("SELECT sum(x) FILTER (WHERE x > 1) AS x, sum(DISTINCT x) FROM (VALUES (1), (2), (2), (4)) t (x)", "SELECT 8, 9");
     }
 
     @Test
@@ -1018,42 +829,6 @@ public abstract class AbstractTestQueries
                         "LIMIT 1");
         MaterializedResult expected = resultBuilder(getSession(), BIGINT).row(1L).build();
         assertEquals(actual, expected);
-    }
-
-    @Test
-    public void testDistinctWhere()
-    {
-        assertQuery("SELECT COUNT(DISTINCT clerk) FROM orders WHERE LENGTH(clerk) > 5");
-    }
-
-    @Test
-    public void testMultipleDifferentDistinct()
-    {
-        assertQuery("SELECT COUNT(DISTINCT orderstatus), SUM(DISTINCT custkey) FROM orders");
-    }
-
-    @Test
-    public void testMultipleDistinct()
-    {
-        assertQuery(
-                "SELECT COUNT(DISTINCT custkey), SUM(DISTINCT custkey) FROM orders",
-                "SELECT COUNT(*), SUM(custkey) FROM (SELECT DISTINCT custkey FROM orders) t");
-    }
-
-    @Test
-    public void testComplexDistinct()
-    {
-        assertQuery(
-                "SELECT COUNT(DISTINCT custkey), " +
-                        "SUM(DISTINCT custkey), " +
-                        "SUM(DISTINCT custkey + 1.0E0), " +
-                        "AVG(DISTINCT custkey), " +
-                        "VARIANCE(DISTINCT custkey) FROM orders",
-                "SELECT COUNT(*), " +
-                        "SUM(custkey), " +
-                        "SUM(custkey + 1.0), " +
-                        "AVG(custkey), " +
-                        "VARIANCE(custkey) FROM (SELECT DISTINCT custkey FROM orders) t");
     }
 
     @Test
@@ -1071,12 +846,6 @@ public abstract class AbstractTestQueries
                         "FROM (VALUES 1) t(x) JOIN (VALUES 10, 20) u(a) ON t.x < u.a " +
                         "LIMIT 100",
                 "SELECT 1");
-    }
-
-    @Test
-    public void testCountDistinct()
-    {
-        assertQuery("SELECT COUNT(DISTINCT custkey + 1) FROM orders", "SELECT COUNT(*) FROM (SELECT DISTINCT custkey + 1 FROM orders) t");
     }
 
     @Test
@@ -1289,7 +1058,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testAggregationWithLimit()
+    public void testLimitWithAggregation()
     {
         MaterializedResult actual = computeActual("SELECT custkey, SUM(CAST(totalprice * 100 AS BIGINT)) FROM orders GROUP BY custkey LIMIT 10");
         MaterializedResult all = computeExpected("SELECT custkey, SUM(CAST(totalprice * 100 AS BIGINT)) FROM orders GROUP BY custkey", actual.getTypes());
@@ -1436,36 +1205,6 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testCountAllWithPredicate()
-    {
-        assertQuery("SELECT COUNT(*) FROM orders WHERE orderstatus = 'F'");
-    }
-
-    @Test
-    public void testGroupByArray()
-    {
-        assertQuery("SELECT col[1], count FROM (SELECT ARRAY[custkey] col, COUNT(*) count FROM orders GROUP BY 1 ORDER BY 1)", "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey ORDER BY custkey");
-    }
-
-    @Test
-    public void testGroupByMap()
-    {
-        assertQuery("SELECT col[1], count FROM (SELECT MAP(ARRAY[1], ARRAY[custkey]) col, COUNT(*) count FROM orders GROUP BY 1)", "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey");
-    }
-
-    @Test
-    public void testGroupByComplexMap()
-    {
-        assertQuery("SELECT MAP_KEYS(x)[1] FROM (VALUES MAP(ARRAY['a'], ARRAY[ARRAY[1]]), MAP(ARRAY['b'], ARRAY[ARRAY[2]])) t(x) GROUP BY x", "VALUES 'a', 'b'");
-    }
-
-    @Test
-    public void testGroupByRow()
-    {
-        assertQuery("SELECT col.col1, count FROM (SELECT CAST(row(custkey, custkey) AS row(col0 bigint, col1 bigint)) col, COUNT(*) count FROM orders GROUP BY 1)", "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey");
-    }
-
-    @Test
     public void testJoinCoercion()
     {
         assertQuery("SELECT COUNT(*) FROM orders t JOIN (SELECT * FROM orders LIMIT 1) t2 ON sin(t2.custkey) = 0");
@@ -1475,399 +1214,6 @@ public abstract class AbstractTestQueries
     public void testJoinCoercionOnEqualityComparison()
     {
         assertQuery("SELECT o.clerk, avg(o.shippriority), COUNT(l.linenumber) FROM orders o LEFT OUTER JOIN lineitem l ON o.orderkey=l.orderkey AND o.shippriority=1 GROUP BY o.clerk");
-    }
-
-    @Test
-    public void testGroupByNoAggregations()
-    {
-        assertQuery("SELECT custkey FROM orders GROUP BY custkey");
-    }
-
-    @Test
-    public void testGroupByCount()
-    {
-        assertQuery(
-                "SELECT orderstatus, COUNT(*) FROM orders GROUP BY orderstatus",
-                "SELECT orderstatus, CAST(COUNT(*) AS INTEGER) FROM orders GROUP BY orderstatus");
-    }
-
-    @Test
-    public void testGroupByMultipleFields()
-    {
-        assertQuery("SELECT custkey, orderstatus, COUNT(*) FROM orders GROUP BY custkey, orderstatus");
-    }
-
-    @Test
-    public void testGroupByWithAlias()
-    {
-        assertQuery(
-                "SELECT orderdate x, COUNT(*) FROM orders GROUP BY orderdate",
-                "SELECT orderdate x, CAST(COUNT(*) AS INTEGER) FROM orders GROUP BY orderdate");
-    }
-
-    @Test
-    public void testGroupBySum()
-    {
-        assertQuery("SELECT suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY suppkey");
-    }
-
-    @Test
-    public void testGroupByRequireIntegerCoercion()
-    {
-        assertQuery("SELECT partkey, COUNT(DISTINCT shipdate), SUM(linenumber) FROM lineitem GROUP BY partkey");
-    }
-
-    @Test
-    public void testGroupByEmptyGroupingSet()
-    {
-        assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY ()",
-                "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupByWithWildcard()
-    {
-        assertQuery("SELECT * FROM (SELECT orderkey FROM orders) t GROUP BY orderkey");
-    }
-
-    @Test
-    public void testSingleGroupingSet()
-    {
-        assertQuery(
-                "SELECT linenumber, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "GROUP BY GROUPING SETS (linenumber)",
-                "SELECT linenumber, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "GROUP BY linenumber");
-    }
-
-    @Test
-    public void testGroupingSets()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
-                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY suppkey");
-    }
-
-    @Test
-    public void testGroupingSetsNoInput()
-    {
-        assertQuery(
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY linenumber, suppkey " +
-                        "UNION " +
-                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY suppkey");
-    }
-
-    @Test
-    public void testGroupingSetsWithGlobalAggregationNoInput()
-    {
-        assertQuery(
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey), ())",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY linenumber, suppkey " +
-                        "UNION " +
-                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY suppkey " +
-                        "UNION " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0");
-    }
-
-    @Test
-    public void testGroupingSetsWithSingleDistinct()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
-                "SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
-                        "SELECT NULL, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)) FROM lineitem GROUP BY suppkey");
-    }
-
-    @Test
-    public void testGroupingSetsWithMultipleDistinct()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
-                "SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) FROM lineitem GROUP BY linenumber, suppkey UNION " +
-                        "SELECT NULL, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) FROM lineitem GROUP BY suppkey");
-    }
-
-    @Test
-    public void testGroupingSetsWithMultipleDistinctNoInput()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY GROUPING SETS ((linenumber, suppkey), (suppkey))",
-                "SELECT linenumber, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY linenumber, suppkey " +
-                        "UNION " +
-                        "SELECT NULL, suppkey, SUM(DISTINCT CAST(quantity AS BIGINT)), COUNT(DISTINCT linestatus) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY suppkey");
-    }
-
-    @Test
-    public void testGroupingSetsGrandTotalSet()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsRepeatedSetsAll()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((), (linenumber, suppkey), (), (linenumber, suppkey))",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem UNION ALL " +
-                        "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsRepeatedSetsAllNoInput()
-    {
-        assertQuery(
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY GROUPING SETS ((), (linenumber, suppkey), (), (linenumber, suppkey))",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY linenumber, suppkey " +
-                        "UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "UNION ALL " +
-                        "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0 " +
-                        "GROUP BY linenumber, suppkey " +
-                        "UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) " +
-                        "FROM lineitem " +
-                        "WHERE quantity < 0");
-    }
-
-    @Test
-    public void testGroupingSetsRepeatedSetsDistinct()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY DISTINCT GROUPING SETS ((), (linenumber, suppkey), (), (linenumber, suppkey))",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsGrandTotalSetFirst()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((), (linenumber), (linenumber, suppkey))",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
-                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsOnlyGrandTotalSet()
-    {
-        assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS (())",
-                "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsMultipleGrandTotalSets()
-    {
-        assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((), ())",
-                "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem UNION ALL " +
-                        "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsMultipleGrandTotalSetsNoInput()
-    {
-        assertQuery("SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY GROUPING SETS ((), ())",
-                "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 UNION ALL " +
-                        "SELECT SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0");
-    }
-
-    @Test
-    public void testGroupingSetsAliasedGroupingColumns()
-    {
-        assertQuery("SELECT lna, lnb, SUM(quantity) " +
-                        "FROM (SELECT linenumber lna, linenumber lnb, CAST(quantity AS BIGINT) quantity FROM lineitem) " +
-                        "GROUP BY GROUPING SETS ((lna, lnb), (lna), (lnb), ())",
-                "SELECT linenumber, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
-                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
-                        "SELECT NULL, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetMixedExpressionAndColumn()
-    {
-        assertQuery("SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate), ROLLUP(suppkey)",
-                "SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate), suppkey UNION ALL " +
-                        "SELECT NULL, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate)");
-    }
-
-    @Test
-    public void testGroupingSetMixedExpressionAndOrdinal()
-    {
-        assertQuery("SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY 2, ROLLUP(suppkey)",
-                "SELECT suppkey, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate), suppkey UNION ALL " +
-                        "SELECT NULL, month(shipdate), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY month(shipdate)");
-    }
-
-    @Test
-    public void testGroupingSetSubsetAndPartitioning()
-    {
-        assertQuery("SELECT COUNT_IF(x IS NULL) FROM (" +
-                        "SELECT x, y, COUNT(z) FROM (SELECT CAST(lineitem.orderkey AS BIGINT) x, lineitem.linestatus y, SUM(lineitem.quantity) z FROM lineitem " +
-                        "JOIN orders ON lineitem.orderkey = orders.orderkey GROUP BY 1, 2) GROUP BY GROUPING SETS ((x, y), ()))",
-                "SELECT 1");
-    }
-
-    @Test
-    public void testGroupingSetPredicatePushdown()
-    {
-        assertQuery("SELECT * FROM (" +
-                        "SELECT COALESCE(orderpriority, 'ALL'), COALESCE(shippriority, -1) sp FROM (" +
-                        "SELECT orderpriority, shippriority, COUNT(1) FROM orders GROUP BY GROUPING SETS ((orderpriority), (shippriority)))) WHERE sp=-1",
-                "SELECT orderpriority, -1 FROM orders GROUP BY orderpriority");
-    }
-
-    @Test
-    public void testGroupingSetsAggregateOnGroupedColumn()
-    {
-        assertQuery("SELECT orderpriority, COUNT(orderpriority) FROM orders GROUP BY ROLLUP (orderpriority)",
-                "SELECT orderpriority, COUNT(orderpriority) FROM orders GROUP BY orderpriority UNION " +
-                        "SELECT NULL, COUNT(orderpriority) FROM orders");
-    }
-
-    @Test
-    public void testGroupingSetsMultipleAggregatesOnGroupedColumn()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
-                "SELECT linenumber, suppkey, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
-                        "SELECT NULL, NULL, SUM(suppkey), COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsMultipleAggregatesOnUngroupedColumn()
-    {
-        assertQuery("SELECT linenumber, suppkey, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
-                "SELECT linenumber, suppkey, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
-                        "SELECT NULL, NULL, COUNT(CAST(quantity AS BIGINT)), SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsMultipleAggregatesWithGroupedColumns()
-    {
-        assertQuery("SELECT linenumber, suppkey, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY GROUPING SETS ((linenumber, suppkey), ())",
-                "SELECT linenumber, suppkey, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION " +
-                        "SELECT NULL, NULL, COUNT(linenumber), SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsWithSingleDistinctAndUnion()
-    {
-        assertQuery("SELECT suppkey, COUNT(DISTINCT linenumber) FROM " +
-                        "(SELECT * FROM lineitem WHERE linenumber%2 = 0 UNION ALL SELECT * FROM lineitem WHERE linenumber%2 = 1) " +
-                        "GROUP BY GROUPING SETS ((suppkey), ())",
-                "SELECT suppkey, COUNT(DISTINCT linenumber) FROM lineitem GROUP BY suppkey UNION ALL " +
-                        "SELECT NULL, COUNT(DISTINCT linenumber) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsWithSingleDistinctAndUnionGroupedArguments()
-    {
-        assertQuery("SELECT linenumber, COUNT(DISTINCT linenumber) FROM " +
-                        "(SELECT * FROM lineitem WHERE linenumber%2 = 0 UNION ALL SELECT * FROM lineitem WHERE linenumber%2 = 1) " +
-                        "GROUP BY GROUPING SETS ((linenumber), ())",
-                "SELECT DISTINCT linenumber, 1 FROM lineitem UNION ALL " +
-                        "SELECT NULL, COUNT(DISTINCT linenumber) FROM lineitem");
-    }
-
-    @Test
-    public void testGroupingSetsWithMultipleDistinctAndUnion()
-    {
-        assertQuery("SELECT linenumber, COUNT(DISTINCT linenumber), SUM(DISTINCT suppkey) FROM " +
-                        "(SELECT * FROM lineitem WHERE linenumber%2 = 0 UNION ALL SELECT * FROM lineitem WHERE linenumber%2 = 1) " +
-                        "GROUP BY GROUPING SETS ((linenumber), ())",
-                "SELECT linenumber, 1, SUM(DISTINCT suppkey) FROM lineitem GROUP BY linenumber UNION ALL " +
-                        "SELECT NULL, COUNT(DISTINCT linenumber), SUM(DISTINCT suppkey) FROM lineitem");
-    }
-
-    @Test
-    public void testRollup()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY ROLLUP (linenumber, suppkey)",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
-                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testCube()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY CUBE (linenumber, suppkey)",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber, suppkey UNION ALL " +
-                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY linenumber UNION ALL " +
-                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY suppkey UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem");
-    }
-
-    @Test
-    public void testCubeNoInput()
-    {
-        assertQuery("SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY CUBE (linenumber, suppkey)",
-                "SELECT linenumber, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY linenumber, suppkey UNION ALL " +
-                        "SELECT linenumber, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY linenumber UNION ALL " +
-                        "SELECT NULL, suppkey, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0 GROUP BY suppkey UNION ALL " +
-                        "SELECT NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem WHERE quantity < 0");
-    }
-
-    @Test
-    public void testGroupingCombinationsAll()
-    {
-        assertQuery("SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, ROLLUP (suppkey, linenumber), CUBE (linenumber)",
-                "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, suppkey, linenumber UNION ALL " +
-                        "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, suppkey, linenumber UNION ALL " +
-                        "SELECT orderkey, partkey, NULL, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, linenumber UNION ALL " +
-                        "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, suppkey, linenumber UNION ALL " +
-                        "SELECT orderkey, partkey, suppkey, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, suppkey UNION ALL " +
-                        "SELECT orderkey, partkey, NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey");
-    }
-
-    @Test
-    public void testGroupingCombinationsDistinct()
-    {
-        assertQuery("SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY DISTINCT orderkey, partkey, ROLLUP (suppkey, linenumber), CUBE (linenumber)",
-                "SELECT orderkey, partkey, suppkey, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, suppkey, linenumber UNION ALL " +
-                        "SELECT orderkey, partkey, NULL, linenumber, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, linenumber UNION ALL " +
-                        "SELECT orderkey, partkey, suppkey, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey, suppkey UNION ALL " +
-                        "SELECT orderkey, partkey, NULL, NULL, SUM(CAST(quantity AS BIGINT)) FROM lineitem GROUP BY orderkey, partkey");
     }
 
     @Test
@@ -2161,99 +1507,9 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testCountAllWithComparison()
-    {
-        assertQuery("SELECT COUNT(*) FROM lineitem WHERE tax < discount");
-    }
-
-    @Test
     public void testSelectWithComparison()
     {
         assertQuery("SELECT orderkey FROM lineitem WHERE tax < discount");
-    }
-
-    @Test
-    public void testCountWithNotPredicate()
-    {
-        assertQuery("SELECT COUNT(*) FROM lineitem WHERE NOT tax < discount");
-    }
-
-    @Test
-    public void testCountWithNullPredicate()
-    {
-        assertQuery("SELECT COUNT(*) FROM lineitem WHERE NULL");
-    }
-
-    @Test
-    public void testCountWithIsNullPredicate()
-    {
-        assertQuery(
-                "SELECT COUNT(*) FROM orders WHERE NULLIF(orderstatus, 'F') IS NULL",
-                "SELECT COUNT(*) FROM orders WHERE orderstatus = 'F' ");
-    }
-
-    @Test
-    public void testCountWithIsNotNullPredicate()
-    {
-        assertQuery(
-                "SELECT COUNT(*) FROM orders WHERE NULLIF(orderstatus, 'F') IS NOT NULL",
-                "SELECT COUNT(*) FROM orders WHERE orderstatus <> 'F' ");
-    }
-
-    @Test
-    public void testCountWithNullIfPredicate()
-    {
-        assertQuery("SELECT COUNT(*) FROM orders WHERE NULLIF(orderstatus, 'F') = orderstatus ");
-    }
-
-    @Test
-    public void testCountWithCoalescePredicate()
-    {
-        assertQuery(
-                "SELECT COUNT(*) FROM orders WHERE COALESCE(NULLIF(orderstatus, 'F'), 'bar') = 'bar'",
-                "SELECT COUNT(*) FROM orders WHERE orderstatus = 'F'");
-    }
-
-    @Test
-    public void testCountWithAndPredicate()
-    {
-        assertQuery("SELECT COUNT(*) FROM lineitem WHERE tax < discount AND tax > 0.01 AND discount < 0.05");
-    }
-
-    @Test
-    public void testCountWithOrPredicate()
-    {
-        assertQuery("SELECT COUNT(*) FROM lineitem WHERE tax < 0.01 OR discount > 0.05");
-    }
-
-    @Test
-    public void testCountWithInlineView()
-    {
-        assertQuery("SELECT COUNT(*) FROM (SELECT orderkey FROM lineitem) x");
-    }
-
-    @Test
-    public void testNestedCount()
-    {
-        assertQuery("SELECT COUNT(*) FROM (SELECT orderkey, COUNT(*) FROM lineitem GROUP BY orderkey) x");
-    }
-
-    @Test
-    public void testAggregationWithProjection()
-    {
-        assertQuery("SELECT sum(totalprice * 2) - sum(totalprice) FROM orders");
-    }
-
-    @Test
-    public void testAggregationWithProjection2()
-    {
-        assertQuery("SELECT sum(totalprice * 2) + sum(totalprice * 2) FROM orders");
-    }
-
-    @Test
-    public void testGroupByOnSupersetOfPartitioning()
-    {
-        assertQuery("SELECT orderdate, c, count(*) FROM (SELECT orderdate, count(*) c FROM orders GROUP BY orderdate) GROUP BY orderdate, c");
     }
 
     @Test
@@ -2272,37 +1528,6 @@ public abstract class AbstractTestQueries
     public void testInlineViewWithProjections()
     {
         assertQuery("SELECT x + 1, y FROM (SELECT orderkey * 10 x, custkey y FROM orders) u");
-    }
-
-    @Test
-    public void testGroupByWithoutAggregation()
-    {
-        assertQuery("SELECT orderstatus FROM orders GROUP BY orderstatus");
-    }
-
-    @Test
-    public void testNestedGroupByWithSameKey()
-    {
-        assertQuery("SELECT custkey, sum(t) FROM (SELECT custkey, count(*) t FROM orders GROUP BY custkey) GROUP BY custkey");
-    }
-
-    @Test
-    public void testGroupByWithNulls()
-    {
-        assertQuery("SELECT key, COUNT(*) FROM (" +
-                "SELECT CASE " +
-                "  WHEN orderkey % 3 = 0 THEN NULL " +
-                "  WHEN orderkey % 5 = 0 THEN 0 " +
-                "  ELSE orderkey " +
-                "  END AS key " +
-                "FROM lineitem) " +
-                "GROUP BY key");
-    }
-
-    @Test
-    public void testHistogram()
-    {
-        assertQuery("SELECT lines, COUNT(*) FROM (SELECT orderkey, COUNT(*) lines FROM lineitem GROUP BY orderkey) U GROUP BY lines");
     }
 
     @Test
@@ -3747,36 +2972,6 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testAggregationOverRightJoinOverSingleStreamProbe()
-    {
-        // this should return one row since value is always 'value'
-        // this test verifies that the two streams produced by the right join
-        // are handled gathered for the aggregation operator
-        assertQueryOrdered("" +
-                        "SELECT\n" +
-                        "  value\n" +
-                        "FROM\n" +
-                        "(\n" +
-                        "    SELECT\n" +
-                        "        key\n" +
-                        "    FROM\n" +
-                        "        (VALUES 'match') AS a(key)\n" +
-                        "        LEFT JOIN (SELECT * FROM (VALUES (0)) LIMIT 0) AS x(ignored)\n" +
-                        "        ON TRUE\n" +
-                        "    GROUP BY 1\n" +
-                        ") a\n" +
-                        "RIGHT JOIN\n" +
-                        "(\n" +
-                        "    VALUES\n" +
-                        "    ('match', 'value'),\n" +
-                        "    ('no-match', 'value')\n" +
-                        ") AS b(key, value)\n" +
-                        "ON a.key = b.key\n" +
-                        "GROUP BY 1\n",
-                "VALUES 'value'");
-    }
-
-    @Test
     public void testOrderBy()
     {
         assertQueryOrdered("SELECT orderstatus FROM orders ORDER BY orderstatus");
@@ -3873,186 +3068,6 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testGroupByOrdinal()
-    {
-        assertQuery(
-                "SELECT orderstatus, sum(totalprice) FROM orders GROUP BY 1",
-                "SELECT orderstatus, sum(totalprice) FROM orders GROUP BY orderstatus");
-    }
-
-    @Test
-    public void testGroupBySearchedCase()
-    {
-        assertQuery("SELECT CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END");
-
-        assertQuery(
-                "SELECT CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
-                        "FROM orders\n" +
-                        "GROUP BY 1",
-                "SELECT CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
-                        "FROM orders\n" +
-                        "GROUP BY CASE WHEN orderstatus = 'O' THEN 'a' ELSE 'b' END");
-    }
-
-    @Test
-    public void testGroupBySearchedCaseNoElse()
-    {
-        // whole CASE in GROUP BY clause
-        assertQuery("SELECT CASE WHEN orderstatus = 'O' THEN 'a' END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY CASE WHEN orderstatus = 'O' THEN 'a' END");
-
-        assertQuery(
-                "SELECT CASE WHEN orderstatus = 'O' THEN 'a' END, count(*)\n" +
-                        "FROM orders\n" +
-                        "GROUP BY 1",
-                "SELECT CASE WHEN orderstatus = 'O' THEN 'a' END, count(*)\n" +
-                        "FROM orders\n" +
-                        "GROUP BY CASE WHEN orderstatus = 'O' THEN 'a' END");
-
-        assertQuery("SELECT CASE WHEN true THEN orderstatus END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY orderstatus");
-    }
-
-    @Test
-    public void testGroupByCase()
-    {
-        // whole CASE in GROUP BY clause
-        assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END");
-
-        assertQuery(
-                "SELECT CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
-                        "FROM orders\n" +
-                        "GROUP BY 1",
-                "SELECT CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
-                        "FROM orders\n" +
-                        "GROUP BY CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END");
-
-        // operand in GROUP BY clause
-        assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' ELSE 'b' END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY orderstatus");
-
-        // condition in GROUP BY clause
-        assertQuery("SELECT CASE 'O' WHEN orderstatus THEN 'a' ELSE 'b' END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY orderstatus");
-
-        // 'then' in GROUP BY clause
-        assertQuery("SELECT CASE 1 WHEN 1 THEN orderstatus ELSE 'x' END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY orderstatus");
-
-        // 'else' in GROUP BY clause
-        assertQuery("SELECT CASE 1 WHEN 1 THEN 'x' ELSE orderstatus END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY orderstatus");
-    }
-
-    @Test
-    public void testGroupByCaseNoElse()
-    {
-        // whole CASE in GROUP BY clause
-        assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY CASE orderstatus WHEN 'O' THEN 'a' END");
-
-        // operand in GROUP BY clause
-        assertQuery("SELECT CASE orderstatus WHEN 'O' THEN 'a' END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY orderstatus");
-
-        // condition in GROUP BY clause
-        assertQuery("SELECT CASE 'O' WHEN orderstatus THEN 'a' END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY orderstatus");
-
-        // 'then' in GROUP BY clause
-        assertQuery("SELECT CASE 1 WHEN 1 THEN orderstatus END, count(*)\n" +
-                "FROM orders\n" +
-                "GROUP BY orderstatus");
-    }
-
-    @Test
-    public void testGroupByCast()
-    {
-        // whole CAST in GROUP BY expression
-        assertQuery("SELECT CAST(orderkey AS VARCHAR), count(*) FROM orders GROUP BY CAST(orderkey AS VARCHAR)");
-
-        assertQuery(
-                "SELECT CAST(orderkey AS VARCHAR), count(*) FROM orders GROUP BY 1",
-                "SELECT CAST(orderkey AS VARCHAR), count(*) FROM orders GROUP BY CAST(orderkey AS VARCHAR)");
-
-        // argument in GROUP BY expression
-        assertQuery("SELECT CAST(orderkey AS VARCHAR), count(*) FROM orders GROUP BY orderkey");
-    }
-
-    @Test
-    public void testGroupByCoalesce()
-    {
-        // whole COALESCE in group by
-        assertQuery("SELECT COALESCE(orderkey, custkey), count(*) FROM orders GROUP BY COALESCE(orderkey, custkey)");
-
-        assertQuery(
-                "SELECT COALESCE(orderkey, custkey), count(*) FROM orders GROUP BY 1",
-                "SELECT COALESCE(orderkey, custkey), count(*) FROM orders GROUP BY COALESCE(orderkey, custkey)");
-
-        // operands in group by
-        assertQuery("SELECT COALESCE(orderkey, 1), count(*) FROM orders GROUP BY orderkey");
-
-        // operands in group by
-        assertQuery("SELECT COALESCE(1, orderkey), count(*) FROM orders GROUP BY orderkey");
-    }
-
-    @Test
-    public void testGroupByNullIf()
-    {
-        // whole NULLIF in group by
-        assertQuery("SELECT NULLIF(orderkey, custkey), count(*) FROM orders GROUP BY NULLIF(orderkey, custkey)");
-
-        assertQuery(
-                "SELECT NULLIF(orderkey, custkey), count(*) FROM orders GROUP BY 1",
-                "SELECT NULLIF(orderkey, custkey), count(*) FROM orders GROUP BY NULLIF(orderkey, custkey)");
-
-        // first operand in group by
-        assertQuery("SELECT NULLIF(orderkey, 1), count(*) FROM orders GROUP BY orderkey");
-
-        // second operand in group by
-        assertQuery("SELECT NULLIF(1, orderkey), count(*) FROM orders GROUP BY orderkey");
-    }
-
-    @Test
-    public void testGroupByExtract()
-    {
-        // whole expression in group by
-        assertQuery("SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY EXTRACT(YEAR FROM now())");
-
-        assertQuery(
-                "SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY 1",
-                "SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY EXTRACT(YEAR FROM now())");
-
-        // argument in group by
-        assertQuery("SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY now()");
-    }
-
-    @Test
-    public void testGroupByNullConstant()
-    {
-        assertQuery("" +
-                "SELECT count(*)\n" +
-                "FROM (\n" +
-                "  SELECT CAST(null AS VARCHAR) constant, orderdate\n" +
-                "  FROM orders\n" +
-                ") a\n" +
-                "group by constant, orderdate\n");
-    }
-
-    @Test
     public void testChecksum()
     {
         assertQuery("SELECT to_hex(checksum(0))", "SELECT '0000000000000000'");
@@ -4083,29 +3098,6 @@ public abstract class AbstractTestQueries
     {
         assertQuery("SELECT y FROM (SELECT MIN_BY(orderkey, totalprice, 2) mx FROM orders) CROSS JOIN UNNEST(mx) u(y)",
                 "SELECT orderkey FROM orders ORDER BY totalprice ASC LIMIT 2");
-    }
-
-    @Test
-    public void testGroupByBetween()
-    {
-        // whole expression in group by
-        assertQuery("SELECT orderkey BETWEEN 1 AND 100 FROM orders GROUP BY orderkey BETWEEN 1 AND 100 ");
-
-        // expression in group by
-        assertQuery("SELECT CAST(orderkey BETWEEN 1 AND 100 AS BIGINT) FROM orders GROUP BY orderkey");
-
-        // min in group by
-        assertQuery("SELECT CAST(50 BETWEEN orderkey AND 100 AS BIGINT) FROM orders GROUP BY orderkey");
-
-        // max in group by
-        assertQuery("SELECT CAST(50 BETWEEN 1 AND orderkey AS BIGINT) FROM orders GROUP BY orderkey");
-    }
-
-    @Test
-    public void testAggregationImplicitCoercion()
-    {
-        assertQuery("SELECT 1.0 / COUNT(*) FROM orders");
-        assertQuery("SELECT custkey, 1.0 / COUNT(*) FROM orders GROUP BY custkey");
     }
 
     @Test
@@ -4292,7 +3284,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testGroupByAsJoinProbe()
+    public void testJoinWithGroupByAsProbe()
     {
         // we join on customer key instead of order key because
         // orders is effectively distributed on order key due the
@@ -4325,12 +3317,6 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT x, T.y, z + 1 FROM (SELECT custkey, orderstatus, totalprice FROM orders) T (x, y, z)",
                 "SELECT custkey, orderstatus, totalprice + 1 FROM orders");
-    }
-
-    @Test
-    public void testSameInputToAggregates()
-    {
-        assertQuery("SELECT max(a), max(b) FROM (SELECT custkey a, custkey b FROM orders) x");
     }
 
     @Test
@@ -5374,16 +4360,6 @@ public abstract class AbstractTestQueries
     {
         assertQuery("SELECT a FROM (VALUES (1),(2)) t(a) WHERE a IN " +
                 "(SELECT b FROM (VALUES (ARRAY[2])) AS t1 (a) CROSS JOIN UNNEST(a) AS t2(b))", "SELECT 2");
-    }
-
-    @Test
-    public void testGroupByIf()
-    {
-        assertQuery(
-                "SELECT IF(orderkey between 1 and 5, 'orders', 'others'), sum(totalprice) FROM orders GROUP BY 1",
-                "SELECT CASE WHEN orderkey BETWEEN 1 AND 5 THEN 'orders' ELSE 'others' END, sum(totalprice)\n" +
-                        "FROM orders\n" +
-                        "GROUP BY CASE WHEN orderkey BETWEEN 1 AND 5 THEN 'orders' ELSE 'others' END");
     }
 
     @Test
@@ -8924,50 +7900,6 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testAggregationPushedBelowOuterJoin()
-    {
-        assertQuery(
-                "SELECT * " +
-                        "FROM nation n1 " +
-                        "WHERE (n1.nationkey > ( " +
-                        "SELECT avg(nationkey) " +
-                        "FROM nation n2 " +
-                        "WHERE n1.regionkey=n2.regionkey))");
-        assertQuery(
-                "SELECT max(name), min(name), count(nationkey) + 1, count(nationkey) " +
-                        "FROM (SELECT DISTINCT regionkey FROM region) AS r1 " +
-                        "LEFT JOIN " +
-                        "nation " +
-                        "ON r1.regionkey = nation.regionkey " +
-                        "GROUP BY r1.regionkey " +
-                        "HAVING sum(nationkey) < 20");
-
-        assertQuery(
-                "SELECT DISTINCT r1.regionkey " +
-                        "FROM (SELECT regionkey FROM region INTERSECT SELECT regionkey FROM region WHERE regionkey < 4) AS r1 " +
-                        "LEFT JOIN " +
-                        "nation " +
-                        "ON r1.regionkey = nation.regionkey");
-
-        assertQuery(
-                "SELECT max(nationkey) " +
-                        "FROM (SELECT regionkey FROM region EXCEPT SELECT regionkey FROM region WHERE regionkey < 4) AS r1 " +
-                        "LEFT JOIN " +
-                        "nation " +
-                        "ON r1.regionkey = nation.regionkey " +
-                        "GROUP BY r1.regionkey");
-
-        assertQuery(
-                "SELECT max(nationkey) " +
-                        "FROM (VALUES CAST (1 AS BIGINT)) v1(col1) " +
-                        "LEFT JOIN " +
-                        "nation " +
-                        "ON v1.col1 = nation.regionkey " +
-                        "GROUP BY v1.col1",
-                "VALUES 24");
-    }
-
-    @Test
     public void testLateralJoin()
     {
         assertQuery(
@@ -9044,100 +7976,6 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT count(*) FROM (VALUES 2) t(a) GROUP BY a", "VALUES 1");
         assertQuery("SELECT a, count(*) FROM (VALUES 2) t(a) GROUP BY a", "VALUES (2, 1)");
         assertQuery("SELECT count(*) FROM (VALUES 2) t(a) GROUP BY a+1", "VALUES 1");
-    }
-
-    @Test
-    public void testAggregationWithOrderBy()
-    {
-        assertQuery(
-                "SELECT sum(x ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
-                "VALUES (8)");
-        assertQuery(
-                "SELECT array_agg(x ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
-                "VALUES ((4, 1, 3))");
-
-        assertQuery(
-                "SELECT array_agg(x ORDER BY y DESC) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
-                "VALUES ((3, 1, 4))");
-
-        assertQuery(
-                "SELECT array_agg(x ORDER BY x DESC) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
-                "VALUES ((4, 3, 1))");
-
-        assertQuery(
-                "SELECT array_agg(x ORDER BY x) FROM (VALUES ('a', 2), ('bcd', 5), ('abcd', 1)) t(x, y)",
-                "VALUES (('a', 'abcd', 'bcd'))");
-
-        assertQuery(
-                "SELECT array_agg(y ORDER BY x) FROM (VALUES ('a', 2), ('bcd', 5), ('abcd', 1)) t(x, y)",
-                "VALUES ((2, 1, 5))");
-
-        assertQuery(
-                "SELECT array_agg(y ORDER BY x) FROM (VALUES ((1, 2), 2), ((3, 4), 5), ((1, 1), 1)) t(x, y)",
-                "VALUES ((1, 2, 5))");
-
-        assertQuery(
-                "SELECT array_agg(z ORDER BY x, y DESC) FROM (VALUES (1, 2, 2), (2, 2, 3), (2, 4, 5), (3, 4, 4), (1, 1, 1)) t(x, y, z)",
-                "VALUES ((2, 1, 5, 3, 4))");
-
-        assertQuery(
-                "SELECT x, array_agg(z ORDER BY y + z DESC) FROM (VALUES (1, 2, 2), (2, 2, 3), (2, 4, 5), (3, 4, 4), (3, 2, 1), (1, 1, 1)) t(x, y, z) GROUP BY x",
-                "VALUES (1, (2, 1)), (2, (5, 3)), (3, (4, 1))");
-
-        assertQuery(
-                "SELECT array_agg(y ORDER BY x.a DESC) FROM (VALUES (CAST(ROW(1) AS ROW(a BIGINT)), 1), (CAST(ROW(2) AS ROW(a BIGINT)), 2)) t(x, y)",
-                "VALUES ((2, 1))");
-
-        assertQuery(
-                "SELECT x, y, array_agg(z ORDER BY z DESC NULLS FIRST) FROM (VALUES (1, 2, NULL), (1, 2, 1), (1, 2, 2), (2, 1, 3), (2, 1, 4), (2, 1, NULL)) t(x, y, z) GROUP BY x, y",
-                "VALUES (1, 2, (NULL, 2, 1)), (2, 1, (NULL, 4, 3))");
-
-        assertQuery(
-                "SELECT x, y, array_agg(z ORDER BY z DESC NULLS LAST) FROM (VALUES (1, 2, 3), (1, 2, 1), (1, 2, 2), (2, 1, 3), (2, 1, 4), (2, 1, NULL)) t(x, y, z) GROUP BY GROUPING SETS ((x), (x, y))",
-                "VALUES (1, 2, (3, 2, 1)), (1, NULL, (3, 2, 1)), (2, 1, (4, 3, NULL)), (2, NULL, (4, 3, NULL))");
-
-        assertQuery(
-                "SELECT x, y, array_agg(z ORDER BY z DESC NULLS LAST) FROM (VALUES (1, 2, 3), (1, 2, 1), (1, 2, 2), (2, 1, 3), (2, 1, 4), (2, 1, NULL)) t(x, y, z) GROUP BY GROUPING SETS ((x), (x, y))",
-                "VALUES (1, 2, (3, 2, 1)), (1, NULL, (3, 2, 1)), (2, 1, (4, 3, NULL)), (2, NULL, (4, 3, NULL))");
-
-        assertQuery(
-                "SELECT x, array_agg(DISTINCT z + y ORDER BY z + y DESC) FROM (VALUES (1, 2, 2), (2, 2, 3), (2, 4, 5), (3, 4, 4), (3, 2, 1), (1, 1, 1)) t(x, y, z) GROUP BY x",
-                "VALUES (1, (4, 2)), (2, (9, 5)), (3, (8, 3))");
-
-        assertQuery(
-                "SELECT x, sum(cast(x AS double))\n" +
-                        "FROM (VALUES '1.0') t(x)\n" +
-                        "GROUP BY x\n" +
-                        "ORDER BY sum(cast(t.x AS double) ORDER BY t.x)",
-                "VALUES ('1.0', 1.0)");
-
-        assertQuery(
-                "SELECT x, y, array_agg(z ORDER BY z) FROM (VALUES (1, 2, 3), (1, 2, 1), (2, 1, 3), (2, 1, 4)) t(x, y, z) GROUP BY GROUPING SETS ((x), (x, y))",
-                "VALUES (1, NULL, (1, 3)), (2, NULL, (3, 4)), (1, 2, (1, 3)), (2, 1, (3, 4))");
-
-        assertQueryFails(
-                "SELECT x, array_agg(z ORDER BY z) FROM (VALUES (1, 2, 3), (1, 2, 1), (2, 1, 3), (2, 1, 4)) t(x, y, z) GROUP BY ROLLUP (x)",
-                ".* ORDER BY in aggregate function with at least one empty grouping set and at least one non-empty grouping set is not supported");
-
-        assertQueryFails(
-                "SELECT x, y, array_agg(z ORDER BY z) FROM (VALUES (1, 2, 3), (1, 2, 1), (2, 1, 3), (2, 1, 4)) t(x, y, z) GROUP BY CUBE (x, y)",
-                ".* ORDER BY in aggregate function with at least one empty grouping set and at least one non-empty grouping set is not supported");
-
-        assertQueryFails(
-                "SELECT array_agg(z ORDER BY z) OVER (PARTITION BY x) FROM (VALUES (1, 2, 3), (1, 2, 1), (2, 1, 3), (2, 1, 4)) t(x, y, z) GROUP BY x, z",
-                ".* Window function with ORDER BY is not supported");
-
-        assertQueryFails(
-                "SELECT array_agg(DISTINCT x ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
-                ".* For aggregate function with DISTINCT, ORDER BY expressions must appear in arguments");
-
-        assertQueryFails(
-                "SELECT array_agg(DISTINCT x+y ORDER BY y) FROM (VALUES (1, 2), (3, 5), (4, 1)) t(x, y)",
-                ".* For aggregate function with DISTINCT, ORDER BY expressions must appear in arguments");
-
-        assertQueryFails(
-                "SELECT x, array_agg(DISTINCT y ORDER BY z + y DESC) FROM (VALUES (1, 2, 2), (2, 2, 3), (2, 4, 5), (3, 4, 4), (3, 2, 1), (1, 1, 1)) t(x, y, z) GROUP BY x",
-                ".* For aggregate function with DISTINCT, ORDER BY expressions must appear in arguments");
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestAggregations.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestAggregations.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.tests.tpch.TpchQueryRunner;
+
+public class TestAggregations
+        extends AbstractTestAggregations
+{
+    public TestAggregations()
+    {
+        super(TpchQueryRunner::createQueryRunner);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
@@ -32,7 +32,7 @@ public class TestDistributedSpilledQueries
         super(TestDistributedSpilledQueries::createQueryRunner);
     }
 
-    private static DistributedQueryRunner createQueryRunner()
+    public static DistributedQueryRunner createQueryRunner()
             throws Exception
     {
         Session defaultSession = testSessionBuilder()

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSpilledAggregations.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSpilledAggregations.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+public class TestSpilledAggregations
+        extends AbstractTestAggregations
+{
+    public TestSpilledAggregations()
+    {
+        super(TestDistributedSpilledQueries::createQueryRunner);
+    }
+}


### PR DESCRIPTION
This moves the aggregation tests from `AbstractTestQueries` to a
separate class. These tests cover Presto's engine behavior, so there is
no point in running them against different connectors.

Test methods were moved verbatim, with inevitable slight reordering
(attempting to actually introduce more order). There were two exceptions:

- `testGroupByRepeatedField` and `testGroupByRepeatedField2` were
  merged
- `testAggregationWithProjection` and `testAggregationWithProjection2`
  were merged