### PR TITLE
Dynamic allocating ORC output buffer

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -98,4 +98,16 @@ public class OrcFileWriterConfig
         options = options.withMaxStringStatisticsLimit(stringStatisticsLimit);
         return this;
     }
+
+    public DataSize getMaxCompressionBufferSize()
+    {
+        return options.getMaxCompressionBufferSize();
+    }
+
+    @Config("hive.orc.writer.max-compression-buffer-size")
+    public OrcFileWriterConfig setMaxCompressionBufferSize(DataSize maxCompressionBufferSize)
+    {
+        options = options.withMaxCompressionBufferSize(maxCompressionBufferSize);
+        return this;
+    }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -23,6 +23,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestOrcFileWriterConfig
@@ -36,7 +37,8 @@ public class TestOrcFileWriterConfig
                 .setStripeMaxRowCount(10_000_000)
                 .setRowGroupMaxRowCount(10_000)
                 .setDictionaryMaxMemory(new DataSize(16, MEGABYTE))
-                .setStringStatisticsLimit(new DataSize(64, BYTE)));
+                .setStringStatisticsLimit(new DataSize(64, BYTE))
+                .setMaxCompressionBufferSize(new DataSize(256, KILOBYTE)));
     }
 
     @Test
@@ -49,6 +51,7 @@ public class TestOrcFileWriterConfig
                 .put("hive.orc.writer.row-group-max-rows", "11")
                 .put("hive.orc.writer.dictionary-max-memory", "13MB")
                 .put("hive.orc.writer.string-statistics-limit", "17MB")
+                .put("hive.orc.writer.max-compression-buffer-size", "19MB")
                 .build();
 
         OrcFileWriterConfig expected = new OrcFileWriterConfig()
@@ -57,7 +60,8 @@ public class TestOrcFileWriterConfig
                 .setStripeMaxRowCount(44)
                 .setRowGroupMaxRowCount(11)
                 .setDictionaryMaxMemory(new DataSize(13, MEGABYTE))
