### PR TITLE
Broadcast distance query

### DIFF
--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.plugin.geospatial;
 
-import com.esri.core.geometry.ogc.OGCGeometry;
 import com.facebook.presto.RowPagesBuilder;
 import com.facebook.presto.operator.Driver;
 import com.facebook.presto.operator.DriverContext;
@@ -24,6 +23,7 @@ import com.facebook.presto.operator.PagesIndex.TestingFactory;
 import com.facebook.presto.operator.PagesSpatialIndex;
 import com.facebook.presto.operator.PagesSpatialIndexFactory;
 import com.facebook.presto.operator.SpatialIndexBuilderOperator.SpatialIndexBuilderOperatorFactory;
+import com.facebook.presto.operator.SpatialIndexBuilderOperator.SpatialPredicate;
 import com.facebook.presto.operator.SpatialJoinOperator.SpatialJoinOperatorFactory;
 import com.facebook.presto.operator.StandardJoinFilterFunction;
 import com.facebook.presto.operator.TaskContext;
@@ -50,7 +50,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiPredicate;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
@@ -58,6 +57,7 @@ import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEqual
 import static com.facebook.presto.plugin.geospatial.GeoFunctions.stGeometryFromText;
 import static com.facebook.presto.plugin.geospatial.GeoFunctions.stPoint;
 import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -122,7 +122,7 @@ public class TestSpatialJoinOperator
                 .row(null, "null")
                 .pageBreak()
                 .row(POLYGON_B, "B");
-        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe) -> build.contains(probe), Optional.empty(), buildPages);
+        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.contains(probe), Optional.empty(), Optional.empty(), buildPages);
 
         RowPagesBuilder probePages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR))
                 .row(POINT_X, "x")
@@ -151,7 +151,7 @@ public class TestSpatialJoinOperator
         DriverContext driverContext = taskContext.addPipelineContext(0, true, true).addDriverContext();
 
         RowPagesBuilder buildPages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR));
-        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe) -> build.contains(probe), Optional.empty(), buildPages);
+        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.contains(probe), Optional.empty(), Optional.empty(), buildPages);
 
         RowPagesBuilder probePages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR))
                 .row(POINT_X, "x")
@@ -179,7 +179,7 @@ public class TestSpatialJoinOperator
                 .row(null, "null")
                 .pageBreak()
                 .row(POLYGON_B, "B");
-        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe) -> build.contains(probe), Optional.empty(), buildPages);
+        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.contains(probe), Optional.empty(), Optional.empty(), buildPages);
 
         RowPagesBuilder probePages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR));
         OperatorFactory joinOperatorFactory = new SpatialJoinOperatorFactory(2, new PlanNodeId("test"), probePages.getTypes(), Ints.asList(1), 0, pagesSpatialIndexFactory);
@@ -211,7 +211,7 @@ public class TestSpatialJoinOperator
                 .row(POLYGON_A, "A")
                 .pageBreak()
                 .row(POLYGON_B, "B");
-        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe) -> build.contains(probe), Optional.of(filterFunction), buildPages);
+        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.contains(probe), Optional.empty(), Optional.of(filterFunction), buildPages);
 
         // 10 points in polygon A (x0...x9)
         // 10 points in polygons A and B (y0...y9)
@@ -252,7 +252,45 @@ public class TestSpatialJoinOperator
         assertEquals(output.getPositionCount(), 40);
     }
 
