### PR TITLE
Added support for skipping of stripe based on TimestampStatistics

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -518,7 +518,7 @@ public class OrcWriteValidation
             ImmutableList.Builder<ColumnStatistics> statisticsBuilders = ImmutableList.builder();
             // if there are no rows, there will be no stats
             if (rowCount > 0) {
-                statisticsBuilders.add(new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null));
+                statisticsBuilders.add(new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null));
                 columnStatisticsValidations.forEach(validation -> validation.build(statisticsBuilders));
             }
             return statisticsBuilders.build();
@@ -676,7 +676,7 @@ public class OrcWriteValidation
         @Override
         public ColumnStatistics buildColumnStatistics()
         {
-            return new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null);
+            return new ColumnStatistics(rowCount, 0, null, null, null, null, null, null, null, null, null);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -337,7 +337,7 @@ public class OrcWriter
 
         // the 0th column is a struct column for the whole row
         columnEncodings.put(0, new ColumnEncoding(DIRECT, 0));
-        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, 0, null, null, null, null, null, null, null, null));
+        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, 0, null, null, null, null, null, null, null, null, null));
 
         StripeFooter stripeFooter = new StripeFooter(allStreams, toDenseList(columnEncodings, orcTypes.size()));
         int footerLength = metadataWriter.writeStripeFooter(output, stripeFooter);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
@@ -225,6 +225,9 @@ public class TupleDomainOrcPredicate<C>
         else if (type.getTypeSignature().getBase().equals(StandardTypes.DATE) && columnStatistics.getDateStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getDateStatistics(), value -> (long) value);
         }
+        else if (type.getTypeSignature().getBase().equals(StandardTypes.TIMESTAMP) && columnStatistics.getTimestampStatistics() != null) {
+            return createDomain(type, hasNullValue, columnStatistics.getTimestampStatistics());
+        }
         else if (type.getJavaType() == long.class && columnStatistics.getIntegerStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getIntegerStatistics());
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -245,6 +245,7 @@ public class DwrfMetadataReader
                 toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup),
                 null,
                 null,
+                null,
                 toBinaryStatistics(statistics.getBinaryStatistics()),
                 null);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -27,6 +27,7 @@ import com.facebook.presto.orc.metadata.statistics.HiveBloomFilter;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
 import com.facebook.presto.orc.metadata.statistics.StringStatistics;
 import com.facebook.presto.orc.metadata.statistics.StripeStatistics;
+import com.facebook.presto.orc.metadata.statistics.TimestampStatistics;
 import com.facebook.presto.orc.proto.OrcProto;
 import com.facebook.presto.orc.proto.OrcProto.RowIndexEntry;
 import com.facebook.presto.orc.protobuf.ByteString;
@@ -271,6 +272,7 @@ public class OrcMetadataReader
                 toDoubleStatistics(statistics.getDoubleStatistics()),
                 toStringStatistics(hiveWriterVersion, statistics.getStringStatistics(), isRowGroup),
                 toDateStatistics(hiveWriterVersion, statistics.getDateStatistics(), isRowGroup),
+                toTimestampStatistics(hiveWriterVersion, statistics.getTimestampStatistics(), isRowGroup),
                 toDecimalStatistics(statistics.getDecimalStatistics()),
                 toBinaryStatistics(statistics.getBinaryStatistics()),
                 null);
@@ -479,6 +481,21 @@ public class OrcMetadataReader
         return new DateStatistics(
                 dateStatistics.hasMinimum() ? dateStatistics.getMinimum() : null,
                 dateStatistics.hasMaximum() ? dateStatistics.getMaximum() : null);
+    }
+
+    private static TimestampStatistics toTimestampStatistics(HiveWriterVersion hiveWriterVersion, OrcProto.TimestampStatistics timestampStatistics, boolean isRowGroup)
+    {
+        if (hiveWriterVersion == ORIGINAL && !isRowGroup) {
+            return null;
+        }
+
+        if (!timestampStatistics.hasMinimum() && !timestampStatistics.hasMaximum()) {
+            return null;
+        }
+
+        return new TimestampStatistics(
+                timestampStatistics.hasMinimum() ? timestampStatistics.getMinimum() : null,
+                timestampStatistics.hasMaximum() ? timestampStatistics.getMaximum() : null);
     }
 
     private static OrcType toType(OrcProto.Type type)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
