### PR TITLE
Various ExpressionInterpreter cleanups

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -230,6 +230,11 @@ public class Analysis
         return unmodifiableMap(coercions);
     }
 
+    public Set<NodeRef<Expression>> getTypeOnlyCoercions()
+    {
+        return unmodifiableSet(typeOnlyCoercions);
+    }
+
     public Type getCoercion(Expression expression)
     {
         return coercions.get(NodeRef.of(expression));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Coercer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Coercer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.Analysis;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.NodeRef;
+
+import java.util.Map;
+import java.util.Set;
+
+public class Coercer
+{
+    private Coercer()
+    {
+    }
+
+    public static Expression addCoercions(Expression expression, Analysis analysis)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new Rewriter(analysis.getCoercions(), analysis.getTypeOnlyCoercions()), expression);
+    }
+
+    private static class Rewriter
+            extends ExpressionRewriter<Void>
+    {
+        private final Map<NodeRef<Expression>, Type> coercions;
+        private Set<NodeRef<Expression>> typeOnlyCoercions;
+
+        public Rewriter(Map<NodeRef<Expression>, Type> coercions, Set<NodeRef<Expression>> typeOnlyCoercions)
+        {
+            this.coercions = coercions;
+            this.typeOnlyCoercions = typeOnlyCoercions;
+        }
+
+        @Override
+        public Expression rewriteExpression(Expression expression, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            Type target = coercions.get(NodeRef.of(expression));
+
+            Expression rewritten = treeRewriter.defaultRewrite(expression, null);
+            if (target != null) {
+                rewritten = new Cast(
+                        rewritten,
+                        target.getTypeSignature().toString(),
+                        false,
+                        typeOnlyCoercions.contains(NodeRef.of(expression)));
+            }
+
+            return rewritten;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Coercer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Coercer.java
@@ -35,6 +35,11 @@ public class Coercer
         return ExpressionTreeRewriter.rewriteWith(new Rewriter(analysis.getCoercions(), analysis.getTypeOnlyCoercions()), expression);
     }
 
+    public static Expression addCoercions(Expression expression, Map<NodeRef<Expression>, Type> coercions, Set<NodeRef<Expression>> typeOnlyCoercions)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new Rewriter(coercions, typeOnlyCoercions), expression);
+    }
+
     private static class Rewriter
             extends ExpressionRewriter<Void>
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -23,7 +23,6 @@ import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RowBlockBuilder;
@@ -351,33 +350,7 @@ public class ExpressionInterpreter
                     throw new UnsupportedOperationException("not yet implemented");
                 }
             }
-            else if (context instanceof RecordCursor) {
-                RecordCursor cursor = (RecordCursor) context;
-                if (cursor.isNull(channel)) {
-                    return null;
-                }
-
-                Class<?> javaType = type.getJavaType();
-                if (javaType == boolean.class) {
-                    return cursor.getBoolean(channel);
-                }
-                else if (javaType == long.class) {
-                    return cursor.getLong(channel);
-                }
-                else if (javaType == double.class) {
-                    return cursor.getDouble(channel);
-                }
-                else if (javaType == Slice.class) {
-                    return cursor.getSlice(channel);
-                }
-                else if (javaType == Block.class) {
-                    return cursor.getObject(channel);
-                }
-                else {
-                    throw new UnsupportedOperationException("not yet implemented");
-                }
-            }
-            throw new UnsupportedOperationException("Inputs or cursor must be set");
+            throw new UnsupportedOperationException("Inputs must be set");
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -183,7 +183,7 @@ public class ExpressionInterpreter
         return evaluateConstantExpression(expression, coercions, metadata, session, ImmutableSet.of(), parameters);
     }
 
-    public static Object evaluateConstantExpression(
+    private static Object evaluateConstantExpression(
             Expression expression,
             Map<NodeRef<Expression>, Type> coercions,
             Metadata metadata, Session session,


### PR DESCRIPTION
This is handled by SimplifyExpressions during optimization,
so it's unnecessary.