### PR TITLE
Fix race-condition when Driver re-consults Operator.isBlocked

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -450,8 +450,13 @@ public class Driver
 
     private void addBlockedOperator(List<Operator> blockedOperators, List<ListenableFuture<?>> blockedFutures, Operator operator, ListenableFuture<?> blockedFuture)
     {
+        // We don't want to duplicate operators on the list. Just update its "entry" with new blocked future.
+        // Having duplicate operators would lead to suboptimal performance, as listeners on blocked futures
+        // would be duplicated, and `OperatorContext.recordBlocked` would be called second time, unnecessarily.
+
+        // We consider operators in order. Each operator is considered once as `next` and then, immediately
+        // afterwards, as `current`. Thus, if `operator` is already on the list, it must be the last one.
         if (!blockedOperators.isEmpty() && getLast(blockedOperators) == operator) {
-            // We don't want to duplicate operators on the list. Just update its "entry" with new blocked future
             blockedFutures.set(blockedFutures.size() - 1, blockedFuture);
             return;
         }


### PR DESCRIPTION
Fixes second problem described in https://github.com/prestodb/presto/issues/10003:

Previously, if `Driver` couldn't make progress (`!movedPage`), we listed
all blocked operators and waited until any of these unblocked. However,
IF an operator become unblocked between the time when it was considered by
the processing loop AND the time when we construct driver's composite
is-blocked future THEN the this fact is lost. Thus, even though an
operator became unblocked, driver will still be blocked, waiting for
something else.