### PR TITLE
Rewrite Driver cpu timing to estimate real cpu usage

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -275,7 +275,7 @@ public class Driver
 
         Optional<ListenableFuture<?>> result = tryWithLock(100, TimeUnit.MILLISECONDS, () -> {
             OperationTimer operationTimer = new OperationTimer();
-            driverContext.startProcessTimer(operationTimer);
+            driverContext.startProcessTimer();
             driverContext.getYieldSignal().setWithDelay(maxRuntime, driverContext.getYieldExecutor());
             try {
                 long start = System.nanoTime();
@@ -289,7 +289,7 @@ public class Driver
             }
             finally {
                 driverContext.getYieldSignal().reset();
-                operationTimer.end();
+                driverContext.recordProcessed(operationTimer);
             }
             return NOT_BLOCKED;
         });
@@ -313,7 +313,7 @@ public class Driver
                 return updateDriverBlockedFuture(future);
             }
             finally {
-                operationTimer.end();
+                operationTimer.end(null);
             }
         });
         return result.orElse(NOT_BLOCKED);

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -18,6 +18,7 @@ import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.memory.QueryContextVisitor;
 import com.facebook.presto.memory.context.MemoryTrackingContext;
+import com.facebook.presto.operator.OperationTimer.OperationTiming;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -68,14 +69,7 @@ public class DriverContext
     private final AtomicLong startNanos = new AtomicLong();
     private final AtomicLong endNanos = new AtomicLong();
 
-    private final AtomicLong intervalWallStart = new AtomicLong();
-    private final AtomicLong intervalCpuStart = new AtomicLong();
-    private final AtomicLong intervalUserStart = new AtomicLong();
-
-    private final AtomicLong processCalls = new AtomicLong();
-    private final AtomicLong processWallNanos = new AtomicLong();
-    private final AtomicLong processCpuNanos = new AtomicLong();
-    private final AtomicLong processUserNanos = new AtomicLong();
+    private final OperationTiming processTimer = new OperationTiming();
 
     private final AtomicReference<BlockedMonitor> blockedMonitor = new AtomicReference<>();
     private final AtomicLong blockedWallNanos = new AtomicLong();
@@ -147,24 +141,14 @@ public class DriverContext
         return pipelineContext.getSession();
     }
 
-    public void startProcessTimer()
+    public void startProcessTimer(OperationTimer operationTimer)
     {
         if (startNanos.compareAndSet(0, System.nanoTime())) {
             pipelineContext.start();
             executionStartTime.set(DateTime.now());
         }
 
-        intervalWallStart.set(System.nanoTime());
-        intervalCpuStart.set(currentThreadCpuTime());
-        intervalUserStart.set(currentThreadUserTime());
-    }
-
-    public void recordProcessed()
-    {
-        processCalls.incrementAndGet();
-        processWallNanos.getAndAdd(nanosBetween(intervalWallStart.get(), System.nanoTime()));
-        processCpuNanos.getAndAdd(nanosBetween(intervalCpuStart.get(), currentThreadCpuTime()));
-        processUserNanos.getAndAdd(nanosBetween(intervalUserStart.get(), currentThreadUserTime()));
+        operationTimer.setOverallTimer(processTimer);
     }
 
     public void recordBlocked(ListenableFuture<?> blocked)
