### PR TITLE
Rename various fields to clarify they are related to user memory

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -112,7 +112,7 @@ public abstract class AbstractOperatorBenchmark
                 if (!driver.isFinished()) {
                     driver.process();
                     long lastPeakMemory = peakMemory;
-                    peakMemory = (long) taskContext.getTaskStats().getMemoryReservation().getValue(BYTE);
+                    peakMemory = (long) taskContext.getTaskStats().getUserMemoryReservation().getValue(BYTE);
                     if (peakMemory <= lastPeakMemory) {
                         peakMemory = lastPeakMemory;
                     }

--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -220,7 +220,7 @@ public class QueryMonitor
                                     queryStats.getOutputPositions(),
                                     queryStats.getLogicalWrittenDataSize().toBytes(),
                                     queryStats.getWrittenPositions(),
-                                    queryStats.getCumulativeMemory(),
+                                    queryStats.getCumulativeUserMemory(),
                                     queryStats.getCompletedDrivers(),
                                     queryInfo.isCompleteInfo(),
                                     getCpuDistributions(queryInfo),

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -89,7 +89,7 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
-    public long getTotalMemoryReservation()
+    public long getUserMemoryReservation()
     {
         return 0;
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -90,7 +90,7 @@ public class FailedQueryExecution
     }
 
     @Override
-    public long getTotalMemoryReservation()
+    public long getUserMemoryReservation()
     {
         return 0;
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -58,7 +58,7 @@ public interface QueryExecution
 
     void setMemoryPool(VersionedMemoryPoolId poolId);
 
-    long getTotalMemoryReservation();
+    long getUserMemoryReservation();
 
     Duration getTotalCpuTime();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -331,8 +331,8 @@ public class QueryStateMachine
         int blockedDrivers = 0;
         int completedDrivers = 0;
 
-        long cumulativeMemory = 0;
-        long totalMemoryReservation = 0;
+        long cumulativeUserMemory = 0;
+        long userMemoryReservation = 0;
 
         long totalScheduledTime = 0;
         long totalCpuTime = 0;
@@ -367,8 +367,8 @@ public class QueryStateMachine
             blockedDrivers += stageStats.getBlockedDrivers();
             completedDrivers += stageStats.getCompletedDrivers();
 
-            cumulativeMemory += stageStats.getCumulativeMemory();
-            totalMemoryReservation += stageStats.getTotalMemoryReservation().toBytes();
+            cumulativeUserMemory += stageStats.getCumulativeUserMemory();
+            userMemoryReservation += stageStats.getUserMemoryReservation().toBytes();
             totalScheduledTime += stageStats.getTotalScheduledTime().roundTo(MILLISECONDS);
             totalCpuTime += stageStats.getTotalCpuTime().roundTo(MILLISECONDS);
             totalUserTime += stageStats.getTotalUserTime().roundTo(MILLISECONDS);
@@ -424,8 +424,8 @@ public class QueryStateMachine
                 blockedDrivers,
                 completedDrivers,
 
-                cumulativeMemory,
-                succinctBytes(totalMemoryReservation),
+                cumulativeUserMemory,
+                succinctBytes(userMemoryReservation),
                 succinctBytes(getPeakUserMemoryInBytes()),
                 succinctBytes(getPeakTotalMemoryInBytes()),
 
@@ -873,8 +873,8 @@ public class QueryStateMachine
                 queryStats.getRunningDrivers(),
                 queryStats.getBlockedDrivers(),
                 queryStats.getCompletedDrivers(),
-                queryStats.getCumulativeMemory(),
-                queryStats.getTotalMemoryReservation(),
+                queryStats.getCumulativeUserMemory(),
+                queryStats.getUserMemoryReservation(),
                 queryStats.getPeakUserMemoryReservation(),
                 queryStats.getPeakTotalMemoryReservation(),
                 queryStats.isScheduled(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -61,8 +61,8 @@ public class QueryStats
     private final int blockedDrivers;
     private final int completedDrivers;
 
-    private final double cumulativeMemory;
-    private final DataSize totalMemoryReservation;
+    private final double cumulativeUserMemory;
+    private final DataSize userMemoryReservation;
     private final DataSize peakUserMemoryReservation;
     private final DataSize peakTotalMemoryReservation;
 
@@ -108,8 +108,8 @@ public class QueryStats
         this.queuedDrivers = 0;
         this.runningDrivers = 0;
         this.completedDrivers = 0;
-        this.cumulativeMemory = 0.0;
-        this.totalMemoryReservation = null;
+        this.cumulativeUserMemory = 0.0;
+        this.userMemoryReservation = null;
         this.peakUserMemoryReservation = null;
         this.peakTotalMemoryReservation = null;
         this.scheduled = false;
@@ -153,9 +153,9 @@ public class QueryStats
             @JsonProperty("blockedDrivers") int blockedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
-            @JsonProperty("cumulativeMemory") double cumulativeMemory,
-            @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
-            @JsonProperty("peakUserMemoryReservation") DataSize peakMemoryReservation,
+            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
+            @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
             @JsonProperty("peakTotalMemoryReservation") DataSize peakTotalMemoryReservation,
 
             @JsonProperty("scheduled") boolean scheduled,
@@ -209,9 +209,9 @@ public class QueryStats
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
 
-        this.cumulativeMemory = requireNonNull(cumulativeMemory, "cumulativeMemory is null");
-        this.totalMemoryReservation = requireNonNull(totalMemoryReservation, "totalMemoryReservation is null");
-        this.peakUserMemoryReservation = requireNonNull(peakMemoryReservation, "peakUserMemoryReservation is null");
+        this.cumulativeUserMemory = requireNonNull(cumulativeUserMemory, "cumulativeUserMemory is null");
+        this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
+        this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
         this.peakTotalMemoryReservation = requireNonNull(peakTotalMemoryReservation, "peakTotalMemoryReservation is null");
         this.scheduled = scheduled;
         this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
@@ -362,15 +362,15 @@ public class QueryStats
     }
 
     @JsonProperty
-    public double getCumulativeMemory()
+    public double getCumulativeUserMemory()
     {
-        return cumulativeMemory;
+        return cumulativeUserMemory;
     }
 
     @JsonProperty
-    public DataSize getTotalMemoryReservation()
+    public DataSize getUserMemoryReservation()
     {
-        return totalMemoryReservation;
+        return userMemoryReservation;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -224,7 +224,7 @@ public final class SqlQueryExecution
     }
 
     @Override
-    public long getTotalMemoryReservation()
+    public long getUserMemoryReservation()
     {
         // acquire reference to outputStage before checking finalQueryInfo, because
         // state change listener sets finalQueryInfo and then clears outputStage when
@@ -232,12 +232,12 @@ public final class SqlQueryExecution
         SqlQueryScheduler scheduler = queryScheduler.get();
         Optional<QueryInfo> finalQueryInfo = stateMachine.getFinalQueryInfo();
         if (finalQueryInfo.isPresent()) {
-            return finalQueryInfo.get().getQueryStats().getTotalMemoryReservation().toBytes();
+            return finalQueryInfo.get().getQueryStats().getUserMemoryReservation().toBytes();
         }
         if (scheduler == null) {
             return 0;
         }
-        return scheduler.getTotalMemoryReservation();
+        return scheduler.getUserMemoryReservation();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -209,9 +209,9 @@ public final class SqlStageExecution
         getAllTasks().forEach(RemoteTask::abort);
     }
 
-    public long getMemoryReservation()
+    public long getUserMemoryReservation()
     {
-        return stateMachine.getMemoryReservation();
+        return stateMachine.getUserMemoryReservation();
     }
 
     public synchronized Duration getTotalCpuTime()

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -203,7 +203,7 @@ public class SqlTask
         int queuedPartitionedDrivers = 0;
         int runningPartitionedDrivers = 0;
         DataSize physicalWrittenDataSize = new DataSize(0, BYTE);
-        DataSize memoryReservation = new DataSize(0, BYTE);
+        DataSize userMemoryReservation = new DataSize(0, BYTE);
         DataSize systemMemoryReservation = new DataSize(0, BYTE);
         // TODO: add a mechanism to avoid sending the whole completedDriverGroups set over the wire for every task status reply
         Set<Lifespan> completedDriverGroups = ImmutableSet.of();
@@ -212,7 +212,7 @@ public class SqlTask
             queuedPartitionedDrivers = taskStats.getQueuedPartitionedDrivers();
             runningPartitionedDrivers = taskStats.getRunningPartitionedDrivers();
             physicalWrittenDataSize = taskStats.getPhysicalWrittenDataSize();
-            memoryReservation = taskStats.getMemoryReservation();
+            userMemoryReservation = taskStats.getUserMemoryReservation();
             systemMemoryReservation = taskStats.getSystemMemoryReservation();
         }
         else if (taskHolder.getTaskExecution() != null) {
@@ -225,7 +225,7 @@ public class SqlTask
                 physicalWrittenBytes += pipelineContext.getPhysicalWrittenDataSize();
             }
             physicalWrittenDataSize = succinctBytes(physicalWrittenBytes);
-            memoryReservation = taskContext.getMemoryReservation();
+            userMemoryReservation = taskContext.getMemoryReservation();
             systemMemoryReservation = taskContext.getSystemMemoryReservation();
             completedDriverGroups = taskContext.getCompletedDriverGroups();
         }
