### PR TITLE
Add trace token support to scheduler and exchange HTTP clients

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -215,6 +215,7 @@ public class CoordinatorModule
 
         httpClientBinder(binder).bindHttpClient("scheduler", ForScheduler.class)
                 .withTracing()
+                .withFilter(GenerateTraceTokenRequestFilter.class)
                 .withConfigDefaults(config -> {
                     config.setIdleTimeout(new Duration(30, SECONDS));
                     config.setRequestTimeout(new Duration(10, SECONDS));

--- a/presto-main/src/main/java/com/facebook/presto/server/GenerateTraceTokenRequestFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/GenerateTraceTokenRequestFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.http.client.HttpRequestFilter;
+import io.airlift.http.client.Request;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.airlift.http.client.Request.Builder.fromRequest;
+import static io.airlift.http.client.TraceTokenRequestFilter.TRACETOKEN_HEADER;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+
+public class GenerateTraceTokenRequestFilter
+        implements HttpRequestFilter
+{
+    private final String prefix = randomUUID().toString().toLowerCase(ENGLISH).replace("-", "");
+    private final AtomicLong sequence = new AtomicLong();
+
+    @Override
+    public Request filterRequest(Request request)
+    {
+        requireNonNull(request, "request is null");
+        String newToken = createToken(sequence.getAndIncrement());
+        return fromRequest(request)
+                .setHeader(TRACETOKEN_HEADER, newToken)
+                .build();
+    }
+
+    private String createToken(long value)
+    {
+        return prefix + format("%010x", value);
+    }
+
+    @VisibleForTesting
+    String getLastToken()
+    {
+        long value = sequence.get();
+        return createToken(value - 1);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -352,6 +352,7 @@ public class ServerMainModule
         binder.bind(new TypeLiteral<ExchangeClientSupplier>() {}).to(ExchangeClientFactory.class).in(Scopes.SINGLETON);
         httpClientBinder(binder).bindHttpClient("exchange", ForExchange.class)
                 .withTracing()
+                .withFilter(GenerateTraceTokenRequestFilter.class)
                 .withConfigDefaults(config -> {
                     config.setIdleTimeout(new Duration(30, SECONDS));
                     config.setRequestTimeout(new Duration(10, SECONDS));

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -50,6 +50,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import com.google.inject.Injector;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
@@ -98,6 +99,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class TestingPrestoServer
         implements Closeable
 {
+    private final Injector injector;
     private final Path baseDataDir;
     private final LifeCycleManager lifeCycleManager;
     private final PluginManager pluginManager;
@@ -236,7 +238,7 @@ public class TestingPrestoServer
             optionalProperties.put("node.environment", environment);
         }
 
-        Injector injector = app
+        injector = app
                 .strictConfig()
                 .doNotInitializeLogging()
                 .setRequiredConfigurationProperties(serverProperties.build())
@@ -432,6 +434,11 @@ public class TestingPrestoServer
     public Set<Node> getActiveNodesWithConnector(ConnectorId connectorId)
     {
         return nodeManager.getActiveConnectorNodes(connectorId);
+    }
+
+    public <T> T getInstance(Key<T> key)
+    {
+        return injector.getInstance(key);
     }
 
     private static void updateConnectorIdAnnouncement(Announcer announcer, ConnectorId connectorId)

--- a/presto-main/src/test/java/com/facebook/presto/server/TestGenerateTokenFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestGenerateTokenFilter.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpRequestFilter;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler.StringResponse;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.inject.Qualifier;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.airlift.http.client.TraceTokenRequestFilter.TRACETOKEN_HEADER;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.airlift.testing.Assertions.assertInstanceOf;
+import static io.airlift.testing.Closeables.closeQuietly;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestGenerateTokenFilter
+{
+    private JettyHttpClient httpClient;
+    private TestingPrestoServer server;
+    private GenerateTraceTokenRequestFilter filter;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        server = new TestingPrestoServer(ImmutableList.of(new TestGenerateTokenFilterModule()));
+        httpClient = (JettyHttpClient) server.getInstance(Key.get(HttpClient.class, GenerateTokenFilterTest.class));
+
+        // extract the filter
+        List<HttpRequestFilter> filters = httpClient.getRequestFilters();
+        assertEquals(filters.size(), 2);
+        assertInstanceOf(filters.get(1), GenerateTraceTokenRequestFilter.class);
+        filter = (GenerateTraceTokenRequestFilter) filters.get(1);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeQuietly(server);
+        closeQuietly(httpClient);
+    }
+
+    @Test
+    public void testTraceToken()
+    {
+        Request request = prepareGet().setUri(server.getBaseUrl().resolve("/testing/echo_token")).build();
+        StringResponse response = httpClient.execute(request, createStringResponseHandler());
+        assertEquals(response.getStatusCode(), SC_OK);
+        assertEquals(response.getBody(), filter.getLastToken());
+    }
+
+    @Retention(RUNTIME)
+    @Target(ElementType.PARAMETER)
+    @Qualifier
+    private @interface GenerateTokenFilterTest {}
+
+    @Path("/testing")
+    public static class TestResource
+    {
+        @GET
+        @Path("/echo_token")
+        public String echoToken(@HeaderParam(TRACETOKEN_HEADER) String token)
+        {
+            return token;
+        }
+    }
+
+    static class TestGenerateTokenFilterModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            jaxrsBinder(binder).bind(TestResource.class);
+            httpClientBinder(binder)
+                    .bindHttpClient("test", GenerateTokenFilterTest.class)
+                    .withTracing()
+                    .withFilter(GenerateTraceTokenRequestFilter.class);
+        }
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/airlift/airlift/pull/616.

`GenerateTraceTokenRequestFilter` doesn't extend or use `TraceTokenManager` in order not to mess with the thread locals. It uses the same approach to generate the tokens.

Also validated with the HTTP client/server logs locally.