### PR TITLE
Minor improvements in SingleBlock for Array/Map/Row

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -25,7 +25,7 @@ public abstract class AbstractSingleArrayBlock
         this.start = start;
     }
 
-    protected abstract BlockBuilder getBlock();
+    protected abstract Block getBlock();
 
     private void checkReadablePosition(int position)
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
@@ -36,7 +36,7 @@ public class SingleArrayBlockWriter
     }
 
     @Override
-    protected BlockBuilder getBlock()
+    protected Block getBlock()
     {
         return blockBuilder;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
@@ -18,6 +18,8 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.function.BiConsumer;
 
+import static java.lang.String.format;
+
 public class SingleArrayBlockWriter
         extends AbstractSingleArrayBlock
         implements BlockBuilder
@@ -150,9 +152,6 @@ public class SingleArrayBlockWriter
     @Override
     public String toString()
     {
-        StringBuilder sb = new StringBuilder("SingleArrayBlockWriter{");
-        sb.append("positionCount=").append(getPositionCount());
-        sb.append('}');
-        return sb.toString();
+        return format("SingleArrayBlockWriter{positionCount=%d}", getPositionCount());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
@@ -26,6 +26,7 @@ import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
+import static java.lang.String.format;
 
 public class SingleMapBlock
         extends AbstractSingleMapBlock
@@ -104,6 +105,12 @@ public class SingleMapBlock
     Block getValueBlock()
     {
         return valueBlock;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("SingleMapBlock{positionCount=%d}", getPositionCount());
     }
 
     int[] getHashTable()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
@@ -18,6 +18,8 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.function.BiConsumer;
 
+import static java.lang.String.format;
+
 public class SingleMapBlockWriter
         extends AbstractSingleMapBlock
         implements BlockBuilder
@@ -222,9 +224,6 @@ public class SingleMapBlockWriter
     @Override
     public String toString()
     {
-        StringBuilder sb = new StringBuilder("SingleMapBlockWriter{");
-        sb.append("positionCount=").append(getPositionCount());
-        sb.append('}');
-        return sb.toString();
+        return format("SingleMapBlockWriter{positionCount=%d}", getPositionCount());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
@@ -207,10 +207,10 @@ public class SingleRowBlockWriter
     public String toString()
     {
         if (!fieldBlockBuilderReturned) {
-            return format("RowBlock{SingleRowBlockWriter=%d, fieldBlockBuilderReturned=false, positionCount=%d}", fieldBlockBuilders.length, getPositionCount());
+            return format("SingleRowBlockWriter{numFields=%d, fieldBlockBuilderReturned=false, positionCount=%d}", fieldBlockBuilders.length, getPositionCount());
         }
         else {
-            return format("RowBlock{SingleRowBlockWriter=%d, fieldBlockBuilderReturned=true}", fieldBlockBuilders.length);
+            return format("SingleRowBlockWriter{numFields=%d, fieldBlockBuilderReturned=true}", fieldBlockBuilders.length);
         }
     }
 


### PR DESCRIPTION
- Change return type for AbstractSingleArrayBlock.getBlock() as Block.
- Minor fix in SingleRowBlockWriter.toString()
- Implement SingleMapBlock.toString() to help debug.