### PR TITLE
Support wildcard `*` in JMX table name to match several MBeans data

### DIFF
--- a/presto-docs/src/main/sphinx/connector/jmx.rst
+++ b/presto-docs/src/main/sphinx/connector/jmx.rst
@@ -81,6 +81,22 @@ for each node::
                          329 |                  10240
     (1 row)
 
+The wildcard character ``*`` may be used with table names in the ``current`` schema.
+This allows matching several MBean objects within a single query. The following query
+returns information from the different Presto memory pools on each node::
+
+    SELECT freebytes, node, object_name
+    FROM jmx.current."com.facebook.presto.memory:*type=memorypool*";
+
+.. code-block:: none
+
+     freebytes  |  node   |                       object_name
+    ------------+---------+----------------------------------------------------------
+      214748364 | example | com.facebook.presto.memory:type=MemoryPool,name=reserved
+     1073741825 | example | com.facebook.presto.memory:type=MemoryPool,name=general
+      858993459 | example | com.facebook.presto.memory:type=MemoryPool,name=system
+    (3 rows)
+
 The ``history`` schema contains the list of tables configured in the connector properties file.
 The tables have the same columns as those in the current schema, but with an additional
 timestamp column that stores the time at which the snapshot was taken::

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxHistoricalData.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxHistoricalData.java
@@ -59,13 +59,13 @@ public class JmxHistoricalData
         tableData.get(lowerCaseTableName).add(row);
     }
 
-    public synchronized List<List<Object>> getRows(String tableName, List<Integer> selectedColumns)
+    public synchronized List<List<Object>> getRows(String objectName, List<Integer> selectedColumns)
     {
-        String lowerCaseTableName = tableName.toLowerCase();
-        if (!tableData.containsKey(lowerCaseTableName)) {
+        String lowerCaseObjectName = objectName.toLowerCase();
+        if (!tableData.containsKey(lowerCaseObjectName)) {
             return ImmutableList.of();
         }
-        return projectRows(tableData.get(lowerCaseTableName), selectedColumns);
+        return projectRows(tableData.get(lowerCaseObjectName), selectedColumns);
     }
 
     private List<List<Object>> projectRows(Collection<List<Object>> rows, List<Integer> selectedColumns)

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
@@ -51,6 +51,7 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Comparator.comparing;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -130,7 +131,7 @@ public class JmxMetadata
             Arrays.stream(mbeanInfo.getAttributes())
                     .filter(MBeanAttributeInfo::isReadable)
                     .map(attribute -> new JmxColumnHandle(attribute.getName(), getColumnType(attribute)))
-                    .sorted((column1, column2) -> column1.getColumnName().compareTo(column2.getColumnName()))
+                    .sorted(comparing(JmxColumnHandle::getColumnName))
                     .forEach(columns::add);
 
             return new JmxTableHandle(objectName.get().toString(), columns.build(), true);

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
@@ -168,7 +168,7 @@ public class JmxMetadata
         Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (ObjectName objectName : mbeanServer.queryNames(WILDCARD, null)) {
             // todo remove lower case when presto supports mixed case names
-            tableNames.add(new SchemaTableName(JMX_SCHEMA_NAME, objectName.toString().toLowerCase(ENGLISH)));
+            tableNames.add(new SchemaTableName(JMX_SCHEMA_NAME, objectName.getCanonicalName().toLowerCase(ENGLISH)));
         }
         return tableNames.build();
     }

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
@@ -108,7 +108,7 @@ public class JmxMetadata
         ImmutableList.Builder<JmxColumnHandle> builder = ImmutableList.builder();
         builder.add(new JmxColumnHandle(TIMESTAMP_COLUMN_NAME, TIMESTAMP));
         builder.addAll(handle.getColumnHandles());
-        return new JmxTableHandle(handle.getObjectName(), builder.build(), false);
+        return new JmxTableHandle(handle.getTableName(), handle.getObjectNames(), builder.build(), false);
     }
 
     private JmxTableHandle getJmxTableHandle(SchemaTableName tableName)