@@ -242,7 +242,7 @@ public class SqlTask
                 runningPartitionedDrivers,
                 isOutputBufferOverutilized(),
                 physicalWrittenDataSize,
-                memoryReservation,
+                userMemoryReservation,
                 systemMemoryReservation);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
@@ -52,9 +52,9 @@ public class StageStats
     private final int blockedDrivers;
     private final int completedDrivers;
 
-    private final double cumulativeMemory;
-    private final DataSize totalMemoryReservation;
-    private final DataSize peakMemoryReservation;
+    private final double cumulativeUserMemory;
+    private final DataSize userMemoryReservation;
+    private final DataSize peakUserMemoryReservation;
 
     private final Duration totalScheduledTime;
     private final Duration totalCpuTime;
@@ -92,9 +92,9 @@ public class StageStats
         this.runningDrivers = 0;
         this.blockedDrivers = 0;
         this.completedDrivers = 0;
-        this.cumulativeMemory = 0.0;
-        this.totalMemoryReservation = null;
-        this.peakMemoryReservation = null;
+        this.cumulativeUserMemory = 0.0;
+        this.userMemoryReservation = null;
+        this.peakUserMemoryReservation = null;
         this.totalScheduledTime = null;
         this.totalCpuTime = null;
         this.totalUserTime = null;
@@ -130,9 +130,9 @@ public class StageStats
             @JsonProperty("blockedDrivers") int blockedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
-            @JsonProperty("cumulativeMemory") double cumulativeMemory,
-            @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
-            @JsonProperty("peakMemoryReservation") DataSize peakMemoryReservation,
+            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
+            @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
 
             @JsonProperty("totalScheduledTime") Duration totalScheduledTime,
             @JsonProperty("totalCpuTime") Duration totalCpuTime,
@@ -178,9 +178,9 @@ public class StageStats
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
 
-        this.cumulativeMemory = requireNonNull(cumulativeMemory, "cumulativeMemory is null");
-        this.totalMemoryReservation = requireNonNull(totalMemoryReservation, "totalMemoryReservation is null");
-        this.peakMemoryReservation = requireNonNull(peakMemoryReservation, "peakMemoryReservation is null");
+        this.cumulativeUserMemory = requireNonNull(cumulativeUserMemory, "cumulativeUserMemory is null");
+        this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
+        this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
 
         this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
         this.totalCpuTime = requireNonNull(totalCpuTime, "totalCpuTime is null");
