### PR TITLE
Add retained size of stats to ORC writers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -360,7 +360,8 @@ public class OrcMetadataReader
         BigDecimal minimum = decimalStatistics.hasMinimum() ? new BigDecimal(decimalStatistics.getMinimum()) : null;
         BigDecimal maximum = decimalStatistics.hasMaximum() ? new BigDecimal(decimalStatistics.getMaximum()) : null;
 
-        return new DecimalStatistics(minimum, maximum);
+        // could be long (16 bytes) or short (8 bytes); use short for estimation
+        return new DecimalStatistics(minimum, maximum, SHORT_DECIMAL_VALUE_BYTES);
     }
 
     private static BinaryStatistics toBinaryStatistics(OrcProto.BinaryStatistics binaryStatistics)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatistics.java
@@ -13,12 +13,16 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class BinaryStatistics
 {
     // 1 byte to denote if null + 4 bytes to denote offset
     public static final long BINARY_VALUE_BYTES_OVERHEAD = Byte.BYTES + Integer.BYTES;
+
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(BinaryStatistics.class).instanceSize();
 
     private final long sum;
 
@@ -30,6 +34,11 @@ public class BinaryStatistics
     public long getSum()
     {
         return sum;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatistics.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -21,6 +23,8 @@ public class BooleanStatistics
 {
     // 1 byte to denote if null + 1 byte for the value
     public static final long BOOLEAN_VALUE_BYTES = Byte.BYTES + Byte.BYTES;
+
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(BooleanStatistics.class).instanceSize();
 
     private final long trueValueCount;
 
@@ -32,6 +36,11 @@ public class BooleanStatistics
     public long getTrueValueCount()
     {
         return trueValueCount;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -27,7 +29,10 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ColumnStatistics
 {
-    private final Long numberOfValues;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ColumnStatistics.class).instanceSize();
+
+    private final boolean hasNumberOfValues;
+    private final long numberOfValues;
     private final long minAverageValueSizeInBytes;
     private final BooleanStatistics booleanStatistics;
     private final IntegerStatistics integerStatistics;
@@ -50,7 +55,8 @@ public class ColumnStatistics
             BinaryStatistics binaryStatistics,
             HiveBloomFilter bloomFilter)
     {
-        this.numberOfValues = numberOfValues;
+        this.hasNumberOfValues = numberOfValues != null;
+        this.numberOfValues = hasNumberOfValues ? numberOfValues : 0;
         this.minAverageValueSizeInBytes = minAverageValueSizeInBytes;
         this.booleanStatistics = booleanStatistics;
         this.integerStatistics = integerStatistics;
@@ -64,12 +70,12 @@ public class ColumnStatistics
 
     public boolean hasNumberOfValues()
     {
-        return numberOfValues != null;
+        return hasNumberOfValues;
     }
 
     public long getNumberOfValues()
     {
-        return numberOfValues == null ? 0 : numberOfValues;
+        return hasNumberOfValues ? numberOfValues : 0;
     }
 
     public boolean hasMinAverageValueSizeInBytes()
@@ -131,7 +137,7 @@ public class ColumnStatistics
     public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
     {
         return new ColumnStatistics(
-                numberOfValues,
+                getNumberOfValues(),
                 minAverageValueSizeInBytes,
                 booleanStatistics,
                 integerStatistics,
@@ -141,6 +147,36 @@ public class ColumnStatistics
                 decimalStatistics,
                 binaryStatistics,
                 bloomFilter);
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        long retainedSizeInBytes = INSTANCE_SIZE;
+        if (booleanStatistics != null) {
+            retainedSizeInBytes += booleanStatistics.getRetainedSizeInBytes();
+        }
+        if (integerStatistics != null) {
+            retainedSizeInBytes += integerStatistics.getRetainedSizeInBytes();
+        }
+        if (doubleStatistics != null) {
+            retainedSizeInBytes += doubleStatistics.getRetainedSizeInBytes();
+        }
+        if (stringStatistics != null) {
+            retainedSizeInBytes += stringStatistics.getRetainedSizeInBytes();
+        }
+        if (dateStatistics != null) {
+            retainedSizeInBytes += dateStatistics.getRetainedSizeInBytes();
+        }
+        if (decimalStatistics != null) {
+            retainedSizeInBytes += decimalStatistics.getRetainedSizeInBytes();
+        }
+        if (binaryStatistics != null) {
+            retainedSizeInBytes += binaryStatistics.getRetainedSizeInBytes();
+        }
+        if (bloomFilter != null) {
+            retainedSizeInBytes += bloomFilter.getRetainedSizeInBytes();
+        }
+        return retainedSizeInBytes;
     }
 
     @Override
@@ -153,7 +189,8 @@ public class ColumnStatistics
             return false;
         }
         ColumnStatistics that = (ColumnStatistics) o;
-        return Objects.equals(numberOfValues, that.numberOfValues) &&
+        return Objects.equals(hasNumberOfValues, that.hasNumberOfValues) &&
+                Objects.equals(getNumberOfValues(), that.getNumberOfValues()) &&
                 Objects.equals(booleanStatistics, that.booleanStatistics) &&
                 Objects.equals(integerStatistics, that.integerStatistics) &&
                 Objects.equals(doubleStatistics, that.doubleStatistics) &&
@@ -166,7 +203,7 @@ public class ColumnStatistics
     @Override
     public int hashCode()
     {
-        return Objects.hash(numberOfValues, booleanStatistics, integerStatistics, doubleStatistics, stringStatistics, dateStatistics, decimalStatistics, bloomFilter);
+        return Objects.hash(hasNumberOfValues, getNumberOfValues(), booleanStatistics, integerStatistics, doubleStatistics, stringStatistics, dateStatistics, decimalStatistics, bloomFilter);
     }
 
     @Override
@@ -174,7 +211,7 @@ public class ColumnStatistics
     {
         return toStringHelper(this)
                 .omitNullValues()
-                .add("numberOfValues", numberOfValues)
+                .add("numberOfValues", getNumberOfValues())
                 .add("booleanStatistics", booleanStatistics)
                 .add("integerStatistics", integerStatistics)
                 .add("doubleStatistics", doubleStatistics)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatistics.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -24,26 +26,41 @@ public class DateStatistics
     // 1 byte to denote if null + 4 bytes for the value (date is of integer type)
     public static final long DATE_VALUE_BYTES = Byte.BYTES + Integer.BYTES;
 
-    private final Integer minimum;
-    private final Integer maximum;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DateStatistics.class).instanceSize();
+
+    private final boolean hasMinimum;
+    private final boolean hasMaximum;
+
+    private final int minimum;
+    private final int maximum;
 
     public DateStatistics(Integer minimum, Integer maximum)
     {
         checkArgument(minimum == null || maximum == null || minimum <= maximum, "minimum is not less than maximum");
-        this.minimum = minimum;
-        this.maximum = maximum;
+
+        this.hasMinimum = minimum != null;
+        this.minimum = hasMinimum ? minimum : 0;
+
+        this.hasMaximum = maximum != null;
+        this.maximum = hasMaximum ? maximum : 0;
     }
 
     @Override
     public Integer getMin()
     {
-        return minimum;
+        return hasMinimum ? minimum : null;
     }
 
     @Override
     public Integer getMax()
     {
-        return maximum;
+        return hasMaximum ? maximum : null;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
     }
 
     @Override
@@ -56,22 +73,22 @@ public class DateStatistics
             return false;
         }
         DateStatistics that = (DateStatistics) o;
-        return Objects.equals(minimum, that.minimum) &&
-                Objects.equals(maximum, that.maximum);
+        return Objects.equals(getMin(), that.getMin()) &&
+                Objects.equals(getMax(), that.getMax());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(minimum, maximum);
+        return Objects.hash(getMin(), getMax());
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("min", minimum)
-                .add("max", maximum)
+                .add("min", getMin())
+                .add("max", getMax())
                 .toString();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalStatistics.java
@@ -13,11 +13,15 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.sizeOf;
 
 public class DecimalStatistics
         implements RangeStatistics<BigDecimal>
@@ -25,14 +29,31 @@ public class DecimalStatistics
     // 1 byte to denote if null
     public static final long DECIMAL_VALUE_BYTES_OVERHEAD = Byte.BYTES;
 
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DecimalStatistics.class).instanceSize();
+    // BigDecimal contains BigInteger and BigInteger contains an integer array.
+    // The size of the integer array is not accessible from outside; thus rely on callers to tell how large the size is.
+    private static final long BIG_DECIMAL_INSTANCE_SIZE = ClassLayout.parseClass(BigDecimal.class).instanceSize() + ClassLayout.parseClass(BigInteger.class).instanceSize() + sizeOf(new int[0]);
+
+    // TODO: replace min/max with LongDecimal/ShortDecimal to calculate retained size
     private final BigDecimal minimum;
     private final BigDecimal maximum;
+    private final long retainedSizeInBytes;
 
-    public DecimalStatistics(BigDecimal minimum, BigDecimal maximum)
+    @SuppressWarnings("NumberEquality")
+    public DecimalStatistics(BigDecimal minimum, BigDecimal maximum, long decimalSizeInBytes)
     {
         checkArgument(minimum == null || maximum == null || minimum.compareTo(maximum) <= 0, "minimum is not less than maximum");
         this.minimum = minimum;
         this.maximum = maximum;
+
+        int retainedSizeInBytes = 0;
+        if (minimum != null) {
+            retainedSizeInBytes += BIG_DECIMAL_INSTANCE_SIZE + decimalSizeInBytes;
+        }
+        if (maximum != null && minimum != maximum) {
+            retainedSizeInBytes += BIG_DECIMAL_INSTANCE_SIZE + decimalSizeInBytes;
+        }
+        this.retainedSizeInBytes = retainedSizeInBytes + INSTANCE_SIZE;
     }
 
     @Override
@@ -45,6 +66,12 @@ public class DecimalStatistics
     public BigDecimal getMax()
     {
         return maximum;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatistics.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -24,28 +26,43 @@ public class DoubleStatistics
     // 1 byte to denote if null + 8 bytes for the value
     public static final long DOUBLE_VALUE_BYTES = Byte.BYTES + Double.BYTES;
 
-    private final Double minimum;
-    private final Double maximum;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DoubleStatistics.class).instanceSize();
+
+    private final boolean hasMinimum;
+    private final boolean hasMaximum;
+
+    private final double minimum;
+    private final double maximum;
 
     public DoubleStatistics(Double minimum, Double maximum)
     {
         checkArgument(minimum == null || !minimum.isNaN(), "minimum is NaN");
         checkArgument(maximum == null || !maximum.isNaN(), "maximum is NaN");
         checkArgument(minimum == null || maximum == null || minimum <= maximum, "minimum is not less than maximum");
-        this.minimum = minimum;
-        this.maximum = maximum;
+
+        this.hasMinimum = minimum != null;
+        this.minimum = hasMinimum ? minimum : 0;
+
+        this.hasMaximum = maximum != null;
+        this.maximum = hasMaximum ? maximum : 0;
     }
 
     @Override
     public Double getMin()
     {
-        return minimum;
+        return hasMinimum ? minimum : null;
     }
 
     @Override
     public Double getMax()
     {
-        return maximum;
+        return hasMaximum ? maximum : null;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
     }
 
     @Override
@@ -58,22 +75,22 @@ public class DoubleStatistics
             return false;
         }
         DoubleStatistics that = (DoubleStatistics) o;
