### PR TITLE
Support ESCAPE in LIKE pattern of SHOW SCHEMAS and SHOW TABLES

### DIFF
--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcDistributedQueries.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcDistributedQueries.java
@@ -30,4 +30,10 @@ public class TestJdbcDistributedQueries
     public void testLargeIn()
     {
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Tpch connector currently does not support create table
+    }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -129,4 +129,10 @@ public class TestCassandraDistributed
     {
         // Cassandra connector currently does not support create table nor insert
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Cassandra connector currently does not support create table, so we run empty test
+    }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -133,6 +133,6 @@ public class TestCassandraDistributed
     @Override
     public void testShowTablesLikeWithEscape()
     {
-        // Cassandra connector currently does not support create table, so we run empty test
+        // Cassandra connector currently does not support create table
     }
 }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
@@ -48,4 +48,10 @@ public class TestKafkaDistributed
     {
         embeddedKafka.close();
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Kafka connector currently does not support create table
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -215,7 +215,7 @@ final class ShowQueriesRewrite
 
             Optional<String> likePattern = showTables.getLikePattern();
             if (likePattern.isPresent()) {
-                Expression likePredicate = new LikePredicate(identifier("table_name"), new StringLiteral(likePattern.get()), null);
+                Expression likePredicate = new LikePredicate(identifier("table_name"), new StringLiteral(likePattern.get()), Optional.empty());
                 predicate = logicalAnd(predicate, likePredicate);
             }
 
@@ -286,7 +286,7 @@ final class ShowQueriesRewrite
             Optional<Expression> predicate = Optional.empty();
             Optional<String> likePattern = node.getLikePattern();
             if (likePattern.isPresent()) {
-                predicate = Optional.of(new LikePredicate(identifier("schema_name"), new StringLiteral(likePattern.get()), null));
+                predicate = Optional.of(new LikePredicate(identifier("schema_name"), new StringLiteral(likePattern.get()), Optional.empty()));
             }
 
             return simpleQuery(
@@ -306,7 +306,7 @@ final class ShowQueriesRewrite
             Optional<Expression> predicate = Optional.empty();
             Optional<String> likePattern = node.getLikePattern();
             if (likePattern.isPresent()) {
-                predicate = Optional.of(new LikePredicate(identifier("Catalog"), new StringLiteral(likePattern.get()), null));
+                predicate = Optional.of(new LikePredicate(identifier("Catalog"), new StringLiteral(likePattern.get()), Optional.empty()));
             }
 
             return simpleQuery(

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -215,7 +215,10 @@ final class ShowQueriesRewrite
 
             Optional<String> likePattern = showTables.getLikePattern();
             if (likePattern.isPresent()) {
-                Expression likePredicate = new LikePredicate(identifier("table_name"), new StringLiteral(likePattern.get()), Optional.empty());
+                Expression likePredicate = new LikePredicate(
+                        identifier("table_name"),
+                        new StringLiteral(likePattern.get()),
+                        showTables.getEscape().map(StringLiteral::new));
                 predicate = logicalAnd(predicate, likePredicate);
             }
 
@@ -286,7 +289,10 @@ final class ShowQueriesRewrite
             Optional<Expression> predicate = Optional.empty();
             Optional<String> likePattern = node.getLikePattern();
             if (likePattern.isPresent()) {
-                predicate = Optional.of(new LikePredicate(identifier("schema_name"), new StringLiteral(likePattern.get()), Optional.empty()));
+                predicate = Optional.of(new LikePredicate(
+                        identifier("schema_name"),
+                        new StringLiteral(likePattern.get()),
+                        node.getEscape().map(StringLiteral::new)));
             }
 
             return simpleQuery(

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -1332,7 +1332,7 @@ public class TestExpressionInterpreter
         Expression predicate = new LikePredicate(
                 rawStringLiteral(Slices.wrappedBuffer(value)),
                 new StringLiteral(pattern),
-                null);
+                Optional.empty());
         assertEquals(evaluate(predicate), expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionUtils.java
@@ -24,6 +24,8 @@ import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.StringLiteral;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 import static com.facebook.presto.sql.ExpressionUtils.normalize;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.IS_DISTINCT_FROM;
@@ -55,7 +57,7 @@ public class TestExpressionUtils
     {
         assertNormalize(new ComparisonExpression(EQUAL, name("a"), new LongLiteral("1")));
         assertNormalize(new IsNullPredicate(name("a")));
-        assertNormalize(new NotExpression(new LikePredicate(name("a"), new StringLiteral("x%"), null)));
+        assertNormalize(new NotExpression(new LikePredicate(name("a"), new StringLiteral("x%"), Optional.empty())));
         assertNormalize(
                 new NotExpression(new ComparisonExpression(EQUAL, name("a"), new LongLiteral("1"))),
                 new ComparisonExpression(NOT_EQUAL, name("a"), new LongLiteral("1")));

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -81,5 +81,11 @@ public class TestMySqlDistributedQueries
         // this connector uses a non-canonical type for varchar columns in tpch
     }
 
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Mysql connector currently does not support create table
+    }
+
     // MySQL specific tests should normally go in TestMySqlIntegrationSmokeTest
 }

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -69,8 +69,10 @@ statement
         ('(' explainOption (',' explainOption)* ')')? statement        #explain
     | SHOW CREATE TABLE qualifiedName                                  #showCreateTable
     | SHOW CREATE VIEW qualifiedName                                   #showCreateView
-    | SHOW TABLES ((FROM | IN) qualifiedName)? (LIKE pattern=string)?  #showTables
-    | SHOW SCHEMAS ((FROM | IN) identifier)? (LIKE pattern=string)?    #showSchemas
+    | SHOW TABLES ((FROM | IN) qualifiedName)?
+        (LIKE pattern=string (ESCAPE escape=string)?)?                 #showTables
+    | SHOW SCHEMAS ((FROM | IN) identifier)?
+        (LIKE pattern=string (ESCAPE escape=string)?)?                 #showSchemas
     | SHOW CATALOGS (LIKE pattern=string)?                             #showCatalogs
     | SHOW COLUMNS (FROM | IN) qualifiedName                           #showColumns
     | SHOW STATS (FOR | ON) qualifiedName                              #showStats

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -613,6 +613,10 @@ public final class SqlFormatter
                     builder.append(" LIKE ")
                             .append(formatStringLiteral(value)));
 
+            node.getEscape().ifPresent((value) ->
+                    builder.append(" ESCAPE ")
+                            .append(formatStringLiteral(value)));
+
             return null;
         }
 