@@ -280,21 +280,21 @@ public class StageStats
     }
 
     @JsonProperty
-    public double getCumulativeMemory()
+    public double getCumulativeUserMemory()
     {
-        return cumulativeMemory;
+        return cumulativeUserMemory;
     }
 
     @JsonProperty
-    public DataSize getTotalMemoryReservation()
+    public DataSize getUserMemoryReservation()
     {
-        return totalMemoryReservation;
+        return userMemoryReservation;
     }
 
     @JsonProperty
-    public DataSize getPeakMemoryReservation()
+    public DataSize getPeakUserMemoryReservation()
     {
-        return peakMemoryReservation;
+        return peakUserMemoryReservation;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -705,7 +705,7 @@ public class InternalResourceGroup
             if (subGroups.isEmpty()) {
                 cachedMemoryUsageBytes = 0;
                 for (QueryExecution query : runningQueries) {
-                    cachedMemoryUsageBytes += query.getTotalMemoryReservation();
+                    cachedMemoryUsageBytes += query.getUserMemoryReservation();
                 }
             }
             else {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -419,10 +419,10 @@ public class SqlQueryScheduler
                 parent.getFailureCause());
     }
 
-    public long getTotalMemoryReservation()
+    public long getUserMemoryReservation()
     {
         return stages.values().stream()
-                .mapToLong(SqlStageExecution::getMemoryReservation)
+                .mapToLong(SqlStageExecution::getUserMemoryReservation)
                 .sum();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -155,7 +155,7 @@ public class ClusterMemoryManager
         boolean queryKilled = false;
         long totalBytes = 0;
         for (QueryExecution query : queries) {
-            long bytes = query.getTotalMemoryReservation();
+            long bytes = query.getUserMemoryReservation();
             DataSize sessionMaxQueryMemory = getQueryMaxMemory(query.getSession());
             long queryMemoryLimit = Math.min(maxQueryMemory.toBytes(), sessionMaxQueryMemory.toBytes());
             totalBytes += bytes;
@@ -180,7 +180,7 @@ public class ClusterMemoryManager
                 nanosSince(lastTimeNotOutOfMemory).compareTo(killOnOutOfMemoryDelay) > 0 &&
                 isLastKilledQueryGone()) {
             List<QueryMemoryInfo> queryMemoryInfoList = Streams.stream(queries)
-                    .map(query -> new QueryMemoryInfo(query.getQueryId(), query.getMemoryPool().getId(), query.getTotalMemoryReservation()))
+                    .map(query -> new QueryMemoryInfo(query.getQueryId(), query.getMemoryPool().getId(), query.getUserMemoryReservation()))
                     .collect(toImmutableList());
             List<MemoryInfo> nodeMemoryInfos = nodes.values().stream()
                     .map(RemoteNodeMemory::getInfo)
@@ -280,7 +280,7 @@ public class ClusterMemoryManager
                         // since their memory usage is unbounded.
                         continue;
                     }
-                    long bytesUsed = queryExecution.getTotalMemoryReservation();
+                    long bytesUsed = queryExecution.getUserMemoryReservation();
                     if (bytesUsed > maxMemory) {
                         biggestQuery = queryExecution;
                         maxMemory = bytesUsed;

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverStats.java
@@ -42,7 +42,7 @@ public class DriverStats
     private final Duration queuedTime;
     private final Duration elapsedTime;
 
-    private final DataSize memoryReservation;
+    private final DataSize userMemoryReservation;
     private final DataSize revocableMemoryReservation;
     private final DataSize systemMemoryReservation;
 
@@ -75,7 +75,7 @@ public class DriverStats
         this.queuedTime = new Duration(0, MILLISECONDS);
         this.elapsedTime = new Duration(0, MILLISECONDS);
 
-        this.memoryReservation = new DataSize(0, BYTE);
+        this.userMemoryReservation = new DataSize(0, BYTE);
         this.revocableMemoryReservation = new DataSize(0, BYTE);
         this.systemMemoryReservation = new DataSize(0, BYTE);
 
@@ -109,7 +109,7 @@ public class DriverStats
             @JsonProperty("queuedTime") Duration queuedTime,
             @JsonProperty("elapsedTime") Duration elapsedTime,
 
-            @JsonProperty("memoryReservation") DataSize memoryReservation,
+            @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("revocableMemoryReservation") DataSize revocableMemoryReservation,
             @JsonProperty("systemMemoryReservation") DataSize systemMemoryReservation,
 
@@ -140,7 +140,7 @@ public class DriverStats
         this.queuedTime = requireNonNull(queuedTime, "queuedTime is null");
         this.elapsedTime = requireNonNull(elapsedTime, "elapsedTime is null");
 
-        this.memoryReservation = requireNonNull(memoryReservation, "memoryReservation is null");
+        this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.revocableMemoryReservation = requireNonNull(revocableMemoryReservation, "revocableMemoryReservation is null");
         this.systemMemoryReservation = requireNonNull(systemMemoryReservation, "systemMemoryReservation is null");
 
@@ -202,9 +202,9 @@ public class DriverStats
     }
 
     @JsonProperty
-    public DataSize getMemoryReservation()
+    public DataSize getUserMemoryReservation()
     {
-        return memoryReservation;
+        return userMemoryReservation;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -65,7 +65,7 @@ public class OperatorStats
     private final Duration finishCpu;
     private final Duration finishUser;
 
-    private final DataSize memoryReservation;
+    private final DataSize userMemoryReservation;
     private final DataSize revocableMemoryReservation;
     private final DataSize systemMemoryReservation;
     private final Optional<BlockedReason> blockedReason;
@@ -105,7 +105,7 @@ public class OperatorStats
             @JsonProperty("finishCpu") Duration finishCpu,
             @JsonProperty("finishUser") Duration finishUser,
 
-            @JsonProperty("memoryReservation") DataSize memoryReservation,
+            @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("revocableMemoryReservation") DataSize revocableMemoryReservation,
             @JsonProperty("systemMemoryReservation") DataSize systemMemoryReservation,
             @JsonProperty("blockedReason") Optional<BlockedReason> blockedReason,
@@ -147,7 +147,7 @@ public class OperatorStats
         this.finishCpu = requireNonNull(finishCpu, "finishCpu is null");
         this.finishUser = requireNonNull(finishUser, "finishUser is null");
 
-        this.memoryReservation = requireNonNull(memoryReservation, "memoryReservation is null");
+        this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.revocableMemoryReservation = requireNonNull(revocableMemoryReservation, "revocableMemoryReservation is null");
         this.systemMemoryReservation = requireNonNull(systemMemoryReservation, "systemMemoryReservation is null");
         this.blockedReason = blockedReason;
@@ -300,9 +300,9 @@ public class OperatorStats
     }
 
     @JsonProperty
-    public DataSize getMemoryReservation()
+    public DataSize getUserMemoryReservation()
     {
-        return memoryReservation;
+        return userMemoryReservation;
     }
 
     @JsonProperty
@@ -363,7 +363,7 @@ public class OperatorStats
         long finishCpu = this.finishCpu.roundTo(NANOSECONDS);
         long finishUser = this.finishUser.roundTo(NANOSECONDS);
 
-        long memoryReservation = this.memoryReservation.toBytes();
+        long memoryReservation = this.userMemoryReservation.toBytes();
         long revocableMemoryReservation = this.revocableMemoryReservation.toBytes();
         long systemMemoryReservation = this.systemMemoryReservation.toBytes();
         Optional<BlockedReason> blockedReason = this.blockedReason;
@@ -398,7 +398,7 @@ public class OperatorStats
 
             blockedWall += operator.getBlockedWall().roundTo(NANOSECONDS);
 
-            memoryReservation += operator.getMemoryReservation().toBytes();
+            memoryReservation += operator.getUserMemoryReservation().toBytes();
             revocableMemoryReservation += operator.getRevocableMemoryReservation().toBytes();
             systemMemoryReservation += operator.getSystemMemoryReservation().toBytes();
             if (operator.getBlockedReason().isPresent()) {
@@ -494,7 +494,7 @@ public class OperatorStats
                 finishWall,
                 finishCpu,
                 finishUser,
-                memoryReservation,
+                userMemoryReservation,
                 revocableMemoryReservation,
                 systemMemoryReservation,
                 blockedReason,

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
@@ -52,7 +52,7 @@ public class PipelineStats
     private final int blockedDrivers;
     private final int completedDrivers;
 
-    private final DataSize memoryReservation;
+    private final DataSize userMemoryReservation;
     private final DataSize revocableMemoryReservation;
     private final DataSize systemMemoryReservation;
 
@@ -99,7 +99,7 @@ public class PipelineStats
             @JsonProperty("blockedDrivers") int blockedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
-            @JsonProperty("memoryReservation") DataSize memoryReservation,
+            @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("revocableMemoryReservation") DataSize revocableMemoryReservation,
             @JsonProperty("systemMemoryReservation") DataSize systemMemoryReservation,
 
@@ -151,7 +151,7 @@ public class PipelineStats
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
 
-        this.memoryReservation = requireNonNull(memoryReservation, "memoryReservation is null");
+        this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.revocableMemoryReservation = requireNonNull(revocableMemoryReservation, "revocableMemoryReservation is null");
         this.systemMemoryReservation = requireNonNull(systemMemoryReservation, "systemMemoryReservation is null");
 
@@ -265,9 +265,9 @@ public class PipelineStats
     }
 
     @JsonProperty
-    public DataSize getMemoryReservation()
+    public DataSize getUserMemoryReservation()
     {
-        return memoryReservation;
+        return userMemoryReservation;
     }
 
     @JsonProperty
@@ -400,7 +400,7 @@ public class PipelineStats
                 runningPartitionedDrivers,
                 blockedDrivers,
                 completedDrivers,
-                memoryReservation,
+                userMemoryReservation,
                 revocableMemoryReservation,
                 systemMemoryReservation,
                 queuedTime,

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -80,10 +80,10 @@ public class TaskContext
     private final boolean cpuTimerEnabled;
 
     private final Object cumulativeMemoryLock = new Object();
-    private final AtomicDouble cumulativeMemory = new AtomicDouble(0.0);
+    private final AtomicDouble cumulativeUserMemory = new AtomicDouble(0.0);
 
     @GuardedBy("cumulativeMemoryLock")
-    private long lastMemoryReservation;
+    private long lastUserMemoryReservation;
 
     @GuardedBy("cumulativeMemoryLock")
     private long lastTaskStatCallNanos;
@@ -397,11 +397,11 @@ public class TaskContext
 
         synchronized (cumulativeMemoryLock) {
             double sinceLastPeriodMillis = (System.nanoTime() - lastTaskStatCallNanos) / 1_000_000.0;
-            long averageMemoryForLastPeriod = (userMemory + lastMemoryReservation) / 2;
-            cumulativeMemory.addAndGet(averageMemoryForLastPeriod * sinceLastPeriodMillis);
+            long averageMemoryForLastPeriod = (userMemory + lastUserMemoryReservation) / 2;
+            cumulativeUserMemory.addAndGet(averageMemoryForLastPeriod * sinceLastPeriodMillis);
 
             lastTaskStatCallNanos = System.nanoTime();
-            lastMemoryReservation = userMemory;
+            lastUserMemoryReservation = userMemory;
         }
 
         Set<PipelineStats> runningPipelineStats = pipelineStats.stream()
@@ -428,7 +428,7 @@ public class TaskContext
                 runningPartitionedDrivers,
                 blockedDrivers,
                 completedDrivers,
-                cumulativeMemory.get(),
+                cumulativeUserMemory.get(),
                 succinctBytes(userMemory),
                 succinctBytes(taskMemoryContext.getRevocableMemory()),
                 succinctBytes(taskMemoryContext.getSystemMemory()),

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -51,8 +51,8 @@ public class TaskStats
     private final int blockedDrivers;
     private final int completedDrivers;
 
-    private final double cumulativeMemory;
-    private final DataSize memoryReservation;
+    private final double cumulativeUserMemory;
+    private final DataSize userMemoryReservation;
     private final DataSize revocableMemoryReservation;
     private final DataSize systemMemoryReservation;
 
@@ -130,8 +130,8 @@ public class TaskStats
             @JsonProperty("blockedDrivers") int blockedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
-            @JsonProperty("cumulativeMemory") double cumulativeMemory,
-            @JsonProperty("memoryReservation") DataSize memoryReservation,
+            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("revocableMemoryReservation") DataSize revocableMemoryReservation,
             @JsonProperty("systemMemoryReservation") DataSize systemMemoryReservation,
 
@@ -181,8 +181,8 @@ public class TaskStats
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
 
-        this.cumulativeMemory = requireNonNull(cumulativeMemory, "cumulativeMemory is null");
-        this.memoryReservation = requireNonNull(memoryReservation, "memoryReservation is null");
+        this.cumulativeUserMemory = requireNonNull(cumulativeUserMemory, "cumulativeUserMemory is null");
+        this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.revocableMemoryReservation = requireNonNull(revocableMemoryReservation, "revocableMemoryReservation is null");
         this.systemMemoryReservation = requireNonNull(systemMemoryReservation, "systemMemoryReservation is null");
 
@@ -287,15 +287,15 @@ public class TaskStats
     }
 
     @JsonProperty
