### PR TITLE
Validate scalar functions with invalid argument types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/ScalarImplementation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/ScalarImplementation.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.type.CodePointsType;
 import com.facebook.presto.type.FunctionType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -335,6 +336,12 @@ public class ScalarImplementation
                             nullableArgument = true;
                             hasNullFlag = true;
                         }
+                    }
+
+                    // skip argument type check for CodePoints
+                    if (!type.value().equals(CodePointsType.NAME)) {
+                        checkArgument(!parameter.isVarArgs(), "Method [%s] has a vararg argument", method);
+                        checkArgument(!parameter.getType().isArray(), "Method [%s] has an array argument", method);
                     }
 
                     if (Primitives.isWrapperType(parameterType)) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarValidation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarValidation.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nullable;
@@ -335,6 +336,38 @@ public class TestScalarValidation
         public static long bad(@TypeParameter("E(VARCHAR)") Type type, @SqlType(StandardTypes.BIGINT) long value)
         {
             return value;
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Method .* has an array argument")
+    public void testInvalidArrayArgument()
+    {
+        extractScalars(InvalidArrayArgument.class);
+    }
+
+    public static final class InvalidArrayArgument
+    {
+        @ScalarFunction
+        @SqlType(StandardTypes.VARCHAR)
+        public static Slice bad(@SqlType(StandardTypes.ARRAY) Slice[] input)
+        {
+            return input[0];
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Method .* has a vararg argument")
+    public void testInvalidVarargsArgument()
+    {
+        extractScalars(InvalidVarargsArgument.class);
+    }
+
+    public static final class InvalidVarargsArgument
+    {
+        @ScalarFunction
+        @SqlType(StandardTypes.VARCHAR)
+        public static Slice bad(@SqlType(StandardTypes.ARRAY) Slice... input)
+        {
+            return input[0];
         }
     }
 


### PR DESCRIPTION
Fixes #8977
cc: @electrum 