### PR TITLE
Run TestMemoryTracking as single threaded

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -52,6 +52,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+@Test(singleThreaded = true)
 public class TestMemoryTracking
 {
     private static final DataSize queryMaxMemory = new DataSize(1, GIGABYTE);


### PR DESCRIPTION
```
java.lang.AssertionError: expected [100000000] but found [600000000]
	at com.facebook.presto.memory.TestMemoryTracking.assertStats(TestMemoryTracking.java:397)
	at com.facebook.presto.memory.TestMemoryTracking.testRevocableMemoryAllocations(TestMemoryTracking.java:260)
```