### PR TITLE
Histogram remove inner classes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/GroupedTypedHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/GroupedTypedHistogram.java
@@ -146,13 +146,6 @@ public class GroupedTypedHistogram
     @Override
     public long getEstimatedSize()
     {
-//        private final LongBigArray counts;
-//        private final LongBigArray groupIds;
-//        private final IntBigArray nextPointers;
-//        private final IntBigArray valuePositions;
-//        private final LongBigArray valueAndGroupHashes;
-//        private final LongBigArray headPointers;
-//        private IntBigArray buckets;
         return INSTANCE_SIZE
                 + counts.sizeOf()
                 + groupIds.sizeOf()
@@ -161,7 +154,6 @@ public class GroupedTypedHistogram
                 + valueAndGroupHashes.sizeOf()
                 + headPointers.sizeOf()
                 + valueStore.getEstimatedSize();
-
     }
 
     @Override
@@ -505,7 +497,7 @@ public class GroupedTypedHistogram
         {
             long existingGroupId = groupIds.get(nodePointer);
 
-            return existingGroupId == groupId && type.equalTo(block, position, values, valuePosition);
+            return existingGroupId == groupId && type.equalTo(block, position, valueStore.getValues(), valuePosition);
         }
 
         private ValueNode createValueNode(int nodePointer)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/ValueStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/ValueStore.java
@@ -159,7 +159,11 @@ public class ValueStore
 
     public long getEstimatedSize()
     {
-        return INSTANCE_SIZE + buckets.sizeOf();
+        return INSTANCE_SIZE + buckets.sizeOf() + values.getRetainedSizeInBytes();
+    }
+
+    BlockBuilder getValues() {
+        return values;
     }
 
     private int nextProbe(int probe)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/ValueStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/ValueStore.java
@@ -37,7 +37,7 @@ import static com.google.common.base.Preconditions.checkState;
  * <p>
  * Note it assumes you're storing # -> Value (Type, Block, position, or the result of the ) somewhere else
  */
-public class ValueStore
+class ValueStore
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedTypedHistogram.class).instanceSize();
     private static final float MAX_FILL_RATIO = 0.5f;
@@ -52,8 +52,9 @@ public class ValueStore
     private int maxFill;
 
     @VisibleForTesting
-    public ValueStore(int expectedSize, BlockBuilder values)
+    ValueStore(int expectedSize, BlockBuilder values)
     {
+        // which will be a power of 2
         bucketCount = computeBucketCount(expectedSize, MAX_FILL_RATIO);
         mask = bucketCount - 1;
         maxFill = calculateMaxFill(bucketCount, MAX_FILL_RATIO);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkGroupedTypedHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkGroupedTypedHistogram.java
@@ -66,9 +66,15 @@ public class BenchmarkGroupedTypedHistogram
     @State(Scope.Thread)
     public static class Data
     {
+<<<<<<< HEAD
         @Param({"10000"}) // larger groups => worse perf for NEW as it's more costly to track a group than with LEGACY. Tweak based on what you want to measure
         private int numGroups;
         @Param({"5000"}) // makes sure legacy impl isn't doing trivial work
+=======
+        @Param({"20000"}) // we target case with larger # of groups
+        private int numGroups;
+        @Param({"1500"}) // makes sure legacy impl isn't doing trivial work
+>>>>>>> Improve perf
         private int rowCount;
         //        @Param({"0.0", "0.1", ".25", "0.50", ".75", "1.0"})
         @Param({"0.1"}) // somewhat arbitrary guess, we don't know this


### PR DESCRIPTION
Removes nested inner classes and replaces with instance method calls
or static method calls where possible.

Other minor cleanup of stale comments was done, and a minor
optimization in rehash was found avoiding an array lookup).

Overall, one should find that inner class methods were moved to
instance/static methods with any members as params. The pattern
was repeated, but the heart of the add() flow is the same, and
can be followed down processAdd() instead of the old flow
with bucketNode.