### PR TITLE
Add support for DATE predicate pushdown with Parquet via min/max and …

### DIFF
--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTypeUtils.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTypeUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet;
+
+import com.facebook.presto.spi.predicate.TupleDomain;
+import org.testng.annotations.Test;
+import parquet.column.ColumnDescriptor;
+import parquet.schema.OriginalType;
+import parquet.schema.PrimitiveType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+
+import static com.facebook.presto.parquet.ParquetTypeUtils.getPrestoType;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static org.testng.Assert.assertEquals;
+import static parquet.schema.Type.Repetition.OPTIONAL;
+
+public class TestParquetTypeUtils
+{
+    @Test
+    public void testMapInt32ToPrestoInteger()
+    {
+        PrimitiveType intType = new PrimitiveType(OPTIONAL, PrimitiveTypeName.INT32, "int_col", OriginalType.INT_32);
+        ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[]{"int_col"}, PrimitiveTypeName.INT32, 0, 1);
+        RichColumnDescriptor intColumn = new RichColumnDescriptor(columnDescriptor, intType);
+        assertEquals(getPrestoType(TupleDomain.all(), intColumn), INTEGER);
+    }
+
+    @Test
+    public void testMapInt32WithoutOriginalTypeToPrestoInteger()
+    {
+        // int32 primitive should default to Presto integer if original type metadata isn't available
+        PrimitiveType intType = new PrimitiveType(OPTIONAL, PrimitiveTypeName.INT32, "int_col");
+        ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[]{"int_col"}, PrimitiveTypeName.INT32, 0, 1);
+        RichColumnDescriptor intColumn = new RichColumnDescriptor(columnDescriptor, intType);
+        assertEquals(getPrestoType(TupleDomain.all(), intColumn), INTEGER);
+    }
+
+    @Test
+    public void testMapInt32ToPrestoDate()
+    {
+        // int32 primitive with original type of date should map to a Presto date
+        PrimitiveType dateType = new PrimitiveType(OPTIONAL, PrimitiveTypeName.INT32, "date_col", OriginalType.DATE);
+        ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[]{"date_col"}, PrimitiveTypeName.INT32, 0, 1);
+        RichColumnDescriptor dateColumn = new RichColumnDescriptor(columnDescriptor, dateType);
+        assertEquals(getPrestoType(TupleDomain.all(), dateColumn), DATE);
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
@@ -27,6 +27,7 @@ import parquet.column.statistics.BinaryStatistics;
 import parquet.column.statistics.BooleanStatistics;
 import parquet.column.statistics.DoubleStatistics;
 import parquet.column.statistics.FloatStatistics;
+import parquet.column.statistics.IntStatistics;
 import parquet.column.statistics.LongStatistics;
 import parquet.column.statistics.Statistics;
 import parquet.io.api.Binary;
@@ -45,6 +46,7 @@ import static com.facebook.presto.spi.predicate.Range.range;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -190,6 +192,16 @@ public class TestTupleDomainParquetPredicate
     }
 
     @Test
+    public void testDate()
+    {
+        assertEquals(getDomain(DATE, 0, null), all(DATE));
+        assertEquals(getDomain(DATE, 10, intColumnStats(100, 100)), singleValue(DATE, 100L));
+        assertEquals(getDomain(DATE, 10, intColumnStats(0, 100)), create(ValueSet.ofRanges(range(DATE, 0L, true, 100L, true)), false));
+        // assert corrupt stats are ignored properly
+        assertEquals(getDomain(DATE, 10, intColumnStats(200, 100)), create(ValueSet.all(DATE), false));
+    }
+
+    @Test
     public void testMatchesWithStatistics()
     {
         String value = "Test";
@@ -225,6 +237,13 @@ public class TestTupleDomainParquetPredicate
     private static FloatStatistics floatColumnStats(float minimum, float maximum)
     {
         FloatStatistics statistics = new FloatStatistics();
+        statistics.setMinMax(minimum, maximum);
+        return statistics;
+    }
+
+    private static IntStatistics intColumnStats(int minimum, int maximum)
+    {
+        IntStatistics statistics = new IntStatistics();
         statistics.setMinMax(minimum, maximum);
         return statistics;
     }


### PR DESCRIPTION
…dictionary (plain). Fix an issue where during existing pushdown this would throw an exception for date to integer domain comparison.

This fixes an issue where because Parquet dates are stored as int32 with logical typing of "date", Presto was detecting that the column was an Integer. Then trying to do comparisons against a Date value the domain comparison would throw an exception:

Mismatched Domain types: date vs integer

This would happen on queries such as:

select count(*) from my_table where date_field > DATE '2018-01-01'

Where the left hand side column was detected as an integer and the right hand side literal was a date. Resolved by inspecting Parquet column data for INT32 to detect if the original type was a DATE.