### PR TITLE
Fix username extraction sample json from built-in sys access control docs

### DIFF
--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -128,7 +128,7 @@ and Kerberos authentication:
 .. code-block:: json
 
     {
-      "catalog": [
+      "catalogs": [
         {
           "allow": true
         }


### PR DESCRIPTION
The mistyped `catalog` in the json snippet made Presto return access denied for every catalog.

Now the sample json implements an exact matching of the full principal name for LDAP and Kerberos authentication, as already described in the docs, allowing access to all the catalogs.