### PR TITLE
Invalidate fractional day interval in sequence

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/SequenceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/SequenceFunction.java
@@ -26,6 +26,8 @@ import com.facebook.presto.type.DateTimeOperators;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
+import java.util.concurrent.TimeUnit;
+
 import static com.facebook.presto.operator.scalar.DateTimeFunctions.diffTimestamp;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -67,6 +69,8 @@ public final class SequenceFunction
             @SqlType(StandardTypes.TIMESTAMP) long stop,
             @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long step)
     {
+        checkCondition(step % TimeUnit.DAYS.toMillis(1) == 0, INVALID_FUNCTION_ARGUMENT,
+                "sequence step for INTERVAL_DAY_TO_SECOND must be a day interval");
         return fixedWidthSequence(start, stop, step, TIMESTAMP);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -1310,6 +1310,7 @@ public class TestArrayOperators
         assertInvalidFunction("SEQUENCE(date '2016-04-12', date '2016-04-14', interval '-1' day)", INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("SEQUENCE(date '2016-04-14', date '2016-04-12', interval '1' day)", INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("SEQUENCE(date '2000-04-14', date '2030-04-12', interval '1' day)", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("SEQUENCE(date '2018-01-01', date '2018-01-04', interval '18' hour)", INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test


### PR DESCRIPTION
There is an unexpected behavior for `INTERVAL_DAY_TO_SECOND` in sequence function described at issue https://github.com/prestodb/presto/issues/9681.

Hence, I created a condition check to invalidate queries with fractional day interval.