@@ -134,7 +134,7 @@ public class JmxMetadata
                     .sorted(comparing(JmxColumnHandle::getColumnName))
                     .forEach(columns::add);
 
-            return new JmxTableHandle(objectName.get().toString(), columns.build(), true);
+            return new JmxTableHandle(tableName, ImmutableList.of(objectName.get().toString()), columns.build(), true);
         }
         catch (JMException e) {
             return null;

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
@@ -43,12 +43,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -193,8 +195,6 @@ public class JmxMetadata
             return ImmutableMap.of();
         }
 
-        ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
-
         List<SchemaTableName> tableNames;
         if (prefix.getTableName() == null) {
             tableNames = listTables(session, prefix.getSchemaName());
@@ -203,11 +203,8 @@ public class JmxMetadata
             tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
         }
 
-        for (SchemaTableName tableName : tableNames) {
-            JmxTableHandle tableHandle = getTableHandle(session, tableName);
-            columns.put(tableName, tableHandle.getTableMetadata().getColumns());
-        }
-        return columns.build();
+        return tableNames.stream()
+                .collect(toImmutableMap(Function.identity(), tableName -> getTableHandle(session, tableName).getTableMetadata().getColumns()));
     }
 
     @Override

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxPeriodicSampler.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxPeriodicSampler.java
@@ -116,11 +116,13 @@ public class JmxPeriodicSampler
 
         for (JmxTableHandle tableHandle : tableHandles) {
             try {
-                List<Object> row = jmxRecordSetProvider.getLiveRow(
-                        tableHandle,
-                        tableHandle.getColumnHandles(),
-                        dumpTimestamp);
-                jmxHistoricalData.addRow(tableHandle.getObjectName(), row);
+                for (String objectName : tableHandle.getObjectNames()) {
+                    List<Object> row = jmxRecordSetProvider.getLiveRow(
+                            objectName,
+                            tableHandle.getColumnHandles(),
+                            dumpTimestamp);
+                    jmxHistoricalData.addRow(tableHandle.getTableName().getTableName(), row);
+                }
             }
             catch (Exception exception) {
                 log.error(exception, "Error reading jmx records");

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxRecordSetProvider.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxRecordSetProvider.java
@@ -69,6 +69,9 @@ public class JmxRecordSetProvider
             if (jmxColumn.getColumnName().equals(JmxMetadata.NODE_COLUMN_NAME)) {
                 row.add(nodeId);
             }
+            else if (jmxColumn.getColumnName().equals(JmxMetadata.OBJECT_NAME_NAME)) {
+                row.add(objectName);
+            }
             else if (jmxColumn.getColumnName().equals(JmxMetadata.TIMESTAMP_COLUMN_NAME)) {
                 row.add(entryTimestamp);
             }

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxRecordSetProvider.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxRecordSetProvider.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class JmxRecordSetProvider
@@ -57,10 +58,10 @@ public class JmxRecordSetProvider
         this.jmxHistoricalData = requireNonNull(jmxHistoricalData, "jmxHistoryHolder is null");
     }
 
-    public List<Object> getLiveRow(JmxTableHandle tableHandle, List<? extends ColumnHandle> columns, long entryTimestamp)
+    public List<Object> getLiveRow(String objectName, List<? extends ColumnHandle> columns, long entryTimestamp)
             throws JMException
     {
-        ImmutableMap<String, Optional<Object>> attributes = getAttributes(getColumnNames(columns), tableHandle);
+        ImmutableMap<String, Optional<Object>> attributes = getAttributes(getColumnNames(columns), objectName);
         List<Object> row = new ArrayList<>();
 
         for (ColumnHandle column : columns) {
@@ -158,12 +159,13 @@ public class JmxRecordSetProvider
         List<List<Object>> rows;
         try {
             if (tableHandle.isLiveData()) {
-                rows = ImmutableList.of(getLiveRow(tableHandle, columns));
+                rows = getLiveRows(tableHandle, columns);
             }
             else {
-                rows = jmxHistoricalData.getRows(
-                        tableHandle.getObjectName(),
-                        calculateSelectedColumns(tableHandle.getColumnHandles(), getColumnNames(columns)));
+                List<Integer> selectedColumns = calculateSelectedColumns(tableHandle.getColumnHandles(), getColumnNames(columns));
+                rows = tableHandle.getObjectNames().stream()
+                        .flatMap(objectName -> jmxHistoricalData.getRows(objectName, selectedColumns).stream())
+                        .collect(toImmutableList());
             }
         }
         catch (JMException e) {
@@ -201,10 +203,10 @@ public class JmxRecordSetProvider
                 .collect(Collectors.toList());
     }
 
-    private ImmutableMap<String, Optional<Object>> getAttributes(Set<String> uniqueColumnNames, JmxTableHandle tableHandle)
+    private ImmutableMap<String, Optional<Object>> getAttributes(Set<String> uniqueColumnNames, String name)
             throws JMException
     {
-        ObjectName objectName = new ObjectName(tableHandle.getObjectName());
+        ObjectName objectName = new ObjectName(name);
 
         String[] columnNamesArray = uniqueColumnNames.toArray(new String[uniqueColumnNames.size()]);
 
@@ -215,9 +217,13 @@ public class JmxRecordSetProvider
         return attributes.build();
     }
 
-    private List<Object> getLiveRow(JmxTableHandle tableHandle, List<? extends ColumnHandle> columns)
+    private List<List<Object>> getLiveRows(JmxTableHandle tableHandle, List<? extends ColumnHandle> columns)
             throws JMException
     {
-        return getLiveRow(tableHandle, columns, 0);
+        ImmutableList.Builder<List<Object>> rows = ImmutableList.builder();
+        for (String objectName : tableHandle.getObjectNames()) {
+            rows.add(getLiveRow(objectName, columns, 0));
+        }
+        return rows.build();
     }
 }

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxTableHandle.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxTableHandle.java
@@ -24,31 +24,43 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.transform;
 import static java.util.Objects.requireNonNull;
 
 public class JmxTableHandle
         implements ConnectorTableHandle
 {
-    private final String objectName;
+    private final SchemaTableName tableName;
+    private final List<String> objectNames;
     private final List<JmxColumnHandle> columnHandles;
     private final boolean liveData;
 
     @JsonCreator
     public JmxTableHandle(
-            @JsonProperty("objectName") String objectName,
+            @JsonProperty("tableName") SchemaTableName tableName,
+            @JsonProperty("objectNames") List<String> objectNames,
             @JsonProperty("columnHandles") List<JmxColumnHandle> columnHandles,
             @JsonProperty("liveData") boolean liveData)
     {
-        this.objectName = requireNonNull(objectName, "objectName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.objectNames = ImmutableList.copyOf(requireNonNull(objectNames, "objectName is null"));
         this.columnHandles = ImmutableList.copyOf(requireNonNull(columnHandles, "columnHandles is null"));
         this.liveData = liveData;
+
+        checkArgument(!objectNames.isEmpty(), "objectsNames is empty");
     }
 
     @JsonProperty
-    public String getObjectName()
+    public SchemaTableName getTableName()
     {
-        return objectName;
+        return tableName;
+    }
+
+    @JsonProperty
+    public List<String> getObjectNames()
+    {
+        return objectNames;
     }
 
     @JsonProperty
@@ -66,7 +78,7 @@ public class JmxTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(objectName, columnHandles, liveData);
+        return Objects.hash(tableName, objectNames, columnHandles, liveData);
     }
 
     @Override
@@ -79,7 +91,8 @@ public class JmxTableHandle
             return false;
         }
         JmxTableHandle other = (JmxTableHandle) obj;
-        return Objects.equals(this.objectName, other.objectName) &&
+        return Objects.equals(tableName, other.tableName) &&
+                Objects.equals(this.objectNames, other.objectNames) &&
                 Objects.equals(this.columnHandles, other.columnHandles) &&
                 Objects.equals(this.liveData, other.liveData);
     }
@@ -88,7 +101,8 @@ public class JmxTableHandle
     public String toString()
     {
         return toStringHelper(this)
-                .add("objectName", objectName)
+                .add("tableName", objectNames)
+                .add("objectNames", objectNames)
                 .add("columnHandles", columnHandles)
                 .add("liveData", liveData)
                 .toString();
@@ -97,7 +111,7 @@ public class JmxTableHandle
     public ConnectorTableMetadata getTableMetadata()
     {
         return new ConnectorTableMetadata(
-                new SchemaTableName(JmxMetadata.JMX_SCHEMA_NAME, objectName),
+                tableName,
                 ImmutableList.copyOf(transform(columnHandles, JmxColumnHandle::getColumnMetadata)));
     }
 }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxMetadata.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxMetadata.java
@@ -56,7 +56,7 @@ public class TestJmxMetadata
     public void testGetTableHandle()
     {
         JmxTableHandle handle = metadata.getTableHandle(SESSION, RUNTIME_TABLE);
-        assertEquals(handle.getObjectName(), RUNTIME_OBJECT);
+        assertEquals(handle.getObjectNames(), ImmutableList.of(RUNTIME_OBJECT));
 
         List<JmxColumnHandle> columns = handle.getColumnHandles();
         assertTrue(columns.contains(new JmxColumnHandle("node", createUnboundedVarcharType())));
@@ -68,7 +68,7 @@ public class TestJmxMetadata
     public void testGetTimeTableHandle()
     {
         JmxTableHandle handle = metadata.getTableHandle(SESSION, RUNTIME_HISTORY_TABLE);
-        assertEquals(handle.getObjectName(), RUNTIME_OBJECT);
+        assertEquals(handle.getObjectNames(), ImmutableList.of(RUNTIME_OBJECT));
 
         List<JmxColumnHandle> columns = handle.getColumnHandles();
         assertTrue(columns.contains(new JmxColumnHandle("timestamp", TIMESTAMP)));

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxMetadata.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxMetadata.java
@@ -76,4 +76,23 @@ public class TestJmxMetadata
         assertTrue(columns.contains(new JmxColumnHandle("Name", createUnboundedVarcharType())));
         assertTrue(columns.contains(new JmxColumnHandle("StartTime", BIGINT)));
     }
+
+    @Test
+    public void testGetCumulativeTableHandle()
+    {
+        JmxTableHandle handle = metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "java.lang:*"));
+        assertTrue(handle.getObjectNames().contains(RUNTIME_OBJECT));
+        assertTrue(handle.getObjectNames().size() > 1);
+
+        List<JmxColumnHandle> columns = handle.getColumnHandles();
+        assertTrue(columns.contains(new JmxColumnHandle("node", createUnboundedVarcharType())));
+        assertTrue(columns.contains(new JmxColumnHandle("object_name", createUnboundedVarcharType())));
+        assertTrue(columns.contains(new JmxColumnHandle("Name", createUnboundedVarcharType())));
+        assertTrue(columns.contains(new JmxColumnHandle("StartTime", BIGINT)));
+
+        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "*java.lang:type=Runtime*")).getObjectNames().contains(RUNTIME_OBJECT));
+        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "java.lang:*=Runtime")).getObjectNames().contains(RUNTIME_OBJECT));
+        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "*")).getObjectNames().contains(RUNTIME_OBJECT));
+        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "*:*")).getObjectNames().contains(RUNTIME_OBJECT));
+    }
 }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxQueries.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxQueries.java
