### PR TITLE
Add state query parameter to getAllQueryInfo endpoint

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryInfo.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.ErrorType;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
@@ -48,17 +49,18 @@ public class BasicQueryInfo
     private final ErrorType errorType;
     private final ErrorCode errorCode;
 
+    @JsonCreator
     public BasicQueryInfo(
-            QueryId queryId,
-            SessionRepresentation session,
-            QueryState state,
-            MemoryPoolId memoryPool,
-            boolean scheduled,
-            URI self,
-            String query,
-            BasicQueryStats queryStats,
-            ErrorType errorType,
-            ErrorCode errorCode)
+            @JsonProperty("queryId") QueryId queryId,
+            @JsonProperty("session") SessionRepresentation session,
+            @JsonProperty("state") QueryState state,
+            @JsonProperty("memoryPool") MemoryPoolId memoryPool,
+            @JsonProperty("scheduled") boolean scheduled,
+            @JsonProperty("self") URI self,
+            @JsonProperty("query") String query,
+            @JsonProperty("queryStats") BasicQueryStats queryStats,
+            @JsonProperty("errorType") ErrorType errorType,
+            @JsonProperty("errorCode") ErrorCode errorCode)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.session = requireNonNull(session, "session is null");

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -15,6 +15,7 @@ package com.facebook.presto.server;
 
 import com.facebook.presto.execution.QueryStats;
 import com.facebook.presto.operator.BlockedReason;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
@@ -57,22 +58,23 @@ public class BasicQueryStats
 
     private final OptionalDouble progressPercentage;
 
+    @JsonCreator
     public BasicQueryStats(
-            DateTime createTime,
-            DateTime endTime,
-            Duration elapsedTime,
-            Duration executionTime,
-            int totalDrivers,
-            int queuedDrivers,
-            int runningDrivers,
-            int completedDrivers,
-            double cumulativeUserMemory,
-            DataSize userMemoryReservation,
-            DataSize peakUserMemoryReservation,
-            Duration totalCpuTime,
-            boolean fullyBlocked,
-            Set<BlockedReason> blockedReasons,
-            OptionalDouble progressPercentage)
+            @JsonProperty("createTime") DateTime createTime,
+            @JsonProperty("endTime") DateTime endTime,
+            @JsonProperty("elapsedTime") Duration elapsedTime,
+            @JsonProperty("executionTime") Duration executionTime,
+            @JsonProperty("totalDrivers") int totalDrivers,
+            @JsonProperty("queuedDrivers") int queuedDrivers,
+            @JsonProperty("runningDrivers") int runningDrivers,
+            @JsonProperty("completedDrivers") int completedDrivers,
+            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
+            @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
+            @JsonProperty("totalCpuTime") Duration totalCpuTime,
+            @JsonProperty("fullyBlocked") boolean fullyBlocked,
+            @JsonProperty("blockedReasons") Set<BlockedReason> blockedReasons,
+            @JsonProperty("progressPercentage") OptionalDouble progressPercentage)
     {
         this.createTime = createTime;
         this.endTime = endTime;

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
@@ -15,6 +15,7 @@ package com.facebook.presto.server;
 
 import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.StageId;
 import com.facebook.presto.spi.QueryId;
 import com.google.common.collect.ImmutableList;
@@ -24,10 +25,12 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 
 import static java.util.Objects.requireNonNull;
@@ -47,18 +50,15 @@ public class QueryResource
     }
 
     @GET