-        return Objects.equals(minimum, that.minimum) &&
-                Objects.equals(maximum, that.maximum);
+        return Objects.equals(getMin(), that.getMin()) &&
+                Objects.equals(getMax(), that.getMax());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(minimum, maximum);
+        return Objects.hash(getMin(), getMax());
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("min", minimum)
-                .add("max", maximum)
+                .add("min", getMin())
+                .add("max", getMax())
                 .toString();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/HiveBloomFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/HiveBloomFilter.java
@@ -15,14 +15,19 @@ package com.facebook.presto.orc.metadata.statistics;
 
 import com.google.common.primitives.Longs;
 import org.apache.hive.common.util.BloomFilter;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import static io.airlift.slice.SizeOf.sizeOf;
+
 public class HiveBloomFilter
         extends BloomFilter
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(HiveBloomFilter.class).instanceSize() + ClassLayout.parseClass(BitSet.class).instanceSize();
+
     // constructor that allows deserialization of a long list into the actual hive bloom filter
     public HiveBloomFilter(List<Long> bits, int numBits, int numHashFunctions)
     {
@@ -36,6 +41,11 @@ public class HiveBloomFilter
         this.bitSet = new BitSet(bloomFilter.getBitSet().clone());
         this.numBits = bloomFilter.getBitSize();
         this.numHashFunctions = bloomFilter.getNumHashFunctions();
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(bitSet.getData());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatistics.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -24,33 +26,51 @@ public class IntegerStatistics
     // 1 byte to denote if null + 8 bytes for the value (integer is of long type)
     public static final long INTEGER_VALUE_BYTES = Byte.BYTES + Long.BYTES;
 
-    private final Long minimum;
-    private final Long maximum;
-    private final Long sum;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntegerStatistics.class).instanceSize();
+
+    private final boolean hasMinimum;
+    private final boolean hasMaximum;
+    private final boolean hasSum;
+
+    private final long minimum;
+    private final long maximum;
+    private final long sum;
 
     public IntegerStatistics(Long minimum, Long maximum, Long sum)
     {
         checkArgument(minimum == null || maximum == null || minimum <= maximum, "minimum is not less than maximum");
-        this.minimum = minimum;
-        this.maximum = maximum;
-        this.sum = sum;
+
+        this.hasMinimum = minimum != null;
+        this.minimum = hasMinimum ? minimum : 0;
+
+        this.hasMaximum = maximum != null;
+        this.maximum = hasMaximum ? maximum : 0;
+
+        this.hasSum = sum != null;
+        this.sum = hasSum ? sum : 0;
     }
 
     @Override
     public Long getMin()
     {
-        return minimum;
+        return hasMinimum ? minimum : null;
     }
 
     @Override
     public Long getMax()
     {
-        return maximum;
+        return hasMaximum ? maximum : null;
     }
 
     public Long getSum()
     {
-        return sum;
+        return hasSum ? sum : null;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
     }
 
     @Override