@@ -67,6 +67,7 @@ public class BinaryStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 binaryStatistics.orElse(null),
                 null);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -76,6 +76,7 @@ public class BooleanStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
@@ -23,6 +23,7 @@ import static com.facebook.presto.orc.metadata.statistics.DoubleStatisticsBuilde
 import static com.facebook.presto.orc.metadata.statistics.IntegerStatisticsBuilder.mergeIntegerStatistics;
 import static com.facebook.presto.orc.metadata.statistics.LongDecimalStatisticsBuilder.mergeDecimalStatistics;
 import static com.facebook.presto.orc.metadata.statistics.StringStatisticsBuilder.mergeStringStatistics;
+import static com.facebook.presto.orc.metadata.statistics.TimestampStatisticsBuilder.mergeTimestampStatistics;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ColumnStatistics
@@ -34,6 +35,7 @@ public class ColumnStatistics
     private final DoubleStatistics doubleStatistics;
     private final StringStatistics stringStatistics;
     private final DateStatistics dateStatistics;
+    private final TimestampStatistics timestampStatistics;
     private final DecimalStatistics decimalStatistics;
     private final BinaryStatistics binaryStatistics;
     private final HiveBloomFilter bloomFilter;
@@ -46,6 +48,7 @@ public class ColumnStatistics
             DoubleStatistics doubleStatistics,
             StringStatistics stringStatistics,
             DateStatistics dateStatistics,
+            TimestampStatistics timestampStatistics,
             DecimalStatistics decimalStatistics,
             BinaryStatistics binaryStatistics,
             HiveBloomFilter bloomFilter)
@@ -57,6 +60,7 @@ public class ColumnStatistics
         this.doubleStatistics = doubleStatistics;
         this.stringStatistics = stringStatistics;
         this.dateStatistics = dateStatistics;
+        this.timestampStatistics = timestampStatistics;
         this.decimalStatistics = decimalStatistics;
         this.binaryStatistics = binaryStatistics;
         this.bloomFilter = bloomFilter;
@@ -96,6 +100,11 @@ public class ColumnStatistics
     public DateStatistics getDateStatistics()
     {
         return dateStatistics;
+    }
+
+    public TimestampStatistics getTimestampStatistics()
+    {
+        return timestampStatistics;
     }
 
     public DoubleStatistics getDoubleStatistics()
@@ -138,6 +147,7 @@ public class ColumnStatistics
                 doubleStatistics,
                 stringStatistics,
                 dateStatistics,
+                timestampStatistics,
                 decimalStatistics,
                 binaryStatistics,
                 bloomFilter);
@@ -159,6 +169,7 @@ public class ColumnStatistics
                 Objects.equals(doubleStatistics, that.doubleStatistics) &&
                 Objects.equals(stringStatistics, that.stringStatistics) &&
                 Objects.equals(dateStatistics, that.dateStatistics) &&
+                Objects.equals(timestampStatistics, that.timestampStatistics) &&
                 Objects.equals(decimalStatistics, that.decimalStatistics) &&
                 Objects.equals(bloomFilter, that.bloomFilter);
     }
@@ -180,6 +191,7 @@ public class ColumnStatistics
                 .add("doubleStatistics", doubleStatistics)
                 .add("stringStatistics", stringStatistics)
                 .add("dateStatistics", dateStatistics)
+                .add("timestampStatistics", timestampStatistics)
                 .add("decimalStatistics", decimalStatistics)
                 .add("bloomFilter", bloomFilter)
                 .toString();
@@ -206,6 +218,7 @@ public class ColumnStatistics
                 mergeDoubleStatistics(stats).orElse(null),
                 mergeStringStatistics(stats).orElse(null),
                 mergeDateStatistics(stats).orElse(null),
