### PR TITLE
Reset resetMemoryRevocationRequestListener when driver is closed

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -316,6 +316,11 @@ public class OperatorContext
 
     public void destroy()
     {
+        // reset memory revocation listener so that OperatorContext doesn't hold any references to Driver instance
+        synchronized (this) {
+            memoryRevocationRequestListener = null;
+        }
+
         operatorMemoryContext.close();
 
         if (operatorMemoryContext.getSystemMemory() != 0) {


### PR DESCRIPTION
resetMemoryRevocationRequestListener should be reset on driver
close. Otherwise OperatorContext holds reference to
Driver and Operator instances thus consuming memory.