### PR TITLE
Fix type comparison in ExpressionAnalyzer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1129,7 +1129,7 @@ public class ExpressionAnalyzer
             int numCapturedValues = node.getValues().size();
             verify(argumentTypes.size() == functionInputTypes.size());
             for (int i = 0; i < numCapturedValues; i++) {
-                verify(functionInputTypes.get(i) == argumentTypes.get(i));
+                verify(functionInputTypes.get(i).equals(argumentTypes.get(i)));
             }
 
             FunctionType result = new FunctionType(argumentTypes.subList(numCapturedValues, argumentTypes.size()), functionType.getReturnType());


### PR DESCRIPTION
Parametric types are not cached and can be different by reference,
even it is the same type.

Use Type.equals() instead of reference comparison.