### PR TITLE
Preserve IN predicate if unable to translate

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -698,7 +698,17 @@ public final class DomainTranslator
             for (Expression expression : valueList.getValues()) {
                 disjuncts.add(new ComparisonExpression(EQUAL, node.getValue(), expression));
             }
-            return process(or(disjuncts.build()), complement);
+            ExtractionResult extractionResult = process(or(disjuncts.build()), complement);
+
+            // preserver original IN predicate as remaining predicate
+            if (extractionResult.tupleDomain.isAll()) {
+                Expression originalPredicate = node;
+                if (complement) {
+                    originalPredicate = new NotExpression(originalPredicate);
+                }
+                return new ExtractionResult(extractionResult.tupleDomain, originalPredicate);
+            }
+            return extractionResult;
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -797,26 +797,11 @@ public class TestDomainTranslator
     @Test
     public void testFromUnprocessableInPredicate()
     {
-        Expression originalExpression = new InPredicate(unprocessableExpression1(C_BIGINT), new InListExpression(ImmutableList.of(TRUE_LITERAL)));
-        ExtractionResult result = fromPredicate(originalExpression);
-        assertEquals(result.getRemainingExpression(), equal(unprocessableExpression1(C_BIGINT), TRUE_LITERAL));
-        assertTrue(result.getTupleDomain().isAll());
-
-        originalExpression = new InPredicate(C_BOOLEAN.toSymbolReference(), new InListExpression(ImmutableList.of(unprocessableExpression1(C_BOOLEAN))));
-        result = fromPredicate(originalExpression);
-        assertEquals(result.getRemainingExpression(), equal(C_BOOLEAN, unprocessableExpression1(C_BOOLEAN)));
-        assertTrue(result.getTupleDomain().isAll());
-
-        originalExpression = new InPredicate(C_BOOLEAN.toSymbolReference(), new InListExpression(ImmutableList.of(TRUE_LITERAL, unprocessableExpression1(C_BOOLEAN))));
-        result = fromPredicate(originalExpression);
-        assertEquals(result.getRemainingExpression(), or(equal(C_BOOLEAN, TRUE_LITERAL), equal(C_BOOLEAN, unprocessableExpression1(C_BOOLEAN))));
-        assertTrue(result.getTupleDomain().isAll());
-
-        // Test complement
-        originalExpression = not(new InPredicate(C_BOOLEAN.toSymbolReference(), new InListExpression(ImmutableList.of(unprocessableExpression1(C_BOOLEAN)))));
-        result = fromPredicate(originalExpression);
-        assertEquals(result.getRemainingExpression(), not(equal(C_BOOLEAN, unprocessableExpression1(C_BOOLEAN))));
-        assertTrue(result.getTupleDomain().isAll());
+        assertUnsupportedPredicate(new InPredicate(unprocessableExpression1(C_BIGINT), new InListExpression(ImmutableList.of(TRUE_LITERAL))));
+        assertUnsupportedPredicate(new InPredicate(C_BOOLEAN.toSymbolReference(), new InListExpression(ImmutableList.of(unprocessableExpression1(C_BOOLEAN)))));
+        assertUnsupportedPredicate(
+                new InPredicate(C_BOOLEAN.toSymbolReference(), new InListExpression(ImmutableList.of(TRUE_LITERAL, unprocessableExpression1(C_BOOLEAN)))));
+        assertUnsupportedPredicate(not(new InPredicate(C_BOOLEAN.toSymbolReference(), new InListExpression(ImmutableList.of(unprocessableExpression1(C_BOOLEAN))))));
     }
 
     @Test
@@ -879,11 +864,9 @@ public class TestDomainTranslator
                         new InListExpression(ImmutableList.of(toExpression(1L, BIGINT)))),
                 withColumnDomains(ImmutableMap.of(C_SMALLINT, Domain.singleValue(SMALLINT, 1L))));
 
-        ExtractionResult result = fromPredicate(new InPredicate(
+        assertUnsupportedPredicate(new InPredicate(
                 cast(C_BIGINT, INTEGER),
                 new InListExpression(ImmutableList.of(toExpression(1L, INTEGER)))));
-        assertEquals(result.getRemainingExpression(), equal(cast(C_BIGINT, INTEGER), toExpression(1L, INTEGER)));
-        assertEquals(result.getTupleDomain(), TupleDomain.all());
     }
 
     @Test
@@ -893,12 +876,9 @@ public class TestDomainTranslator
                 C_BIGINT.toSymbolReference(),
                 new InListExpression(ImmutableList.of(cast(toExpression(null, SMALLINT), BIGINT)))));
 
-        Expression originalExpression = not(new InPredicate(
+        assertUnsupportedPredicate(not(new InPredicate(
                 cast(C_SMALLINT, BIGINT),
-                new InListExpression(ImmutableList.of(toExpression(null, BIGINT)))));
-        ExtractionResult result = fromPredicate(originalExpression);
-        assertEquals(result.getRemainingExpression(), not(equal(cast(C_SMALLINT, BIGINT), toExpression(null, BIGINT))));
-        assertEquals(result.getTupleDomain(), TupleDomain.all());
+                new InListExpression(ImmutableList.of(toExpression(null, BIGINT))))));
 
         assertPredicateTranslates(
                 new InPredicate(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -900,12 +900,11 @@ public class TestDomainTranslator
         assertEquals(result.getRemainingExpression(), not(equal(cast(C_SMALLINT, BIGINT), toExpression(null, BIGINT))));
         assertEquals(result.getTupleDomain(), TupleDomain.all());
 
-        originalExpression = new InPredicate(
-                C_BIGINT.toSymbolReference(),
-                new InListExpression(ImmutableList.of(cast(toExpression(null, SMALLINT), BIGINT), toExpression(1L, BIGINT))));
-        result = fromPredicate(originalExpression);
-        assertEquals(result.getRemainingExpression(), TRUE_LITERAL);
-        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L)), false))));
+        assertPredicateTranslates(
+                new InPredicate(
+                        C_BIGINT.toSymbolReference(),
+                        new InListExpression(ImmutableList.of(cast(toExpression(null, SMALLINT), BIGINT), toExpression(1L, BIGINT)))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L)), false))));
 
         assertPredicateIsAlwaysFalse(not(new InPredicate(
                 C_BIGINT.toSymbolReference(),

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4325,6 +4325,9 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (" + longValues + ")");
         assertQuery("SELECT orderkey FROM orders WHERE orderkey NOT IN (" + longValues + ")");
 
+        assertQuery("SELECT orderkey FROM orders WHERE orderkey IN (mod(1000, orderkey), " + longValues + ")");
+        assertQuery("SELECT orderkey FROM orders WHERE orderkey NOT IN (mod(1000, orderkey), " + longValues + ")");
+
         String arrayValues = range(0, 5000)
                 .mapToObj(i -> format("ARRAY[%s, %s, %s]", i, i + 1, i + 2))
                 .collect(joining(", "));


### PR DESCRIPTION
Preserve IN predicate if unable to translate

When DomainTranslator is unable to translate InPredicate it should
preserver IN predicate. Leaving IN predicate rewritten to a tree of ORs
of <column> = <value> is invalid, because it loses or dissolves the
information that could be leveraged further (e.g. in expression compiler).
