### PR TITLE
Use more portable expression in QueryBuilder

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
@@ -59,6 +59,10 @@ import static org.joda.time.DateTimeZone.UTC;
 
 public class QueryBuilder
 {
+    // not all databases support booleans, so use 1=1 and 1=0 instead
+    private static final String ALWAYS_TRUE = "1=1";
+    private static final String ALWAYS_FALSE = "1=0";
+
     private final String quote;
 
     private static class TypeAndValue
@@ -211,11 +215,11 @@ public class QueryBuilder
         checkArgument(domain.getType().isOrderable(), "Domain type must be orderable");
 
         if (domain.getValues().isNone()) {
-            return domain.isNullAllowed() ? quote(columnName) + " IS NULL" : "FALSE";
+            return domain.isNullAllowed() ? quote(columnName) + " IS NULL" : ALWAYS_FALSE;
         }
 
         if (domain.getValues().isAll()) {
-            return domain.isNullAllowed() ? "TRUE" : quote(columnName) + " IS NOT NULL";
+            return domain.isNullAllowed() ? ALWAYS_TRUE : quote(columnName) + " IS NOT NULL";
         }
 
         List<String> disjuncts = new ArrayList<>();


### PR DESCRIPTION
Not all databases understand `TRUE` and `FALSE`, so let's use more
portable expression.

In fact, this code is not currently reachable, since planner eliminates
table scan when condition is known to be false. Also, it eliminates
`TupleDomain`'s domains which contain all values. However,
`QueryBuilder` doesn't need to rely on that behavior.