@@ -79,4 +79,12 @@ public class TestJmxQueries
         MaterializedResult expected = computeActual(format("SELECT DISTINCT node FROM \"%s\"", name));
         assertEqualsIgnoreOrder(actual, expected);
     }
+
+    @Test
+    public void testOrderOfParametersIsIgnored()
+    {
+        assertEqualsIgnoreOrder(
+                computeActual("SELECT node FROM \"java.nio:type=bufferpool,name=direct\""),
+                computeActual("SELECT node FROM \"java.nio:name=direct,type=bufferpool\""));
+    }
 }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxQueries.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxQueries.java
@@ -87,4 +87,13 @@ public class TestJmxQueries
                 computeActual("SELECT node FROM \"java.nio:type=bufferpool,name=direct\""),
                 computeActual("SELECT node FROM \"java.nio:name=direct,type=bufferpool\""));
     }
+
+    @Test
+    public void testQueryCumulativeTable()
+    {
+        computeActual("SELECT * FROM \"*:*\"");
+        computeActual("SELECT * FROM \"java.util.logging:*\"");
+        assertTrue(computeActual("SELECT * FROM \"java.lang:*\"").getRowCount() > 1);
+        assertTrue(computeActual("SELECT * FROM \"jAVA.LANg:*\"").getRowCount() > 1);
+    }
 }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
