### PR TITLE
Add an array_sort function that takes a lambda comparator

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -62,6 +62,37 @@ Array Functions
     Sorts and returns the array ``x``. The elements of ``x`` must be orderable.
     Null elements will be placed at the end of the returned array.
 
+.. function:: array_sort(array<T>, function<T,T,int>) -> array<T>
+
+    Sorts and returns the ``array`` based on the given comparator ``function``. The comparator will take
+    two nullable arguments representing two nullable elements of the ``array``. It returns -1, 0, or 1
+    as the first nullable element is less than, equal to, or greater than the second nullable element.
+    If the comparator function returns other values (including ``NULL``), the query will fail and raise an error ::
+
+        SELECT array_sort(ARRAY [3, 2, 5, 1, 2], (x, y) -> IF(x < y, 1, IF(x = y, 0, -1))); -- [5, 3, 2, 2, 1]
+        SELECT array_sort(ARRAY ['bc', 'ab', 'dc'], (x, y) -> IF(x < y, 1, IF(x = y, 0, -1))); -- ['dc', 'bc', 'ab']
+        SELECT array_sort(ARRAY [3, 2, null, 5, null, 1, 2], -- sort null first with descending order
+                          (x, y) -> CASE WHEN x IS NULL THEN -1
+                                         WHEN y IS NULL THEN 1
+                                         WHEN x < y THEN 1
+                                         WHEN x = y THEN 0
+                                         ELSE -1 END); -- [null, null, 5, 3, 2, 2, 1]
+        SELECT array_sort(ARRAY [3, 2, null, 5, null, 1, 2], -- sort null last with descending order
+                          (x, y) -> CASE WHEN x IS NULL THEN 1
+                                         WHEN y IS NULL THEN -1
+                                         WHEN x < y THEN 1
+                                         WHEN x = y THEN 0
+                                         ELSE -1 END); -- [5, 3, 2, 2, 1, null, null]
+        SELECT array_sort(ARRAY ['a', 'abcd', 'abc'], -- sort by string length
+                          (x, y) -> IF(length(x) < length(y),
+                                       -1,
+                                       IF(length(x) = length(y), 0, 1))); -- ['a', 'abc', 'abcd']
+        SELECT array_sort(ARRAY [ARRAY[2, 3, 1], ARRAY[4, 2, 1, 4], ARRAY[1, 2]], -- sort by array length
+                          (x, y) -> IF(cardinality(x) < cardinality(y),
+                                       -1,
+                                       IF(cardinality(x) = cardinality(y), 0, 1))); -- [[1, 2], [2, 3, 1], [4, 2, 1, 4]]
+
+
 .. function:: arrays_overlap(x, y) -> boolean
 
     Tests if arrays ``x`` and ``y`` have any any non-null elements in common.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -76,6 +76,7 @@ import com.facebook.presto.operator.scalar.ArrayRemoveFunction;
 import com.facebook.presto.operator.scalar.ArrayReverseFunction;
 import com.facebook.presto.operator.scalar.ArrayShuffleFunction;
 import com.facebook.presto.operator.scalar.ArraySliceFunction;
+import com.facebook.presto.operator.scalar.ArraySortComparatorFunction;
 import com.facebook.presto.operator.scalar.ArraySortFunction;
 import com.facebook.presto.operator.scalar.ArrayUnionFunction;
 import com.facebook.presto.operator.scalar.ArraysOverlapFunction;
@@ -504,6 +505,7 @@ public class FunctionRegistry
                 .scalar(ArrayGreaterThanOrEqualOperator.class)
                 .scalar(ArrayElementAtFunction.class)
                 .scalar(ArraySortFunction.class)