-    public double getCumulativeMemory()
+    public double getCumulativeUserMemory()
     {
-        return cumulativeMemory;
+        return cumulativeUserMemory;
     }
 
     @JsonProperty
-    public DataSize getMemoryReservation()
+    public DataSize getUserMemoryReservation()
     {
-        return memoryReservation;
+        return userMemoryReservation;
     }
 
     @JsonProperty
@@ -423,8 +423,8 @@ public class TaskStats
                 runningPartitionedDrivers,
                 blockedDrivers,
                 completedDrivers,
-                cumulativeMemory,
-                memoryReservation,
+                cumulativeUserMemory,
+                userMemoryReservation,
                 revocableMemoryReservation,
                 systemMemoryReservation,
                 totalScheduledTime,
@@ -460,8 +460,8 @@ public class TaskStats
                 runningPartitionedDrivers,
                 blockedDrivers,
                 completedDrivers,
-                cumulativeMemory,
-                memoryReservation,
+                cumulativeUserMemory,
+                userMemoryReservation,
                 revocableMemoryReservation,
                 systemMemoryReservation,
                 totalScheduledTime,

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -47,9 +47,9 @@ public class BasicQueryStats
     private final int runningDrivers;
     private final int completedDrivers;
 
-    private final double cumulativeMemory;
-    private final DataSize totalMemoryReservation;
-    private final DataSize peakMemoryReservation;
+    private final double cumulativeUserMemory;
+    private final DataSize userMemoryReservation;
+    private final DataSize peakUserMemoryReservation;
     private final Duration totalCpuTime;
 
     private final boolean fullyBlocked;