@@ -85,7 +85,7 @@ public class TestJmxSplitManager
                             });
 
     private final JmxColumnHandle columnHandle = new JmxColumnHandle("node", createUnboundedVarcharType());
-    private final JmxTableHandle tableHandle = new JmxTableHandle("objectName", ImmutableList.of(columnHandle), true);
+    private final JmxTableHandle tableHandle = new JmxTableHandle(new SchemaTableName("schema", "tableName"), ImmutableList.of("objectName"), ImmutableList.of(columnHandle), true);
 
     private final JmxSplitManager splitManager = jmxConnector.getSplitManager();
     private final JmxMetadata metadata = jmxConnector.getMetadata(new ConnectorTransactionHandle() {});

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxTableHandle.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxTableHandle.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.connector.jmx;
 
+import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableList;
 import io.airlift.testing.EquivalenceTester;
 import org.testng.annotations.Test;
@@ -30,7 +31,8 @@ public class TestJmxTableHandle
             .add(new JmxColumnHandle("id", BIGINT))
             .add(new JmxColumnHandle("name", createUnboundedVarcharType()))
             .build();
-    public static final JmxTableHandle TABLE = new JmxTableHandle("objectName", COLUMNS, true);
+    public static final SchemaTableName SCHEMA_TABLE_NAME = new SchemaTableName("schema", "tableName");
+    public static final JmxTableHandle TABLE = new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("objectName"), COLUMNS, true);
 
     @Test
     public void testJsonRoundTrip()