-    private PagesSpatialIndexFactory buildIndex(DriverContext driverContext, BiPredicate<OGCGeometry, OGCGeometry> spatialRelationshipTest, Optional<InternalJoinFilterFunction> filterFunction, RowPagesBuilder buildPages)
+    @Test
+    public void testDistanceQuery()
+    {
+        TaskContext taskContext = createTaskContext();
+        DriverContext driverContext = taskContext.addPipelineContext(0, true, true).addDriverContext();
+
+        RowPagesBuilder buildPages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR, DOUBLE))
+                .row(stPoint(0, 0), "0_0", 1.5)
+                .row(null, "null", 1.5)
+                .row(stPoint(1, 0), "1_0", 1.5)
+                .pageBreak()
+                .row(stPoint(3, 0), "3_0", 1.5)
+                .pageBreak()
+                .row(stPoint(10, 0), "10_0", 1.5);
+        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.distance(probe) <= r.getAsDouble(), Optional.of(2), Optional.empty(), buildPages);
+
+        RowPagesBuilder probePages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR))
+                .row(stPoint(0, 1), "0_1")
+                .row(null, "null")
+                .row(stPoint(1, 1), "1_1")
+                .pageBreak()
+                .row(stPoint(3, 1), "3_1")
+                .pageBreak()
+                .row(stPoint(10, 1), "10_1");
+        OperatorFactory joinOperatorFactory = new SpatialJoinOperatorFactory(2, new PlanNodeId("test"), probePages.getTypes(), Ints.asList(1), 0, pagesSpatialIndexFactory);
+
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.of(VARCHAR, VARCHAR))
+                .row("0_1", "0_0")
+                .row("0_1", "1_0")
+                .row("1_1", "0_0")
+                .row("1_1", "1_0")
+                .row("3_1", "3_0")
+                .row("10_1", "10_0")
+                .build();
+
+        assertOperatorEquals(joinOperatorFactory, driverContext, probePages.build(), expected);
+    }
+
+    private PagesSpatialIndexFactory buildIndex(DriverContext driverContext, SpatialPredicate spatialRelationshipTest, Optional<Integer> radiusChannel, Optional<InternalJoinFilterFunction> filterFunction, RowPagesBuilder buildPages)
     {
         Optional<JoinFilterFunctionCompiler.JoinFilterFunctionFactory> filterFunctionFactory = filterFunction
                 .map(function -> (session, addresses, channels) -> new StandardJoinFilterFunction(function, addresses, channels));
@@ -264,6 +302,7 @@ public class TestSpatialJoinOperator
                 buildPages.getTypes(),
                 Ints.asList(1),
                 0,
+                radiusChannel,
                 spatialRelationshipTest,
                 filterFunctionFactory,
                 10_000,

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinPlanning.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinPlanning.java
@@ -88,6 +88,26 @@ public class TestSpatialJoinPlanning
     }
 
     @Test