+                mergeTimestampStatistics(stats).orElse(null),
                 mergeDecimalStatistics(stats).orElse(null),
                 mergeBinaryStatistics(stats).orElse(null),
                 null);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
@@ -70,6 +70,7 @@ public class DateStatisticsBuilder
                 dateStatistics.orElse(null),
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -94,6 +94,7 @@ public class DoubleStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -100,6 +100,7 @@ public class LongDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 decimalStatistics.orElse(null),
                 null,
                 null);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -66,6 +66,7 @@ public class ShortDecimalStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 decimalStatistics.orElse(null),
                 null,
                 null);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -95,6 +95,7 @@ public class StringStatisticsBuilder
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatistics.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class TimestampStatistics
         implements RangeStatistics<Long>
 {
-    // 1 byte to denote if null + 4 bytes for the value (date is of integer type)
+    // 1 byte to denote if null + 8 bytes for the value (timestamp is of long type)
     public static final long TIMESTAMP_VALUE_BYTES = Byte.BYTES + Long.BYTES;
 
     private final Long minimum;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatistics.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class TimestampStatistics
+        implements RangeStatistics<Long>
+{
+    // 1 byte to denote if null + 4 bytes for the value (date is of integer type)
+    public static final long TIMESTAMP_VALUE_BYTES = Byte.BYTES + Long.BYTES;
+
+    private final Long minimum;
+    private final Long maximum;
+
+    public TimestampStatistics(Long minimum, Long maximum)
+    {
+        checkArgument(minimum == null || maximum == null || minimum <= maximum, "minimum is not less than maximum");
+        this.minimum = minimum;
+        this.maximum = maximum;
+    }
+
+    @Override
+    public Long getMin()
+    {
+        return minimum;
+    }
+
+    @Override
+    public Long getMax()
+    {
+        return maximum;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TimestampStatistics that = (TimestampStatistics) o;
+        return Objects.equals(minimum, that.minimum) &&
+                Objects.equals(maximum, that.maximum);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(minimum, maximum);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("min", minimum)
+                .add("max", maximum)
+                .toString();
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/TimestampStatisticsBuilder.java
@@ -57,16 +57,16 @@ public class TimestampStatisticsBuilder
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
-        Optional<TimestampStatistics> dateStatistics = buildTimestampStatistics();
+        Optional<TimestampStatistics> timestampStatistics = buildTimestampStatistics();
         return new ColumnStatistics(
                 nonNullValueCount,
-                dateStatistics.map(s -> TIMESTAMP_VALUE_BYTES).orElse(0L),
+                timestampStatistics.map(s -> TIMESTAMP_VALUE_BYTES).orElse(0L),
                 null,
                 null,
                 null,
                 null,
                 null,
-                dateStatistics.orElse(null),
+                timestampStatistics.orElse(null),
                 null,
                 null,
                 null);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -109,7 +109,7 @@ public class ByteColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
         return ImmutableMap.of(column, statistics);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriters.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriters.java
@@ -19,6 +19,7 @@ import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.statistics.BinaryStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.DateStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatisticsBuilder;
+import com.facebook.presto.orc.metadata.statistics.TimestampStatisticsBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTimeZone;
@@ -71,7 +72,7 @@ public final class ColumnWriters
                 return new DecimalColumnWriter(columnIndex, type, compression, bufferSize, orcEncoding);
 
             case TIMESTAMP:
-                return new TimestampColumnWriter(columnIndex, type, compression, bufferSize, orcEncoding, hiveStorageTimeZone);
+                return new TimestampColumnWriter(columnIndex, type, compression, bufferSize, orcEncoding, hiveStorageTimeZone, TimestampStatisticsBuilder::new);
 
             case BINARY:
                 return new SliceDirectColumnWriter(columnIndex, type, compression, bufferSize, orcEncoding, BinaryStatisticsBuilder::new);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -138,7 +138,7 @@ public class ListColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -145,7 +145,7 @@ public class MapColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -135,7 +135,7 @@ public class StructColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
         nonNullValueCount = 0;
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
@@ -292,6 +292,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 toHiveBloomFilter(orcBloomFilter)));
 
         Map<Integer, ColumnStatistics> nonMatchingStatisticsByColumnIndex = ImmutableMap.of(0, new ColumnStatistics(
@@ -304,6 +305,7 @@ public class TestOrcBloomFilters
                 null,
                 null,
                 null,
+                null,
                 toHiveBloomFilter(emptyOrcBloomFilter)));
 
         Map<Integer, ColumnStatistics> withoutBloomFilterStatisticsByColumnIndex = ImmutableMap.of(0, new ColumnStatistics(
@@ -311,6 +313,7 @@ public class TestOrcBloomFilters
                 0,
                 null,
                 new IntegerStatistics(10L, 2000L, null),
+                null,
                 null,
                 null,
                 null,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -21,6 +21,7 @@ import com.facebook.presto.orc.metadata.statistics.DecimalStatistics;
 import com.facebook.presto.orc.metadata.statistics.DoubleStatistics;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
 import com.facebook.presto.orc.metadata.statistics.StringStatistics;
+import com.facebook.presto.orc.metadata.statistics.TimestampStatistics;
 import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.Type;
@@ -47,6 +48,7 @@ import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -87,7 +89,7 @@ public class TestTupleDomainOrcPredicate
         if (trueValueCount != null) {
             booleanStatistics = new BooleanStatistics(trueValueCount);
         }
-        return new ColumnStatistics(numberOfValues, 2L, booleanStatistics, null, null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 2L, booleanStatistics, null, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -116,7 +118,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics integerColumnStats(Long numberOfValues, Long minimum, Long maximum)
     {
-        return new ColumnStatistics(numberOfValues, 9L, null, new IntegerStatistics(minimum, maximum, null), null, null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, new IntegerStatistics(minimum, maximum, null), null, null, null, null, null, null, null);
     }
 
     @Test
@@ -145,7 +147,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics doubleColumnStats(Long numberOfValues, Double minimum, Double maximum)
     {
-        return new ColumnStatistics(numberOfValues, 9L, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, null, new DoubleStatistics(minimum, maximum), null, null, null, null, null, null);
     }
 
     @Test
@@ -235,7 +237,7 @@ public class TestTupleDomainOrcPredicate
         Slice minimumSlice = minimum == null ? null : utf8Slice(minimum);
         Slice maximumSlice = maximum == null ? null : utf8Slice(maximum);
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new ColumnStatistics(numberOfValues, 10L, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L), null, null, null, null);
+        return new ColumnStatistics(numberOfValues, 10L, null, null, null, new StringStatistics(minimumSlice, maximumSlice, 100L), null, null, null, null, null);
     }
 
     @Test
@@ -264,7 +266,36 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics dateColumnStats(Long numberOfValues, Integer minimum, Integer maximum)
     {
-        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null);
+        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, new DateStatistics(minimum, maximum), null, null, null, null);
+    }
+
+    @Test
+    public void testTimestamp()
+    {
+        assertEquals(getDomain(TIMESTAMP, 0, null), none(TIMESTAMP));
+        assertEquals(getDomain(TIMESTAMP, 10, null), all(TIMESTAMP));
+
+        assertEquals(getDomain(TIMESTAMP, 0, timestampColumnStats(null, null, null)), none(TIMESTAMP));
+        assertEquals(getDomain(TIMESTAMP, 0, timestampColumnStats(0L, null, null)), none(TIMESTAMP));
+        assertEquals(getDomain(TIMESTAMP, 0, timestampColumnStats(0L, 100L, 100L)), none(TIMESTAMP));
+
+        assertEquals(getDomain(TIMESTAMP, 10, timestampColumnStats(0L, null, null)), onlyNull(TIMESTAMP));
+        assertEquals(getDomain(TIMESTAMP, 10, timestampColumnStats(10L, null, null)), notNull(TIMESTAMP));
+
+        assertEquals(getDomain(TIMESTAMP, 10, timestampColumnStats(10L, 100L, 100L)), singleValue(TIMESTAMP, 100L));
+
+        assertEquals(getDomain(TIMESTAMP, 10, timestampColumnStats(10L, 0L, 100L)), create(ValueSet.ofRanges(range(TIMESTAMP, 0L, true, 100L, true)), false));
+        assertEquals(getDomain(TIMESTAMP, 10, timestampColumnStats(10L, null, 100L)), create(ValueSet.ofRanges(lessThanOrEqual(TIMESTAMP, 100L)), false));
+        assertEquals(getDomain(TIMESTAMP, 10, timestampColumnStats(10L, 0L, null)), create(ValueSet.ofRanges(greaterThanOrEqual(TIMESTAMP, 0L)), false));
+
+        assertEquals(getDomain(TIMESTAMP, 10, timestampColumnStats(5L, 0L, 100L)), create(ValueSet.ofRanges(range(TIMESTAMP, 0L, true, 100L, true)), true));
+        assertEquals(getDomain(TIMESTAMP, 10, timestampColumnStats(5L, null, 100L)), create(ValueSet.ofRanges(lessThanOrEqual(TIMESTAMP, 100L)), true));
+        assertEquals(getDomain(TIMESTAMP, 10, timestampColumnStats(5L, 0L, null)), create(ValueSet.ofRanges(greaterThanOrEqual(TIMESTAMP, 0L)), true));
+    }
+
+    private static ColumnStatistics timestampColumnStats(Long numberOfValues, Long minimum, Long maximum)
+    {
+        return new ColumnStatistics(numberOfValues, 5L, null, null, null, null, null, new TimestampStatistics(minimum, maximum), null, null, null);
     }
 
     @Test