@@ -627,6 +631,10 @@ public final class SqlFormatter
 
             node.getLikePattern().ifPresent(value ->
                     builder.append(" LIKE ")
+                            .append(formatStringLiteral(value)));
+
+            node.getEscape().ifPresent(value ->
+                    builder.append(" ESCAPE ")
                             .append(formatStringLiteral(value)));
 
             return null;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -723,6 +723,8 @@ class AstBuilder
                 Optional.ofNullable(context.qualifiedName())
                         .map(this::getQualifiedName),
                 getTextIfPresent(context.pattern)
+                        .map(AstBuilder::unquote),
+                getTextIfPresent(context.escape)
                         .map(AstBuilder::unquote));
     }
 
@@ -733,6 +735,8 @@ class AstBuilder
                 getLocation(context),
                 visitIfPresent(context.identifier(), Identifier.class),
                 getTextIfPresent(context.pattern)
+                        .map(AstBuilder::unquote),
+                getTextIfPresent(context.escape)
                         .map(AstBuilder::unquote));
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/LikePredicate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/LikePredicate.java
@@ -38,6 +38,12 @@ public class LikePredicate
         this(Optional.of(location), value, pattern, escape);
     }
 
+    // TODO cleanup LikePredicate so that escape is always passed using Optional
+    public LikePredicate(Expression value, Expression pattern, Optional<Expression> escape)
+    {
+        this(Optional.empty(), value, pattern, requireNonNull(escape, "escape is null").isPresent() ? escape.get() : null);
+    }
+
     private LikePredicate(Optional<NodeLocation> location, Expression value, Expression pattern, Expression escape)
     {
         super(location);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
@@ -27,22 +27,24 @@ public class ShowSchemas
 {
     private final Optional<Identifier> catalog;
     private final Optional<String> likePattern;
+    private final Optional<String> escape;
 
-    public ShowSchemas(Optional<Identifier> catalog, Optional<String> likePattern)
+    public ShowSchemas(Optional<Identifier> catalog, Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.empty(), catalog, likePattern);
+        this(Optional.empty(), catalog, likePattern, escape);
     }
 
-    public ShowSchemas(NodeLocation location, Optional<Identifier> catalog, Optional<String> likePattern)
+    public ShowSchemas(NodeLocation location, Optional<Identifier> catalog, Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.of(location), catalog, likePattern);
+        this(Optional.of(location), catalog, likePattern, escape);
     }
 