@@ -63,24 +83,24 @@ public class IntegerStatistics
             return false;
         }
         IntegerStatistics that = (IntegerStatistics) o;
-        return Objects.equals(minimum, that.minimum) &&
-                Objects.equals(maximum, that.maximum) &&
-                Objects.equals(sum, that.sum);
+        return Objects.equals(getMin(), that.getMin()) &&
+                Objects.equals(getMax(), that.getMax()) &&
+                Objects.equals(getSum(), that.getSum());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(minimum, maximum, sum);
+        return Objects.hash(getMin(), getMax(), getSum());
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("min", minimum)
-                .add("max", maximum)
-                .add("sum", sum)
+                .add("min", getMin())
+                .add("max", getMax())
+                .add("sum", getSum())
                 .toString();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.statistics.DecimalStatistics.DECIMAL_VALUE_BYTES_OVERHEAD;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class LongDecimalStatisticsBuilder
@@ -85,7 +86,8 @@ public class LongDecimalStatisticsBuilder
         if (nonNullValueCount == 0) {
             return Optional.empty();
         }
-        return Optional.of(new DecimalStatistics(minimum, maximum));
+        checkState(minimum != null && maximum != null);
+        return Optional.of(new DecimalStatistics(minimum, maximum, LONG_DECIMAL_VALUE_BYTES));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/RangeStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/RangeStatistics.java
@@ -18,4 +18,6 @@ public interface RangeStatistics<T>
     T getMin();
 
     T getMax();
