### PR TITLE
Disable optimize-mixed-distinct-aggregations in tests by default

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -258,8 +258,7 @@ public class LocalQueryRunner
     {
         this(
                 defaultSession,
-                new FeaturesConfig()
-                        .setOptimizeMixedDistinctAggregations(true),
+                new FeaturesConfig(),
                 false,
                 false);
     }
@@ -267,8 +266,7 @@ public class LocalQueryRunner
     public LocalQueryRunner(Session defaultSession, boolean alwaysRevokeMemory)
     {
         this(defaultSession,
-                new FeaturesConfig()
-                        .setOptimizeMixedDistinctAggregations(true),
+                new FeaturesConfig(),
                 false,
                 alwaysRevokeMemory);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestOptimizeMixedDistinctAggregations.java
@@ -41,10 +41,10 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableS
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
 
-public class TestMixedDistinctAggregationOptimizer
+public class TestOptimizeMixedDistinctAggregations
         extends BasePlanTest
 {
-    public TestMixedDistinctAggregationOptimizer()
+    public TestOptimizeMixedDistinctAggregations()
     {
         super(ImmutableMap.of(SystemSessionProperties.OPTIMIZE_DISTINCT_AGGREGATIONS, "true"));
     }
@@ -108,7 +108,7 @@ public class TestMixedDistinctAggregationOptimizer
                                                 anyTree(values(ImmutableMap.of())))))));
     }
 
-    public void assertUnitPlan(String sql, PlanMatchPattern pattern)
+    private void assertUnitPlan(String sql, PlanMatchPattern pattern)
     {
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(),

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -182,6 +182,7 @@ public abstract class AbstractTestAggregations
     public void testCountDistinct()
     {
         assertQuery("SELECT COUNT(DISTINCT custkey + 1) FROM orders", "SELECT COUNT(*) FROM (SELECT DISTINCT custkey + 1 FROM orders) t");
+        assertQuery("SELECT COUNT(DISTINCT linenumber), COUNT(*) from lineitem where linenumber < 0");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -119,7 +119,6 @@ public class DistributedQueryRunner
             }
 
             Map<String, String> extraCoordinatorProperties = new HashMap<>();
-            extraCoordinatorProperties.put("optimizer.optimize-mixed-distinct-aggregations", "true");
             extraCoordinatorProperties.put("experimental.iterative-optimizer-enabled", "true");
             extraCoordinatorProperties.putAll(extraProperties);
             extraCoordinatorProperties.putAll(coordinatorProperties);
@@ -185,8 +184,7 @@ public class DistributedQueryRunner
                 .put("exchange.http-client.idle-timeout", "1h")
                 .put("task.max-index-memory", "16kB") // causes index joins to fault load
                 .put("datasources", "system")
-                .put("distributed-index-joins-enabled", "true")
-                .put("optimizer.optimize-mixed-distinct-aggregations", "true");
+                .put("distributed-index-joins-enabled", "true");
         if (coordinator) {
             propertiesBuilder.put("node-scheduler.include-coordinator", "true");
             propertiesBuilder.put("distributed-joins-enabled", "true");

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizeMixedDistinctAggregations.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizeMixedDistinctAggregations.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.tests.tpch.TpchQueryRunner;
+import com.google.common.collect.ImmutableMap;
+
+public class TestOptimizeMixedDistinctAggregations
+        extends AbstractTestAggregations
+{
+    public TestOptimizeMixedDistinctAggregations()
+    {
+        super(() -> TpchQueryRunner.createQueryRunner(ImmutableMap.of("optimizer.optimize-mixed-distinct-aggregations", "true")));
+    }
+
+    @Override
+    public void testCountDistinct()
+    {
+        // TODO https://github.com/prestodb/presto/issues/8894 . Once fixed, remove test override.
+
+        assertQuery("SELECT COUNT(DISTINCT custkey + 1) FROM orders", "SELECT COUNT(*) FROM (SELECT DISTINCT custkey + 1 FROM orders) t");
+        // assertQuery("SELECT COUNT(DISTINCT linenumber), COUNT(*) from lineitem where linenumber < 0");
+    }
+
+    // TODO add dedicated test cases and remove `extends AbstractTestAggregation`
+}


### PR DESCRIPTION
`optimizer.optimize-mixed-distinct-aggregations` is false by default, so
it should not be turned on in tests by default.