### PR TITLE
Add a configuration option to disable creating non-managed Hive table

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -173,6 +173,8 @@ Property Name                                      Description                  
                                                    See :ref:`hive-file-based-authorization` for details.
 
 ``hive.non-managed-table-writes-enabled``          Enable writes to non-managed (external) Hive tables.         ``false``
+
+``hive.non-managed-table-creates-enabled``         Enable creating non-managed (external) Hive tables.          ``true``
 ================================================== ============================================================ ==========
 
 Amazon S3 Configuration

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -122,6 +122,8 @@ public class HiveClientConfig
     private int fileSystemMaxCacheSize = 1000;
 
     private boolean writesToNonManagedTablesEnabled;
+    private boolean createsOfNonManagedTablesEnabled = true;
+
     private boolean tableStatisticsEnabled = true;
 
     public int getMaxInitialSplits()
@@ -951,6 +953,19 @@ public class HiveClientConfig
     public boolean getWritesToNonManagedTablesEnabled()
     {
         return writesToNonManagedTablesEnabled;
+    }
+
+    @Config("hive.non-managed-table-creates-enabled")
+    @ConfigDescription("Enable non-managed (external) table creates")
+    public HiveClientConfig setCreatesOfNonManagedTablesEnabled(boolean createsOfNonManagedTablesEnabled)
+    {
+        this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
+        return this;
+    }
+
+    public boolean getCreatesOfNonManagedTablesEnabled()
+    {
+        return createsOfNonManagedTablesEnabled;
     }
 
     @Config("hive.table-statistics-enabled")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -185,6 +185,7 @@ public class HiveMetadata
     private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
     private final boolean bucketWritingEnabled;
     private final boolean writesToNonManagedTablesEnabled;
+    private final boolean createsOfNonManagedTablesEnabled;
     private final TypeTranslator typeTranslator;
     private final String prestoVersion;
     private final HiveStatisticsProvider hiveStatisticsProvider;
@@ -197,6 +198,7 @@ public class HiveMetadata
             boolean allowCorruptWritesForTesting,
             boolean bucketWritingEnabled,
             boolean writesToNonManagedTablesEnabled,
+            boolean createsOfNonManagedTablesEnabled,
             TypeManager typeManager,
             LocationService locationService,
             TableParameterCodec tableParameterCodec,
@@ -217,6 +219,7 @@ public class HiveMetadata
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
         this.bucketWritingEnabled = bucketWritingEnabled;
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
+        this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
         this.typeTranslator = requireNonNull(typeTranslator, "typeTranslator is null");
         this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
         this.hiveStatisticsProvider = requireNonNull(hiveStatisticsProvider, "hiveStatisticsProvider is null");
@@ -479,6 +482,10 @@ public class HiveMetadata
         boolean external;
         String externalLocation = getExternalLocation(tableMetadata.getProperties());
         if (externalLocation != null) {
+            if (!createsOfNonManagedTablesEnabled) {
+                throw new PrestoException(NOT_SUPPORTED, "Cannot create non-managed Hive table");
+            }
+
             external = true;
             targetPath = getExternalPath(new HdfsContext(session, schemaName, tableName), externalLocation);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -37,6 +37,7 @@ public class HiveMetadataFactory
     private final boolean bucketWritingEnabled;
     private final boolean skipDeletionForAlter;
     private final boolean writesToNonManagedTablesEnabled;
+    private final boolean createsOfNonManagedTablesEnabled;
     private final long perTransactionCacheMaximumSize;
     private final ExtendedHiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
@@ -75,6 +76,7 @@ public class HiveMetadataFactory
                 hiveClientConfig.isSkipDeletionForAlter(),
                 hiveClientConfig.isBucketWritingEnabled(),
                 hiveClientConfig.getWritesToNonManagedTablesEnabled(),
+                hiveClientConfig.getCreatesOfNonManagedTablesEnabled(),
                 hiveClientConfig.getPerTransactionMetastoreCacheMaximumSize(),
                 typeManager,
                 locationService,
@@ -95,6 +97,7 @@ public class HiveMetadataFactory
             boolean skipDeletionForAlter,
             boolean bucketWritingEnabled,
             boolean writesToNonManagedTablesEnabled,
+            boolean createsOfNonManagedTablesEnabled,
             long perTransactionCacheMaximumSize,
             TypeManager typeManager,
             LocationService locationService,
@@ -108,6 +111,7 @@ public class HiveMetadataFactory
         this.skipDeletionForAlter = skipDeletionForAlter;
         this.bucketWritingEnabled = bucketWritingEnabled;
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
+        this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
         this.perTransactionCacheMaximumSize = perTransactionCacheMaximumSize;
 
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -147,6 +151,7 @@ public class HiveMetadataFactory
                 allowCorruptWritesForTesting,
                 bucketWritingEnabled,
                 writesToNonManagedTablesEnabled,
+                createsOfNonManagedTablesEnabled,
                 typeManager,
                 locationService,
                 tableParameterCodec,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -528,6 +528,7 @@ public abstract class AbstractTestHiveClient
                 false,
                 true,
                 false,
+                true,
                 1000,
                 TYPE_MANAGER,
                 locationService,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -98,7 +98,8 @@ public class TestHiveClientConfig
                 .setBucketWritingEnabled(true)
                 .setFileSystemMaxCacheSize(1000)
                 .setTableStatisticsEnabled(true)
-                .setWritesToNonManagedTablesEnabled(false));
+                .setWritesToNonManagedTablesEnabled(false)
+                .setCreatesOfNonManagedTablesEnabled(true));
     }
 
     @Test
@@ -167,6 +168,7 @@ public class TestHiveClientConfig
                 .put("hive.fs.cache.max-size", "1010")
                 .put("hive.table-statistics-enabled", "false")
                 .put("hive.non-managed-table-writes-enabled", "true")
+                .put("hive.non-managed-table-creates-enabled", "false")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -231,7 +233,8 @@ public class TestHiveClientConfig
                 .setBucketWritingEnabled(false)
                 .setFileSystemMaxCacheSize(1010)
                 .setTableStatisticsEnabled(false)
-                .setWritesToNonManagedTablesEnabled(true);
+                .setWritesToNonManagedTablesEnabled(true)
+                .setCreatesOfNonManagedTablesEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add a configuration option using which one can disable creating
a non-managed (external) table. This will prevent the current
case where one can create an external table to query any data
in S3.