### PR TITLE
Optimize the ST_XMin, ST_XMax, ST_YMin, ST_YMax functions

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -238,43 +238,55 @@ public final class GeoFunctions
         return geometry.getEsriGeometry().calculateLength2D();
     }
 
+    @SqlNullable
     @Description("Returns X maxima of a bounding box of a Geometry")
     @ScalarFunction("ST_XMax")
     @SqlType(DOUBLE)
-    public static double stXMax(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
+    public static Double stXMax(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
-        OGCGeometry geometry = deserialize(input);
-        Envelope envelope = getEnvelope(geometry);
+        Envelope envelope = deserializeEnvelope(input);
+        if (envelope == null) {
+            return null;
+        }
         return envelope.getXMax();
     }
 
+    @SqlNullable
     @Description("Returns Y maxima of a bounding box of a Geometry")
     @ScalarFunction("ST_YMax")
     @SqlType(DOUBLE)
-    public static double stYMax(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
+    public static Double stYMax(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
-        OGCGeometry geometry = deserialize(input);
-        Envelope envelope = getEnvelope(geometry);
+        Envelope envelope = deserializeEnvelope(input);
+        if (envelope == null) {
+            return null;
+        }
         return envelope.getYMax();
     }
 
+    @SqlNullable
     @Description("Returns X minima of a bounding box of a Geometry")
     @ScalarFunction("ST_XMin")
     @SqlType(DOUBLE)
-    public static double stXMin(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
+    public static Double stXMin(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
-        OGCGeometry geometry = deserialize(input);
-        Envelope envelope = getEnvelope(geometry);
+        Envelope envelope = deserializeEnvelope(input);
+        if (envelope == null) {
+            return null;
+        }
         return envelope.getXMin();
     }
 
+    @SqlNullable
     @Description("Returns Y minima of a bounding box of a Geometry")
     @ScalarFunction("ST_YMin")
     @SqlType(DOUBLE)
-    public static double stYMin(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
+    public static Double stYMin(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
-        OGCGeometry geometry = deserialize(input);
-        Envelope envelope = getEnvelope(geometry);
+        Envelope envelope = deserializeEnvelope(input);
+        if (envelope == null) {
+            return null;
+        }
         return envelope.getYMin();
     }
 
@@ -591,13 +603,6 @@ public final class GeoFunctions
         if (!validTypes.contains(type)) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("%s only applies to %s. Input type is: %s", function, OR_JOINER.join(validTypes), type));
         }
-    }
-
-    private static Envelope getEnvelope(OGCGeometry geometry)
-    {
-        Envelope envelope = new Envelope();
-        geometry.getEsriGeometry().queryEnvelope(envelope);
-        return envelope;
     }
 
     private static void verifySameSpatialReference(OGCGeometry leftGeometry, OGCGeometry rightGeometry)

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkSTXMin.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkSTXMin.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import io.airlift.slice.Slice;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.io.IOException;
+
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stGeometryFromText;
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stXMin;
+import static com.facebook.presto.plugin.geospatial.GeometryBenchmarkUtils.loadPolygon;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@OutputTimeUnit(NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkSTXMin
+{
+    @Benchmark
+    public double simpleGeometry(BenchmarkData data)
+    {
+        return stXMin(data.simpleGeometry);
+    }
+
+    @Benchmark
+    public double complexGeometry(BenchmarkData data)
+    {
+        return stXMin(data.complexGeometry);
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private Slice complexGeometry;
+        private Slice simpleGeometry;
+
+        @Setup
+        public void setup()
+                throws IOException
+        {
+            complexGeometry = stGeometryFromText(utf8Slice(loadPolygon("large_polygon.txt")));
+            simpleGeometry = stGeometryFromText(utf8Slice("POLYGON ((1 1, 4 1, 1 4))"));
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkSTXMin.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoQueries.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoQueries.java
@@ -188,6 +188,12 @@ public class TestGeoQueries
         assertFunction("ST_YMax(ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))'))", DOUBLE, 1.0);
         assertFunction("ST_XMax(ST_GeometryFromText('MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1)), ((2 4, 2 6, 6 6, 6 4)))'))", DOUBLE, 6.0);
         assertFunction("ST_YMax(ST_GeometryFromText('MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1)), ((2 4, 2 6, 6 10, 6 4)))'))", DOUBLE, 10.0);
+        assertFunction("ST_XMax(ST_GeometryFromText('POLYGON EMPTY'))", DOUBLE, null);
+        assertFunction("ST_YMax(ST_GeometryFromText('POLYGON EMPTY'))", DOUBLE, null);
+        assertFunction("ST_XMax(ST_GeometryFromText('GEOMETRYCOLLECTION (POINT (5 1), LINESTRING (3 4, 4 4))'))", DOUBLE, 5.0);
+        assertFunction("ST_YMax(ST_GeometryFromText('GEOMETRYCOLLECTION (POINT (5 1), LINESTRING (3 4, 4 4))'))", DOUBLE, 4.0);
+        assertFunction("ST_XMax(null)", DOUBLE, null);
+        assertFunction("ST_YMax(null)", DOUBLE, null);
     }
 
     @Test
@@ -205,6 +211,12 @@ public class TestGeoQueries
         assertFunction("ST_YMin(ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))'))", DOUBLE, 0.0);
         assertFunction("ST_XMin(ST_GeometryFromText('MULTIPOLYGON (((1 10, 1 3, 3 3, 3 10)), ((2 4, 2 6, 6 6, 6 4)))'))", DOUBLE, 1.0);
         assertFunction("ST_YMin(ST_GeometryFromText('MULTIPOLYGON (((1 10, 1 3, 3 3, 3 10)), ((2 4, 2 6, 6 10, 6 4)))'))", DOUBLE, 3.0);
+        assertFunction("ST_XMin(ST_GeometryFromText('POLYGON EMPTY'))", DOUBLE, null);
+        assertFunction("ST_YMin(ST_GeometryFromText('POLYGON EMPTY'))", DOUBLE, null);
+        assertFunction("ST_XMin(ST_GeometryFromText('GEOMETRYCOLLECTION (POINT (5 1), LINESTRING (3 4, 4 4))'))", DOUBLE, 3.0);
+        assertFunction("ST_YMin(ST_GeometryFromText('GEOMETRYCOLLECTION (POINT (5 1), LINESTRING (3 4, 4 4))'))", DOUBLE, 1.0);
+        assertFunction("ST_XMin(null)", DOUBLE, null);
+        assertFunction("ST_YMin(null)", DOUBLE, null);
     }
 
     @Test


### PR DESCRIPTION
Similar to [#9953](https://github.com/prestodb/presto/pull/9953), ST_XMin, ST_XMax, ST_YMin, and ST_YMax geospatial functions spend most of the time deserializing geometry from Slice. This PR updates them to limit deserialization to just the envelope.

This change fixes the NullPointerException reported in [#10027](https://github.com/prestodb/presto/pull/10027) as well.

Micro-benchmarking shows a big performance improvement.

Before:

```
Benchmark                       Mode  Cnt Score     Error    Units
BenchmarkSTXmin.complexGeometry avgt 20 123830.375 ± 4063.732 ns/op
BenchmarkSTXmin.simpleGeometry avgt 20 535.399 ± 56.854 ns/op`
```

and after:

```
Benchmark                       Mode  Cnt Score   Error  Units
BenchmarkSTXmin.complexGeometry avgt 20 59.393 ± 5.843 ns/op
BenchmarkSTXmin.simpleGeometry avgt 20 54.984 ± 1.887 ns/op
```