### PR TITLE
Properly mark the request start time in RequestErrorTracker

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/RequestErrorTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/RequestErrorTracker.java
@@ -88,6 +88,7 @@ class RequestErrorTracker
         if (backoff.getFailureCount() == 0) {
             requestSucceeded();
         }
+        backoff.startRequest();
     }
 
     public void requestSucceeded()


### PR DESCRIPTION
Otherwise Backoff.failureRequestTimeTotal will not be calculated
correctly.

Currently `failureRequestTimeTotal` can be zero:
```
com.facebook.presto.spi.PrestoTransportException: Encountered too many errors talking to a worker node. The node may have crashed or be under too much load. This is probably a transient issue, so please retry your query in a few minutes. (getting task status http://[2401:db00:1020:6212:face:0:5:0]:7777/v1/task/20180222_034236_01849_hf6pb.2.47 - 461 failures, failure duration 300.07s, total failed request time 0.00s)
	at com.facebook.presto.server.remotetask.RequestErrorTracker.requestFailed(RequestErrorTracker.java:130)
	at com.facebook.presto.server.remotetask.ContinuousTaskStatusFetcher.failed(ContinuousTaskStatusFetcher.java:187)
	at com.facebook.presto.server.remotetask.SimpleHttpResponseHandler.onFailure(SimpleHttpResponseHandler.java:86)
	at com.google.common.util.concurrent.Futures$4.run(Futures.java:1126)
	at io.airlift.concurrent.BoundedExecutor.drainQueue(BoundedExecutor.java:78)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```