+    public void testDistanceQuery()
+    {
+        assertPlan("SELECT b.name, a.name " +
+                        "FROM (VALUES (2.1, 2.1, 'x')) AS a (lng, lat, name), (VALUES (2.1, 2.1, 'x')) AS b (lng, lat, name) " +
+                        "WHERE ST_Distance(ST_Point(a.lng, a.lat), ST_Point(b.lng, b.lat)) <= 3.1",
+                anyTree(
+                        spatialJoin("st_distance(st_point_a, st_point_b) <= radius",
+                                project(ImmutableMap.of("st_point_a", expression("ST_Point(cast(a_lng as double), cast(a_lat as double))")), anyTree(values(ImmutableMap.of("a_lng", 0, "a_lat", 1)))),
+                                anyTree(project(ImmutableMap.of("st_point_b", expression("ST_Point(cast(b_lng as double), cast(b_lat as double))"), "radius", expression("3.1e0")), anyTree(values(ImmutableMap.of("b_lng", 0, "b_lat", 1))))))));
+
+        assertPlan("SELECT b.name, a.name " +
+                        "FROM (VALUES (2.1, 2.1, 'x')) AS a (lng, lat, name), (VALUES (2.1, 2.1, 'x')) AS b (lng, lat, name) " +
+                        "WHERE ST_Distance(ST_Point(a.lng, a.lat), ST_Point(b.lng, b.lat)) <= 300 / (111321 * cos(radians(b.lat)))",
+                anyTree(
+                        spatialJoin("st_distance(st_point_a, st_point_b) <= radius",
+                                project(ImmutableMap.of("st_point_a", expression("ST_Point(cast(a_lng as double), cast(a_lat as double))")), anyTree(values(ImmutableMap.of("a_lng", 0, "a_lat", 1)))),
+                                anyTree(project(ImmutableMap.of("st_point_b", expression("ST_Point(cast(b_lng as double), cast(b_lat as double))"), "radius", expression("3e2 / (111.321e3 * cos(radians(cast(b_lat as double))))")), anyTree(values(ImmutableMap.of("b_lng", 0, "b_lat", 1))))))));
+    }
+
+    @Test
     public void testNotContains()
     {
         assertPlan("SELECT b.name, a.name " +

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.operator;
 
-import com.esri.core.geometry.ogc.OGCGeometry;
 import com.facebook.presto.Session;
+import com.facebook.presto.operator.SpatialIndexBuilderOperator.SpatialPredicate;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
@@ -43,7 +43,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.BiPredicate;
 import java.util.function.IntUnaryOperator;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
@@ -443,13 +442,14 @@ public class PagesIndex
     public PagesSpatialIndexSupplier createPagesSpatialIndex(
             Session session,
             int geometryChannel,
-            BiPredicate<OGCGeometry, OGCGeometry> spatialRelationshipTest,
+            Optional<Integer> radiusChannel,
+            SpatialPredicate spatialRelationshipTest,
             Optional<JoinFilterFunctionFactory> filterFunctionFactory,
             List<Integer> outputChannels)
     {
         // TODO probably shouldn't copy to reduce memory and for memory accounting's sake
         List<List<Block>> channels = ImmutableList.copyOf(this.channels);
-        return new PagesSpatialIndexSupplier(session, valueAddresses, types, outputChannels, channels, geometryChannel, spatialRelationshipTest, filterFunctionFactory);
+        return new PagesSpatialIndexSupplier(session, valueAddresses, types, outputChannels, channels, geometryChannel, radiusChannel, spatialRelationshipTest, filterFunctionFactory);
     }
 
     public LookupSourceSupplier createLookupSourceSupplier(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformSpatialPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformSpatialPredicateToJoin.java
@@ -27,6 +27,7 @@ import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.SymbolReference;
@@ -40,32 +41,64 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.planner.ExpressionNodeInliner.replaceExpression;
 import static com.facebook.presto.sql.planner.SymbolsExtractor.extractUnique;
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.LESS_THAN;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.util.SpatialJoinUtils.extractSupportedSpatialComparisons;
 import static com.facebook.presto.util.SpatialJoinUtils.extractSupportedSpatialFunctions;
 import static com.google.common.base.Verify.verify;
 
 /**
- * Applies to broadcast spatial joins using ST_Contains and ST_Intersects functions.
+ * Applies to broadcast spatial joins expressed via ST_Contains, ST_Intersects and
+ * ST_Distance functions.
  * <p>
- * Applies only if all of the following conditions are met:
- * - each argument of the spatial function is an expression using at least one of the symbols
- *      from the join relations
- * - each argument's expression uses symbols from only one side of the join
- * - different arguments use symbols from different sides of the join
+ * For example:
+ * <ul>
+ *      <li>SELECT ... FROM a, b WHERE ST_Contains(b.geometry, a.geometry)</li>
+ *      <li>SELECT ... FROM a, b WHERE ST_Intersects(b.geometry, a.geometry)</li>
+ *      <li>SELECT ... FROM a, b WHERE ST_Distance(b.geometry, a.geometry) <= 300</li>
+ *      <li>SELECT ... FROM a, b WHERE 15.5 > ST_Distance(b.geometry, a.geometry)</li>
+ * </ul>
  * <p>
- * Replaces cross join node with a filter on top with a single spatial join node.
+ * Joins expressed via ST_Contains and ST_Intersects functions must match all of
+ * the following criteria:
+ * <p>
+ * - arguments of the spatial function are non-scalar expressions;
+ * - one of the arguments uses symbols from left side of the join, the other from right.
+ * <p>
+ * Joins expressed via ST_Distance function must use less than or less than or equals operator
+ * to compare ST_Distance value with a radius and must match all of the following criteria:
+ * <p>
+ * - arguments of the spatial function are non-scalar expressions;
+ * - one of the arguments uses symbols from left side of the join, the other from right;
+ * - radius is either scalar expression or uses symbols only from the right (build) side of the join.
+ * <p>
+ * Replaces cross join node and a qualifying filter on top with a single spatial join node.
  * <p>
  * Pushes non-trivial expressions of the spatial function arguments into projections on top of
  * join child nodes.
  * <p>
- * For example, rewrites ST_Contains(ST_GeometryFromText(a.wkt), ST_Point(b.longitude, b.latitude)) join
- * as ST_Contains(st_geometryfromtext, st_point) with st_geometryfromtext -> 'ST_GeometryFromText(a.wkt)' and
+ * Examples:
+ * <p>
+ * Point-in-polygon inner join
+ *      ST_Contains(ST_GeometryFromText(a.wkt), ST_Point(b.longitude, b.latitude))
+ * becomes a spatial join
+ *      ST_Contains(st_geometryfromtext, st_point)
+ * with st_geometryfromtext -> 'ST_GeometryFromText(a.wkt)' and
  * st_point -> 'ST_Point(b.longitude, b.latitude)' projections on top of child nodes.
+ * <p>
+ * Distance query
+ *      ST_Distance(ST_Point(a.lon, a.lat), ST_Point(b.lon, b.lat)) <= 10 / (111.321 * cos(radians(b.lat)))
+ * becomes a spatial join
+ *      ST_Distance(st_point_a, st_point_b) <= radius
+ * with st_point_a -> 'ST_Point(a.lon, a.lat)', st_point_b -> 'ST_Point(b.lon, b.lat)'
+ * and radius -> '10 / (111.321 * cos(radians(b.lat)))' projections on top of child nodes.
  */
 public class TransformSpatialPredicateToJoin
         implements Rule<FilterNode>
@@ -101,74 +134,155 @@ public class TransformSpatialPredicateToJoin
 
         Expression filter = node.getPredicate();
         List<FunctionCall> spatialFunctions = extractSupportedSpatialFunctions(filter);
-        if (spatialFunctions.isEmpty()) {
-            return Result.empty();
-        }
 
         for (FunctionCall spatialFunction : spatialFunctions) {
-            List<Expression> arguments = spatialFunction.getArguments();
-            verify(arguments.size() == 2);
-
-            Expression firstArgument = arguments.get(0);
-            Expression secondArgument = arguments.get(1);
-
-            Set<Symbol> firstSymbols = extractUnique(firstArgument);
-            Set<Symbol> secondSymbols = extractUnique(secondArgument);
-
-            if (firstSymbols.isEmpty() || secondSymbols.isEmpty()) {
-                return Result.empty();
+            Result result = tryCreateSpatialJoin(context, node, joinNode, filter, spatialFunction);
+            if (!result.isEmpty()) {
+                return result;
             }
+        }
 
-            Optional<Symbol> newFirstSymbol = newSymbol(context, firstArgument);
-            Optional<Symbol> newSecondSymbol = newSymbol(context, secondArgument);
-
-            Expression newFirstArgument = toExpression(newFirstSymbol, firstArgument);
-            Expression newSecondArgument = toExpression(newSecondSymbol, secondArgument);
-
-            Expression newSpatialFunction = new FunctionCall(spatialFunction.getName(), ImmutableList.of(newFirstArgument, newSecondArgument));
-            Expression newFilter = replaceExpression(filter, ImmutableMap.of(spatialFunction, newSpatialFunction));
-
-            PlanNode leftNode = joinNode.getLeft();
-            PlanNode rightNode = joinNode.getRight();
-
-            List<Symbol> leftSymbols = leftNode.getOutputSymbols();
-            List<Symbol> rightSymbols = rightNode.getOutputSymbols();
-
-            PlanNode newLeftNode;
-            PlanNode newRightNode;
-
-            if (leftSymbols.containsAll(firstSymbols)
-                    && containsNone(leftSymbols, secondSymbols)
-                    && rightSymbols.containsAll(secondSymbols)
-                    && containsNone(rightSymbols, firstSymbols)) {
-                newLeftNode = newFirstSymbol.map(symbol -> addProjection(context, leftNode, symbol, firstArgument)).orElse(leftNode);
-                newRightNode = newSecondSymbol.map(symbol -> addProjection(context, rightNode, symbol, secondArgument)).orElse(rightNode);
+        List<ComparisonExpression> spatialComparisons = extractSupportedSpatialComparisons(filter);
+        for (ComparisonExpression spatialComparison : spatialComparisons) {
+            Result result = tryCreateSpatialJoin(context, node, joinNode, filter, spatialComparison);
+            if (!result.isEmpty()) {
+                return result;
             }
-            else if (leftSymbols.containsAll(secondSymbols)
-                    && containsNone(leftSymbols, firstSymbols)
-                    && rightSymbols.containsAll(firstSymbols)
-                    && containsNone(rightSymbols, secondSymbols)) {
-                newLeftNode = newSecondSymbol.map(symbol -> addProjection(context, leftNode, symbol, secondArgument)).orElse(leftNode);
-                newRightNode = newFirstSymbol.map(symbol -> addProjection(context, rightNode, symbol, firstArgument)).orElse(rightNode);
-            }
-            else {
-                continue;
-            }
-
-            return Result.ofPlanNode(new JoinNode(
-                    node.getId(),
-                    joinNode.getType(),
-                    newLeftNode,
-                    newRightNode,
-                    joinNode.getCriteria(),
-                    node.getOutputSymbols(),
-                    Optional.of(newFilter),
-                    joinNode.getLeftHashSymbol(),
-                    joinNode.getRightHashSymbol(),
-                    joinNode.getDistributionType()));
         }
 
         return Result.empty();
+    }
+
+    private Result tryCreateSpatialJoin(Context context, FilterNode filterNode, JoinNode joinNode, Expression filter, ComparisonExpression spatialComparison)
+    {
+        PlanNode leftNode = joinNode.getLeft();
+        PlanNode rightNode = joinNode.getRight();
+
+        List<Symbol> leftSymbols = leftNode.getOutputSymbols();
+        List<Symbol> rightSymbols = rightNode.getOutputSymbols();
+
+        Expression radius;
+        Optional<Symbol> newRadiusSymbol;
+        ComparisonExpression newComparison;
+        if (spatialComparison.getType() == LESS_THAN || spatialComparison.getType() == LESS_THAN_OR_EQUAL) {
+            // ST_Distance(a, b) <= r
+            radius = spatialComparison.getRight();
+            Set<Symbol> radiusSymbols = extractUnique(radius);
+            if (radiusSymbols.isEmpty() || (rightSymbols.containsAll(radiusSymbols) && containsNone(leftSymbols, radiusSymbols))) {
+                newRadiusSymbol = newRadiusSymbol(context, radius);
+                newComparison = new ComparisonExpression(spatialComparison.getType(), spatialComparison.getLeft(), toExpression(newRadiusSymbol, radius));
+            }
+            else {
+                return Result.empty();
+            }
+        }
+        else {
+            // r >= ST_Distance(a, b)
+            radius = spatialComparison.getLeft();
+            Set<Symbol> radiusSymbols = extractUnique(radius);
+            if (radiusSymbols.isEmpty() || (rightSymbols.containsAll(radiusSymbols) && containsNone(leftSymbols, radiusSymbols))) {
+                newRadiusSymbol = newRadiusSymbol(context, radius);
+                newComparison = new ComparisonExpression(spatialComparison.getType().flip(), spatialComparison.getRight(), toExpression(newRadiusSymbol, radius));
+            }
+            else {
+                return Result.empty();
+            }
+        }
+
+        Expression newFilter = replaceExpression(filter, ImmutableMap.of(spatialComparison, newComparison));
+        PlanNode newRightNode = newRadiusSymbol.map(symbol -> addProjection(context, rightNode, symbol, radius)).orElse(rightNode);
+
+        JoinNode newJoinNode = new JoinNode(
+                joinNode.getId(),
+                joinNode.getType(),
+                leftNode,
+                newRightNode,
+                joinNode.getCriteria(),
+                joinNode.getOutputSymbols(),
+                Optional.of(newFilter),
+                joinNode.getLeftHashSymbol(),
+                joinNode.getRightHashSymbol(),
+                joinNode.getDistributionType());
+
+        return tryCreateSpatialJoin(context, filterNode, newJoinNode, newFilter, (FunctionCall) newComparison.getLeft());
+    }
+
+    private Result tryCreateSpatialJoin(Context context, FilterNode filterNode, JoinNode joinNode, Expression filter, FunctionCall spatialFunction)
+    {
+        List<Expression> arguments = spatialFunction.getArguments();
+        verify(arguments.size() == 2);
+
+        Expression firstArgument = arguments.get(0);
+        Expression secondArgument = arguments.get(1);
+
+        Set<Symbol> firstSymbols = extractUnique(firstArgument);
+        Set<Symbol> secondSymbols = extractUnique(secondArgument);
+
+        if (firstSymbols.isEmpty() || secondSymbols.isEmpty()) {
+            return Result.empty();
+        }
+
+        Optional<Symbol> newFirstSymbol = newGeometrySymbol(context, firstArgument);
+        Optional<Symbol> newSecondSymbol = newGeometrySymbol(context, secondArgument);
+
+        PlanNode leftNode = joinNode.getLeft();
+        PlanNode rightNode = joinNode.getRight();
+
+        PlanNode newLeftNode;
+        PlanNode newRightNode;
+
+        int alignment = checkAlignment(joinNode, firstSymbols, secondSymbols);
+        if (alignment > 0) {
+            newLeftNode = newFirstSymbol.map(symbol -> addProjection(context, leftNode, symbol, firstArgument)).orElse(leftNode);
+            newRightNode = newSecondSymbol.map(symbol -> addProjection(context, rightNode, symbol, secondArgument)).orElse(rightNode);
+        }
+        else if (alignment < 0) {
+            newLeftNode = newSecondSymbol.map(symbol -> addProjection(context, leftNode, symbol, secondArgument)).orElse(leftNode);
+            newRightNode = newFirstSymbol.map(symbol -> addProjection(context, rightNode, symbol, firstArgument)).orElse(rightNode);
+        }
+        else {
+            return Result.empty();
+        }
+
+        Expression newFirstArgument = toExpression(newFirstSymbol, firstArgument);
+        Expression newSecondArgument = toExpression(newSecondSymbol, secondArgument);
+
+        Expression newSpatialFunction = new FunctionCall(spatialFunction.getName(), ImmutableList.of(newFirstArgument, newSecondArgument));
+        Expression newFilter = replaceExpression(filter, ImmutableMap.of(spatialFunction, newSpatialFunction));
+
+        return Result.ofPlanNode(new JoinNode(
+                filterNode.getId(),
+                joinNode.getType(),
+                newLeftNode,
+                newRightNode,
+                joinNode.getCriteria(),
+                filterNode.getOutputSymbols(),
+                Optional.of(newFilter),
+                joinNode.getLeftHashSymbol(),
+                joinNode.getRightHashSymbol(),
+                joinNode.getDistributionType()));
+    }
+
+    private static int checkAlignment(JoinNode joinNode, Set<Symbol> maybeLeftSymbols, Set<Symbol> maybeRightSymbols)
+    {
+        List<Symbol> leftSymbols = joinNode.getLeft().getOutputSymbols();
+        List<Symbol> rightSymbols = joinNode.getRight().getOutputSymbols();
+
+        if (leftSymbols.containsAll(maybeLeftSymbols)
+                && containsNone(leftSymbols, maybeRightSymbols)
+                && rightSymbols.containsAll(maybeRightSymbols)
+                && containsNone(rightSymbols, maybeLeftSymbols)) {
+            return 1;
+        }
+        else if (leftSymbols.containsAll(maybeRightSymbols)
+                && containsNone(leftSymbols, maybeLeftSymbols)
+                && rightSymbols.containsAll(maybeLeftSymbols)
+                && containsNone(rightSymbols, maybeRightSymbols)) {
+            return -1;
+        }
+        else {
+            return 0;
+        }
     }
 
     private Expression toExpression(Optional<Symbol> optionalSymbol, Expression defaultExpression)
@@ -176,13 +290,22 @@ public class TransformSpatialPredicateToJoin
         return optionalSymbol.map(symbol -> (Expression) symbol.toSymbolReference()).orElse(defaultExpression);
     }
 
-    private Optional<Symbol> newSymbol(Context context, Expression expression)
+    private Optional<Symbol> newGeometrySymbol(Context context, Expression expression)
     {
         if (expression instanceof SymbolReference) {
             return Optional.empty();
         }
 
         return Optional.of(context.getSymbolAllocator().newSymbol(expression, metadata.getType(GEOMETRY_TYPE_SIGNATURE)));
+    }
+
+    private Optional<Symbol> newRadiusSymbol(Context context, Expression expression)
+    {
+        if (expression instanceof SymbolReference) {
+            return Optional.empty();
+        }
+
+        return Optional.of(context.getSymbolAllocator().newSymbol(expression, DOUBLE));
     }
 
     private PlanNode addProjection(Context context, PlanNode node, Symbol symbol, Expression expression)
@@ -196,7 +319,7 @@ public class TransformSpatialPredicateToJoin
         return new ProjectNode(context.getIdAllocator().getNextId(), node, projections.build());
     }
 
-    private boolean containsNone(Collection<Symbol> values, Collection<Symbol> testValues)
+    private static boolean containsNone(Collection<Symbol> values, Collection<Symbol> testValues)
     {
         return values.stream().noneMatch(ImmutableSet.copyOf(testValues)::contains);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -58,7 +58,6 @@ public class JoinNode
     private final Optional<Symbol> leftHashSymbol;
     private final Optional<Symbol> rightHashSymbol;
     private final Optional<DistributionType> distributionType;
-    private final boolean spatialJoin;
 
     @JsonCreator
     public JoinNode(@JsonProperty("id") PlanNodeId id,
@@ -92,7 +91,6 @@ public class JoinNode
         this.leftHashSymbol = leftHashSymbol;
         this.rightHashSymbol = rightHashSymbol;
         this.distributionType = distributionType;
-        this.spatialJoin = type == INNER && criteria.isEmpty() && filter.isPresent() && isSpatialJoinFilter(left, right, filter.get());
 
         List<Symbol> inputSymbols = ImmutableList.<Symbol>builder()
                 .addAll(left.getOutputSymbols())
@@ -248,7 +246,7 @@ public class JoinNode
 
     public boolean isSpatialJoin()
     {
-        return spatialJoin;
+        return type == INNER && criteria.isEmpty() && filter.isPresent() && isSpatialJoinFilter(left, right, filter.get());
     }
 
     public static class EquiJoinClause

--- a/presto-main/src/main/java/com/facebook/presto/util/SpatialJoinUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/SpatialJoinUtils.java
@@ -15,8 +15,10 @@ package com.facebook.presto.util;
 
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Literal;
 import com.facebook.presto.sql.tree.SymbolReference;
 
 import java.util.Collection;
@@ -24,6 +26,8 @@ import java.util.List;
 import java.util.Set;
 
 import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.LESS_THAN;
+import static com.facebook.presto.sql.tree.ComparisonExpressionType.LESS_THAN_OR_EQUAL;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -32,9 +36,17 @@ public class SpatialJoinUtils
 {
     public static final String ST_CONTAINS = "st_contains";
     public static final String ST_INTERSECTS = "st_intersects";
+    public static final String ST_DISTANCE = "st_distance";
 
     private SpatialJoinUtils() {}
 
+    /**
+     * Returns a subset of conjuncts matching one of the following shapes:
+     * - ST_Contains(...)
+     * - ST_Intersects(...)
+     *
+     * Doesn't check or guarantee anything about function arguments.
+     */
     public static List<FunctionCall> extractSupportedSpatialFunctions(Expression filterExpression)
     {
         return extractConjuncts(filterExpression).stream()
@@ -50,29 +62,93 @@ public class SpatialJoinUtils
         return functionName.equalsIgnoreCase(ST_CONTAINS) || functionName.equalsIgnoreCase(ST_INTERSECTS);
     }
 
+    /**
+     * Returns a subset of conjuncts matching one the following shapes:
+     * - ST_Distance(...) <= ...
+     * - ST_Distance(...) < ...
+     * - ... >= ST_Distance(...)
+     * - ... > ST_Distance(...)
+     *
+     * Doesn't check or guarantee anything about ST_Distance functions arguments
+     * or the other side of the comparison.
+     */
+    public static List<ComparisonExpression> extractSupportedSpatialComparisons(Expression filterExpression)
+    {
+        return extractConjuncts(filterExpression).stream()
+                .filter(ComparisonExpression.class::isInstance)
+                .map(ComparisonExpression.class::cast)
+                .filter(SpatialJoinUtils::isSupportedSpatialComparison)
+                .collect(toImmutableList());
+    }
+
+    private static boolean isSupportedSpatialComparison(ComparisonExpression expression)
+    {
+        switch (expression.getType()) {
+            case LESS_THAN:
+            case LESS_THAN_OR_EQUAL:
+                return isSTDistance(expression.getLeft());
+            case GREATER_THAN:
+            case GREATER_THAN_OR_EQUAL:
+                return isSTDistance(expression.getRight());
+            default:
+                return false;
+        }
+    }
+
+    private static boolean isSTDistance(Expression expression)
+    {
+        if (expression instanceof FunctionCall) {
+            return ((FunctionCall) expression).getName().toString().equalsIgnoreCase(ST_DISTANCE);
+        }
+
+        return false;
+    }
+
     public static boolean isSpatialJoinFilter(PlanNode left, PlanNode right, Expression filterExpression)
     {
         List<FunctionCall> functionCalls = extractSupportedSpatialFunctions(filterExpression);
         for (FunctionCall functionCall : functionCalls) {
-            List<Expression> arguments = functionCall.getArguments();
-            verify(arguments.size() == 2);
-            if (!(arguments.get(0) instanceof SymbolReference) || !(arguments.get(1) instanceof SymbolReference)) {
-                continue;
-            }
-
-            SymbolReference firstSymbol = (SymbolReference) arguments.get(0);
-            SymbolReference secondSymbol = (SymbolReference) arguments.get(1);
-
-            Set<SymbolReference> probeSymbols = getSymbolReferences(left.getOutputSymbols());
-            Set<SymbolReference> buildSymbols = getSymbolReferences(right.getOutputSymbols());
-
-            if (probeSymbols.contains(firstSymbol) && buildSymbols.contains(secondSymbol)) {
+            if (isSpatialJoinFilter(left, right, functionCall)) {
                 return true;
             }
+        }
 
-            if (probeSymbols.contains(secondSymbol) && buildSymbols.contains(firstSymbol)) {
-                return true;
+        List<ComparisonExpression> spatialComparisons = extractSupportedSpatialComparisons(filterExpression);
+        for (ComparisonExpression spatialComparison : spatialComparisons) {
+            if (spatialComparison.getType() == LESS_THAN || spatialComparison.getType() == LESS_THAN_OR_EQUAL) {
+                // ST_Distance(a, b) <= r
+                Expression radius = spatialComparison.getRight();
+                if (radius instanceof Literal || (radius instanceof SymbolReference && getSymbolReferences(right.getOutputSymbols()).contains(radius))) {
+                    if (isSpatialJoinFilter(left, right, (FunctionCall) spatialComparison.getLeft())) {
+                        return true;
+                    }
+                }
             }
+        }
+
+        return false;
+    }
+
+    private static boolean isSpatialJoinFilter(PlanNode left, PlanNode right, FunctionCall spatialFunction)
+    {
+        List<Expression> arguments = spatialFunction.getArguments();
+        verify(arguments.size() == 2);
+        if (!(arguments.get(0) instanceof SymbolReference) || !(arguments.get(1) instanceof SymbolReference)) {
+            return false;
+        }
+
+        SymbolReference firstSymbol = (SymbolReference) arguments.get(0);
+        SymbolReference secondSymbol = (SymbolReference) arguments.get(1);
+
+        Set<SymbolReference> probeSymbols = getSymbolReferences(left.getOutputSymbols());
+        Set<SymbolReference> buildSymbols = getSymbolReferences(right.getOutputSymbols());
+
+        if (probeSymbols.contains(firstSymbol) && buildSymbols.contains(secondSymbol)) {
+            return true;
+        }
+
+        if (probeSymbols.contains(secondSymbol) && buildSymbols.contains(firstSymbol)) {
+            return true;
         }
 
         return false;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ExpressionVerifier.java
@@ -20,6 +20,7 @@ import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DecimalLiteral;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
@@ -224,6 +225,16 @@ final class ExpressionVerifier
     }
 
     @Override
+    protected Boolean visitDecimalLiteral(DecimalLiteral actual, Node expected)
+    {
+        if (expected instanceof DecimalLiteral) {
+            return getValueFromLiteral(actual).equals(getValueFromLiteral(expected));
+        }
+
+        return false;
+    }
+
+    @Override
     protected Boolean visitBooleanLiteral(BooleanLiteral actual, Node expected)
     {
         if (expected instanceof BooleanLiteral) {
@@ -242,6 +253,9 @@ final class ExpressionVerifier
         }
         else if (expression instanceof DoubleLiteral) {
             return String.valueOf(((DoubleLiteral) expression).getValue());
+        }
+        else if (expression instanceof DecimalLiteral) {
+            return String.valueOf(((DecimalLiteral) expression).getValue());
         }
         else if (expression instanceof GenericLiteral) {
             return ((GenericLiteral) expression).getValue();


### PR DESCRIPTION
Implements broadcast distance query as described in #10163 and includes the following:

- Changes `TransformSpatialPredicateToJoin` optimizer rule to recognize `ST_Distance(left, right) <= R` query pattern and transform corresponding cross join node with a filter on top into a spatial join node. 
- `ST_Distance(left, right) < R`, `R > ST_Distance(left, right)` and `R >= ST_Distance(left, right)` query patterns are supported as well.
- Changes `SpatialIndexBuilderOperator` to build an R-Tree using envelopes expanded by radius in four directions (up, down, left and right) and use radius to perform final spatial relationship test on pairs of geometries with intersecting envelopes.

Optimizer rule applies if all of the following is true:

- comparison type is either (1) `<` or `<=` with `radius` expression on the right side or (2) `>` or `>=` with `radius` expression on the left side;
- radius is either a scalar expression or uses symbols only from the build (right) side of the join
- arguments of `ST_Distance` are non-scalar expressions; one of the arguments uses symbols from left side of the join, the other from right.

