### PR TITLE
Fix string stats trunction for original orc writer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -384,7 +384,11 @@ public class OrcMetadataReader
             return null;
         }
 
-        int index = findStringStatisticTruncationPosition(value, version);
+        if (version != ORIGINAL) {
+            return value;
+        }
+
+        int index = findStringStatisticTruncationPositionForOriginalOrcWriter(value);
         if (index == value.length()) {
             return value;
         }
@@ -401,7 +405,11 @@ public class OrcMetadataReader
             return null;
         }
 
-        int index = findStringStatisticTruncationPosition(value, version);
+        if (version != ORIGINAL) {
+            return value;
+        }
+
+        int index = findStringStatisticTruncationPositionForOriginalOrcWriter(value);
         if (index == value.length()) {
             return value;
         }
@@ -409,7 +417,7 @@ public class OrcMetadataReader
     }
 
     @VisibleForTesting
-    static int findStringStatisticTruncationPosition(Slice utf8, HiveWriterVersion version)
+    static int findStringStatisticTruncationPositionForOriginalOrcWriter(Slice utf8)
     {
         int length = utf8.length();
 
@@ -426,7 +434,7 @@ public class OrcMetadataReader
             // replaces invalid UTF-8 sequences with the unicode replacement character.  This can cause the min value to be
             // greater than expected which can result in data sections being skipped instead of being processed. As a work around,
             // the string stats are truncated at the first replacement character.
-            if (version == ORIGINAL && codePoint == REPLACEMENT_CHARACTER_CODE_POINT) {
+            if (codePoint == REPLACEMENT_CHARACTER_CODE_POINT) {
                 break;
             }
 
@@ -449,7 +457,7 @@ public class OrcMetadataReader
             //   at the first occurrence of the surrogate character (to exclude the surrogate character)
             // * if a max string has a surrogate character, the max string is truncated
             //   at the first occurrence the surrogate character and 0xFF byte is appended to it.
-            if (version == ORIGINAL && codePoint >= MIN_SUPPLEMENTARY_CODE_POINT) {
+            if (codePoint >= MIN_SUPPLEMENTARY_CODE_POINT) {
                 break;
             }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestOrcMetadataReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestOrcMetadataReader.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.facebook.presto.orc.metadata.OrcMetadataReader.findStringStatisticTruncationPosition;
+import static com.facebook.presto.orc.metadata.OrcMetadataReader.findStringStatisticTruncationPositionForOriginalOrcWriter;
 import static com.facebook.presto.orc.metadata.OrcMetadataReader.maxStringTruncateToValidRange;
 import static com.facebook.presto.orc.metadata.OrcMetadataReader.minStringTruncateToValidRange;
 import static com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion.ORC_HIVE_8732;
@@ -57,7 +57,7 @@ public class TestOrcMetadataReader
                 continue;
             }
             Slice value = codePointToUtf8(codePoint);
-            if (findStringStatisticTruncationPosition(value, ORIGINAL) == value.length()) {
+            if (findStringStatisticTruncationPositionForOriginalOrcWriter(value) == value.length()) {
                 assertEquals(minStringTruncateToValidRange(value, ORIGINAL), value);
             }
             else {
@@ -72,7 +72,7 @@ public class TestOrcMetadataReader
                 continue;
             }
             Slice value = concatSlice(prefix, codePointToUtf8(codePoint));
-            if (findStringStatisticTruncationPosition(value, ORIGINAL) == value.length()) {
+            if (findStringStatisticTruncationPositionForOriginalOrcWriter(value) == value.length()) {
                 assertEquals(minStringTruncateToValidRange(value, ORIGINAL), value);
             }
             else {
@@ -93,7 +93,7 @@ public class TestOrcMetadataReader
                 continue;
             }
             Slice value = codePointToUtf8(codePoint);
-            if (findStringStatisticTruncationPosition(value, ORIGINAL) == value.length()) {
+            if (findStringStatisticTruncationPositionForOriginalOrcWriter(value) == value.length()) {
                 assertEquals(maxStringTruncateToValidRange(value, ORIGINAL), value);
             }
             else {
@@ -109,7 +109,7 @@ public class TestOrcMetadataReader
                 continue;
             }
             Slice value = concatSlice(prefix, codePointToUtf8(codePoint));
-            if (findStringStatisticTruncationPosition(value, ORIGINAL) == value.length()) {
+            if (findStringStatisticTruncationPositionForOriginalOrcWriter(value) == value.length()) {
                 assertEquals(maxStringTruncateToValidRange(value, ORIGINAL), value);
             }
             else {


### PR DESCRIPTION
We need to check if the orc writer version before trying to truncate the
string to get the stats given there could be invalid code points.