### PR TITLE
Add support for escape sequences in LIKE pattern of SHOW SCHEMAS and SHOW TABLES

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -215,7 +215,14 @@ final class ShowQueriesRewrite
 
             Optional<String> likePattern = showTables.getLikePattern();
             if (likePattern.isPresent()) {
-                Expression likePredicate = new LikePredicate(identifier("table_name"), new StringLiteral(likePattern.get()), null);
+                Expression likePredicate;
+                Optional<String> escape = showTables.getEscape();
+                if (escape.isPresent()){
+                    likePredicate = new LikePredicate(identifier("table_name"), new StringLiteral(likePattern.get()), new StringLiteral(escape.get()));
+                }
+                else {
+                    likePredicate = new LikePredicate(identifier("table_name"), new StringLiteral(likePattern.get()), null);
+                }
                 predicate = logicalAnd(predicate, likePredicate);
             }
 
@@ -286,7 +293,13 @@ final class ShowQueriesRewrite
             Optional<Expression> predicate = Optional.empty();
             Optional<String> likePattern = node.getLikePattern();
             if (likePattern.isPresent()) {
-                predicate = Optional.of(new LikePredicate(identifier("schema_name"), new StringLiteral(likePattern.get()), null));
+                Optional<String> escape = node.getEscape();
+                if (escape.isPresent()) {
+                    predicate = Optional.of(new LikePredicate(identifier("schema_name"), new StringLiteral(likePattern.get()), new StringLiteral(escape.get())));
+                }
+                else {
+                    predicate = Optional.of(new LikePredicate(identifier("schema_name"), new StringLiteral(likePattern.get()), null));
+                }
             }
 
             return simpleQuery(

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -69,8 +69,10 @@ statement
         ('(' explainOption (',' explainOption)* ')')? statement        #explain
     | SHOW CREATE TABLE qualifiedName                                  #showCreateTable
     | SHOW CREATE VIEW qualifiedName                                   #showCreateView
-    | SHOW TABLES ((FROM | IN) qualifiedName)? (LIKE pattern=string)?  #showTables
-    | SHOW SCHEMAS ((FROM | IN) identifier)? (LIKE pattern=string)?    #showSchemas
+    | SHOW TABLES ((FROM | IN) qualifiedName)?
+        (LIKE pattern=string (ESCAPE escape=string)?)?                 #showTables
+    | SHOW SCHEMAS ((FROM | IN) identifier)?
+        (LIKE pattern=string (ESCAPE escape=string)?)?                 #showSchemas
     | SHOW CATALOGS (LIKE pattern=string)?                             #showCatalogs
     | SHOW COLUMNS (FROM | IN) qualifiedName                           #showColumns
     | SHOW STATS (FOR | ON) qualifiedName                              #showStats

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -723,6 +723,8 @@ class AstBuilder
                 Optional.ofNullable(context.qualifiedName())
                         .map(this::getQualifiedName),
                 getTextIfPresent(context.pattern)
+                        .map(AstBuilder::unquote),
+                getTextIfPresent(context.escape)
                         .map(AstBuilder::unquote));
     }
 
@@ -733,6 +735,8 @@ class AstBuilder
                 getLocation(context),
                 visitIfPresent(context.identifier(), Identifier.class),
                 getTextIfPresent(context.pattern)
+                        .map(AstBuilder::unquote),
+                getTextIfPresent(context.escape)
                         .map(AstBuilder::unquote));
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
@@ -27,22 +27,24 @@ public class ShowSchemas
 {
     private final Optional<Identifier> catalog;
     private final Optional<String> likePattern;
+    private final Optional<String> escape;
 
-    public ShowSchemas(Optional<Identifier> catalog, Optional<String> likePattern)
+    public ShowSchemas(Optional<Identifier> catalog, Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.empty(), catalog, likePattern);
+        this(Optional.empty(), catalog, likePattern, escape);
     }
 
-    public ShowSchemas(NodeLocation location, Optional<Identifier> catalog, Optional<String> likePattern)
+    public ShowSchemas(NodeLocation location, Optional<Identifier> catalog, Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.of(location), catalog, likePattern);
+        this(Optional.of(location), catalog, likePattern, escape);
     }
 
-    private ShowSchemas(Optional<NodeLocation> location, Optional<Identifier> catalog, Optional<String> likePattern)
+    private ShowSchemas(Optional<NodeLocation> location, Optional<Identifier> catalog, Optional<String> likePattern, Optional<String> escape)
     {
         super(location);
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.likePattern = requireNonNull(likePattern, "likePattern is null");
+        this.escape = requireNonNull(escape, "escape is null");
     }
 
     public Optional<Identifier> getCatalog()
@@ -53,6 +55,11 @@ public class ShowSchemas
     public Optional<String> getLikePattern()
     {
         return likePattern;
+    }
+
+    public Optional<String> getEscape()
+    {
+        return escape;
     }
 
     @Override
@@ -70,7 +77,7 @@ public class ShowSchemas
     @Override
     public int hashCode()
     {
-        return catalog.hashCode();
+        return Objects.hash(catalog, likePattern, escape);
     }
 
     @Override
@@ -83,7 +90,9 @@ public class ShowSchemas
             return false;
         }
         ShowSchemas o = (ShowSchemas) obj;
