### PR TITLE
Fix setting timeout for Hive metastore Thrift client

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/Transport.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/Transport.java
@@ -64,6 +64,7 @@ public final class Transport
         Socket socket = new Socket(proxy);
         try {
             socket.connect(new InetSocketAddress(address.getHost(), address.getPort()), timeoutMillis);
+            socket.setSoTimeout(timeoutMillis);
 
             if (sslContext.isPresent()) {
                 // SSL will connect to the SOCKS address when present


### PR DESCRIPTION
This was lost in 0.191 when SSL support was added.