### PR TITLE
remove repeated hdfs fopen calls in ParquetPageSource

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HdfsParquetDataSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HdfsParquetDataSource.java
@@ -101,4 +101,9 @@ public class HdfsParquetDataSource
             throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, format("Error opening Hive split %s (offset=%s, length=%s): %s", path, start, length, e.getMessage()), e);
         }
     }
+
+    public static HdfsParquetDataSource buildHdfsParquetDataSource(FSDataInputStream inputStream, Path path, long fileSize)
+    {
+        return new HdfsParquetDataSource(path, fileSize, inputStream);
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTimeZone;
@@ -39,6 +40,7 @@ import parquet.schema.MessageType;
 
 import javax.inject.Inject;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,6 +61,7 @@ import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.b
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.getParquetTupleDomain;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.predicateMatches;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -145,10 +148,11 @@ public class ParquetPageSourceFactory
         ParquetDataSource dataSource = null;
         try {
             FileSystem fileSystem = hdfsEnvironment.getFileSystem(user, path, configuration);
-            dataSource = buildHdfsParquetDataSource(fileSystem, path, start, length, fileSize);
-            ParquetMetadata parquetMetadata = ParquetMetadataReader.readFooter(fileSystem, path, fileSize);
+            FSDataInputStream inputStream = fileSystem.open(path);
+            ParquetMetadata parquetMetadata = ParquetMetadataReader.readFooter(inputStream, path, fileSize);
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
+            dataSource = buildHdfsParquetDataSource(inputStream, path, fileSize);
 
             List<parquet.schema.Type> fields = columns.stream()
                     .filter(column -> column.getColumnType() == REGULAR)
@@ -205,6 +209,10 @@ public class ParquetPageSourceFactory
             }
             if (e instanceof PrestoException) {
                 throw (PrestoException) e;
+            }
+            if (nullToEmpty(e.getMessage()).trim().equals("Filesystem closed") ||
+                    e instanceof FileNotFoundException) {
+                throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, e);
             }
             String message = format("Error opening Hive split %s (offset=%s, length=%s): %s", path, start, length, e.getMessage());
             if (e.getClass().getSimpleName().equals("BlockMissingException")) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetMetadataReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetMetadataReader.java