-        return Objects.equals(catalog, o.catalog);
+        return Objects.equals(catalog, o.catalog) &&
+                Objects.equals(likePattern, o.likePattern) &&
+                Objects.equals(escape, o.escape);
     }
 
     @Override
@@ -91,6 +100,8 @@ public class ShowSchemas
     {
         return toStringHelper(this)
                 .add("catalog", catalog)
+                .add("likePattern", likePattern)
+                .add("escape", escape)
                 .toString();
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowTables.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowTables.java
@@ -27,25 +27,28 @@ public class ShowTables
 {
     private final Optional<QualifiedName> schema;
     private final Optional<String> likePattern;
+    private final Optional<String> escape;
 
-    public ShowTables(Optional<QualifiedName> schema, Optional<String> likePattern)
+    public ShowTables(Optional<QualifiedName> schema, Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.empty(), schema, likePattern);
+        this(Optional.empty(), schema, likePattern, escape);
     }
 
-    public ShowTables(NodeLocation location, Optional<QualifiedName> schema, Optional<String> likePattern)
+    public ShowTables(NodeLocation location, Optional<QualifiedName> schema, Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.of(location), schema, likePattern);
+        this(Optional.of(location), schema, likePattern, escape);
     }
 
-    private ShowTables(Optional<NodeLocation> location, Optional<QualifiedName> schema, Optional<String> likePattern)
+    private ShowTables(Optional<NodeLocation> location, Optional<QualifiedName> schema, Optional<String> likePattern, Optional<String> escape)
     {
         super(location);
         requireNonNull(schema, "schema is null");
         requireNonNull(likePattern, "likePattern is null");
+        requireNonNull(escape, "escape is null");
 
         this.schema = schema;
         this.likePattern = likePattern;
+        this.escape = escape;
     }
 
     public Optional<QualifiedName> getSchema()
@@ -56,6 +59,11 @@ public class ShowTables
     public Optional<String> getLikePattern()
     {
         return likePattern;
+    }
+
+    public Optional<String> getEscape()
+    {
+        return escape;
     }
 
     @Override
@@ -73,7 +81,7 @@ public class ShowTables
     @Override
     public int hashCode()
     {
-        return Objects.hash(schema, likePattern);
+        return Objects.hash(schema, likePattern, escape);
     }
 
     @Override
@@ -87,7 +95,8 @@ public class ShowTables
         }
         ShowTables o = (ShowTables) obj;
         return Objects.equals(schema, o.schema) &&
-                Objects.equals(likePattern, o.likePattern);
+                Objects.equals(likePattern, o.likePattern) &&
+                Objects.equals(escape,o.escape);
     }
 
     @Override
@@ -96,6 +105,7 @@ public class ShowTables
         return toStringHelper(this)
                 .add("schema", schema)
                 .add("likePattern", likePattern)
+                .add("escape", escape)
                 .toString();
     }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -805,18 +805,18 @@ public class TestSqlParser
     @Test
     public void testShowSchemas()
     {
-        assertStatement("SHOW SCHEMAS", new ShowSchemas(Optional.empty(), Optional.empty()));
-        assertStatement("SHOW SCHEMAS FROM foo", new ShowSchemas(Optional.of(identifier("foo")), Optional.empty()));
-        assertStatement("SHOW SCHEMAS IN foo LIKE '%'", new ShowSchemas(Optional.of(identifier("foo")), Optional.of("%")));
+        assertStatement("SHOW SCHEMAS", new ShowSchemas(Optional.empty(), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW SCHEMAS FROM foo", new ShowSchemas(Optional.of(identifier("foo")), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW SCHEMAS IN foo LIKE '%'", new ShowSchemas(Optional.of(identifier("foo")), Optional.of("%"), Optional.empty()));
     }
 
     @Test
     public void testShowTables()
     {
-        assertStatement("SHOW TABLES", new ShowTables(Optional.empty(), Optional.empty()));
-        assertStatement("SHOW TABLES FROM a", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.empty()));
-        assertStatement("SHOW TABLES FROM \"awesome schema\"", new ShowTables(Optional.of(QualifiedName.of("awesome schema")), Optional.empty()));
-        assertStatement("SHOW TABLES IN a LIKE '%'", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.of("%")));
+        assertStatement("SHOW TABLES", new ShowTables(Optional.empty(), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW TABLES FROM a", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW TABLES FROM \"awesome schema\"", new ShowTables(Optional.of(QualifiedName.of("awesome schema")), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW TABLES IN a LIKE '%'", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.of("%"), Optional.empty()));
     }
 
     @Test


### PR DESCRIPTION
When schema name or table name have underscore '_', current LIKE clause of SHOW SCHEMAS or SHOW TABLES do not support to accurate matching as in SELECT query using ESCAPE.
eg:
Current, can not accurate matching in like pattern
\>show tables;
 t_1        
 t_square_2 
 test
(3 rows)
\>show tables like 't\_%';
 t_1        
 t_square_2 
 test
(3 rows)
\>show tables like 't\\\_%';
(0 rows)
\>show tables like 't\\\_%' escape '\\';
failed: line 1:25: mismatched input 'escape' expecting \<EOF\>

After add support
\>show tables like 't\\\_%' escape '\\';
 t_1        
 t_square_2 
(2 rows)