+                .scalar(ArraySortComparatorFunction.class)
                 .scalar(ArrayShuffleFunction.class)
                 .scalar(ArrayReverseFunction.class)
                 .scalar(ArrayMinFunction.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortComparatorFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortComparatorFunction.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.function.TypeParameterSpecialization;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.lambda.LambdaFunctionInterface;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import io.airlift.slice.Slice;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.util.Failures.checkCondition;
+
+@ScalarFunction("array_sort")
+@Description("Sorts the given array with a lambda comparator.")
+public final class ArraySortComparatorFunction
+{
+    private final PageBuilder pageBuilder;
+    private static final int INITIAL_LENGTH = 128;
+    private static final String COMPARATOR_RETURN_ERROR = "Lambda comparator must return either -1, 0, or 1";
+    private List<Integer> positions = Ints.asList(new int[INITIAL_LENGTH]);
+
+    @TypeParameter("T")
+    public ArraySortComparatorFunction(@TypeParameter("T") Type elementType)
+    {
+        pageBuilder = new PageBuilder(ImmutableList.of(elementType));
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = long.class)
+    @SqlType("array(T)")
+    public Block sortLong(
+            @TypeParameter("T") Type type,
+            @SqlType("array(T)") Block block,
+            @SqlType("function(T, T, int)") ComparatorLongLambda function)
+    {
+        int arrayLength = block.getPositionCount();
+        initPositionsList(arrayLength);
+
+        positions.subList(0, arrayLength).sort((p1, p2) -> {
+            Long lambdaResult = function.apply(
+                    block.isNull(p1) ? null : type.getLong(block, p1),
+                    block.isNull(p2) ? null : type.getLong(block, p2));
+            checkCondition(
+                    lambdaResult != null && (lambdaResult == -1 || lambdaResult == 0 || lambdaResult == 1),
+                    INVALID_FUNCTION_ARGUMENT,
+                    COMPARATOR_RETURN_ERROR);
+            return lambdaResult.intValue();
+        });
+
+        return computeResultBlock(type, block, arrayLength);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = double.class)
+    @SqlType("array(T)")
+    public Block sortDouble(
+            @TypeParameter("T") Type type,
+            @SqlType("array(T)") Block block,
+            @SqlType("function(T, T, int)") ComparatorDoubleLambda function)
+    {
+        int arrayLength = block.getPositionCount();
+        initPositionsList(arrayLength);
+
+        positions.subList(0, arrayLength).sort((p1, p2) -> {
+            Long lambdaResult = function.apply(
+                    block.isNull(p1) ? null : type.getDouble(block, p1),
+                    block.isNull(p2) ? null : type.getDouble(block, p2));
+            checkCondition(
+                    lambdaResult != null && (lambdaResult == -1 || lambdaResult == 0 || lambdaResult == 1),
+                    INVALID_FUNCTION_ARGUMENT,
+                    COMPARATOR_RETURN_ERROR);
+            return lambdaResult.intValue();
+        });
+
+        return computeResultBlock(type, block, arrayLength);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = boolean.class)
+    @SqlType("array(T)")
+    public Block sortBoolean(
+            @TypeParameter("T") Type type,
+            @SqlType("array(T)") Block block,
+            @SqlType("function(T, T, int)") ComparatorBooleanLambda function)
+    {
+        int arrayLength = block.getPositionCount();
+        initPositionsList(arrayLength);
+
+        positions.subList(0, arrayLength).sort((p1, p2) -> {
+            Long lambdaResult = function.apply(
+                    block.isNull(p1) ? null : type.getBoolean(block, p1),
+                    block.isNull(p2) ? null : type.getBoolean(block, p2));
+            checkCondition(
+                    lambdaResult != null && (lambdaResult == -1 || lambdaResult == 0 || lambdaResult == 1),
+                    INVALID_FUNCTION_ARGUMENT,
+                    COMPARATOR_RETURN_ERROR);
+            return lambdaResult.intValue();
+        });
+
+        return computeResultBlock(type, block, arrayLength);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = Slice.class)
+    @SqlType("array(T)")
+    public Block sortSlice(
+            @TypeParameter("T") Type type,
+            @SqlType("array(T)") Block block,
+            @SqlType("function(T, T, int)") ComparatorSliceLambda function)
+    {
+        int arrayLength = block.getPositionCount();
+        initPositionsList(arrayLength);
+
+        positions.subList(0, arrayLength).sort((p1, p2) -> {
+            Long lambdaResult = function.apply(
+                    block.isNull(p1) ? null : type.getSlice(block, p1),
+                    block.isNull(p2) ? null : type.getSlice(block, p2));
+            checkCondition(
+                    lambdaResult != null && (lambdaResult == -1 || lambdaResult == 0 || lambdaResult == 1),
+                    INVALID_FUNCTION_ARGUMENT,
+                    COMPARATOR_RETURN_ERROR);
+            return lambdaResult.intValue();
+        });
+
+        return computeResultBlock(type, block, arrayLength);
+    }
+
+    @TypeParameter("T")
+    @TypeParameterSpecialization(name = "T", nativeContainerType = Block.class)
+    @SqlType("array(T)")
+    public Block sortObject(
+            @TypeParameter("T") Type type,
+            @SqlType("array(T)") Block block,
+            @SqlType("function(T, T, int)") ComparatorBlockLambda function)
+    {
+        int arrayLength = block.getPositionCount();
+        initPositionsList(arrayLength);
+
+        positions.subList(0, arrayLength).sort((p1, p2) -> {
+            Long lambdaResult = function.apply(
+                    block.isNull(p1) ? null : (Block) type.getObject(block, p1),
+                    block.isNull(p2) ? null : (Block) type.getObject(block, p2));
+            checkCondition(
+                    lambdaResult != null && (lambdaResult == -1 || lambdaResult == 0 || lambdaResult == 1),
+                    INVALID_FUNCTION_ARGUMENT,
+                    COMPARATOR_RETURN_ERROR);
+            return lambdaResult.intValue();
+        });
+
+        return computeResultBlock(type, block, arrayLength);
+    }
+
+    private void initPositionsList(int arrayLength)
+    {
+        if (positions.size() < arrayLength) {
+            positions = Ints.asList(new int[arrayLength]);
+        }
+        for (int i = 0; i < arrayLength; i++) {
+            positions.set(i, i);
+        }
+    }
+
+    private Block computeResultBlock(Type type, Block block, int arrayLength)
+    {
+        if (pageBuilder.isFull()) {
+            pageBuilder.reset();
+        }
+
+        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+
+        for (int i = 0; i < arrayLength; ++i) {
+            type.appendTo(block, positions.get(i), blockBuilder);
+        }
+        pageBuilder.declarePositions(arrayLength);
+
+        return blockBuilder.getRegion(blockBuilder.getPositionCount() - arrayLength, arrayLength);
+    }
+
+    @FunctionalInterface
+    public interface ComparatorLongLambda
+            extends LambdaFunctionInterface
+    {
+        Long apply(Long x, Long y);
+    }
+
+    @FunctionalInterface
+    public interface ComparatorDoubleLambda
+            extends LambdaFunctionInterface
+    {
+        Long apply(Double x, Double y);
+    }
+
+    @FunctionalInterface
+    public interface ComparatorBooleanLambda
+            extends LambdaFunctionInterface
+    {
+        Long apply(Boolean x, Boolean y);
+    }
+
+    @FunctionalInterface
+    public interface ComparatorSliceLambda
+            extends LambdaFunctionInterface
+    {
+        Long apply(Slice x, Slice y);
+    }
+
+    @FunctionalInterface
+    public interface ComparatorBlockLambda
+            extends LambdaFunctionInterface
+    {
+        Long apply(Block x, Block y);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -789,12 +789,121 @@ public class TestArrayOperators
                 new ArrayType(new ArrayType(INTEGER)),
                 ImmutableList.of(ImmutableList.of(1), ImmutableList.of(2)));
 
+        // with lambda function
+        assertFunction(
+                "ARRAY_SORT(ARRAY[2, 3, 2, null, null, 4, 1], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN -1 " +
+                        "WHEN y IS NULL THEN 1 " +
+                        "WHEN x < y THEN 1 " +
+                        "WHEN x = y THEN 0 " +
+                        "ELSE -1 END)",
+                new ArrayType(INTEGER),
+                asList(null, null, 4, 3, 2, 2, 1));
+        assertFunction(
+                "ARRAY_SORT(ARRAY[2, 3, 2, null, null, 4, 1], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN 1 " +
+                        "WHEN y IS NULL THEN -1 " +
+                        "WHEN x < y THEN 1 " +
+                        "WHEN x = y THEN 0 " +
+                        "ELSE -1 END)",
+                new ArrayType(INTEGER),
+                asList(4, 3, 2, 2, 1, null, null));
+        assertFunction(
+                "ARRAY_SORT(ARRAY[2, null, BIGINT '3', 4, null, 1], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN -1 " +
+                        "WHEN y IS NULL THEN 1 " +
+                        "WHEN x < y THEN 1 " +
+                        "WHEN x = y THEN 0 " +
+                        "ELSE -1 END)",
+                new ArrayType(BIGINT),
+                asList(null, null, 4L, 3L, 2L, 1L));
+        assertFunction(
+                "ARRAY_SORT(ARRAY['bc', null, 'ab', 'dc', null], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN -1 " +
+                        "WHEN y IS NULL THEN 1 " +
+                        "WHEN x < y THEN 1 " +
+                        "WHEN x = y THEN 0 " +
+                        "ELSE -1 END)",
+                new ArrayType(createVarcharType(2)),
+                asList(null, null, "dc", "bc", "ab"));
+        assertFunction(
+                "ARRAY_SORT(ARRAY['a', null, 'abcd', null, 'abc', 'zx'], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN -1 " +
+                        "WHEN y IS NULL THEN 1 " +
+                        "WHEN length(x) < length(y) THEN 1 " +
+                        "WHEN length(x) = length(y) THEN 0 " +
+                        "ELSE -1 END)",
+                new ArrayType(createVarcharType(4)),
+                asList(null, null, "abcd", "abc", "zx", "a"));
+        assertFunction(
+                "ARRAY_SORT(ARRAY[TRUE, null, FALSE, TRUE, null, FALSE, TRUE], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN -1 " +
+                        "WHEN y IS NULL THEN 1 " +
+                        "WHEN x = y THEN 0 " +
+                        "WHEN x THEN -1 " +
+                        "ELSE 1 END)",
+                new ArrayType(BOOLEAN),
+                asList(null, null, true, true, true, false, false));
+        assertFunction(
+                "ARRAY_SORT(ARRAY[22.1E0, null, null, 11.1E0, 1.1E0, 44.1E0], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN -1 " +
+                        "WHEN y IS NULL THEN 1 " +
+                        "WHEN x < y THEN 1 " +
+                        "WHEN x = y THEN 0 " +
+                        "ELSE -1 END)",
+                new ArrayType(DOUBLE),
+                asList(null, null, 44.1, 22.1, 11.1, 1.1));
+        assertFunction(
+                "ARRAY_SORT(ARRAY[from_unixtime(100), null, from_unixtime(1), null, from_unixtime(200)], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN -1 " +
+                        "WHEN y IS NULL THEN 1 " +
+                        "WHEN date_diff('millisecond', y, x) < 0 THEN 1 " +
+                        "WHEN date_diff('millisecond', y, x) = 0 THEN 0 " +
+                        "ELSE -1 END)",
+                new ArrayType(TIMESTAMP),
+                asList(null, null, sqlTimestamp(200 * 1000), sqlTimestamp(100 * 1000), sqlTimestamp(1000)));
+        assertFunction(
+                "ARRAY_SORT(ARRAY[ARRAY[2, 3, 1], null, ARRAY[4, null, 2, 1, 4], ARRAY[1, 2], null], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN -1 " +
+                        "WHEN y IS NULL THEN 1 " +
+                        "WHEN cardinality(x) < cardinality(y) THEN 1 " +
+                        "WHEN cardinality(x) = cardinality(y) THEN 0 " +
+                        "ELSE -1 END)",
+                new ArrayType(new ArrayType(INTEGER)),
+                asList(null, null, asList(4, null, 2, 1, 4), asList(2, 3, 1), asList(1, 2)));
+        assertFunction(
+                "ARRAY_SORT(ARRAY[2.3, null, 2.1, null, 2.2], (x, y) -> CASE " +
+                        "WHEN x IS NULL THEN -1 " +
+                        "WHEN y IS NULL THEN 1 " +
+                        "WHEN x < y THEN 1 " +
+                        "WHEN x = y THEN 0 " +
+                        "ELSE -1 END)",
+                new ArrayType(createDecimalType(2, 1)),
+                asList(null, null, decimal("2.3"), decimal("2.2"), decimal("2.1")));
+
         // with null in the array, should be in nulls-last order
         List<Integer> expected = asList(-1, 0, 1, null, null);
         assertFunction("ARRAY_SORT(ARRAY[1, null, 0, null, -1])", new ArrayType(INTEGER), expected);
         assertFunction("ARRAY_SORT(ARRAY[1, null, null, -1, 0])", new ArrayType(INTEGER), expected);
 
+        // invalid functions
         assertInvalidFunction("ARRAY_SORT(ARRAY[color('red'), color('blue')])", FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "ARRAY_SORT(ARRAY[2, 1, 2, 4], (x, y) -> y - x)",
+                INVALID_FUNCTION_ARGUMENT,
+                "Lambda comparator must return either -1, 0, or 1");
+        assertInvalidFunction(
+                "ARRAY_SORT(ARRAY[1, 2], (x, y) -> x / COALESCE(y, 0))",
+                INVALID_FUNCTION_ARGUMENT,
+                "Lambda comparator must return either -1, 0, or 1");
+        assertInvalidFunction(
+                "ARRAY_SORT(ARRAY[2, 3, 2, 4, 1], (x, y) -> IF(x > y, NULL, IF(x = y, 0, -1)))",
+                INVALID_FUNCTION_ARGUMENT,
+                "Lambda comparator must return either -1, 0, or 1");
+        assertInvalidFunction(
+                "ARRAY_SORT(ARRAY[1, null], (x, y) -> x / COALESCE(y, 0))",
+                INVALID_FUNCTION_ARGUMENT,
+                "Lambda comparator must return either -1, 0, or 1");
 
         assertCachedInstanceHasBoundedRetainedSize("ARRAY_SORT(ARRAY[2, 3, 4, 1])");
     }

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/array_functions/checkArrayFunctionsRegistered.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/array_functions/checkArrayFunctionsRegistered.result
@@ -5,5 +5,6 @@
  cardinality | bigint | array(E) | scalar | true | Returns the cardinality (length) of the array |
  contains | boolean | array(T), T | scalar | true | Determines whether given value exists in the array |
  array_sort | array(E) | array(E) | scalar | true | Sorts the given array in ascending order according to the natural ordering of its elements. |
+ array_sort | array(T) | array(T), function(T,T,integer) | scalar | true | Sorts the given array with a lambda comparator. |
  array_intersect | array(E) | array(E), array(E) | scalar | true | Intersects elements of the two given arrays |
  array_distinct | array(E) | array(E) | scalar | true | Remove duplicate values from the given array |


### PR DESCRIPTION
Change the scalar annotation parser to let implementations have different signatures with type parameters instead of one. It will then allow ``array_sort`` function to overload and make a new signature with ``TypeParameter`` for the lambda comparator feature.

Resolves https://github.com/prestodb/presto/issues/9166