### PR TITLE
Add ST_IsValid and geometry_invalid_reason functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -163,6 +163,11 @@ Accessors
 
     Returns ``true`` if and only if the line is closed and simple.
 
+.. function:: ST_IsValid(Geometry) -> boolean
+
+    Returns ``true`` if and only if the input geometry is well formed.
+    Use :func:`geometry_invalid_reason` to determine why the geometry is not well formed.
+
 .. function:: ST_Length(Geometry) -> double
 
     Returns the length of a linestring or multi-linestring using Euclidean measurement on a
@@ -208,6 +213,11 @@ Accessors
 .. function:: ST_NumInteriorRing(Geometry) -> bigint
 
     Returns the cardinality of the collection of interior rings of a polygon.
+
+.. function:: geometry_invalid_reason(Geometry) -> varchar
+
+    Returns the reason for why the input geometry is not valid.
+    Returns null if the input is valid.
 
 Bing Tiles
 ----------

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -21,6 +21,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
         </dependency>

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
@@ -108,7 +108,7 @@ public final class GeometryUtils
         return n < -1.0E38D ? (0.0D / 0.0) : n;
     }
 
-    private static boolean isEsriNaN(double d)
+    public static boolean isEsriNaN(double d)
     {
         return Double.isNaN(d) || Double.isNaN(translateFromAVNaN(d));
     }

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/JtsGeometryUtils.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/JtsGeometryUtils.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial;
+
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.geospatial.GeometryUtils.isEsriNaN;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static java.util.Objects.requireNonNull;
+
+public class JtsGeometryUtils
+{
+    /**
+     * Shape type codes from ERSI's specification
+     * https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
+     */
+    private enum EsriShapeType
+    {
+        POINT(1),
+        POLYLINE(3),
+        POLYGON(5),
+        MULTI_POINT(8);
+
+        final int code;
+
+        EsriShapeType(int code)
+        {
+            this.code = code;
+        }
+
+        static EsriShapeType valueOf(int code)
+        {
+            for (EsriShapeType type : values()) {
+                if (type.code == code) {
+                    return type;
+                }
+            }
+
+            throw new IllegalArgumentException("Unsupported ESRI shape code: " + code);
+        }
+    }
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
+    private JtsGeometryUtils() {}
+
+    /**
+     * Deserializes ESRI shape as described in
+     * https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
+     * into JTS Geometry object.
+     */
+    public static Geometry deserialize(Slice shape)
+    {
+        if (shape == null) {
+            return null;
+        }
+
+        BasicSliceInput input = shape.getInput();
+        int geometryType = input.readByte();
+        if (geometryType != GeometryUtils.GeometryTypeName.GEOMETRY_COLLECTION.code()) {
+            return readGeometry(input);
+        }
+
+        if (input.available() == 0) {
+            return GEOMETRY_FACTORY.createGeometryCollection();
+        }
+
+        // GeometryCollection: geometry-type|len-of-shape1|bytes-of-shape1|len-of-shape2|bytes-of-shape2...
+        List<Geometry> geometries = new ArrayList<>();
+        while (input.available() > 0) {
+            int length = input.readInt();
+            geometries.add(readGeometry(input.readSlice(length).getInput()));
+        }
+
+        return GEOMETRY_FACTORY.createGeometryCollection(geometries.toArray(new Geometry[0]));
+    }
+
+    private static Geometry readGeometry(SliceInput input)
+    {
+        requireNonNull(input, "input is null");
+        int geometryType = input.readInt();
+        switch (EsriShapeType.valueOf(geometryType)) {
+            case POINT:
+                return readPoint(input);
+            case POLYLINE:
+                return readPolyline(input);
+            case POLYGON:
+                return readPolygon(input);
+            case MULTI_POINT:
+                return readMultiPoint(input);
+            default:
+                throw new UnsupportedOperationException("Invalid geometry type: " + geometryType);
+        }
+    }
+
+    private static Point readPoint(SliceInput input)
+    {
+        requireNonNull(input, "input is null");
+        Coordinate coordinates = readCoordinate(input);
+        if (isEsriNaN(coordinates.x) || isEsriNaN(coordinates.y)) {
+            return GEOMETRY_FACTORY.createPoint();
+        }
+        return GEOMETRY_FACTORY.createPoint(coordinates);
+    }
+
+    private static Coordinate readCoordinate(SliceInput input)
+    {
+        requireNonNull(input, "input is null");
+        return new Coordinate(input.readDouble(), input.readDouble());
+    }
+
+    private static Geometry readMultiPoint(SliceInput input)
+    {
+        requireNonNull(input, "input is null");
+        skipEnvelope(input);
+        int pointCount = input.readInt();
+        Point[] points = new Point[pointCount];
+        for (int i = 0; i < pointCount; i++) {
+            points[i] = readPoint(input);
+        }
+        return GEOMETRY_FACTORY.createMultiPoint(points);
+    }
+
+    private static Geometry readPolyline(SliceInput input)
+    {
+        requireNonNull(input, "input is null");
+        skipEnvelope(input);
+        int partCount = input.readInt();
+        if (partCount == 0) {
+            return GEOMETRY_FACTORY.createLineString();
+        }
+
+        int pointCount = input.readInt();
+        LineString[] lineStrings = new LineString[partCount];
+
+        int[] partLengths = new int[partCount];
+        input.readInt();    // skip first index; it is always 0
+        if (partCount > 1) {
+            partLengths[0] = input.readInt();
+            for (int i = 1; i < partCount - 1; i++) {
+                partLengths[i] = input.readInt() - partLengths[i - 1];
+            }
+            partLengths[partCount - 1] = pointCount - partLengths[partCount - 2];
+        }
+        else {
+            partLengths[0] = pointCount;
+        }
+
+        for (int i = 0; i < partCount; i++) {
+            lineStrings[i] = GEOMETRY_FACTORY.createLineString(readCoordinates(input, partLengths[i]));
+        }
+
+        if (lineStrings.length == 1) {
+            return lineStrings[0];
+        }
+        return GEOMETRY_FACTORY.createMultiLineString(lineStrings);
+    }
+
+    private static Coordinate[] readCoordinates(SliceInput input, int count)
+    {
+        requireNonNull(input, "input is null");
+        verify(count > 0);
+        Coordinate[] coordinates = new Coordinate[count];
+        for (int i = 0; i < count; i++) {
+            coordinates[i] = readCoordinate(input);
+        }
+        return coordinates;
+    }
+
+    private static Geometry readPolygon(SliceInput input)
+    {
+        requireNonNull(input, "input is null");
+        skipEnvelope(input);
+        int partCount = input.readInt();
+        if (partCount == 0) {
+            return GEOMETRY_FACTORY.createPolygon();
+        }
+
+        int pointCount = input.readInt();
+        int[] startIndexes = new int[partCount];
+        for (int i = 0; i < partCount; i++) {
+            startIndexes[i] = input.readInt();
+        }
+
+        int[] partLengths = new int[partCount];
+        if (partCount > 1) {
+            partLengths[0] = startIndexes[1];
+            for (int i = 1; i < partCount - 1; i++) {
+                partLengths[i] = startIndexes[i + 1] - startIndexes[i];
+            }
+        }
+        partLengths[partCount - 1] = pointCount - startIndexes[partCount - 1];
+
+        LinearRing shell = null;
+        List<LinearRing> holes = new ArrayList<>();
+        List<Polygon> polygons = new ArrayList<>();
+        for (int i = 0; i < partCount; i++) {
+            Coordinate[] coordinates = readCoordinates(input, partLengths[i]);
+            if (!isClockwise(coordinates)) {
+                holes.add(GEOMETRY_FACTORY.createLinearRing(coordinates));
+                continue;
+            }
+            if (shell != null) {
+                polygons.add(GEOMETRY_FACTORY.createPolygon(shell, holes.toArray(new LinearRing[0])));
+            }
+            shell = GEOMETRY_FACTORY.createLinearRing(coordinates);
+            holes.clear();
+        }
+        polygons.add(GEOMETRY_FACTORY.createPolygon(shell, holes.toArray(new LinearRing[0])));
+
+        if (polygons.size() == 1) {
+            return polygons.get(0);
+        }
+        return GEOMETRY_FACTORY.createMultiPolygon(polygons.toArray(new Polygon[0]));
+    }
+
+    private static void skipEnvelope(SliceInput input)
+    {
+        requireNonNull(input, "input is null");
+        input.skip(4 * SIZE_OF_DOUBLE);
+    }
+
+    private static boolean isClockwise(Coordinate[] coordinates)
+    {
+        // Sum over the edges: (x2 − x1) * (y2 + y1).
+        // If the result is positive the curve is clockwise,
+        // if it's negative the curve is counter-clockwise.
+        double area = 0;
+        for (int i = 1; i < coordinates.length; i++) {
+            area += (coordinates[i].x - coordinates[i - 1].x) * (coordinates[i].y + coordinates[i - 1].y);
+        }
+        area += (coordinates[0].x - coordinates[coordinates.length - 1].x) * (coordinates[0].y + coordinates[coordinates.length - 1].y);
+        return area > 0;
+    }
+}

