### PR TITLE
Fix 'integer overflow' in PagesRTreeIndex

### DIFF
--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
@@ -210,6 +210,7 @@ public class TestSpatialJoinOperator
 
         RowPagesBuilder buildPages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR))
                 .row(POLYGON_A, "A")
+                .pageBreak()
                 .row(POLYGON_B, "B");
         PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe) -> build.contains(probe), Optional.of(filterFunction), buildPages);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinFilterFunction.java
@@ -20,5 +20,5 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public interface JoinFilterFunction
 {
-    boolean filter(int leftAddress, int rightPosition, Page rightPage);
+    boolean filter(int leftPosition, int rightPosition, Page rightPage);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndex.java
@@ -18,30 +18,30 @@ import com.facebook.presto.spi.PageBuilder;
 
 public interface PagesSpatialIndex
 {
-    long[] findJoinAddresses(int probePosition, Page probe, int probeGeometryChannel);
+    int[] findJoinPositions(int probePosition, Page probe, int probeGeometryChannel);
 
-    boolean isJoinAddressEligible(long joinPosition, int probePosition, Page probe);
+    boolean isJoinPositionEligible(int joinPosition, int probePosition, Page probe);
 
-    void appendTo(long joinAddress, PageBuilder pageBuilder, int outputChannelOffset);
+    void appendTo(int joinPosition, PageBuilder pageBuilder, int outputChannelOffset);
 
     PagesSpatialIndex EMPTY_INDEX = new PagesSpatialIndex()
     {
-        private final long[] emptyAddresses = new long[0];
+        private final int[] emptyAddresses = new int[0];
 
         @Override
-        public long[] findJoinAddresses(int probePosition, Page probe, int probeGeometryChannel)
+        public int[] findJoinPositions(int probePosition, Page probe, int probeGeometryChannel)
         {
             return emptyAddresses;
         }
 
         @Override
-        public boolean isJoinAddressEligible(long joinPosition, int probePosition, Page probe)
+        public boolean isJoinPositionEligible(int joinPosition, int probePosition, Page probe)
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void appendTo(long joinAddress, PageBuilder pageBuilder, int outputChannelOffset)
+        public void appendTo(int joinPosition, PageBuilder pageBuilder, int outputChannelOffset)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexSupplier.java
@@ -15,7 +15,7 @@ package com.facebook.presto.operator;
 
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.facebook.presto.Session;
-import com.facebook.presto.operator.PagesRTreeIndex.GeometryWithAddress;
+import com.facebook.presto.operator.PagesRTreeIndex.GeometryWithPosition;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
@@ -103,7 +103,7 @@ public class PagesSpatialIndexSupplier
                 continue;
             }
 
-            rtree.insert(getEnvelope(ogcGeometry), new GeometryWithAddress(ogcGeometry, pageAddress));
+            rtree.insert(getEnvelope(ogcGeometry), new GeometryWithPosition(ogcGeometry, position));
         }
 
         rtree.build();
@@ -128,7 +128,7 @@ public class PagesSpatialIndexSupplier
 
     private long computeMemorySizeInBytes(ItemBoundable item)
     {
-        return ENVELOPE_INSTANCE_SIZE + ((GeometryWithAddress) item.getItem()).getEstimatedMemorySizeInBytes();
+        return ENVELOPE_INSTANCE_SIZE + ((GeometryWithPosition) item.getItem()).getEstimatedMemorySizeInBytes();
     }
 
     // doesn't include memory used by channels and addresses which are shared with PagesIndex

--- a/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunction.java
@@ -54,9 +54,9 @@ public class StandardJoinFilterFunction
     }
 
     @Override
-    public boolean filter(int leftAddress, int rightPosition, Page rightPage)
+    public boolean filter(int leftPosition, int rightPosition, Page rightPage)
     {
-        long pageAddress = addresses.getLong(leftAddress);
+        long pageAddress = addresses.getLong(leftPosition);
         int blockIndex = decodeSliceIndex(pageAddress);
         int blockPosition = decodePosition(pageAddress);
 


### PR DESCRIPTION
`PagesRTreeIndex#isJoinPositionEligible` threw "integer overflow" from `toIntExact(joinAddress)` conversion performed before invoking `JoinFilterFunction`. `joinAddress` is a `SynteticAddress` that encodes pageIndex and position within the page. `toIntExact(joinAddress)` succeeds only if `pageIndex == 0` and throws "integer overflow" when `pageIndex > 0`.

This issue affects spatial joins with additional filters applied to columns from both sides of the join.

Spatial joins without additional filters are not affected.

Fixes #10169 