@@ -66,9 +66,9 @@ public class BasicQueryStats
             int queuedDrivers,
             int runningDrivers,
             int completedDrivers,
-            double cumulativeMemory,
-            DataSize totalMemoryReservation,
-            DataSize peakMemoryReservation,
+            double cumulativeUserMemory,
+            DataSize userMemoryReservation,
+            DataSize peakUserMemoryReservation,
             Duration totalCpuTime,
             boolean fullyBlocked,
             Set<BlockedReason> blockedReasons,
@@ -89,9 +89,9 @@ public class BasicQueryStats
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
 
-        this.cumulativeMemory = cumulativeMemory;
-        this.totalMemoryReservation = totalMemoryReservation;
-        this.peakMemoryReservation = peakMemoryReservation;
+        this.cumulativeUserMemory = cumulativeUserMemory;
+        this.userMemoryReservation = userMemoryReservation;
+        this.peakUserMemoryReservation = peakUserMemoryReservation;
         this.totalCpuTime = totalCpuTime;
 
         this.fullyBlocked = fullyBlocked;
@@ -110,8 +110,8 @@ public class BasicQueryStats
                 queryStats.getQueuedDrivers(),
                 queryStats.getRunningDrivers(),
                 queryStats.getCompletedDrivers(),
-                queryStats.getCumulativeMemory(),
-                queryStats.getTotalMemoryReservation(),
+                queryStats.getCumulativeUserMemory(),
+                queryStats.getUserMemoryReservation(),
                 queryStats.getPeakUserMemoryReservation(),
                 queryStats.getTotalCpuTime(),
                 queryStats.isFullyBlocked(),
@@ -168,21 +168,21 @@ public class BasicQueryStats
     }
 
     @JsonProperty
-    public double getCumulativeMemory()
+    public double getCumulativeUserMemory()
     {
-        return cumulativeMemory;
+        return cumulativeUserMemory;
     }
 
     @JsonProperty
-    public DataSize getTotalMemoryReservation()
+    public DataSize getUserMemoryReservation()
     {
-        return totalMemoryReservation;
+        return userMemoryReservation;
     }
 
     @JsonProperty