-                .setStringStatisticsLimit(new DataSize(17, MEGABYTE));
+                .setStringStatisticsLimit(new DataSize(17, MEGABYTE))
+                .setMaxCompressionBufferSize(new DataSize(19, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.checkpoint.InputStreamCheckpoint;
 import com.facebook.presto.orc.metadata.CompressionKind;
+import com.google.common.annotations.VisibleForTesting;
 import io.airlift.compress.Compressor;
 import io.airlift.compress.lz4.Lz4Compressor;
 import io.airlift.compress.snappy.SnappyCompressor;
@@ -36,6 +37,8 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
@@ -44,18 +47,21 @@ public class OrcOutputBuffer
         extends SliceOutput
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(OrcOutputBuffer.class).instanceSize();
-    private static final int MINIMUM_BUFFER_SIZE = 32 * 1024;
+    private static final int INITIAL_BUFFER_SIZE = 256;
+    private static final int DIRECT_FLUSH_SIZE = 32 * 1024;
     private static final int MINIMUM_OUTPUT_BUFFER_CHUNK_SIZE = 4 * 1024;
     private static final int MAXIMUM_OUTPUT_BUFFER_CHUNK_SIZE = 1024 * 1024;
+
+    private final int maxBufferSize;
 
     private final ChunkedSliceOutput compressedOutputStream;
 
     @Nullable
     private final Compressor compressor;
-    private final byte[] compressionBuffer;
+    private byte[] compressionBuffer = new byte[0];
 
-    private final Slice slice;
-    private final byte[] buffer;
+    private Slice slice;
+    private byte[] buffer;
 
     /**
      * Offset of buffer within stream.
@@ -66,31 +72,29 @@ public class OrcOutputBuffer
      */
     private int bufferPosition;
 
-    public OrcOutputBuffer(CompressionKind compression, int bufferSize)
+    public OrcOutputBuffer(CompressionKind compression, int maxBufferSize)
     {
         requireNonNull(compression, "compression is null");
-        checkArgument(bufferSize >= MINIMUM_BUFFER_SIZE, "minimum buffer size of " + MINIMUM_BUFFER_SIZE + " required");
+        checkArgument(maxBufferSize > 0, "maximum buffer size should be greater than 0");
 
-        this.buffer = new byte[bufferSize];
+        this.maxBufferSize = maxBufferSize;
+
+        this.buffer = new byte[INITIAL_BUFFER_SIZE];
         this.slice = wrappedBuffer(buffer);
 
         compressedOutputStream = new ChunkedSliceOutput(MINIMUM_OUTPUT_BUFFER_CHUNK_SIZE, MAXIMUM_OUTPUT_BUFFER_CHUNK_SIZE);
 
         if (compression == CompressionKind.NONE) {
             this.compressor = null;
-            this.compressionBuffer = new byte[0];
         }
         else if (compression == CompressionKind.SNAPPY) {
             this.compressor = new SnappyCompressor();
-            this.compressionBuffer = new byte[compressor.maxCompressedLength(bufferSize)];
         }
         else if (compression == CompressionKind.ZLIB) {
             this.compressor = new DeflateCompressor();
-            this.compressionBuffer = new byte[compressor.maxCompressedLength(bufferSize)];
         }
         else if (compression == CompressionKind.LZ4) {
             this.compressor = new Lz4Compressor();
-            this.compressionBuffer = new byte[compressor.maxCompressedLength(bufferSize)];
         }
         else {
             throw new IllegalArgumentException("Unsupported compression " + compression);
@@ -220,7 +224,7 @@ public class OrcOutputBuffer
     public void writeBytes(Slice source, int sourceIndex, int length)
     {
         // Write huge chunks direct to OutputStream
-        if (length >= MINIMUM_BUFFER_SIZE) {
+        if (length >= DIRECT_FLUSH_SIZE) {
             flushBufferToOutputStream();
             writeDirectlyToOutputStream((byte[]) source.getBase(), sourceIndex + (int) (slice.getAddress() - ARRAY_BYTE_BASE_OFFSET), length);
             bufferOffset += length;
@@ -242,7 +246,7 @@ public class OrcOutputBuffer
     public void writeBytes(byte[] source, int sourceIndex, int length)
     {
         // Write huge chunks direct to OutputStream
-        if (length >= MINIMUM_BUFFER_SIZE) {
+        if (length >= DIRECT_FLUSH_SIZE) {
             // todo fill buffer before flushing
             flushBufferToOutputStream();
             writeDirectlyToOutputStream(source, sourceIndex, length);
@@ -366,15 +370,37 @@ public class OrcOutputBuffer
 
     private void ensureWritableBytes(int minWritableBytes)
     {
-        if (bufferPosition + minWritableBytes > slice.length()) {
+        int neededBufferSize = bufferPosition + minWritableBytes;
+        if (neededBufferSize <= slice.length()) {
+            return;
+        }
+
+        if (slice.length() >= maxBufferSize) {
             flushBufferToOutputStream();
+            return;
+        }
+
+        // grow the buffer size
+        int newBufferSize = min(max(slice.length() * 2, minWritableBytes), maxBufferSize);
+        if (neededBufferSize <= newBufferSize) {
+            // we have capacity in the new buffer; just copy the data to the new buffer
+            byte[] previousBuffer = buffer;
+            buffer = new byte[newBufferSize];
+            slice = wrappedBuffer(buffer);
+            System.arraycopy(previousBuffer, 0, buffer, 0, bufferPosition);
+        }
+        else {
+            // there is no enough capacity in the new buffer; flush the data and allocate the new buffer
+            flushBufferToOutputStream();
+            buffer = new byte[newBufferSize];
+            slice = wrappedBuffer(buffer);
         }
     }
 
     private int ensureBatchSize(int length)
     {
-        ensureWritableBytes(Math.min(MINIMUM_BUFFER_SIZE, length));
-        return Math.min(length, slice.length() - bufferPosition);
+        ensureWritableBytes(min(DIRECT_FLUSH_SIZE, length));
+        return min(length, slice.length() - bufferPosition);
     }
 
     private void flushBufferToOutputStream()
@@ -394,6 +420,12 @@ public class OrcOutputBuffer
         }
 
         checkArgument(length <= buffer.length, "Write chunk length must be less than compression buffer size");
+
+        int minCompressionBufferSize = compressor.maxCompressedLength(length);
+        if (compressionBuffer.length < minCompressionBufferSize) {
+            compressionBuffer = new byte[minCompressionBufferSize];
+        }
+
         int compressedSize = compressor.compress(chunk, offset, length, compressionBuffer, 0, compressionBuffer.length);
         if (compressedSize < length) {
             int chunkHeader = (compressedSize << 1);
@@ -424,5 +456,11 @@ public class OrcOutputBuffer
             length -= chunkSize;
             bytesOffset += chunkSize;
         }
+    }
+
+    @VisibleForTesting
+    int getBufferCapacity()
+    {
+        return slice.length();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -18,6 +18,7 @@ import io.airlift.units.DataSize;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 
@@ -29,6 +30,7 @@ public class OrcWriterOptions
     private static final int DEFAULT_ROW_GROUP_MAX_ROW_COUNT = 10_000;
     private static final DataSize DEFAULT_DICTIONARY_MAX_MEMORY = new DataSize(16, MEGABYTE);
     public static final DataSize DEFAULT_MAX_STRING_STATISTICS_LIMIT = new DataSize(64, BYTE);
+    private static final DataSize DEFAULT_MAX_COMPRESSION_BUFFER_SIZE = new DataSize(256, KILOBYTE);
 
     private final DataSize stripeMaxSize;
     private final int stripeMinRowCount;
@@ -36,6 +38,7 @@ public class OrcWriterOptions
     private final int rowGroupMaxRowCount;
     private final DataSize dictionaryMaxMemory;
     private final DataSize maxStringStatisticsLimit;
+    private final DataSize maxCompressionBufferSize;
 
     public OrcWriterOptions()
     {
@@ -45,10 +48,18 @@ public class OrcWriterOptions
                 DEFAULT_STRIPE_MAX_ROW_COUNT,
                 DEFAULT_ROW_GROUP_MAX_ROW_COUNT,
                 DEFAULT_DICTIONARY_MAX_MEMORY,
-                DEFAULT_MAX_STRING_STATISTICS_LIMIT);
+                DEFAULT_MAX_STRING_STATISTICS_LIMIT,
+                DEFAULT_MAX_COMPRESSION_BUFFER_SIZE);
     }
 
-    private OrcWriterOptions(DataSize stripeMaxSize, int stripeMinRowCount, int stripeMaxRowCount, int rowGroupMaxRowCount, DataSize dictionaryMaxMemory, DataSize maxStringStatisticsLimit)
+    private OrcWriterOptions(
+            DataSize stripeMaxSize,
+            int stripeMinRowCount,
+            int stripeMaxRowCount,
+            int rowGroupMaxRowCount,
+            DataSize dictionaryMaxMemory,
+            DataSize maxStringStatisticsLimit,
+            DataSize maxCompressionBufferSize)
     {
         requireNonNull(stripeMaxSize, "stripeMaxSize is null");
         checkArgument(stripeMinRowCount >= 1, "stripeMinRowCount must be at least 1");
@@ -56,6 +67,7 @@ public class OrcWriterOptions
         checkArgument(rowGroupMaxRowCount >= 1, "rowGroupMaxRowCount must be at least 1");
         requireNonNull(dictionaryMaxMemory, "dictionaryMaxMemory is null");
         requireNonNull(maxStringStatisticsLimit, "maxStringStatisticsLimit is null");
+        requireNonNull(maxCompressionBufferSize, "maxCompressionBufferSize is null");
 
         this.stripeMaxSize = stripeMaxSize;
         this.stripeMinRowCount = stripeMinRowCount;
@@ -63,6 +75,7 @@ public class OrcWriterOptions
         this.rowGroupMaxRowCount = rowGroupMaxRowCount;
         this.dictionaryMaxMemory = dictionaryMaxMemory;
         this.maxStringStatisticsLimit = maxStringStatisticsLimit;
+        this.maxCompressionBufferSize = maxCompressionBufferSize;
     }
 
     public DataSize getStripeMaxSize()
@@ -95,34 +108,44 @@ public class OrcWriterOptions
         return maxStringStatisticsLimit;
     }
 
+    public DataSize getMaxCompressionBufferSize()
+    {
+        return maxCompressionBufferSize;
+    }
+
     public OrcWriterOptions withStripeMaxSize(DataSize stripeMaxSize)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit);
+        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withStripeMinRowCount(int stripeMinRowCount)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit);
+        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withStripeMaxRowCount(int stripeMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit);
+        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withRowGroupMaxRowCount(int rowGroupMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit);
+        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withDictionaryMaxMemory(DataSize dictionaryMaxMemory)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit);
+        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withMaxStringStatisticsLimit(DataSize maxStringStatisticsLimit)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit);
+        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+    }
+
+    public OrcWriterOptions withMaxCompressionBufferSize(DataSize maxCompressionBufferSize)
+    {
+        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     @Override
@@ -135,6 +158,7 @@ public class OrcWriterOptions
                 .add("rowGroupMaxRowCount", rowGroupMaxRowCount)
                 .add("dictionaryMaxMemory", dictionaryMaxMemory)
                 .add("maxStringStatisticsLimit", maxStringStatisticsLimit)
+                .add("maxCompressionBufferSize", maxCompressionBufferSize)
                 .toString();
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.CompressionKind;
+import io.airlift.slice.DynamicSliceOutput;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.testng.Assert.assertEquals;
+
+public class TestOrcOutputBuffer
+{
+    @Test
+    public void testWriteHugeByteChucks()
+    {
+        int size = 1024 * 1024;
+        byte[] largeByteArray = new byte[size];
+        Arrays.fill(largeByteArray, (byte) 0xA);
+        OrcOutputBuffer sliceOutput = new OrcOutputBuffer(CompressionKind.NONE, 256 * 1024);
+
+        DynamicSliceOutput output = new DynamicSliceOutput(size);
+        sliceOutput.writeBytes(largeByteArray, 10, size - 10);
+        assertEquals(sliceOutput.writeDataTo(output), size - 10);
+        assertEquals(output.slice(), wrappedBuffer(largeByteArray, 10, size - 10));
+
+        sliceOutput.reset();
+        output.reset();
+        sliceOutput.writeBytes(wrappedBuffer(largeByteArray), 100, size - 100);
+        assertEquals(sliceOutput.writeDataTo(output), size - 100);
+        assertEquals(output.slice(), wrappedBuffer(largeByteArray, 100, size - 100));
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
@@ -30,6 +30,7 @@ import static org.testng.Assert.assertTrue;
 
 public abstract class AbstractTestValueStream<T, C extends StreamCheckpoint, W extends ValueOutputStream<C>, R extends ValueInputStream<C>>
 {
+    static final int COMPRESSION_BLOCK_SIZE = 256 * 1024;
     static final OrcDataSourceId ORC_DATA_SOURCE_ID = new OrcDataSourceId("test");
 
     protected void testWriteValue(List<List<T>> groups)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestByteArrayStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestByteArrayStream.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 
 public class TestByteArrayStream

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestByteStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestByteStream.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 
 public class TestByteStream

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestDoubleStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestDoubleStream.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 
 public class TestDoubleStream

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestFloatStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestFloatStream.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 
 public class TestFloatStream

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongDecimalStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongDecimalStream.java
@@ -28,7 +28,6 @@ import java.util.Random;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamDwrf.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamDwrf.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.LONG;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV1.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV1.java
@@ -27,7 +27,6 @@ import java.util.Random;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV2.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV2.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestShortDecimalStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestShortDecimalStream.java
@@ -28,7 +28,6 @@ import java.util.Random;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.OrcWriter.COMPRESSION_BLOCK_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 
 public class TestShortDecimalStream


### PR DESCRIPTION
ORC output buffer is used by all the output streams in the ORC writer.
However, each stream can vary in sizes due to different data types. A
buffer size should be adaptive based on data types. The patch starts
with a small buffer size and gradually grow it if necessary.