-    private ShowSchemas(Optional<NodeLocation> location, Optional<Identifier> catalog, Optional<String> likePattern)
+    private ShowSchemas(Optional<NodeLocation> location, Optional<Identifier> catalog, Optional<String> likePattern, Optional<String> escape)
     {
         super(location);
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.likePattern = requireNonNull(likePattern, "likePattern is null");
+        this.escape = requireNonNull(escape, "escape is null");
     }
 
     public Optional<Identifier> getCatalog()
@@ -53,6 +55,11 @@ public class ShowSchemas
     public Optional<String> getLikePattern()
     {
         return likePattern;
+    }
+
+    public Optional<String> getEscape()
+    {
+        return escape;
     }
 
     @Override
@@ -70,7 +77,7 @@ public class ShowSchemas
     @Override
     public int hashCode()
     {
-        return catalog.hashCode();
+        return Objects.hash(catalog, likePattern, escape);
     }
 
     @Override
@@ -83,7 +90,9 @@ public class ShowSchemas
             return false;
         }
         ShowSchemas o = (ShowSchemas) obj;
-        return Objects.equals(catalog, o.catalog);
+        return Objects.equals(catalog, o.catalog) &&
+                Objects.equals(likePattern, o.likePattern) &&
+                Objects.equals(escape, o.escape);
     }
 
     @Override
@@ -91,6 +100,8 @@ public class ShowSchemas
     {
         return toStringHelper(this)
                 .add("catalog", catalog)
+                .add("likePattern", likePattern)
+                .add("escape", escape)
                 .toString();
     }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowTables.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowTables.java
@@ -27,25 +27,28 @@ public class ShowTables
 {
     private final Optional<QualifiedName> schema;
     private final Optional<String> likePattern;
+    private final Optional<String> escape;
 
-    public ShowTables(Optional<QualifiedName> schema, Optional<String> likePattern)
+    public ShowTables(Optional<QualifiedName> schema, Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.empty(), schema, likePattern);
+        this(Optional.empty(), schema, likePattern, escape);
     }
 
-    public ShowTables(NodeLocation location, Optional<QualifiedName> schema, Optional<String> likePattern)
+    public ShowTables(NodeLocation location, Optional<QualifiedName> schema, Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.of(location), schema, likePattern);
+        this(Optional.of(location), schema, likePattern, escape);
     }
 
-    private ShowTables(Optional<NodeLocation> location, Optional<QualifiedName> schema, Optional<String> likePattern)
+    private ShowTables(Optional<NodeLocation> location, Optional<QualifiedName> schema, Optional<String> likePattern, Optional<String> escape)
     {
         super(location);
         requireNonNull(schema, "schema is null");
         requireNonNull(likePattern, "likePattern is null");
+        requireNonNull(escape, "escape is null");
 
         this.schema = schema;
         this.likePattern = likePattern;
+        this.escape = escape;
     }
 
     public Optional<QualifiedName> getSchema()
