### PR TITLE
Change NULL IN treatment in ExpressionInterpreter so it's "more correct"

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -641,9 +641,6 @@ public class ExpressionInterpreter
         protected Object visitInPredicate(InPredicate node, Object context)
         {
             Object value = process(node.getValue(), context);
-            if (value == null) {
-                return null;
-            }
 
             Expression valueListExpression = node.getValueList();
             if (!(valueListExpression instanceof InListExpression)) {
@@ -653,6 +650,10 @@ public class ExpressionInterpreter
                 return node;
             }
             InListExpression valueList = (InListExpression) valueListExpression;
+            verify(!valueList.getValues().isEmpty()); // `NULL IN ()` would be false, but is not possible
+            if (value == null) {
+                return null;
+            }
 
             Set<?> set = inListCache.get(valueList);
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/InListExpression.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/InListExpression.java
@@ -13,9 +13,14 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 public class InListExpression
         extends Expression
@@ -35,7 +40,9 @@ public class InListExpression
     private InListExpression(Optional<NodeLocation> location, List<Expression> values)
     {
         super(location);
-        this.values = values;
+        requireNonNull(values, "values is null");
+        checkArgument(!values.isEmpty(), "values cannot be empty");
+        this.values = ImmutableList.copyOf(values);
     }
 
     public List<Expression> getValues()


### PR DESCRIPTION
Apparently it was not possible to reach `ExpressionInterpreter` with
`InPredicate` having empty values. However, if it was possible, the
logic to return `null` for `NULL IN ...` would not be correct.

This commit changes the code so that it's more obvious why it's correct.