-    public DataSize getPeakMemoryReservation()
+    public DataSize getPeakUserMemoryReservation()
     {
-        return peakMemoryReservation;
+        return peakUserMemoryReservation;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
@@ -84,7 +84,7 @@ public class ClusterStatsResource
                 totalInputRows += query.getQueryStats().getRawInputPositions();
                 totalCpuTimeSecs += query.getQueryStats().getTotalCpuTime().getValue(SECONDS);
 
-                memoryReservation += query.getQueryStats().getTotalMemoryReservation().toBytes();
+                memoryReservation += query.getQueryStats().getUserMemoryReservation().toBytes();
                 runningDrivers += query.getQueryStats().getRunningDrivers();
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryExecutionResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryExecutionResource.java
@@ -129,7 +129,7 @@ public class QueryExecutionResource
                         task.getStats().getRawInputPositions(),
                         task.getStats().getOutputDataSize().roundTo(DataSize.Unit.BYTE),
                         task.getStats().getOutputPositions(),
-                        task.getStats().getMemoryReservation().roundTo(DataSize.Unit.BYTE),
+                        task.getStats().getUserMemoryReservation().roundTo(DataSize.Unit.BYTE),
                         task.getStats().getQueuedDrivers(),
                         task.getStats().getRunningDrivers(),
                         task.getStats().getCompletedDrivers(),

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryProgressStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryProgressStats.java
@@ -76,7 +76,7 @@ public class QueryProgressStats
                 queryStats.getTotalCpuTime().toMillis(),
                 queryStats.getTotalScheduledTime().toMillis(),
                 queryStats.getTotalBlockedTime().toMillis(),
-                queryStats.getTotalMemoryReservation().toBytes(),
+                queryStats.getUserMemoryReservation().toBytes(),
                 queryStats.getPeakUserMemoryReservation().toBytes(),
                 queryStats.getRawInputPositions(),
                 queryStats.getRawInputDataSize().toBytes(),

--- a/presto-main/src/main/resources/com/facebook/presto/server/plan.html
+++ b/presto-main/src/main/resources/com/facebook/presto/server/plan.html
@@ -179,7 +179,7 @@ function update(graph, query)
                         "<div style='color:#f00'>Blocked: " + stats.totalBlockedTime + "</div>" :
                         "<div>Blocked: " + stats.totalBlockedTime + "</div>"
                 ) +
-                "<div>Memory: " + stats.totalMemoryReservation + "</div>" +
+                "<div>Memory: " + stats.userMemoryReservation + "</div>" +
                 "<div>Splits: Q:" + stats.queuedDrivers + ", R:" + stats.runningDrivers + ", F:" + stats.completedDrivers + "</div>" +
 
                 "<hr>" +

--- a/presto-main/src/main/resources/webapp/assets/plan.js
+++ b/presto-main/src/main/resources/webapp/assets/plan.js
@@ -82,7 +82,7 @@ let StageStatistics = React.createClass({
                         <div style= {{ color: '#ff0000' }}>Blocked: { stats.totalBlockedTime } </div> :
                         <div>Blocked: { stats.totalBlockedTime } </div>
                     }
-                    Memory: { stats.totalMemoryReservation }
+                    Memory: { stats.userMemoryReservation }
                     <br />
                     Splits: {"Q:" + stats.queuedDrivers + ", R:" + stats.runningDrivers + ", F:" + stats.completedDrivers }
                     <hr />

--- a/presto-main/src/main/resources/webapp/assets/query-list.js
+++ b/presto-main/src/main/resources/webapp/assets/query-list.js
@@ -90,15 +90,15 @@
             <div className="col-xs-12 tinystat-row">
                 <span className="tinystat" data-toggle="tooltip" data-placement="top" title="Current reserved memory">
                     <span className="glyphicon glyphicon-scale" style={ GLYPHICON_HIGHLIGHT }/>&nbsp;&nbsp;
-                    { query.queryStats.totalMemoryReservation }
+                    { query.queryStats.userMemoryReservation }
                 </span>
                 <span className="tinystat" data-toggle="tooltip" data-placement="top" title="Peak memory">
                     <span className="glyphicon glyphicon-fire" style={ GLYPHICON_HIGHLIGHT }/>&nbsp;&nbsp;
-                    { query.queryStats.peakMemoryReservation }
+                    { query.queryStats.peakUserMemoryReservation }
                 </span>
                 <span className="tinystat" data-toggle="tooltip" data-placement="top" title="Cumulative memory">
                     <span className="glyphicon glyphicon-equalizer" style={ GLYPHICON_HIGHLIGHT }/>&nbsp;&nbsp;
-                    { formatDataSizeBytes(query.queryStats.cumulativeMemory) }
+                    { formatDataSizeBytes(query.queryStats.cumulativeUserMemory) }
                 </span>
             </div> );
 