@@ -65,81 +65,89 @@ public final class ParquetMetadataReader
             throws IOException
     {
         try (FSDataInputStream inputStream = fileSystem.open(file)) {
-            // Parquet File Layout:
-            //
-            // MAGIC
-            // variable: Data
-            // variable: Metadata
-            // 4 bytes: MetadataLength
-            // MAGIC
-
-            validateParquet(fileSize >= MAGIC.length + PARQUET_METADATA_LENGTH + MAGIC.length, "%s is not a valid Parquet File", file);
-            long metadataLengthIndex = fileSize - PARQUET_METADATA_LENGTH - MAGIC.length;
-
-            inputStream.seek(metadataLengthIndex);
-            int metadataLength = readIntLittleEndian(inputStream);
-
-            byte[] magic = new byte[MAGIC.length];
-            inputStream.readFully(magic);
-            validateParquet(Arrays.equals(MAGIC, magic), "Not valid Parquet file: %s expected magic number: %s got: %s", file, Arrays.toString(MAGIC), Arrays.toString(magic));
-
-            long metadataIndex = metadataLengthIndex - metadataLength;
-            validateParquet(
-                    metadataIndex >= MAGIC.length && metadataIndex < metadataLengthIndex,
-                    "Corrupted Parquet file: %s metadata index: %s out of range",
-                    file,
-                    metadataIndex);
-            inputStream.seek(metadataIndex);
-            FileMetaData fileMetaData = readFileMetaData(inputStream);
-            List<SchemaElement> schema = fileMetaData.getSchema();
-            validateParquet(!schema.isEmpty(), "Empty Parquet schema in file: %s", file);
-
-            MessageType messageType = readParquetSchema(schema);
-            List<BlockMetaData> blocks = new ArrayList<>();
-            List<RowGroup> rowGroups = fileMetaData.getRow_groups();
-            if (rowGroups != null) {
-                for (RowGroup rowGroup : rowGroups) {
-                    BlockMetaData blockMetaData = new BlockMetaData();
-                    blockMetaData.setRowCount(rowGroup.getNum_rows());
-                    blockMetaData.setTotalByteSize(rowGroup.getTotal_byte_size());
-                    List<ColumnChunk> columns = rowGroup.getColumns();
-                    validateParquet(!columns.isEmpty(), "No columns in row group: %s", rowGroup);
-                    String filePath = columns.get(0).getFile_path();
-                    for (ColumnChunk columnChunk : columns) {
-                        validateParquet(
-                                (filePath == null && columnChunk.getFile_path() == null)
-                                        || (filePath != null && filePath.equals(columnChunk.getFile_path())),
-                                "all column chunks of the same row group must be in the same file");
-                        ColumnMetaData metaData = columnChunk.meta_data;
-                        String[] path = metaData.path_in_schema.toArray(new String[metaData.path_in_schema.size()]);
-                        ColumnPath columnPath = ColumnPath.get(path);
-                        ColumnChunkMetaData column = ColumnChunkMetaData.get(
-                                columnPath,
-                                messageType.getType(columnPath.toArray()).asPrimitiveType().getPrimitiveTypeName(),
-                                CompressionCodecName.fromParquet(metaData.codec),
-                                readEncodings(metaData.encodings),
-                                readStats(metaData.statistics, messageType.getType(columnPath.toArray()).asPrimitiveType().getPrimitiveTypeName()),
-                                metaData.data_page_offset,
-                                metaData.dictionary_page_offset,
-                                metaData.num_values,
-                                metaData.total_compressed_size,
-                                metaData.total_uncompressed_size);
-                        blockMetaData.addColumn(column);
-                    }
-                    blockMetaData.setPath(filePath);
-                    blocks.add(blockMetaData);
-                }
-            }
-
-            Map<String, String> keyValueMetaData = new HashMap<>();
-            List<KeyValue> keyValueList = fileMetaData.getKey_value_metadata();
-            if (keyValueList != null) {
-                for (KeyValue keyValue : keyValueList) {
-                    keyValueMetaData.put(keyValue.key, keyValue.value);
-                }
-            }
-            return new ParquetMetadata(new parquet.hadoop.metadata.FileMetaData(messageType, keyValueMetaData, fileMetaData.getCreated_by()), blocks);
+            return readFooter(inputStream, file, fileSize);
         }
+    }
+
+    public static ParquetMetadata readFooter(FSDataInputStream inputStream, Path file, long fileSize)
+            throws IOException
+
+    {
+        // Parquet File Layout:
+        //
+        // MAGIC
+        // variable: Data
+        // variable: Metadata
+        // 4 bytes: MetadataLength
+        // MAGIC
+
+        validateParquet(fileSize >= MAGIC.length + PARQUET_METADATA_LENGTH + MAGIC.length, "%s is not a valid Parquet File", file);
+        long metadataLengthIndex = fileSize - PARQUET_METADATA_LENGTH - MAGIC.length;
+
+        inputStream.seek(metadataLengthIndex);
+        int metadataLength = readIntLittleEndian(inputStream);
+
+        byte[] magic = new byte[MAGIC.length];
+        inputStream.readFully(magic);
+        validateParquet(Arrays.equals(MAGIC, magic), "Not valid Parquet file: %s expected magic number: %s got: %s", file, Arrays.toString(MAGIC), Arrays.toString(magic));
+
+        long metadataIndex = metadataLengthIndex - metadataLength;
+        validateParquet(
+                metadataIndex >= MAGIC.length && metadataIndex < metadataLengthIndex,
+                "Corrupted Parquet file: %s metadata index: %s out of range",
+                file,
+                metadataIndex);
+        inputStream.seek(metadataIndex);
+        FileMetaData fileMetaData = readFileMetaData(inputStream);
+        List<SchemaElement> schema = fileMetaData.getSchema();
+        validateParquet(!schema.isEmpty(), "Empty Parquet schema in file: %s", file);
+
+        MessageType messageType = readParquetSchema(schema);
+        List<BlockMetaData> blocks = new ArrayList<>();
+        List<RowGroup> rowGroups = fileMetaData.getRow_groups();
+        if (rowGroups != null) {
+            for (RowGroup rowGroup : rowGroups) {
+                BlockMetaData blockMetaData = new BlockMetaData();
+                blockMetaData.setRowCount(rowGroup.getNum_rows());
+                blockMetaData.setTotalByteSize(rowGroup.getTotal_byte_size());
+                List<ColumnChunk> columns = rowGroup.getColumns();
+                validateParquet(!columns.isEmpty(), "No columns in row group: %s", rowGroup);
+                String filePath = columns.get(0).getFile_path();
+                for (ColumnChunk columnChunk : columns) {
+                    validateParquet(
+                            (filePath == null && columnChunk.getFile_path() == null)
+                                    || (filePath != null && filePath.equals(columnChunk.getFile_path())),
+                            "all column chunks of the same row group must be in the same file");
+                    ColumnMetaData metaData = columnChunk.meta_data;
+                    String[] path = metaData.path_in_schema.toArray(new String[metaData.path_in_schema.size()]);
+                    ColumnPath columnPath = ColumnPath.get(path);
+                    PrimitiveTypeName primitiveTypeName = messageType.getType(columnPath.toArray()).asPrimitiveType().getPrimitiveTypeName();
+                    ColumnChunkMetaData column = ColumnChunkMetaData.get(
+                            columnPath,
+                            primitiveTypeName,
+                            CompressionCodecName.fromParquet(metaData.codec),
+                            readEncodings(metaData.encodings),
+                            readStats(metaData.statistics, primitiveTypeName),
+                            metaData.data_page_offset,
+                            metaData.dictionary_page_offset,
+                            metaData.num_values,
+                            metaData.total_compressed_size,
+                            metaData.total_uncompressed_size);
+                    blockMetaData.addColumn(column);
+                }
+                blockMetaData.setPath(filePath);
+                blocks.add(blockMetaData);
+            }
+        }
+
+        Map<String, String> keyValueMetaData = new HashMap<>();
+        List<KeyValue> keyValueList = fileMetaData.getKey_value_metadata();
+        if (keyValueList != null) {
+            for (KeyValue keyValue : keyValueList) {
+                keyValueMetaData.put(keyValue.key, keyValue.value);
+            }
+        }
+        return new ParquetMetadata(new parquet.hadoop.metadata.FileMetaData(messageType, keyValueMetaData, fileMetaData.getCreated_by()), blocks);
     }
 
     private static MessageType readParquetSchema(List<SchemaElement> schema)


### PR DESCRIPTION
The optimized parquet reader will call HDFS `open()` twice in `createParquetPageSource()`, one for reading the footer and the other for building `dataSource`. Since the execution is completely serialized, we can reuse the inputStream in `readFooter()` to avoid repeated `open` call() to HDFS NameNode.