--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -27,6 +27,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-geospatial-toolkit</artifactId>
         </dependency>

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -191,6 +191,51 @@ public class TestGeoFunctions
     }
 
     @Test
+    public void testSTIsValid()
+    {
+        // empty geometries are valid
+        assertValidGeometry("POINT EMPTY");
+        assertValidGeometry("MULTIPOINT EMPTY");
+        assertValidGeometry("LINESTRING EMPTY");
+        assertValidGeometry("MULTILINESTRING EMPTY");
+        assertValidGeometry("POLYGON EMPTY");
+        assertValidGeometry("MULTIPOLYGON EMPTY");
+        assertValidGeometry("GEOMETRYCOLLECTION EMPTY");
+
+        // valid geometries
+        assertValidGeometry("POINT (1 2)");
+        assertValidGeometry("MULTIPOINT (1 2, 3 4)");
+        assertValidGeometry("LINESTRING (0 0, 1 2, 3 4)");
+        assertValidGeometry("MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))");
+        assertValidGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
+        assertValidGeometry("MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1)), ((2 4, 2 6, 6 6, 6 4)))");
+        assertValidGeometry("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (0 0, 1 2, 3 4), POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)))");
+
+        // invalid geometries
+        assertInvalidGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0), (2 2, 2 3, 3 3, 3 2, 2 2))", "Hole lies outside shell at or near point (2.0, 2.0, NaN)");
+        assertInvalidGeometry("POLYGON ((0 0, 0 1, 2 1, 1 1, 1 0, 0 0))", "Self-intersection at or near point (1.0, 1.0, NaN)");
+        assertInvalidGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0), (0 1, 1 1, 0.5 0.5, 0 1))", "Self-intersection at or near point (0.0, 1.0, NaN)");
+        assertInvalidGeometry("MULTIPOLYGON (((0 0, 0 1, 1 1, 1 0, 0 0)), ((0.5 0.5, 0.5 2, 2 2, 2 0.5, 0.5 0.5)))", "Self-intersection at or near point (0.5, 1.0, NaN)");
+        assertInvalidGeometry("GEOMETRYCOLLECTION (POINT (1 2), POLYGON ((0 0, 0 1, 2 1, 1 1, 1 0, 0 0)))", "Self-intersection at or near point (1.0, 1.0, NaN)");
+
+        // corner cases
+        assertFunction("ST_IsValid(ST_GeometryFromText(null))", BOOLEAN, null);
+        assertFunction("geometry_invalid_reason(ST_GeometryFromText(null))", VARCHAR, null);
+    }
+
+    private void assertValidGeometry(String wkt)
+    {
+        assertFunction("ST_IsValid(ST_GeometryFromText('" + wkt + "'))", BOOLEAN, true);
+        assertFunction("geometry_invalid_reason(ST_GeometryFromText('" + wkt + "'))", VARCHAR, null);
+    }
+
+    private void assertInvalidGeometry(String wkt, String reason)
+    {
+        assertFunction("ST_IsValid(ST_GeometryFromText('" + wkt + "'))", BOOLEAN, false);
+        assertFunction("geometry_invalid_reason(ST_GeometryFromText('" + wkt + "'))", VARCHAR, reason);
+    }
+
+    @Test
     public void testSTLength()
     {
         assertFunction("ST_Length(ST_GeometryFromText('LINESTRING EMPTY'))", DOUBLE, 0.0);

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestJtsGeometryUtils.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestJtsGeometryUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import com.facebook.presto.geospatial.JtsGeometryUtils;
+import io.airlift.slice.Slice;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stGeometryFromText;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertTrue;
+
+public class TestJtsGeometryUtils
+{
+    private static final WKTReader WKT_READER = new WKTReader();
+
+    @Test
+    public void testPoint()
+            throws Exception
+    {
+        assertGeometry("POINT EMPTY");
+        assertGeometry("POINT (1 2)");
+    }
+
+    @Test
+    public void testMultiPoint()
+            throws Exception
+    {
+        assertGeometry("MULTIPOINT EMPTY");
+        assertGeometry("MULTIPOINT ((1 2), (3 4))");
+    }
+
+    @Test
+    public void testLineString()
+            throws Exception
+    {
+        assertGeometry("LINESTRING EMPTY");
+        assertGeometry("LINESTRING (1 2, 3 4, 5 6)");
+    }
+
+    @Test
+    public void testMultiLineString()
+            throws Exception
+    {
+        assertGeometry("MULTILINESTRING EMPTY");
+        assertGeometry("MULTILINESTRING ((1 2, 3 4, 5 6), (10.1 11.2, 12.3 13.4))");
+    }
+
+    @Test
+    public void testPolygon()
+            throws Exception
+    {
+        assertGeometry("POLYGON EMPTY");
+        assertGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
+        assertGeometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0), (0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.2, 0.1 0.1))");
+    }
+
+    @Test
+    public void testMultiPolygon()
+            throws Exception
+    {
+        assertGeometry("MULTIPOLYGON EMPTY");
+        assertGeometry("MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1, 1 1)), ((2 4, 2 6, 6 6, 2 4)))");
+        assertGeometry("MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1, 1 1)), ((2 4, 2 6, 6 6, 2 4)), ((0 0, 0 1, 1 1, 1 0, 0 0), (0.1 0.1, 0.2 0.1, 0.2 0.2, 0.1 0.2, 0.1 0.1)))");
+    }
+
+    @Test
+    public void testGeometryCollection()
+            throws Exception
+    {
+        assertGeometry("GEOMETRYCOLLECTION EMPTY");
+        assertGeometry("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (0 0, 1 2, 3 4), POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)))");
+    }
+
+    private static void assertGeometry(String wkt)
+            throws ParseException
+    {
+        Slice geometry = stGeometryFromText(utf8Slice(wkt));
+        Geometry expected = WKT_READER.read(wkt);
+        Geometry actual = JtsGeometryUtils.deserialize(geometry);
+
+        // ESRI shape serialization format doesn't contain enough information
+        // to distinguish between empty LineString and MultiLineString or
+        // empty Polygon and MultiPolygon.
+        if (expected.isEmpty()) {
+            assertTrue(actual.isEmpty());
+        }
+        else {
+            assertEquals(actual, expected);
+        }
+    }
+}


### PR DESCRIPTION
Add functions to check whether a given geometry is well formed and understand why if it is not.

- ST_IsValid function returns true iff input geometry value is well formed
- geometry_invalid_reason returns the reason why geometry is not well formed or null if it is

ST_IsValid function follows SQL/MM Part 3 standard. The standard doesn't have a function to return a reason for why geometry is not well formed, hence, geometry_invalid_reason name follows Presto convention.

https://postgis.net/docs/using_postgis_dbmanagement.html#OGC_Validity provides a good explanation of what it means for a geometry to be well formed.

The implementation is based on functionality provided by the Java Topology Suite (JTS). ESRI library is missing this functionality.

Existing geospatial functions encode geometry objects into Slices using ESRI shapefile format described in https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf. This PR includes a new deserialization method that converts geometry Slice into JTS geometry object.