### PR TITLE
Move TestHiveBucketedTables tests to big_query group

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -60,6 +60,7 @@ public final class TestGroups
     public static final String SKIP_ON_CDH = "skip_on_cdh";
     public static final String TLS = "tls";
     public static final String CANCEL_QUERY = "cancel_query";
+    public static final String BIG_QUERY = "big_query";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
@@ -23,6 +23,7 @@ import io.prestodb.tempto.fulfillment.table.TableDefinitionsRepository;
 import io.prestodb.tempto.fulfillment.table.hive.HiveTableDefinition;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.tests.TestGroups.BIG_QUERY;
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.utils.QueryExecutors.onHive;
 import static io.prestodb.tempto.assertions.QueryAssert.Row.row;
@@ -60,7 +61,7 @@ public class TestHiveBucketedTables
                 immutableTable(NATION));
     }
 
-    @Test(groups = {HIVE_CONNECTOR})
+    @Test(groups = {HIVE_CONNECTOR, BIG_QUERY})
     public void testIgnorePartitionBucketingIfNotBucketed()
     {
         String tableName = mutableTablesState().get(BUCKETED_PARTITIONED_NATION).getNameInDatabase();


### PR DESCRIPTION
Move TestHiveBucketedTables tests to big_query group

This test is running two map-reduce jobs schedulled from hive.
Each of them is using up to 6 yarn containers.
Such huge resource consumption cases this test be unreliable in travis
environments.