@@ -56,6 +59,11 @@ public class ShowTables
     public Optional<String> getLikePattern()
     {
         return likePattern;
+    }
+
+    public Optional<String> getEscape()
+    {
+        return escape;
     }
 
     @Override
@@ -73,7 +81,7 @@ public class ShowTables
     @Override
     public int hashCode()
     {
-        return Objects.hash(schema, likePattern);
+        return Objects.hash(schema, likePattern, escape);
     }
 
     @Override
@@ -87,7 +95,8 @@ public class ShowTables
         }
         ShowTables o = (ShowTables) obj;
         return Objects.equals(schema, o.schema) &&
-                Objects.equals(likePattern, o.likePattern);
+                Objects.equals(likePattern, o.likePattern) &&
+                Objects.equals(escape, o.escape);
     }
 
     @Override
@@ -96,6 +105,7 @@ public class ShowTables
         return toStringHelper(this)
                 .add("schema", schema)
                 .add("likePattern", likePattern)
+                .add("escape", escape)
                 .toString();
     }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -805,18 +805,19 @@ public class TestSqlParser
     @Test
     public void testShowSchemas()
     {
-        assertStatement("SHOW SCHEMAS", new ShowSchemas(Optional.empty(), Optional.empty()));
-        assertStatement("SHOW SCHEMAS FROM foo", new ShowSchemas(Optional.of(identifier("foo")), Optional.empty()));
-        assertStatement("SHOW SCHEMAS IN foo LIKE '%'", new ShowSchemas(Optional.of(identifier("foo")), Optional.of("%")));
+        assertStatement("SHOW SCHEMAS", new ShowSchemas(Optional.empty(), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW SCHEMAS FROM foo", new ShowSchemas(Optional.of(identifier("foo")), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW SCHEMAS IN foo LIKE '%'", new ShowSchemas(Optional.of(identifier("foo")), Optional.of("%"), Optional.empty()));
+        assertStatement("SHOW SCHEMAS IN foo LIKE '%$_%' ESCAPE '$'", new ShowSchemas(Optional.of(identifier("foo")), Optional.of("%$_%"), Optional.of("$")));
     }
 
     @Test
     public void testShowTables()
     {
-        assertStatement("SHOW TABLES", new ShowTables(Optional.empty(), Optional.empty()));
-        assertStatement("SHOW TABLES FROM a", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.empty()));
-        assertStatement("SHOW TABLES FROM \"awesome schema\"", new ShowTables(Optional.of(QualifiedName.of("awesome schema")), Optional.empty()));
-        assertStatement("SHOW TABLES IN a LIKE '%'", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.of("%")));
+        assertStatement("SHOW TABLES", new ShowTables(Optional.empty(), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW TABLES FROM a", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW TABLES FROM \"awesome schema\"", new ShowTables(Optional.of(QualifiedName.of("awesome schema")), Optional.empty(), Optional.empty()));
+        assertStatement("SHOW TABLES IN a LIKE '%$_%' ESCAPE '$'", new ShowTables(Optional.of(QualifiedName.of("a")), Optional.of("%$_%"), Optional.of("$")));
     }
 
     @Test

--- a/presto-parser/src/test/java/com/facebook/presto/sql/tree/TestLikePredicate.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/tree/TestLikePredicate.java
@@ -16,6 +16,8 @@ package com.facebook.presto.sql.tree;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 import static org.testng.Assert.assertEquals;
 
 public class TestLikePredicate
@@ -28,6 +30,6 @@ public class TestLikePredicate
         StringLiteral escape = new StringLiteral("c");
 
         assertEquals(new LikePredicate(value, pattern, escape).getChildren(), ImmutableList.of(value, pattern, escape));