@@ -200,8 +200,8 @@ const SORT_TYPE = {
     ELAPSED: function (query) {return parseDuration(query.queryStats.elapsedTime)},
     EXECUTION: function (query) {return parseDuration(query.queryStats.executionTime)},
     CPU: function (query) {return parseDuration(query.queryStats.totalCpuTime)},
-    CUMULATIVE_MEMORY: function (query) {return query.queryStats.cumulativeMemory},
-    CURRENT_MEMORY: function (query) {return parseDataSize(query.queryStats.totalMemoryReservation)},
+    CUMULATIVE_MEMORY: function (query) {return query.queryStats.cumulativeUserMemory},
+    CURRENT_MEMORY: function (query) {return parseDataSize(query.queryStats.userMemoryReservation)},
 };
 
 const SORT_ORDER = {

--- a/presto-main/src/main/resources/webapp/assets/query.js
+++ b/presto-main/src/main/resources/webapp/assets/query.js
@@ -360,7 +360,7 @@ let StageDetail = React.createClass({
                                                     Cumulative
                                                 </td>
                                                 <td className="stage-table-stat-text">
-                                                    { formatDataSizeBytes(stage.stageStats.cumulativeMemory / 1000) }
+                                                    { formatDataSizeBytes(stage.stageStats.cumulativeUserMemory / 1000) }
                                                 </td>
                                             </tr>
                                             <tr>
@@ -368,7 +368,7 @@ let StageDetail = React.createClass({
                                                     Current
                                                 </td>
                                                 <td className="stage-table-stat-text">
-                                                    { stage.stageStats.totalMemoryReservation }
+                                                    { stage.stageStats.userMemoryReservation }
                                                 </td>
                                             </tr>
                                             <tr>
@@ -384,7 +384,7 @@ let StageDetail = React.createClass({
                                                     Peak
                                                 </td>
                                                 <td className="stage-table-stat-text">
-                                                    { stage.stageStats.peakMemoryReservation }
+                                                    { stage.stageStats.peakUserMemoryReservation }
                                                 </td>
                                             </tr>
                                         </tbody>
@@ -669,7 +669,7 @@ let QueryDetail = React.createClass({
                     cpuTimeRate: addToHistory(currentCpuTimeRate, this.state.cpuTimeRate),
                     rowInputRate: addToHistory(currentRowInputRate, this.state.rowInputRate),
                     byteInputRate: addToHistory(currentByteInputRate, this.state.byteInputRate),
-                    reservedMemory: addToHistory(parseDataSize(query.queryStats.totalMemoryReservation), this.state.reservedMemory),
+                    reservedMemory: addToHistory(parseDataSize(query.queryStats.userMemoryReservation), this.state.reservedMemory),
                 });
             }
             this.resetTimer();
@@ -1221,7 +1221,7 @@ let QueryDetail = React.createClass({
                                                 Cumulative Memory
                                             </td>
                                             <td className="info-text">
-                                                { formatDataSizeBytes(query.queryStats.cumulativeMemory / 1000.0, "") + " seconds" }
+                                                { formatDataSizeBytes(query.queryStats.cumulativeUserMemory / 1000.0, "") + " seconds" }
                                             </td>
                                         </tr>
                                         <tr>

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -213,7 +213,7 @@ public class MockQueryExecution
     }
 
     @Override
-    public long getTotalMemoryReservation()
+    public long getUserMemoryReservation()
     {
         return memoryUsage;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -259,7 +259,7 @@ public class MockRemoteTaskFactory
                     stats.getRunningPartitionedDrivers(),
                     false,
                     stats.getPhysicalWrittenDataSize(),
-                    stats.getMemoryReservation(),
+                    stats.getUserMemoryReservation(),
                     stats.getSystemMemoryReservation());
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -214,8 +214,8 @@ public class TestQueryStats
         assertEquals(actual.getBlockedDrivers(), 30);
         assertEquals(actual.getCompletedDrivers(), 16);
 
-        assertEquals(actual.getCumulativeMemory(), 17.0);
-        assertEquals(actual.getTotalMemoryReservation(), new DataSize(18, BYTE));
+        assertEquals(actual.getCumulativeUserMemory(), 17.0);
+        assertEquals(actual.getUserMemoryReservation(), new DataSize(18, BYTE));
         assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(19, BYTE));
         assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(20, BYTE));
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
@@ -100,9 +100,9 @@ public class TestStageStats
         assertEquals(actual.getBlockedDrivers(), 26);
         assertEquals(actual.getCompletedDrivers(), 11);
 
-        assertEquals(actual.getCumulativeMemory(), 12.0);
-        assertEquals(actual.getTotalMemoryReservation(), new DataSize(13, BYTE));
-        assertEquals(actual.getPeakMemoryReservation(), new DataSize(14, BYTE));
+        assertEquals(actual.getCumulativeUserMemory(), 12.0);
+        assertEquals(actual.getUserMemoryReservation(), new DataSize(13, BYTE));
+        assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(14, BYTE));
 
         assertEquals(actual.getTotalScheduledTime(), new Duration(15, NANOSECONDS));
         assertEquals(actual.getTotalCpuTime(), new Duration(16, NANOSECONDS));

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -395,10 +395,10 @@ public class TestMemoryTracking
             long expectedRevocableMemory,
             long expectedSystemMemory)
     {
-        assertEquals(operatorStats.getMemoryReservation().toBytes(), expectedUserMemory);
-        assertEquals(driverStats.getMemoryReservation().toBytes(), expectedUserMemory);
-        assertEquals(pipelineStats.getMemoryReservation().toBytes(), expectedUserMemory);
-        assertEquals(taskStats.getMemoryReservation().toBytes(), expectedUserMemory);
+        assertEquals(operatorStats.getUserMemoryReservation().toBytes(), expectedUserMemory);
+        assertEquals(driverStats.getUserMemoryReservation().toBytes(), expectedUserMemory);
+        assertEquals(pipelineStats.getUserMemoryReservation().toBytes(), expectedUserMemory);
+        assertEquals(taskStats.getUserMemoryReservation().toBytes(), expectedUserMemory);
 
         assertEquals(operatorStats.getSystemMemoryReservation().toBytes(), expectedSystemMemory);
         assertEquals(driverStats.getSystemMemoryReservation().toBytes(), expectedSystemMemory);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriverStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriverStats.java
@@ -81,7 +81,7 @@ public class TestDriverStats
         assertEquals(actual.getQueuedTime(), new Duration(4, NANOSECONDS));
         assertEquals(actual.getElapsedTime(), new Duration(5, NANOSECONDS));
 
-        assertEquals(actual.getMemoryReservation(), new DataSize(6, BYTE));
+        assertEquals(actual.getUserMemoryReservation(), new DataSize(6, BYTE));
         assertEquals(actual.getRevocableMemoryReservation(), new DataSize(7, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(8, BYTE));
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -299,7 +299,7 @@ public class TestHashAggregationOperator
 
         Operator operator = operatorFactory.createOperator(driverContext);
         toPages(operator, input.iterator());
-        assertEquals(operator.getOperatorContext().getOperatorStats().getMemoryReservation().toBytes(), 0);
+        assertEquals(operator.getOperatorContext().getOperatorStats().getUserMemoryReservation().toBytes(), 0);
     }
 
     @Test(dataProvider = "hashEnabled", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 10B")

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -148,7 +148,7 @@ public class TestOperatorStats
         assertEquals(actual.getFinishCpu(), new Duration(18, NANOSECONDS));
         assertEquals(actual.getFinishUser(), new Duration(19, NANOSECONDS));
 
-        assertEquals(actual.getMemoryReservation(), new DataSize(20, BYTE));
+        assertEquals(actual.getUserMemoryReservation(), new DataSize(20, BYTE));
         assertEquals(actual.getRevocableMemoryReservation(), new DataSize(21, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(22, BYTE));
         assertEquals(actual.getInfo().getClass(), SplitOperatorInfo.class);
@@ -187,7 +187,7 @@ public class TestOperatorStats
         assertEquals(actual.getFinishWall(), new Duration(3 * 17, NANOSECONDS));
         assertEquals(actual.getFinishCpu(), new Duration(3 * 18, NANOSECONDS));
         assertEquals(actual.getFinishUser(), new Duration(3 * 19, NANOSECONDS));
-        assertEquals(actual.getMemoryReservation(), new DataSize(3 * 20, BYTE));
+        assertEquals(actual.getUserMemoryReservation(), new DataSize(3 * 20, BYTE));
         assertEquals(actual.getRevocableMemoryReservation(), new DataSize(3 * 21, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(3 * 22, BYTE));
         assertEquals(actual.getInfo(), null);
@@ -225,7 +225,7 @@ public class TestOperatorStats
         assertEquals(actual.getFinishWall(), new Duration(3 * 17, NANOSECONDS));
         assertEquals(actual.getFinishCpu(), new Duration(3 * 18, NANOSECONDS));
         assertEquals(actual.getFinishUser(), new Duration(3 * 19, NANOSECONDS));
-        assertEquals(actual.getMemoryReservation(), new DataSize(3 * 20, BYTE));
+        assertEquals(actual.getUserMemoryReservation(), new DataSize(3 * 20, BYTE));
         assertEquals(actual.getRevocableMemoryReservation(), new DataSize(3 * 21, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(3 * 22, BYTE));
         assertEquals(actual.getInfo().getClass(), PartitionedOutputInfo.class);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
@@ -105,7 +105,7 @@ public class TestPipelineStats
         assertEquals(actual.getBlockedDrivers(), 19);
         assertEquals(actual.getCompletedDrivers(), 4);
 
-        assertEquals(actual.getMemoryReservation(), new DataSize(5, BYTE));
+        assertEquals(actual.getUserMemoryReservation(), new DataSize(5, BYTE));
         assertEquals(actual.getRevocableMemoryReservation(), new DataSize(6, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(7, BYTE));
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -99,8 +99,8 @@ public class TestTaskStats
         assertEquals(actual.getBlockedDrivers(), 24);
         assertEquals(actual.getCompletedDrivers(), 10);
 
-        assertEquals(actual.getCumulativeMemory(), 11.0);
-        assertEquals(actual.getMemoryReservation(), new DataSize(12, BYTE));
+        assertEquals(actual.getCumulativeUserMemory(), 11.0);
+        assertEquals(actual.getUserMemoryReservation(), new DataSize(12, BYTE));
         assertEquals(actual.getRevocableMemoryReservation(), new DataSize(13, BYTE));
         assertEquals(actual.getSystemMemoryReservation(), new DataSize(14, BYTE));
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -122,9 +122,9 @@ public class TestBasicQueryInfo
         assertEquals(basicInfo.getQueryStats().getRunningDrivers(), 18);
         assertEquals(basicInfo.getQueryStats().getCompletedDrivers(), 19);
 
-        assertEquals(basicInfo.getQueryStats().getCumulativeMemory(), 20.0);
-        assertEquals(basicInfo.getQueryStats().getTotalMemoryReservation(), DataSize.valueOf("21GB"));
-        assertEquals(basicInfo.getQueryStats().getPeakMemoryReservation(), DataSize.valueOf("22GB"));
+        assertEquals(basicInfo.getQueryStats().getCumulativeUserMemory(), 20.0);
+        assertEquals(basicInfo.getQueryStats().getUserMemoryReservation(), DataSize.valueOf("21GB"));
+        assertEquals(basicInfo.getQueryStats().getPeakUserMemoryReservation(), DataSize.valueOf("22GB"));
         assertEquals(basicInfo.getQueryStats().getTotalCpuTime(), Duration.valueOf("24m"));
 
         assertEquals(basicInfo.getQueryStats().isFullyBlocked(), true);

--- a/presto-product-tests/src/test/resources/com/facebook/presto/tests/querystats/single_query_info_response.json
+++ b/presto-product-tests/src/test/resources/com/facebook/presto/tests/querystats/single_query_info_response.json
@@ -39,6 +39,7 @@
     "queuedDrivers": 0,
     "runningDrivers": 0,
     "completedDrivers": 1,
+    "userMemoryReservation": "0B",
     "totalMemoryReservation": "0B",
     "peakUserMemoryReservation": "0B",
     "peakTotalMemoryReservation": "0B",


### PR DESCRIPTION
Fields such as `memoryReservation`, `totalMemoryReservation`, `cumulativeMemory`, `peakMemory` are renamed to have the word `user` in them to make it clear that they are user memory related.

I just wanted to get this in as I am working on unifying the system/user pool right now.