### PR TITLE
Improve client protocol latency at query completion

### DIFF
--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -19,6 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-client</artifactId>
         </dependency>
 

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestQueryRunner.java
@@ -14,10 +14,10 @@
 package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
-import com.facebook.presto.client.ClientTypeSignature;
 import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementStats;
+import com.facebook.presto.spi.type.BigintType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -114,7 +114,7 @@ public class TestQueryRunner
                 server.url("/query.html?20160128_214710_00012_rk68b").uri(),
                 null,
                 null,
-                ImmutableList.of(new Column("_col0", "bigint", new ClientTypeSignature("bigint", ImmutableList.of()))),
+                ImmutableList.of(new Column("_col0", BigintType.BIGINT)),
                 ImmutableList.of(ImmutableList.of(123)),
                 StatementStats.builder().setState("FINISHED").build(),
                 //new StatementStats("FINISHED", false, true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),

--- a/presto-client/src/main/java/com/facebook/presto/client/Column.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/Column.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.client;
 
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignature;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -26,6 +28,16 @@ public class Column
     private final String name;
     private final String type;
     private final ClientTypeSignature typeSignature;
+
+    public Column(String name, Type type)
+    {
+        this(name, type.getTypeSignature());
+    }
+
+    public Column(String name, TypeSignature signature)
+    {
+        this(name, signature.toString(), new ClientTypeSignature(signature));
+    }
 
     @JsonCreator
     public Column(

--- a/presto-client/src/test/java/com/facebook/presto/client/TestFixJsonDataUtils.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestFixJsonDataUtils.java
@@ -60,7 +60,7 @@ public class TestFixJsonDataUtils
     private void assertQueryResult(String type, Object data, Object expected)
     {
         List<List<Object>> rows = newArrayList(fixData(
-                ImmutableList.of(new Column("test", type, new ClientTypeSignature(parseTypeSignature(type)))),
+                ImmutableList.of(new Column("test", parseTypeSignature(type))),
                 ImmutableList.of(ImmutableList.of(data))));
         assertEquals(rows.size(), 1);
         assertEquals(rows.get(0).size(), 1);

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -13,10 +13,10 @@
  */
 package com.facebook.presto.jdbc;
 
-import com.facebook.presto.client.ClientTypeSignature;
 import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementStats;
+import com.facebook.presto.spi.type.BigintType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
 import okhttp3.mockwebserver.MockResponse;
@@ -68,7 +68,7 @@ public class TestProgressMonitor
 
     private List<String> createResults()
     {
-        List<Column> columns = ImmutableList.of(new Column("_col0", "bigint", new ClientTypeSignature("bigint", ImmutableList.of())));
+        List<Column> columns = ImmutableList.of(new Column("_col0", BigintType.BIGINT));
         return ImmutableList.<String>builder()
                 .add(newQueryResults(null, 1, null, null, "QUEUED"))
                 .add(newQueryResults(1, 2, columns, null, "RUNNING"))

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.execution.QueryExecution.QueryOutputInfo;
+import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.server.SessionContext;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
@@ -29,6 +30,8 @@ public interface QueryManager
     List<QueryInfo> getAllQueryInfo();
 
     void addOutputInfoListener(QueryId queryId, Consumer<QueryOutputInfo> listener);
+
+    void addStateChangeListener(QueryId queryId, StateChangeListener<QueryState> listener);
 
     ListenableFuture<QueryState> getStateChange(QueryId queryId, QueryState currentState);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -20,6 +20,7 @@ import com.facebook.presto.event.query.QueryMonitor;
 import com.facebook.presto.execution.QueryExecution.QueryExecutionFactory;
 import com.facebook.presto.execution.QueryExecution.QueryOutputInfo;
 import com.facebook.presto.execution.SqlQueryExecution.SqlQueryExecutionFactory;
+import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.resourceGroups.QueryQueueFullException;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.memory.ClusterMemoryManager;
@@ -299,6 +300,14 @@ public class SqlQueryManager
         requireNonNull(listener, "listener is null");
 
         getQuery(queryId).addOutputInfoListener(listener);
+    }
+
+    @Override
+    public void addStateChangeListener(QueryId queryId, StateChangeListener<QueryState> listener)
+    {
+        requireNonNull(listener, "listener is null");
+
+        getQuery(queryId).addStateChangeListener(listener);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -296,89 +296,50 @@ public class SqlQueryManager
     @Override
     public void addOutputInfoListener(QueryId queryId, Consumer<QueryOutputInfo> listener)
     {
-        requireNonNull(queryId, "queryId is null");
         requireNonNull(listener, "listener is null");
 
-        QueryExecution query = queries.get(queryId);
-        if (query == null) {
-            throw new NoSuchElementException();
-        }
-
-        query.addOutputInfoListener(listener);
+        getQuery(queryId).addOutputInfoListener(listener);
     }
 
     @Override
     public ListenableFuture<QueryState> getStateChange(QueryId queryId, QueryState currentState)
     {
-        requireNonNull(queryId, "queryId is null");
-
-        QueryExecution query = queries.get(queryId);
-        if (query == null) {
-            return immediateFailedFuture(new NoSuchElementException());
-        }
-
-        return query.getStateChange(currentState);
+        return tryGetQuery(queryId)
+                .map(query -> query.getStateChange(currentState))
+                .orElseGet(() -> immediateFailedFuture(new NoSuchElementException()));
     }
 
     @Override
     public QueryInfo getQueryInfo(QueryId queryId)
     {
-        requireNonNull(queryId, "queryId is null");
-
-        QueryExecution query = queries.get(queryId);
-        if (query == null) {
-            throw new NoSuchElementException();
-        }
-
-        return query.getQueryInfo();
+        return getQuery(queryId).getQueryInfo();
     }
 
     @Override
     public Optional<ResourceGroupId> getQueryResourceGroup(QueryId queryId)
     {
-        requireNonNull(queryId, "queryId is null");
-
-        QueryExecution query = queries.get(queryId);
-        if (query != null) {
-            return query.getResourceGroup();
-        }
-
-        return Optional.empty();
+        return tryGetQuery(queryId)
+                .flatMap(QueryExecution::getResourceGroup);
     }
 
     @Override
     public Plan getQueryPlan(QueryId queryId)
     {
-        requireNonNull(queryId, "queryId is null");
-
-        QueryExecution query = queries.get(queryId);
-        if (query == null) {
-            throw new NoSuchElementException();
-        }
-
-        return query.getQueryPlan();
+        return getQuery(queryId).getQueryPlan();
     }
 
     @Override
     public Optional<QueryState> getQueryState(QueryId queryId)
     {
-        requireNonNull(queryId, "queryId is null");
-
-        return Optional.ofNullable(queries.get(queryId))
+        return tryGetQuery(queryId)
                 .map(QueryExecution::getState);
     }
 
     @Override
     public void recordHeartbeat(QueryId queryId)
     {
-        requireNonNull(queryId, "queryId is null");
-
-        QueryExecution query = queries.get(queryId);
-        if (query == null) {
-            return;
-        }
-
-        query.recordHeartbeat();
+        tryGetQuery(queryId)
+                .ifPresent(QueryExecution::recordHeartbeat);
     }
 
     @Override
@@ -515,26 +476,19 @@ public class SqlQueryManager
     @Override
     public void failQuery(QueryId queryId, Throwable cause)
     {
-        requireNonNull(queryId, "queryId is null");
         requireNonNull(cause, "cause is null");
 
-        QueryExecution query = queries.get(queryId);
-        if (query != null) {
-            query.fail(cause);
-        }
+        tryGetQuery(queryId)
+                .ifPresent(query -> query.fail(cause));
     }
 
     @Override
     public void cancelQuery(QueryId queryId)
     {
-        requireNonNull(queryId, "queryId is null");
-
         log.debug("Cancel query %s", queryId);
 
-        QueryExecution query = queries.get(queryId);
-        if (query != null) {
-            query.cancelQuery();
-        }
+        tryGetQuery(queryId)
+                .ifPresent(QueryExecution::cancelQuery);
     }
 
     @Override
@@ -544,10 +498,8 @@ public class SqlQueryManager
 
         log.debug("Cancel stage %s", stageId);
 
-        QueryExecution query = queries.get(stageId.getQueryId());
-        if (query != null) {
-            query.cancelStage(stageId);
-        }
+        tryGetQuery(stageId.getQueryId())
+                .ifPresent(query -> query.cancelStage(stageId));
     }
 
     @Override
@@ -747,5 +699,17 @@ public class SqlQueryManager
         if (queryExecution.getState().isDone() && taskExecuted.compareAndSet(false, true)) {
             callback.run();
         }
+    }
+
+    private QueryExecution getQuery(QueryId queryId)
+    {
+        return tryGetQuery(queryId)
+                .orElseThrow(NoSuchElementException::new);
+    }
+
+    private Optional<QueryExecution> tryGetQuery(QueryId queryId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        return Optional.ofNullable(queries.get(queryId));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.server.protocol;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.client.ClientTypeSignature;
 import com.facebook.presto.client.Column;
 import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.client.QueryError;
@@ -38,9 +37,9 @@ import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.transaction.TransactionId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -367,7 +366,7 @@ class Query
                 exchangeClient.close();
 
                 // Return a single value for clients that require a result.
-                columns = ImmutableList.of(new Column("result", "boolean", new ClientTypeSignature(StandardTypes.BOOLEAN, ImmutableList.of())));
+                columns = ImmutableList.of(new Column("result", BooleanType.BOOLEAN));
                 data = ImmutableSet.of(ImmutableList.of(true));
             }
         }
@@ -428,10 +427,7 @@ class Query
 
             ImmutableList.Builder<Column> list = ImmutableList.builder();
             for (int i = 0; i < columnNames.size(); i++) {
-                String name = columnNames.get(i);
-                TypeSignature typeSignature = columnTypes.get(i).getTypeSignature();
-                String type = typeSignature.toString();
-                list.add(new Column(name, type, new ClientTypeSignature(typeSignature)));
+                list.add(new Column(columnNames.get(i), columnTypes.get(i)));
             }
             columns = list.build();
             types = outputInfo.getColumnTypes();


### PR DESCRIPTION
The statement resource was waiting the maximum time at query completion
for the exchange client to have data, which never occurs if there is no
data for the query.