### PR TITLE
Add index size for probe during join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinPageBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinPageBuilder.java
@@ -145,7 +145,9 @@ public class LookupJoinPageBuilder
         verify(previousPosition <= position);
         isSequentialProbeIndices &= position == previousPosition + 1 || previousPosition == -1;
 
+        // Update probe indices and size
         probeIndexBuilder.add(position);
+        estimatedProbeBlockBytes += Integer.BYTES;
 
         // Update memory usage for probe side.
         //


### PR DESCRIPTION
Estimated size for probe should have both dictionary size and id size.
Otherwise, in the extreme case where nothing is appended on the build
and same row appended on the probe can lead to the builder increasing
continuously.