@@ -320,7 +351,7 @@ public class TestTupleDomainOrcPredicate
     {
         BigDecimal minimumDecimal = minimum == null ? null : new BigDecimal(minimum);
         BigDecimal maximumDecimal = maximum == null ? null : new BigDecimal(maximum);
-        return new ColumnStatistics(numberOfValues, 9L, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal), null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal), null, null);
     }
 
     @Test
@@ -342,7 +373,7 @@ public class TestTupleDomainOrcPredicate
     private static ColumnStatistics binaryColumnStats(Long numberOfValues)
     {
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new ColumnStatistics(numberOfValues, 10L, null, null, null, null, null, null, new BinaryStatistics(100L), null);
+        return new ColumnStatistics(numberOfValues, 10L, null, null, null, null, null, null, null, new BinaryStatistics(100L), null);
     }
 
     private static Long shortDecimal(String value)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
 {
     public enum StatisticsType
     {
-        NONE, BOOLEAN, INTEGER, DOUBLE, STRING, DATE, DECIMAL
+        NONE, BOOLEAN, INTEGER, DOUBLE, STRING, DATE, DECIMAL, TIMESTAMP
     }
 
     private final StatisticsType statisticsType;
@@ -171,7 +171,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
     static List<ColumnStatistics> insertEmptyColumnStatisticsAt(List<ColumnStatistics> statisticsList, int index, long numberOfValues)
     {
         List<ColumnStatistics> newStatisticsList = new ArrayList<>(statisticsList);
-        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, 0, null, null, null, null, null, null, null, null));
+        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, 0, null, null, null, null, null, null, null, null, null));
         return newStatisticsList;
     }
 
