### PR TITLE
check history path is readable/writable, otherwise use MemoryHistory

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -363,15 +363,23 @@ public class Console
     {
         MemoryHistory history;
         File historyFile = new File(getUserHome(), ".presto_history");
-        try {
-            history = new FileHistory(historyFile);
-            history.setMaxSize(10000);
-        }
-        catch (IOException e) {
-            System.err.printf("WARNING: Failed to load history file (%s): %s. " +
+        if (!historyFile.canWrite() || !historyFile.canRead()) {
+            System.err.printf("WARNING: Failed to load history file (%s): Not readable/writable path (%s). " +
                             "History will not be available during this session.%n",
-                    historyFile, e.getMessage());
+                    historyFile, historyFile.getAbsolutePath());
             history = new MemoryHistory();
+        }
+        else {
+            try {
+                history = new FileHistory(historyFile);
+                history.setMaxSize(10000);
+            }
+            catch (IOException e) {
+                System.err.printf("WARNING: Failed to load history file (%s): %s. " +
+                                "History will not be available during this session.%n",
+                        historyFile, e.getMessage());
+                history = new MemoryHistory();
+            }
         }
         history.setAutoTrim(true);
         return history;

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -16,6 +16,7 @@ package com.facebook.presto.cli;
 import com.facebook.presto.cli.ClientOptions.OutputFormat;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.sql.parser.StatementSplitter;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
@@ -361,25 +362,31 @@ public class Console
 
     private static MemoryHistory getHistory()
     {
-        MemoryHistory history;
-        File historyFile = new File(getUserHome(), ".presto_history");
+        return getHistory(new File(getUserHome(), ".presto_history"));
+    }
+
+    @VisibleForTesting
+    static MemoryHistory getHistory(File historyFile)
+    {
         if (!historyFile.canWrite() || !historyFile.canRead()) {
             System.err.printf("WARNING: Failed to load history file (%s): Not readable/writable path (%s). " +
                             "History will not be available during this session.%n",
                     historyFile, historyFile.getAbsolutePath());
-            history = new MemoryHistory();
+            MemoryHistory history = new MemoryHistory();
+            history.setAutoTrim(true);
+            return history;
         }
-        else {
-            try {
-                history = new FileHistory(historyFile);
-                history.setMaxSize(10000);
-            }
-            catch (IOException e) {
-                System.err.printf("WARNING: Failed to load history file (%s): %s. " +
-                                "History will not be available during this session.%n",
-                        historyFile, e.getMessage());
-                history = new MemoryHistory();
-            }
+
+        MemoryHistory history;
+        try {
+            history = new FileHistory(historyFile);
+            history.setMaxSize(10000);
+        }
+        catch (IOException e) {
+            System.err.printf("WARNING: Failed to load history file (%s): %s. " +
+                            "History will not be available during this session.%n",
+                    historyFile, e.getMessage());
+            history = new MemoryHistory();
         }
         history.setAutoTrim(true);
         return history;

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestConsoleHistory.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestConsoleHistory.java
@@ -17,28 +17,23 @@ import jline.console.history.MemoryHistory;
 import jline.console.history.PersistentHistory;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Method;
+import java.io.File;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 
 public class TestConsoleHistory
 {
-    private static Object invokeGetHistory() throws Exception
-    {
-        final Method declaredMethod = Console.class.getDeclaredMethod("getHistory");
-        declaredMethod.setAccessible(true);
-        return declaredMethod.invoke(null);
-    }
 
     @Test
     public void testNonExistingHomeFolder() throws Exception
     {
-        System.setProperty("user.home", "/?");
-        final Object result = invokeGetHistory();
+        final File historyFile = new File("/?", ".history");
+        assertFalse(historyFile.canRead(), "shouldn't read invalid location");
+        assertFalse(historyFile.canWrite(), "shouldn't write invalid location");
+        MemoryHistory result = Console.getHistory(historyFile);
         assertNotNull(result, "result is null");
-        final MemoryHistory history = (MemoryHistory) result;
-        history.add("foo foo");
-        assertFalse(history instanceof PersistentHistory, "must not be PersistentHistory");
+        result.add("foo foo");
+        assertFalse(result instanceof PersistentHistory, "must not be PersistentHistory");
     }
 }

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestConsoleHistory.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestConsoleHistory.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertNotNull;
 
 public class TestConsoleHistory
 {
-
     @Test
     public void testNonExistingHomeFolder() throws Exception
     {

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestConsoleHistory.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestConsoleHistory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import jline.console.history.MemoryHistory;
+import jline.console.history.PersistentHistory;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+
+public class TestConsoleHistory
+{
+    private static Object invokeGetHistory() throws Exception
+    {
+        final Method declaredMethod = Console.class.getDeclaredMethod("getHistory");
+        declaredMethod.setAccessible(true);
+        return declaredMethod.invoke(null);
+    }
+
+    @Test
+    public void testNonExistingHomeFolder() throws Exception
+    {
+        System.setProperty("user.home", "/?");
+        final Object result = invokeGetHistory();
+        assertNotNull(result, "result is null");
+        final MemoryHistory history = (MemoryHistory) result;
+        history.add("foo foo");
+        assertFalse(history instanceof PersistentHistory, "must not be PersistentHistory");
+    }
+}


### PR DESCRIPTION
This addresses the issue described in https://github.com/prestodb/presto/issues/10083

When the history file path isn't readable/writeable - jline lib will fail with `IOException` which will cause the CLI to exit. This adds better handling of the described scenario.