### PR TITLE
Fix type mismatch in Parquet predicate pushdown

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
@@ -48,6 +48,7 @@ import java.util.Set;
 
 import static com.facebook.presto.hive.parquet.ParquetCompressionUtils.decompress;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptor;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getDescriptorExactPath;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetEncoding;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
@@ -83,7 +84,7 @@ public final class ParquetPredicateUtils
 
         ImmutableMap.Builder<ColumnDescriptor, Domain> predicate = ImmutableMap.builder();
         for (Entry<HiveColumnHandle, Domain> entry : effectivePredicate.getDomains().get().entrySet()) {
-            Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, ImmutableList.of(entry.getKey().getName()));
+            Optional<RichColumnDescriptor> descriptor = getDescriptorExactPath(fileSchema, requestedSchema, ImmutableList.of(entry.getKey().getName()));
             if (descriptor.isPresent()) {
                 predicate.put(descriptor.get(), entry.getValue());
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -23,6 +23,8 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DateType;
@@ -484,6 +486,13 @@ public abstract class AbstractTestHiveFileFormats
             columns.add(new HiveColumnHandle(testColumn.getName(), hiveType, hiveType.getTypeSignature(), columnIndex, testColumn.isPartitionKey() ? PARTITION_KEY : REGULAR, Optional.empty()));
         }
         return columns;
+    }
+
+    protected TupleDomain<HiveColumnHandle> createEffectivePredicate(List<TestColumn> predicateColumns)
+    {
+        ImmutableMap<HiveColumnHandle, Domain> domains = getColumnHandles(predicateColumns).stream()
+                .collect(ImmutableMap.toImmutableMap(column -> column, column -> Domain.notNull(column.getHiveType().getType(TYPE_MANAGER))));
+        return TupleDomain.withColumnDomains(domains);
     }
 
     public static FileSplit createTestFile(


### PR DESCRIPTION
There is a bug in current implementation of parquet predicate pushdown when push down the complex  type in the predicates.

To reproduce, create a table with a RowType column like the following `test_tbl` table:
```
        Column    |             Type               |     Extra     |        Comment
------------------+--------------------------------+---------------+---------------------------
 a                | bigint                         |               |
 b                | row(b1 bigint, b2 varchar)     |               |
```

and query like 
```
select * from test_tbl where b is not NULL
```

will fail due to type mismatch

```
Mismatched Domain types: row(b1 bigint,b2 varchar) vs varchar
```

The reason it fails is that  `getParquetTupleDomain()` function will return incorrect `parquetTupleDomain` when `effectivePredicate` is a `RowType`. It will traverse down to the end fields and add them to the `parquetTupleDomain`.

One resolution I used is avoiding pushdown of complex type. I add another utility function to find the descriptor that exactly match the path so we won't be able to find the descriptor for the complex type, thus do not push down this predicate.

+cc @Yaliang 

@zhenxiao @dain @nezihyigitbasi 