### PR TITLE
Fix type mismatch in Parquet predicate pushdown

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestTupleDomainParquetPredicate.java
@@ -13,15 +13,30 @@
  */
 package com.facebook.presto.hive.parquet;
 
+import com.facebook.presto.hive.parquet.predicate.ParquetDictionaryDescriptor;
+import com.facebook.presto.hive.parquet.predicate.TupleDomainParquetPredicate;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.type.VarcharType;
 import org.testng.annotations.Test;
+import parquet.column.ColumnDescriptor;
 import parquet.column.statistics.BinaryStatistics;
 import parquet.column.statistics.BooleanStatistics;
 import parquet.column.statistics.DoubleStatistics;
 import parquet.column.statistics.FloatStatistics;
 import parquet.column.statistics.LongStatistics;
+import parquet.column.statistics.Statistics;
 import parquet.io.api.Binary;
+import parquet.schema.PrimitiveType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import parquet.schema.Type.Repetition;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static com.facebook.presto.hive.parquet.predicate.TupleDomainParquetPredicate.getDomain;
 import static com.facebook.presto.spi.predicate.Domain.all;
 import static com.facebook.presto.spi.predicate.Domain.create;
@@ -36,9 +51,14 @@ import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.floatToRawIntBits;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static parquet.column.statistics.Statistics.getStatsBasedOnType;
 
 public class TestTupleDomainParquetPredicate
 {
@@ -164,6 +184,46 @@ public class TestTupleDomainParquetPredicate
                 create(ValueSet.ofRanges(range(REAL, (long) floatToRawIntBits(minimum), true, (long) floatToRawIntBits(maximum), true)), false));
 
         assertEquals(getDomain(REAL, 10, floatColumnStats(maximum, minimum)), create(ValueSet.all(REAL), false));
+    }
+
+    @Test
+    public void testMatchesWithStatistics()
+    {
+        RichColumnDescriptor column = getColumn();
+        String value = "Test";
+        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createVarcharType(255), value);
+        List<RichColumnDescriptor> columns = singletonList(column);
+        TupleDomainParquetPredicate predicate = new TupleDomainParquetPredicate(effectivePredicate, columns);
+        Statistics stats = getStatsBasedOnType(column.getType());
+        stats.setNumNulls(1L);
+        stats.setMinMaxFromBytes(value.getBytes(), value.getBytes());
+        assertTrue(predicate.matches(2, singletonMap(column, stats)));
+    }
+
+    @Test
+    public void testMatchesWithDescriptors()
+    {
+        RichColumnDescriptor column = getColumn();
+        String value = "Test2";
+        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createVarcharType(255), value);
+        List<RichColumnDescriptor> columns = singletonList(column);
+        TupleDomainParquetPredicate predicate = new TupleDomainParquetPredicate(effectivePredicate, columns);
+        ParquetDictionaryPage page = new ParquetDictionaryPage(utf8Slice(value), 2, PLAIN_DICTIONARY);
+        assertTrue(predicate.matches(singletonMap(column, new ParquetDictionaryDescriptor(column, Optional.of(page)))));
+    }
+
+    private TupleDomain<ColumnDescriptor> getEffectivePredicate(RichColumnDescriptor column, VarcharType type, String value)
+    {
+        ColumnDescriptor predicateColumn = new ColumnDescriptor(column.getPath(), column.getType(), 0, 0);
+        Domain predicateDomain = Domain.singleValue(type, utf8Slice(value));
+        Map<ColumnDescriptor, Domain> predicateColumns = singletonMap(predicateColumn, predicateDomain);
+        return TupleDomain.withColumnDomains(predicateColumns);
+    }
+
+    private RichColumnDescriptor getColumn()
+    {
+        PrimitiveType type = new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.BINARY, "Test column");
+        return new RichColumnDescriptor(new String[] {"path"}, type, 0, 0);
     }
 
     private static FloatStatistics floatColumnStats(float minimum, float maximum)


### PR DESCRIPTION
The parquet predicate pushdown logic was refactored to allow nested pushdown in the beginning of last year and seems like there was one minor but annoying bug that is still in the latest version and issue was opened here: https://github.com/prestodb/presto/issues/9084
We use presto with hive and can reliably reproduce this with the schema containing column of fixed varchar (say varchar(255))
The effectivePredicate seems to have the hive's column type which is varchar(255) however the type header of the parquet chunk gets translated to varchar and because of this mismatch we fail the type check that happens later.

```
Caused by: java.lang.IllegalArgumentException: Mismatched Domain types: varchar(255) vs varchar
	at com.facebook.presto.spi.predicate.Domain.checkCompatibility(Domain.java:228)
	at com.facebook.presto.spi.predicate.Domain.intersect(Domain.java:183)
	at com.facebook.presto.spi.predicate.TupleDomain.intersect(TupleDomain.java:196)
	at com.facebook.presto.spi.predicate.TupleDomain.overlaps(TupleDomain.java:299)
```

Please have a look at this @nezihyigitbasi @zhenxiao @dain  