### PR TITLE
Push SemiJoin predicate inferred from filter side to source side (v2)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
@@ -100,10 +100,21 @@ public class EqualityInference
     /**
      * Attempts to rewrite an Expression in terms of the symbols allowed by the symbol scope
      * given the known equalities. Returns null if unsuccessful.
+     * This method checks if rewritten expression is non-deterministic.
      */
     public Expression rewriteExpression(Expression expression, Predicate<Symbol> symbolScope)
     {
         checkArgument(DeterminismEvaluator.isDeterministic(expression), "Only deterministic expressions may be considered for rewrite");
+        return rewriteExpression(expression, symbolScope, true);
+    }
+
+    /**
+     * Attempts to rewrite an Expression in terms of the symbols allowed by the symbol scope
+     * given the known equalities. Returns null if unsuccessful.
+     * This method allows rewriting non-deterministic expressions.
+     */
+    public Expression rewriteExpressionAllowNonDeterministic(Expression expression, Predicate<Symbol> symbolScope)
+    {
         return rewriteExpression(expression, symbolScope, true);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -808,7 +808,7 @@ public class PredicatePushDown
             // Push inheritedPredicates down to the source if they don't involve the semi join output
             EqualityInference inheritedInference = createEqualityInference(inheritedPredicate);
             for (Expression conjunct : EqualityInference.nonInferrableConjuncts(inheritedPredicate)) {
-                Expression rewrittenConjunct = inheritedInference.rewriteExpression(conjunct, in(node.getSource().getOutputSymbols()));
+                Expression rewrittenConjunct = inheritedInference.rewriteExpressionAllowNonDeterministic(conjunct, in(node.getSource().getOutputSymbols()));
                 // Since each source row is reflected exactly once in the output, ok to push non-deterministic predicates down
                 if (rewrittenConjunct != null) {
                     sourceConjuncts.add(rewrittenConjunct);


### PR DESCRIPTION
Followup of #10048

Now with guarding that semi-join output is actually used for filtering out rows above semi join.
Still a point change. Could be extended with restructuring PP for SemiJoin to also move predicates from source side to filter side.
And eventually migrated to Iterative optimizer as discussed elsewhere.

Wait till tests pass before rewiew.

cc: @kokosing, @sopel39, @martint, @findepi 

Also fixes #10085