@@ -212,6 +212,13 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
         }
         else {
             assertNull(columnStatistics.getDateStatistics());
+        }
+
+        if (statisticsType == StatisticsType.TIMESTAMP && expectedNumberOfValues > 0) {
+            assertRangeStatistics(columnStatistics.getTimestampStatistics(), expectedMin, expectedMax);
+        }
+        else {
+            assertNull(columnStatistics.getTimestampStatistics());
         }
 
         if (statisticsType == StatisticsType.DECIMAL && expectedNumberOfValues > 0) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestTimestampStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestTimestampStatistics.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import org.testng.annotations.Test;
+
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
+
+public class TestTimestampStatistics
+        extends AbstractRangeStatisticsTest<TimestampStatistics, Long>
+{
+    @Override
+    protected TimestampStatistics getCreateStatistics(Long min, Long max)
+    {
+        return new TimestampStatistics(min, max);
+    }
+
+    @Test
+    public void test()
+    {
+        assertMinMax(0L, 42L);
+        assertMinMax(42L, 42L);
+        assertMinMax(MIN_VALUE, 42L);
+        assertMinMax(42L, MAX_VALUE);
+        assertMinMax(MIN_VALUE, MAX_VALUE);
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestTimestampStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestTimestampStatisticsBuilder.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Range;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.TIMESTAMP;
+import static com.facebook.presto.orc.metadata.statistics.TimestampStatistics.TIMESTAMP_VALUE_BYTES;
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
+import static org.testng.Assert.fail;
+
+public class TestTimestampStatisticsBuilder
+        extends AbstractStatisticsBuilderTest<TimestampStatisticsBuilder, Long>
+{
+    public TestTimestampStatisticsBuilder()
+    {
+        super(TIMESTAMP, TimestampStatisticsBuilder::new, TimestampStatisticsBuilder::addValue);
+    }
+
+    @Test
+    public void testMinMaxValues()
+    {
+        assertMinMaxValues(0L, 0L);
+        assertMinMaxValues(42L, 42L);
+        assertMinMaxValues(MIN_VALUE, MIN_VALUE);
+        assertMinMaxValues(MAX_VALUE, MAX_VALUE);
+
+        assertMinMaxValues(0L, 42L);
+        assertMinMaxValues(42L, 42L);
+        assertMinMaxValues(MIN_VALUE, 42L);
+        assertMinMaxValues(42L, MAX_VALUE);
+        assertMinMaxValues(MIN_VALUE, MAX_VALUE);
+
+        assertValues(-42L, 0L, ContiguousSet.create(Range.closed(-42L, 0L), DiscreteDomain.longs()).asList());
+        assertValues(-42L, 42L, ContiguousSet.create(Range.closed(-42L, 42L), DiscreteDomain.longs()).asList());
+        assertValues(0L, 42L, ContiguousSet.create(Range.closed(0L, 42L), DiscreteDomain.longs()).asList());
+        assertValues(MIN_VALUE, MIN_VALUE + 42, ContiguousSet.create(Range.closed(MIN_VALUE, MIN_VALUE + 42), DiscreteDomain.longs()).asList());
+        assertValues(MAX_VALUE - 42, MAX_VALUE, ContiguousSet.create(Range.closed(MAX_VALUE - 42, MAX_VALUE), DiscreteDomain.longs()).asList());
+    }
+
+    @Test
+    public void testValueOutOfRange()
+    {
+        try {
+            new DateStatisticsBuilder().addValue(MAX_VALUE + 1L);
+            fail("Expected ArithmeticException");
+        }
+        catch (ArithmeticException expected) {
+        }
+
+        try {
+            new DateStatisticsBuilder().addValue(MIN_VALUE - 1L);
+            fail("Expected ArithmeticException");
+        }
+        catch (ArithmeticException expected) {
+        }
+    }
+
+    @Test
+    public void testMinAverageValueBytes()
+    {
+        assertMinAverageValueBytes(0L, ImmutableList.of());
+        assertMinAverageValueBytes(TIMESTAMP_VALUE_BYTES, ImmutableList.of(42L));
+        assertMinAverageValueBytes(TIMESTAMP_VALUE_BYTES, ImmutableList.of(0L));
+        assertMinAverageValueBytes(TIMESTAMP_VALUE_BYTES, ImmutableList.of(0L, 42L, 42L, 43L));
+    }
+}


### PR DESCRIPTION
Statistics of the Timestamp column is now used to determine whether a given stripe or a row group matches the filter criteria (TupleDomain). It is the follow up of #8615, #7880.