### PR TITLE
Add csv output option without quotes

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -113,7 +113,7 @@ public class ClientOptions
     @Option(name = "--execute", title = "execute", description = "Execute specified statements and exit")
     public String execute;
 
-    @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode [ALIGNED, VERTICAL, CSV, TSV, CSV_HEADER, TSV_HEADER, NULL] (default: CSV)")
+    @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode [ALIGNED, VERTICAL, CSV, TSV, CSV_HEADER, TSV_HEADER, CSV_WITHOUT_QUOTES, CSV_HEADER_WITHOUT_QUOTES, NULL] (default: CSV)")
     public OutputFormat outputFormat = OutputFormat.CSV;
 
     @Option(name = "--session", title = "session", description = "Session property (property can be used multiple times; format is key=value; use 'SHOW SESSION' to see available properties)")
@@ -138,7 +138,9 @@ public class ClientOptions
         CSV,
         TSV,
         CSV_HEADER,
+        CSV_WITHOUT_QUOTES,
         TSV_HEADER,
+        CSV_HEADER_WITHOUT_QUOTES,
         NULL
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/CsvPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/CsvPrinter.java
@@ -31,12 +31,12 @@ public class CsvPrinter
 
     private boolean needHeader;
 
-    public CsvPrinter(List<String> fieldNames, Writer writer, boolean header)
+    public CsvPrinter(List<String> fieldNames, Writer writer, char quote, boolean header)
     {
         requireNonNull(fieldNames, "fieldNames is null");
         requireNonNull(writer, "writer is null");
         this.fieldNames = ImmutableList.copyOf(fieldNames);
-        this.writer = new CSVWriter(writer);
+        this.writer = new CSVWriter(writer, ',', quote);
         this.needHeader = header;
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -275,9 +275,13 @@ public class Query
             case VERTICAL:
                 return new VerticalRecordPrinter(fieldNames, writer);
             case CSV:
-                return new CsvPrinter(fieldNames, writer, false);
+                return new CsvPrinter(fieldNames, writer, '"', false);
             case CSV_HEADER:
-                return new CsvPrinter(fieldNames, writer, true);
+                return new CsvPrinter(fieldNames, writer, '"', true);
+            case CSV_WITHOUT_QUOTES:
+                return new CsvPrinter(fieldNames, writer, '\u0000', false);
+            case CSV_HEADER_WITHOUT_QUOTES:
+                return new CsvPrinter(fieldNames, writer, '\u0000', true);
             case TSV:
                 return new TsvPrinter(fieldNames, writer, false);
             case TSV_HEADER:

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestCsvPrinter.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestCsvPrinter.java
@@ -32,7 +32,7 @@ public class TestCsvPrinter
     {
         StringWriter writer = new StringWriter();
         List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
-        OutputPrinter printer = new CsvPrinter(fieldNames, writer, true);
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, '"', true);
 
         printer.printRows(rows(
                 row("hello", "world", 123),
@@ -63,7 +63,7 @@ public class TestCsvPrinter
     {
         StringWriter writer = new StringWriter();
         List<String> fieldNames = ImmutableList.of("first", "last");
-        OutputPrinter printer = new CsvPrinter(fieldNames, writer, true);
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, '"', true);
 
         printer.finish();
 
@@ -76,7 +76,7 @@ public class TestCsvPrinter
     {
         StringWriter writer = new StringWriter();
         List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
-        OutputPrinter printer = new CsvPrinter(fieldNames, writer, false);
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, '"', false);
 
         printer.printRows(rows(
                 row("hello", "world", 123),
@@ -92,12 +92,46 @@ public class TestCsvPrinter
     }
 
     @Test
+    public void testCsvPrintingNoRowsWithoutQuotes()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last");
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, '\u0000', true);
+
+        printer.finish();
+
+        assertEquals(writer.getBuffer().toString(), "first,last\n");
+    }
+
+    @Test
+    public void testCsvPrintingNoHeaderWithoutQuotes()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, '\u0000', false);
+
+        printer.printRows(rows(
+                row("hello", "world", 123),
+                row("a", null, 4.5)),
+                true);
+        printer.finish();
+
+        String expected = "" +
+                "hello,world,123\n" +
+                "a,,4.5\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
     public void testCsvVarbinaryPrinting()
             throws IOException
     {
         StringWriter writer = new StringWriter();
         List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
-        OutputPrinter printer = new CsvPrinter(fieldNames, writer, false);
+        OutputPrinter printer = new CsvPrinter(fieldNames, writer, '"', false);
 
         printer.printRows(rows(row("hello".getBytes(), null, 123)), true);
         printer.finish();


### PR DESCRIPTION
#8845 

Add CSV_WITHOUT_QUOTES and CSV_HEADER_WITHOUT_QUOTES
```
$ presto-cli-0.197-SNAPSHOT-executable.jar -f select.txt --output-format CSV_WITHOUT_QUOTES
1,1,1
$ 
$ presto-cli-0.197-SNAPSHOT-executable.jar -f select.txt --output-format CSV_HEADER_WITHOUT_QUOTES
c1,c2,c3
1,1,1
```