+
+    long getRetainedSizeInBytes();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -51,7 +51,8 @@ public class ShortDecimalStatisticsBuilder
         }
         return Optional.of(new DecimalStatistics(
                 new BigDecimal(BigInteger.valueOf(minimum), scale),
-                new BigDecimal(BigInteger.valueOf(maximum), scale)));
+                new BigDecimal(BigInteger.valueOf(maximum), scale),
+                SHORT_DECIMAL_VALUE_BYTES));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatistics.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.metadata.statistics;
 
 import io.airlift.slice.Slice;
+import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -28,13 +29,15 @@ public class StringStatistics
     // 1 byte to denote if null + 4 bytes to denote offset
     public static final long STRING_VALUE_BYTES_OVERHEAD = Byte.BYTES + Integer.BYTES;
 
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(StringStatistics.class).instanceSize();
+
     @Nullable
     private final Slice minimum;
     @Nullable
     private final Slice maximum;
     private final long sum;
 
-    public StringStatistics(Slice minimum, Slice maximum, long sum)
+    public StringStatistics(@Nullable Slice minimum, @Nullable Slice maximum, long sum)
     {
         checkArgument(minimum == null || maximum == null || minimum.compareTo(maximum) <= 0, "minimum is not less than maximum");
         this.minimum = minimum;
@@ -57,6 +60,12 @@ public class StringStatistics
     public long getSum()
     {
         return sum;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + (minimum == null ? 0 : minimum.getRetainedSize()) + ((maximum == null || maximum == minimum) ? 0 : maximum.getRetainedSize());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StripeStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StripeStatistics.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.metadata.statistics;
 
 import com.google.common.collect.ImmutableList;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Objects;
@@ -22,16 +23,25 @@ import static java.util.Objects.requireNonNull;
 
 public class StripeStatistics
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(StripeStatistics.class).instanceSize();
+
     private final List<ColumnStatistics> columnStatistics;
+    private final long retainedSizeInBytes;
 
     public StripeStatistics(List<ColumnStatistics> columnStatistics)
     {
         this.columnStatistics = ImmutableList.copyOf(requireNonNull(columnStatistics, "columnStatistics is null"));
+        this.retainedSizeInBytes = INSTANCE_SIZE + columnStatistics.stream().mapToLong(ColumnStatistics::getRetainedSizeInBytes).sum();
     }
 
     public List<ColumnStatistics> getColumnStatistics()
     {
         return columnStatistics;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import java.math.BigDecimal;
 
 import static com.facebook.presto.orc.TupleDomainOrcPredicate.getDomain;
+import static com.facebook.presto.orc.metadata.statistics.ShortDecimalStatisticsBuilder.SHORT_DECIMAL_VALUE_BYTES;
 import static com.facebook.presto.spi.predicate.Domain.all;
 import static com.facebook.presto.spi.predicate.Domain.create;
 import static com.facebook.presto.spi.predicate.Domain.none;
@@ -320,7 +321,7 @@ public class TestTupleDomainOrcPredicate
     {
         BigDecimal minimumDecimal = minimum == null ? null : new BigDecimal(minimum);
         BigDecimal maximumDecimal = maximum == null ? null : new BigDecimal(maximum);
-        return new ColumnStatistics(numberOfValues, 9L, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal), null, null);
+        return new ColumnStatistics(numberOfValues, 9L, null, null, null, null, null, new DecimalStatistics(minimumDecimal, maximumDecimal, SHORT_DECIMAL_VALUE_BYTES), null, null);
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractRangeStatisticsTest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractRangeStatisticsTest.java
@@ -33,6 +33,11 @@ public abstract class AbstractRangeStatisticsTest<R extends RangeStatistics<T>, 
         }
     }
 
+    void assertRetainedSize(T min, T max, long expectedSizeInBytes)
+    {
+        assertEquals(getCreateStatistics(min, max).getRetainedSizeInBytes(), expectedSizeInBytes);
+    }
+
     private void assertMinMaxStatistics(T min, T max)
     {
         R statistics = getCreateStatistics(min, max);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDateStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDateStatistics.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import static java.lang.Integer.MAX_VALUE;
@@ -21,6 +22,8 @@ import static java.lang.Integer.MIN_VALUE;
 public class TestDateStatistics
         extends AbstractRangeStatisticsTest<DateStatistics, Integer>
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DateStatistics.class).instanceSize();
+
     @Override
     protected DateStatistics getCreateStatistics(Integer min, Integer max)
     {
@@ -35,5 +38,15 @@ public class TestDateStatistics
         assertMinMax(MIN_VALUE, 42);
         assertMinMax(42, MAX_VALUE);
         assertMinMax(MIN_VALUE, MAX_VALUE);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        assertRetainedSize(0, 42, INSTANCE_SIZE);
+        assertRetainedSize(42, 42, INSTANCE_SIZE);
+        assertRetainedSize(MIN_VALUE, 42, INSTANCE_SIZE);
+        assertRetainedSize(42, MAX_VALUE, INSTANCE_SIZE);
+        assertRetainedSize(MIN_VALUE, MAX_VALUE, INSTANCE_SIZE);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDecimalStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDecimalStatistics.java
@@ -1,4 +1,3 @@
-package com.facebook.presto.orc.metadata.statistics;
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,15 +11,24 @@ package com.facebook.presto.orc.metadata.statistics;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.facebook.presto.orc.metadata.statistics;
+
+import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
+import static com.facebook.presto.orc.metadata.statistics.LongDecimalStatisticsBuilder.LONG_DECIMAL_VALUE_BYTES;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.math.BigDecimal.ZERO;
 
 public class TestDecimalStatistics
         extends AbstractRangeStatisticsTest<DecimalStatistics, BigDecimal>
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DecimalStatistics.class).instanceSize();
+    private static final long BIG_DECIMAL_INSTANCE_SIZE = ClassLayout.parseClass(BigDecimal.class).instanceSize() + ClassLayout.parseClass(BigInteger.class).instanceSize() + sizeOf(new int[0]);
+
     private static final BigDecimal MEDIUM_VALUE = new BigDecimal("890.37492");
     private static final BigDecimal LARGE_POSITIVE_VALUE = new BigDecimal("123456789012345678901234567890.12345");
     private static final BigDecimal LARGE_NEGATIVE_VALUE = LARGE_POSITIVE_VALUE.negate();
@@ -28,7 +36,7 @@ public class TestDecimalStatistics
     @Override
     protected DecimalStatistics getCreateStatistics(BigDecimal min, BigDecimal max)
     {
-        return new DecimalStatistics(min, max);
+        return new DecimalStatistics(min, max, LONG_DECIMAL_VALUE_BYTES);
     }
 
     @Test
@@ -39,5 +47,15 @@ public class TestDecimalStatistics
         assertMinMax(LARGE_NEGATIVE_VALUE, MEDIUM_VALUE);
         assertMinMax(MEDIUM_VALUE, LARGE_POSITIVE_VALUE);
         assertMinMax(LARGE_NEGATIVE_VALUE, LARGE_POSITIVE_VALUE);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        assertRetainedSize(LARGE_NEGATIVE_VALUE, LARGE_NEGATIVE_VALUE, INSTANCE_SIZE + BIG_DECIMAL_INSTANCE_SIZE + LONG_DECIMAL_VALUE_BYTES);
+        assertRetainedSize(LARGE_NEGATIVE_VALUE, LARGE_POSITIVE_VALUE, INSTANCE_SIZE + (BIG_DECIMAL_INSTANCE_SIZE + LONG_DECIMAL_VALUE_BYTES) * 2);
+        assertRetainedSize(null, LARGE_POSITIVE_VALUE, INSTANCE_SIZE + BIG_DECIMAL_INSTANCE_SIZE + LONG_DECIMAL_VALUE_BYTES);
+        assertRetainedSize(LARGE_NEGATIVE_VALUE, null, INSTANCE_SIZE + BIG_DECIMAL_INSTANCE_SIZE + LONG_DECIMAL_VALUE_BYTES);
+        assertRetainedSize(null, null, INSTANCE_SIZE);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDoubleStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestDoubleStatistics.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import static java.lang.Double.NEGATIVE_INFINITY;
@@ -23,6 +24,8 @@ import static org.testng.Assert.assertThrows;
 public class TestDoubleStatistics
         extends AbstractRangeStatisticsTest<DoubleStatistics, Double>
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DoubleStatistics.class).instanceSize();
+
     @Override
     protected DoubleStatistics getCreateStatistics(Double min, Double max)
     {
@@ -46,5 +49,15 @@ public class TestDoubleStatistics
         assertThrows(() -> new DoubleStatistics(0.0, NaN));
         assertThrows(() -> new DoubleStatistics(NaN, 0.0));
         assertThrows(() -> new DoubleStatistics(NaN, NaN));
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        assertRetainedSize(0.0, 42.0, INSTANCE_SIZE);
+        assertRetainedSize(42.0, 42.0, INSTANCE_SIZE);
+        assertRetainedSize(NEGATIVE_INFINITY, 42.0, INSTANCE_SIZE);
+        assertRetainedSize(42.0, POSITIVE_INFINITY, INSTANCE_SIZE);
+        assertRetainedSize(NEGATIVE_INFINITY, POSITIVE_INFINITY, INSTANCE_SIZE);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestIntegerStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestIntegerStatistics.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import static java.lang.Long.MAX_VALUE;
@@ -21,6 +22,8 @@ import static java.lang.Long.MIN_VALUE;
 public class TestIntegerStatistics
         extends AbstractRangeStatisticsTest<IntegerStatistics, Long>
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntegerStatistics.class).instanceSize();
+
     @Override
     protected IntegerStatistics getCreateStatistics(Long min, Long max)
     {
@@ -36,5 +39,15 @@ public class TestIntegerStatistics
         assertMinMax(MIN_VALUE, 42L);
         assertMinMax(42L, MAX_VALUE);
         assertMinMax(MIN_VALUE, MAX_VALUE);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        assertRetainedSize(0L, 42L, INSTANCE_SIZE);
+        assertRetainedSize(42L, 42L, INSTANCE_SIZE);
+        assertRetainedSize(MIN_VALUE, 42L, INSTANCE_SIZE);
+        assertRetainedSize(42L, MAX_VALUE, INSTANCE_SIZE);
+        assertRetainedSize(MIN_VALUE, MAX_VALUE, INSTANCE_SIZE);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatistics.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatistics.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.metadata.statistics;
 
 import io.airlift.slice.Slice;
+import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import static io.airlift.slice.Slices.EMPTY_SLICE;
@@ -22,6 +23,8 @@ import static io.airlift.slice.Slices.utf8Slice;
 public class TestStringStatistics
         extends AbstractRangeStatisticsTest<StringStatistics, Slice>
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(StringStatistics.class).instanceSize();
+
     // U+0000 to U+D7FF
     private static final Slice LOW_BOTTOM_VALUE = utf8Slice("foo \u0000");
     private static final Slice LOW_TOP_VALUE = utf8Slice("foo \uD7FF");
@@ -68,5 +71,17 @@ public class TestStringStatistics
         assertMinMax(MEDIUM_TOP_VALUE, HIGH_TOP_VALUE);
 
         assertMinMax(HIGH_BOTTOM_VALUE, HIGH_TOP_VALUE);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        assertRetainedSize(EMPTY_SLICE, LOW_BOTTOM_VALUE, INSTANCE_SIZE + EMPTY_SLICE.getRetainedSize() + LOW_BOTTOM_VALUE.getRetainedSize());
+        assertRetainedSize(LOW_TOP_VALUE, LOW_TOP_VALUE, INSTANCE_SIZE + LOW_TOP_VALUE.getRetainedSize());
+        assertRetainedSize(EMPTY_SLICE, EMPTY_SLICE, INSTANCE_SIZE + EMPTY_SLICE.getRetainedSize());
+        assertRetainedSize(MEDIUM_TOP_VALUE, HIGH_BOTTOM_VALUE, INSTANCE_SIZE + MEDIUM_TOP_VALUE.getRetainedSize() + HIGH_BOTTOM_VALUE.getRetainedSize());
+        assertRetainedSize(null, HIGH_BOTTOM_VALUE, INSTANCE_SIZE + HIGH_BOTTOM_VALUE.getRetainedSize());
+        assertRetainedSize(EMPTY_SLICE, null, INSTANCE_SIZE + EMPTY_SLICE.getRetainedSize());
+        assertRetainedSize(null, null, INSTANCE_SIZE);
     }
 }


### PR DESCRIPTION
An ORC writer maintains all the stripe statistics until the writer is
closed. The stats can take GBs of memory when the output table is large.
Also, some of the stats contain boxed types, which can cause object
overhead. This patch does the following things:
- Use primitive types in stats if possible
- Track stripe statistics for ORC writers
- Track row group statistics for ORC writer validators