### PR TITLE
Make is_json_scalar throw on invalid input

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonFunctions.java
@@ -45,8 +45,10 @@ public class TestJsonFunctions
         assertFunction("IS_JSON_SCALAR('[1, 2, 3]')", BOOLEAN, false);
         assertFunction("IS_JSON_SCALAR('{\"a\": 1, \"b\": 2}')", BOOLEAN, false);
 
-        assertFunction("IS_JSON_SCALAR('')", BOOLEAN, null);
-        assertFunction("IS_JSON_SCALAR('[1')", BOOLEAN, null);
+        assertInvalidFunction("IS_JSON_SCALAR('')", INVALID_FUNCTION_ARGUMENT, "Invalid JSON value: ");
+        assertInvalidFunction("IS_JSON_SCALAR('[1')", INVALID_FUNCTION_ARGUMENT, "Invalid JSON value: [1");
+        assertInvalidFunction("IS_JSON_SCALAR('1 trailing')", INVALID_FUNCTION_ARGUMENT, "Invalid JSON value: 1 trailing");
+        assertInvalidFunction("IS_JSON_SCALAR('[1, 2] trailing')", INVALID_FUNCTION_ARGUMENT, "Invalid JSON value: [1, 2] trailing");
     }
 
     @Test


### PR DESCRIPTION
is_json_scalar returns null on invalid input. However, this can be
too lenient. Make it more strict for now and we can consider relax
it later if necessary.