-        assertEquals(new LikePredicate(value, pattern, null).getChildren(), ImmutableList.of(value, pattern));
+        assertEquals(new LikePredicate(value, pattern, Optional.empty()).getChildren(), ImmutableList.of(value, pattern));
     }
 }

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -48,5 +48,11 @@ public class TestPostgreSqlDistributedQueries
         postgreSqlServer.close();
     }
 
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // PostgreSQL connector currently does not support create table
+    }
+
     // PostgreSQL specific tests should normally go in TestPostgreSqlIntegrationSmokeTest
 }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributed.java
@@ -44,4 +44,10 @@ public class TestRedisDistributed
     {
         embeddedRedis.close();
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Redis connector currently does not support create table
+    }
 }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisDistributedHash.java
@@ -44,4 +44,10 @@ public class TestRedisDistributedHash
     {
         embeddedRedis.close();
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Redis connector currently does not support create table
+    }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4713,7 +4713,7 @@ public abstract class AbstractTestQueries
         assertQueryFails("SHOW TABLES IN a LIKE '%$_%' ESCAPE", "line 1:36: no viable alternative at input '<EOF>'");
         assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE ''", "Escape string must be a single character");
         assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE '$$'", "Escape string must be a single character");
- 
+
         assertUpdate("CREATE TABLE test_escape_1 (a bigint)");
         assertUpdate("CREATE TABLE test_escape11 (a bigint)");
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -91,6 +91,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -4639,6 +4640,20 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testShowSchemasLikeWithEscape()
+    {
+        assertQueryFails("SHOW SCHEMAS IN foo LIKE '%$_%' ESCAPE", "line 1:39: no viable alternative at input '<EOF>'");
+        assertQueryFails("SHOW SCHEMAS LIKE 't$_%' ESCAPE ''", "Escape string must be a single character");
+        assertQueryFails("SHOW SCHEMAS LIKE 't$_%' ESCAPE '$$'", "Escape string must be a single character");
+
+        Set<Object> allSchemas = computeActual("SHOW SCHEMAS").getOnlyColumnAsSet();
+        assertEquals(allSchemas, computeActual("SHOW SCHEMAS LIKE '%_%'").getOnlyColumnAsSet());
+        Set<Object> result = computeActual("SHOW SCHEMAS LIKE '%$_%' ESCAPE '$'").getOnlyColumnAsSet();
+        assertNotEquals(allSchemas, result);
+        assertThat(result).contains("information_schema").allMatch(schemaName -> ((String) schemaName).contains("_"));
+    }
+
+    @Test
     public void testShowTables()
     {
         Set<String> expectedTables = ImmutableSet.copyOf(transform(TpchTable.getTables(), TpchTable::getTableName));
@@ -4690,6 +4705,31 @@ public abstract class AbstractTestQueries
         assertThat(computeActual("SHOW TABLES LIKE 'or%'").getOnlyColumnAsSet())
                 .contains("orders")
                 .allMatch(tableName -> ((String) tableName).startsWith("or"));
+    }
+
+    @Test
+    public void testShowTablesLikeWithEscape()
+    {
+        assertQueryFails("SHOW TABLES IN a LIKE '%$_%' ESCAPE", "line 1:36: no viable alternative at input '<EOF>'");
+        assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE ''", "Escape string must be a single character");
+        assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE '$$'", "Escape string must be a single character");
+
+        try {
+            assertUpdate("CREATE TABLE test_escape_1 (a bigint)");
+            assertUpdate("CREATE TABLE test_escape11 (a bigint)");
+        }
+        catch (RuntimeException e) {
+            assertTrue(ImmutableSet.of("This connector does not support creating tables",
+                    "Unsupported statement type CreateTable")
+                    .contains(e.getMessage()));
+            return;
+        }
+
+        assertQuery("SHOW TABLES LIKE 'test_escape_%'", "VALUES 'test_escape_1', 'test_escape11'");
+        assertQuery("SHOW TABLES LIKE 'test_escape\\_%' ESCAPE '\\'", "VALUES 'test_escape_1'");
+
+        assertUpdate("DROP TABLE test_escape_1");
+        assertUpdate("DROP TABLE test_escape11");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4713,17 +4713,9 @@ public abstract class AbstractTestQueries
         assertQueryFails("SHOW TABLES IN a LIKE '%$_%' ESCAPE", "line 1:36: no viable alternative at input '<EOF>'");
         assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE ''", "Escape string must be a single character");
         assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE '$$'", "Escape string must be a single character");
-
-        try {
-            assertUpdate("CREATE TABLE test_escape_1 (a bigint)");
-            assertUpdate("CREATE TABLE test_escape11 (a bigint)");
-        }
-        catch (RuntimeException e) {
-            assertTrue(ImmutableSet.of("This connector does not support creating tables",
-                    "Unsupported statement type CreateTable")
-                    .contains(e.getMessage()));
-            return;
-        }
+ 
+        assertUpdate("CREATE TABLE test_escape_1 (a bigint)");
+        assertUpdate("CREATE TABLE test_escape11 (a bigint)");
 
         assertQuery("SHOW TABLES LIKE 'test_escape_%'", "VALUES 'test_escape_1', 'test_escape11'");
         assertQuery("SHOW TABLES LIKE 'test_escape\\_%' ESCAPE '\\'", "VALUES 'test_escape_1'");

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesNoHashGeneration.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesNoHashGeneration.java
@@ -24,4 +24,10 @@ public class TestDistributedQueriesNoHashGeneration
                 .setSingleCoordinatorProperty("optimizer.optimize-hash-generation", "false")
                 .build());
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Tpch connector currently does not support create table
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
@@ -68,4 +68,10 @@ public class TestDistributedSpilledQueries
         // TODO: disabled until https://github.com/prestodb/presto/issues/8926 is resolved
         //       due to long running query test created many spill files on disk.
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Tpch connector currently does not support create table
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -100,4 +100,10 @@ public class TestLocalQueries
         assertQuery("SELECT 1.", "SELECT CAST('1.0' AS DECIMAL)");
         assertQuery("SELECT 0.1", "SELECT CAST('0.1' AS DECIMAL)");
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Local connector currently does not support create table
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestNonIterativeDistributedQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestNonIterativeDistributedQueries.java
@@ -25,4 +25,10 @@ public class TestNonIterativeDistributedQueries
     {
         super(() -> TpchQueryRunnerBuilder.builder().setSingleExtraProperty("experimental.iterative-optimizer-enabled", "false").build());
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Tpch connector currently does not support create table
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
@@ -214,4 +214,10 @@ public class TestQueryPlanDeterminism
         determinismChecker.checkPlanIsDeterministic(sql);
         return super.computeExpected(sql, resultTypes);
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Local connector currently does not support create table
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueries.java
@@ -51,4 +51,10 @@ public class TestTpchDistributedQueries
         }
         assertTrue(sampleSizeFound, "Table sample returned unexpected number of rows");
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Tpch connector currently does not support create table
+    }
 }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueries.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueries.java
@@ -30,4 +30,10 @@ public class TestThriftDistributedQueries
     {
         // this test can take a long time
     }
+
+    @Override
+    public void testShowTablesLikeWithEscape()
+    {
+        // Thrift connector currently does not support create table
+    }
 }


### PR DESCRIPTION
recreate pull request https://github.com/prestodb/presto/pull/10146

When schema name or table name have underscore '\_', current LIKE clause of SHOW SCHEMAS or SHOW TABLES do not support to accurate matching as in SELECT query using ESCAPE.
eg:
Current, can not accurate matching in like pattern
\>show tables;
t_1
t_square_2
test
(3 rows)
\>show tables like 't_%';
t_1
t_square_2
test
(3 rows)
\>show tables like 't\\\_%';
(0 rows)
\>show tables like 't\\\_%' escape '\\';
failed: line 1:25: mismatched input 'escape' expecting \<EOF\>

After add support
\>show tables like 't\\\_%' escape '\\\';
t_1
t_square_2
(2 rows)