### PR TITLE
Fix query peak user/total memory tracking

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
@@ -64,6 +64,8 @@ public class MemoryTrackingRemoteTaskFactory
             implements StateChangeListener<TaskStatus>
     {
         private final QueryStateMachine stateMachine;
+        private long previousUserMemory;
+        private long previousSystemMemory;
 
         public UpdatePeakMemory(QueryStateMachine stateMachine)
         {
@@ -75,7 +77,11 @@ public class MemoryTrackingRemoteTaskFactory
         {
             long currentUserMemory = newStatus.getMemoryReservation().toBytes();
             long currentSystemMemory = newStatus.getSystemMemoryReservation().toBytes();
-            stateMachine.updateMemoryUsage(currentUserMemory, currentSystemMemory);
+            long deltaUserMemoryInBytes = currentUserMemory - previousUserMemory;
+            long deltaTotalMemoryInBytes = (currentUserMemory + currentSystemMemory) - (previousUserMemory + previousSystemMemory);
+            previousUserMemory = currentUserMemory;
+            previousSystemMemory = currentSystemMemory;
+            stateMachine.updateMemoryUsage(deltaUserMemoryInBytes, deltaTotalMemoryInBytes);
         }
     }
 }


### PR DESCRIPTION
Previously, the query peak user/total memory was incorrectly calculated
as the peak of task user/total memory.

This is similar to the approach used by the original commit that added the query peak memory tracking: https://github.com/prestodb/presto/commit/60127c66529d1a12981607d06658ccc9a0411868

Verified the correctness with some prod query.