@@ -46,23 +48,23 @@ public class TestJmxTableHandle
         List<JmxColumnHandle> singleColumn = ImmutableList.of(COLUMNS.get(0));
         EquivalenceTester.equivalenceTester()
                 .addEquivalentGroup(
-                        new JmxTableHandle("name", COLUMNS, true),
-                        new JmxTableHandle("name", COLUMNS, true))
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("name"), COLUMNS, true),
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("name"), COLUMNS, true))
                 .addEquivalentGroup(
-                        new JmxTableHandle("name", COLUMNS, false),
-                        new JmxTableHandle("name", COLUMNS, false))
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("name"), COLUMNS, false),
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("name"), COLUMNS, false))
                 .addEquivalentGroup(
-                        new JmxTableHandle("nameX", COLUMNS, true),
-                        new JmxTableHandle("nameX", COLUMNS, true))
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("nameX"), COLUMNS, true),
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("nameX"), COLUMNS, true))
                 .addEquivalentGroup(
-                        new JmxTableHandle("nameX", COLUMNS, false),
-                        new JmxTableHandle("nameX", COLUMNS, false))
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("nameX"), COLUMNS, false),
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("nameX"), COLUMNS, false))
                 .addEquivalentGroup(
-                        new JmxTableHandle("name", singleColumn, true),
-                        new JmxTableHandle("name", singleColumn, true))
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("name"), singleColumn, true),
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("name"), singleColumn, true))
                 .addEquivalentGroup(
-                        new JmxTableHandle("name", singleColumn, false),
-                        new JmxTableHandle("name", singleColumn, false))
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("name"), singleColumn, false),
+                        new JmxTableHandle(SCHEMA_TABLE_NAME, ImmutableList.of("name"), singleColumn, false))
                 .check();
     }
 }


### PR DESCRIPTION
Add cumulative schema to JMX connector

Thanks to this change user would not need to query each JMX table to find out which IterativeOptimizer rule takes the most time, instead they could:
```
select * from jmx.cumulative."com.facebook.presto.sql.planner.iterative";
```