@@ -316,9 +300,9 @@ public class DriverContext
 
     public DriverStats getDriverStats()
     {
-        long totalScheduledTime = processWallNanos.get();
-        long totalCpuTime = processCpuNanos.get();
-        long totalUserTime = processUserNanos.get();
+        long totalScheduledTime = processTimer.getWallNanos();
+        long totalCpuTime = processTimer.getEstimatedCpuNanos();
+        long totalUserTime = processTimer.getEstimatedUserNanos();
 
         long totalBlockedTime = blockedWallNanos.get();
         BlockedMonitor blockedMonitor = this.blockedMonitor.get();

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperationTimer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperationTimer.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.base.Ticker;
+import io.airlift.units.Duration;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class OperationTimer
+{
+    private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+    private static final long DEFAULT_MIN_NANOS_FOR_CPU_TIMING = new Duration(250, TimeUnit.MILLISECONDS).roundTo(NANOSECONDS);
+
+    private final Ticker ticker;
+    private final long minNanosForCpuTiming;
+
+    private final long wallStart;
+    private final long cpuStart;
+    private final long userStart;
+
+    private long intervalWallStart;
+
+    private long intervalUnaccountedCpuWallTime;
+    private long intervalCpuStart;
+    private long intervalUserStart;
+
+    private OperationTiming overallTiming;
+    private final Map<OperationTiming, InternalTiming> timings = new HashMap<>();
+
+    public OperationTimer()
+    {
+        this(Ticker.systemTicker(), DEFAULT_MIN_NANOS_FOR_CPU_TIMING);
+    }
+
+    public OperationTimer(Ticker ticker, long minNanosForCpuTiming)
+    {
+        this.ticker = requireNonNull(ticker, "ticker is null");
+        this.minNanosForCpuTiming = minNanosForCpuTiming;
+
+        wallStart = ticker.read();
+        cpuStart = currentThreadCpuTime();
+        userStart = currentThreadUserTime();
+
+        intervalWallStart = wallStart;
+        intervalCpuStart = cpuStart;
+        intervalUserStart = userStart;
+    }
+
+    public void setOverallTimer(OperationTiming overallTiming)
+    {
+        requireNonNull(overallTiming, "overallTiming is null");
+        checkState(this.overallTiming == null, "Overall timer already set");
+        this.overallTiming = overallTiming;
+    }
+
+    public void recordOperationComplete(OperationTiming timing)
+    {
+        requireNonNull(timing, "timing is null");
+        InternalTiming internalTiming = timings.computeIfAbsent(timing, InternalTiming::new);
+
+        long intervalWallEnd = ticker.read();
+        long intervalWallDuration = intervalWallEnd - intervalWallStart;
+        // only measure cpu time if the wall interval is large
+        if (intervalWallDuration < minNanosForCpuTiming) {
+            long intervalCpuEnd = currentThreadCpuTime();
+            long intervalCpuDuration = max(0, intervalCpuEnd - intervalCpuStart - intervalUnaccountedCpuWallTime);
+
+            long intervalUserEnd = currentThreadUserTime();
+            long intervalUserDuration = max(0, intervalUserEnd - intervalUserStart - intervalUnaccountedCpuWallTime);
+
+            internalTiming.recordMeasuredCpuTime(intervalWallDuration, intervalCpuDuration, intervalUserDuration);
+
+            intervalUnaccountedCpuWallTime = 0;
+            intervalWallStart = intervalWallEnd;
+            intervalCpuStart = intervalCpuEnd;
+            intervalUserStart = intervalUserEnd;
+        }
+        else {
+            internalTiming.recordUnaccountedCpuTime(intervalWallDuration);
+
+            intervalUnaccountedCpuWallTime += intervalWallDuration;
+            intervalWallStart = intervalWallEnd;
+        }
+    }
+
+    public void end()
+    {
+        if (overallTiming == null && timings.isEmpty()) {
+            return;
+        }
+
+        long wallEnd = ticker.read();
+
+        long cpuEnd;
+        long userEnd;
+        // remeasure cpu timings if the current interval is large
+        if (wallEnd - intervalWallStart < minNanosForCpuTiming) {
+            cpuEnd = currentThreadCpuTime();
+            userEnd = currentThreadUserTime();
+        }
+        else {
+            cpuEnd = intervalCpuStart;
+            userEnd = intervalUserStart;
+        }
+
+        if (overallTiming != null) {
+            long wallDuration = wallEnd - wallStart;
+            overallTiming.recordWallTime(wallDuration);
+            if (cpuEnd > cpuStart) {
+                overallTiming.recordEstimatedCpuTime(cpuEnd - cpuStart);
+                overallTiming.recordEstimatedUserTime(userEnd - userStart);
+            }
+            else {
+                overallTiming.recordEstimatedCpuTime(wallDuration);
+                overallTiming.recordEstimatedUserTime(wallDuration);
+            }
+        }
+
+        long totalUnaccountedCpuWallNanos = timings.values().stream()
+                .mapToLong(InternalTiming::getCpuUnaccountedWallNanos)
+                .sum();
+
+        long totalMeasuredCpuNanos = timings.values().stream()
+                .mapToLong(InternalTiming::getCpuMeasuredNanos)
+                .sum();
+        long totalUnaccountedCpuNanos = max(0, cpuEnd - cpuStart - totalMeasuredCpuNanos);
+
+        long totalMeasuredUserNanos = timings.values().stream()
+                .mapToLong(InternalTiming::getUserMeasuredNanos)
+                .sum();
+        long totalUnaccountedUserNanos = max(0, userEnd - userStart - totalMeasuredUserNanos);
+
+        for (InternalTiming timing : timings.values()) {
+            timing.recordTimings(totalUnaccountedCpuNanos, totalUnaccountedUserNanos, totalUnaccountedCpuWallNanos);
+        }
+    }
+
+    private static long currentThreadUserTime()
+    {
+        return THREAD_MX_BEAN.getCurrentThreadUserTime();
+    }
+
+    private static long currentThreadCpuTime()
+    {
+        return THREAD_MX_BEAN.getCurrentThreadCpuTime();
+    }
+
+    private static class InternalTiming
+    {
+        private final OperationTiming operationTiming;
+
+        private long cpuMeasuredNanos;
+        private long userMeasuredNanos;
+        private long cpuUnaccountedWallNanos;
+
+        public InternalTiming(OperationTiming operationTiming)
+        {
+            this.operationTiming = operationTiming;
+        }
+
+        public void recordMeasuredCpuTime(long intervalWallNanos, long intervalCpuNanos, long intervalUserNanos)
+        {
+            operationTiming.recordWallTime(intervalWallNanos);
+
+            cpuMeasuredNanos += intervalCpuNanos;
+            userMeasuredNanos += intervalUserNanos;
+        }
+
+        public void recordUnaccountedCpuTime(long intervalWallNanos)
+        {
+            operationTiming.recordWallTime(intervalWallNanos);
+            cpuUnaccountedWallNanos += intervalWallNanos;
+        }
+
+        public long getCpuMeasuredNanos()
+        {
+            return cpuMeasuredNanos;
+        }
+
+        public long getCpuUnaccountedWallNanos()
+        {
+            return cpuUnaccountedWallNanos;
+        }
+
+        public long getUserMeasuredNanos()
+        {
+            return userMeasuredNanos;
+        }
+
+        public void recordTimings(long totalUnaccountedCpuNanos, long totalUnaccountedUserNanos, long totalUnaccountedCpuWallNanos)
+        {
+            if (cpuUnaccountedWallNanos > 0) {
+                // measured CPU + this timers portion of the unaccounted CPU
+                operationTiming.recordEstimatedCpuTime(cpuMeasuredNanos + totalUnaccountedCpuNanos * (totalUnaccountedCpuWallNanos / cpuUnaccountedWallNanos));
+                // measured USER + this timers portion of the unaccounted USER
+                operationTiming.recordEstimatedUserTime(userMeasuredNanos + totalUnaccountedUserNanos * (totalUnaccountedCpuWallNanos / cpuUnaccountedWallNanos));
+            }
+            else {
+                operationTiming.recordEstimatedCpuTime(cpuMeasuredNanos);
+                operationTiming.recordEstimatedUserTime(userMeasuredNanos);
+            }
+        }
+    }
+
+    @ThreadSafe
+    public static class OperationTiming
+    {
+        private final AtomicLong calls = new AtomicLong();
+        private final AtomicLong wallNanos = new AtomicLong();
+        private final AtomicLong estimatedCpuNanos = new AtomicLong();
+        private final AtomicLong estimatedUserNanos = new AtomicLong();
+
+        public long getCalls()
+        {
+            return calls.get();
+        }
+
+        public long getWallNanos()
+        {
+            return wallNanos.get();
+        }
+
+        public long getEstimatedCpuNanos()
+        {
+            return estimatedCpuNanos.get();
+        }
+
+        public long getEstimatedUserNanos()
+        {
+            return estimatedUserNanos.get();
+        }
+
+        void recordWallTime(long wallNanos)
+        {
+            this.calls.incrementAndGet();
+            this.wallNanos.addAndGet(wallNanos);
+        }
+
+        void recordEstimatedCpuTime(long estimatedCpuNanos)
+        {
+            this.estimatedCpuNanos.addAndGet(estimatedCpuNanos);
+        }
+
+        void recordEstimatedUserTime(long estimatedUserNanos)
+        {
+            this.estimatedUserNanos.addAndGet(estimatedUserNanos);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("calls", calls)
+                    .add("wallNanos", wallNanos)
+                    .add("estimatedCpuNanos", estimatedCpuNanos)
+                    .add("estimatedUserNanos", estimatedUserNanos)
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -18,6 +18,7 @@ import com.facebook.presto.memory.QueryContextVisitor;
 import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.memory.context.MemoryTrackingContext;
+import com.facebook.presto.operator.OperationTimer.OperationTiming;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
@@ -63,21 +64,11 @@ public class OperatorContext
     private final DriverContext driverContext;
     private final Executor executor;
 
-    private final AtomicLong intervalWallStart = new AtomicLong();
-    private final AtomicLong intervalCpuStart = new AtomicLong();
-    private final AtomicLong intervalUserStart = new AtomicLong();
-
-    private final AtomicLong addInputCalls = new AtomicLong();
-    private final AtomicLong addInputWallNanos = new AtomicLong();
-    private final AtomicLong addInputCpuNanos = new AtomicLong();
-    private final AtomicLong addInputUserNanos = new AtomicLong();
+    private final OperationTiming addInputTiming = new OperationTiming();
     private final CounterStat inputDataSize = new CounterStat();
     private final CounterStat inputPositions = new CounterStat();
 
-    private final AtomicLong getOutputCalls = new AtomicLong();
-    private final AtomicLong getOutputWallNanos = new AtomicLong();
-    private final AtomicLong getOutputCpuNanos = new AtomicLong();
-    private final AtomicLong getOutputUserNanos = new AtomicLong();
+    private final OperationTiming getOutputTiming = new OperationTiming();
     private final CounterStat outputDataSize = new CounterStat();
     private final CounterStat outputPositions = new CounterStat();
 
@@ -88,10 +79,7 @@ public class OperatorContext
     private final AtomicReference<BlockedMonitor> blockedMonitor = new AtomicReference<>();
     private final AtomicLong blockedWallNanos = new AtomicLong();
 
-    private final AtomicLong finishCalls = new AtomicLong();
-    private final AtomicLong finishWallNanos = new AtomicLong();
-    private final AtomicLong finishCpuNanos = new AtomicLong();
-    private final AtomicLong finishUserNanos = new AtomicLong();
+    private final OperationTiming finishTiming = new OperationTiming();
 
     private final SpillContext spillContext;
     private final AtomicReference<Supplier<OperatorInfo>> infoSupplier = new AtomicReference<>();
@@ -160,19 +148,9 @@ public class OperatorContext
         return driverContext.isDone();
     }
 
-    void startIntervalTimer()
+    void recordAddInput(OperationTimer operationTimer, Page page)
     {
-        intervalWallStart.set(System.nanoTime());
-        intervalCpuStart.set(currentThreadCpuTime());
-        intervalUserStart.set(currentThreadUserTime());
-    }
-
-    void recordAddInput(Page page)
-    {
-        addInputCalls.incrementAndGet();
-        recordInputWallNanos(nanosBetween(intervalWallStart.get(), System.nanoTime()));
-        addInputCpuNanos.getAndAdd(nanosBetween(intervalCpuStart.get(), currentThreadCpuTime()));
-        addInputUserNanos.getAndAdd(nanosBetween(intervalUserStart.get(), currentThreadUserTime()));
+        operationTimer.recordOperationComplete(addInputTiming);
 
         if (page != null) {
             inputDataSize.update(page.getSizeInBytes());
@@ -189,20 +167,12 @@ public class OperatorContext
     {
         inputDataSize.update(sizeInBytes);
         inputPositions.update(positions);
-        recordInputWallNanos(readNanos);
+        addInputTiming.recordWallTime(readNanos);
     }
 
-    private long recordInputWallNanos(long readNanos)
+    void recordGetOutput(OperationTimer operationTimer, Page page)
     {
-        return addInputWallNanos.getAndAdd(readNanos);
-    }
-
-    void recordGetOutput(Page page)
-    {
-        getOutputCalls.incrementAndGet();
-        getOutputWallNanos.getAndAdd(nanosBetween(intervalWallStart.get(), System.nanoTime()));
-        getOutputCpuNanos.getAndAdd(nanosBetween(intervalCpuStart.get(), currentThreadCpuTime()));
-        getOutputUserNanos.getAndAdd(nanosBetween(intervalUserStart.get(), currentThreadUserTime()));
+        operationTimer.recordOperationComplete(getOutputTiming);
 
         if (page != null) {
             outputDataSize.update(page.getSizeInBytes());
@@ -236,12 +206,9 @@ public class OperatorContext
         // Do not register blocked with driver context.  The driver handles this directly.
     }
 
-    void recordFinish()
+    void recordFinish(OperationTimer operationTimer)
     {
-        finishCalls.incrementAndGet();
-        finishWallNanos.getAndAdd(nanosBetween(intervalWallStart.get(), System.nanoTime()));
-        finishCpuNanos.getAndAdd(nanosBetween(intervalCpuStart.get(), currentThreadCpuTime()));
-        finishUserNanos.getAndAdd(nanosBetween(intervalUserStart.get(), currentThreadUserTime()));
+        operationTimer.recordOperationComplete(finishTiming);
     }
 
     public ListenableFuture<?> isWaitingForMemory()
@@ -469,18 +436,18 @@ public class OperatorContext
 
                 1,
 
-                addInputCalls.get(),
-                new Duration(addInputWallNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                new Duration(addInputCpuNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                new Duration(addInputUserNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                addInputTiming.getCalls(),
+                new Duration(addInputTiming.getWallNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(addInputTiming.getEstimatedCpuNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(addInputTiming.getEstimatedUserNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 succinctBytes(inputDataSize.getTotalCount()),
                 inputPositionsCount,
                 (double) inputPositionsCount * inputPositionsCount,
 
-                getOutputCalls.get(),
-                new Duration(getOutputWallNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                new Duration(getOutputCpuNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                new Duration(getOutputUserNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                getOutputTiming.getCalls(),
+                new Duration(getOutputTiming.getWallNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(getOutputTiming.getEstimatedCpuNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(getOutputTiming.getEstimatedUserNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 succinctBytes(outputDataSize.getTotalCount()),
                 outputPositions.getTotalCount(),
 
@@ -488,10 +455,10 @@ public class OperatorContext
 
                 new Duration(blockedWallNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
 
-                finishCalls.get(),
-                new Duration(finishWallNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                new Duration(finishCpuNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                new Duration(finishUserNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                finishTiming.getCalls(),
+                new Duration(finishTiming.getWallNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(finishTiming.getEstimatedCpuNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
+                new Duration(finishTiming.getEstimatedUserNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
 
                 succinctBytes(operatorMemoryContext.getUserMemory()),
                 succinctBytes(getReservedRevocableBytes()),

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -160,14 +160,14 @@ public class OperatorContext
         return driverContext.isDone();
     }
 
-    public void startIntervalTimer()
+    void startIntervalTimer()
     {
         intervalWallStart.set(System.nanoTime());
         intervalCpuStart.set(currentThreadCpuTime());
         intervalUserStart.set(currentThreadUserTime());
     }
 
-    public void recordAddInput(Page page)
+    void recordAddInput(Page page)
     {
         addInputCalls.incrementAndGet();
         recordInputWallNanos(nanosBetween(intervalWallStart.get(), System.nanoTime()));
@@ -192,12 +192,12 @@ public class OperatorContext
         recordInputWallNanos(readNanos);
     }
 
-    public long recordInputWallNanos(long readNanos)
+    private long recordInputWallNanos(long readNanos)
     {
         return addInputWallNanos.getAndAdd(readNanos);
     }
 
-    public void recordGetOutput(Page page)
+    void recordGetOutput(Page page)
     {
         getOutputCalls.incrementAndGet();
         getOutputWallNanos.getAndAdd(nanosBetween(intervalWallStart.get(), System.nanoTime()));
@@ -236,7 +236,7 @@ public class OperatorContext
         // Do not register blocked with driver context.  The driver handles this directly.
     }
 
-    public void recordFinish()
+    void recordFinish()
     {
         finishCalls.incrementAndGet();
         finishWallNanos.getAndAdd(nanosBetween(intervalWallStart.get(), System.nanoTime()));


### PR DESCRIPTION
The idea is to record real CPU usage only when the operation wall time was "large".  Otherwise the CPU time is estimated:
```
  totalCpuTime = measure directly from driver process start to end
  totalAccountedCpuTime = sum(operatorCpuMeasuredTime)
  totalUnaccountedCpuTime = totalCpuTime - totalAccountedCpuTime 
  unaccountedCpuWallTime = sum(operatorWallTimeWhenCpuNotMeasured)
  oppreatorEstimatedCpu = operatorCpuMeasuredTime + totalUnaccountedCpuTime * (unaccountedCpuWallTime / operatorWallTimeWhenCpuNotMeasured)
```
Basically, we determine how much CPU time was not directly measured, and spread it amongst the operators based on the wall time spend when CPU time is not measured.

Credit for this idea goes to @electrum 