-    public List<BasicQueryInfo> getAllQueryInfo()
+    public List<BasicQueryInfo> getAllQueryInfo(@QueryParam("state") String queryState)
     {
-        return extractBasicQueryInfo(queryManager.getAllQueryInfo());
-    }
-
-    private static List<BasicQueryInfo> extractBasicQueryInfo(List<QueryInfo> allQueryInfo)
-    {
-        ImmutableList.Builder<BasicQueryInfo> basicQueryInfo = ImmutableList.builder();
-        for (QueryInfo queryInfo : allQueryInfo) {
-            basicQueryInfo.add(new BasicQueryInfo(queryInfo));
+        ImmutableList.Builder<BasicQueryInfo> builder = new ImmutableList.Builder<>();
+        for (QueryInfo queryInfo : queryManager.getAllQueryInfo()) {
+            if (queryState == null || queryInfo.getState().equals(QueryState.valueOf(queryState.toUpperCase(Locale.ENGLISH)))) {
+                builder.add(new BasicQueryInfo(queryInfo));
+            }
         }
-        return basicQueryInfo.build();
+        return builder.build();
     }
 
     @GET

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryResource.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryResource.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.List;
+
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_USER;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.json.JsonCodec.listJsonCodec;
+import static io.airlift.testing.Closeables.closeQuietly;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.fail;
+
+@Test(singleThreaded = true)
+public class TestQueryResource
+{
+    private final HttpClient client = new JettyHttpClient();
+    private TestingPrestoServer server;
+
+    public TestQueryResource()
+            throws Exception
+    {
+        server = new TestingPrestoServer();
+    }
+
+    @BeforeClass
+    public void setup()
+    {
+        runToCompletion("SELECT 1");
+        runToCompletion("SELECT 2");
+        runToCompletion("SELECT x FROM y");
+    }
+
+    private void runToCompletion(String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        Request request = preparePost()
+                .setHeader(PRESTO_USER, "user")
+                .setUri(uri)
+                .setBodyGenerator(createStaticBodyGenerator(sql, UTF_8))
+                .build();
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        while (queryResults.getNextUri() != null) {
+            request = prepareGet()
+                    .setHeader(PRESTO_USER, "user")
+                    .setUri(queryResults.getNextUri())
+                    .build();
+            queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(server);
+        closeQuietly(client);
+    }
+
+    @Test
+    public void testGetQueryInfos()
+    {
+        List<BasicQueryInfo> infos = getQueryInfos("/v1/query");
+        assertEquals(infos.size(), 3);
+        assertStateCounts(infos, 2, 1, 0);
+
+        infos = getQueryInfos("/v1/query?state=finished");
+        assertEquals(infos.size(), 2);
+        assertStateCounts(infos, 2, 0, 0);
+
+        infos = getQueryInfos("/v1/query?state=failed");
+        assertEquals(infos.size(), 1);
+        assertStateCounts(infos, 0, 1, 0);
+
+        infos = getQueryInfos("/v1/query?state=running");
+        assertEquals(infos.size(), 0);
+        assertStateCounts(infos, 0, 0, 0);
+    }
+
+    private List<BasicQueryInfo> getQueryInfos(String path)
+    {
+        Request request = prepareGet().setUri(server.resolve(path)).build();
+        return client.execute(request, createJsonResponseHandler(listJsonCodec(BasicQueryInfo.class)));
+    }
+
+    private void assertStateCounts(List<BasicQueryInfo> infos, int expectedFinished, int expectedFailed, int expectedRunning)
+    {
+        int failed = 0;
+        int finished = 0;
+        int running = 0;
+        for (BasicQueryInfo info : infos) {
+            switch (info.getState()) {
+                case FINISHED:
+                    finished++;
+                    break;
+                case FAILED:
+                    failed++;
+                    break;
+                case RUNNING:
+                    running++;
+                    break;
+                default:
+                    fail("Unexpected query state " + info.getState());
+            }
+        }
+        assertEquals(failed, expectedFailed);
+        assertEquals(finished, expectedFinished);
+        assertEquals(running, expectedRunning);
+    }
+}


### PR DESCRIPTION
This change adds a state query parameter to the getAllQueryInfo
endpoint to filter queries by the specified state as this endpoint can
return a large number of queries.

The reason for this change is to aid debugging, sometimes I curl this endpoint from the command line  and do a bunch of other stuff, and the data this endpoint returns is huge.