### PR TITLE
[geospatial] Optimize st-intersects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1199,6 +1199,21 @@
                     <fork>false</fork>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration combine.children="append">
+                    <includes>
+                        <include>**/Test*.java</include>
+                        <include>**/Benchmark*.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*jmhTest*.java</exclude>
+                        <exclude>**/*jmhType*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1201,4 +1201,47 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>tests-with-dependencies</id>
+            <!--
+                Assembles an uber (fat) jar that includes the entire "test" scope classpath for a module.
+
+                For example after running:
+
+                ./mvnw clean install -P tests-with-dependencies -pl presto-geospatial
+
+                The uber jar that contains the entire "test" scope class path of the "presto-geospatial"
+                is created and placed to that modules target directory:
+
+                ./presto-geospatial/target/presto-geospatial-0.197-SNAPSHOT-tests-with-dependencies.jar
+
+                Now using this jar we can easily run any benchmark from that module via command line:
+
+                java \
+                  -cp ./presto-geospatial/target/presto-geospatial-*-tests-with-dependencies.jar \
+                  com.facebook.presto.plugin.geospatial.BenchmarkSTIntersects
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptor>${air.main.basedir}/src/assembly/tests-with-dependencies.xml</descriptor>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -539,6 +539,11 @@ public final class GeoFunctions
     @SqlType(StandardTypes.BOOLEAN)
     public static Boolean stIntersects(@SqlType(GEOMETRY_TYPE_NAME) Slice left, @SqlType(GEOMETRY_TYPE_NAME) Slice right)
     {
+        Envelope leftEnvelope = deserializeEnvelope(left);
+        Envelope rightEnvelope = deserializeEnvelope(right);
+        if (leftEnvelope == null || rightEnvelope == null || !leftEnvelope.intersect(rightEnvelope)) {
+            return false;
+        }
         OGCGeometry leftGeometry = deserialize(left);
         OGCGeometry rightGeometry = deserialize(right);
         verifySameSpatialReference(leftGeometry, rightGeometry);

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkSTIntersects.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkSTIntersects.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import io.airlift.slice.Slice;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stContains;
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stEnvelope;
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stGeometryFromText;
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stIntersects;
+import static com.facebook.presto.plugin.geospatial.GeometryBenchmarkUtils.loadPolygon;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.Slices.utf8Slice;
+
+@State(Scope.Thread)
+@Fork(3)
+@Warmup(iterations = 5, time = 3)
+@Measurement(iterations = 5, time = 5)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class BenchmarkSTIntersects
+{
+    @Benchmark
+    public Object stIntersectsInnerLine(BenchmarkData data)
+    {
+        return stIntersects(data.innerLine, data.geometry);
+    }
+
+    @Benchmark
+    public Object stIntersectsInnerLineSimpleGeometry(BenchmarkData data)
+    {
+        return stIntersects(data.innerLine, data.simpleGeometry);
+    }
+
+    @Benchmark
+    public Object stIntersectsCrossingLine(BenchmarkData data)
+    {
+        return stIntersects(data.crossingLine, data.geometry);
+    }
+
+    @Benchmark
+    public Object stIntersectsCrossingLineSimpleGeometry(BenchmarkData data)
+    {
+        return stIntersects(data.crossingLine, data.simpleGeometry);
+    }
+
+    @Benchmark
+    public Object stIntersectsOuterLineInEnvelope(BenchmarkData data)
+    {
+        return stIntersects(data.outerLineInEnvelope, data.geometry);
+    }
+
+    @Benchmark
+    public Object stIntersectsOuterLineInEnvelopeSimpleGeometry(BenchmarkData data)
+    {
+        return stIntersects(data.outerLineInEnvelope, data.simpleGeometry);
+    }
+
+    @Benchmark
+    public Object stIntersectsOuterLineNotInEnvelope(BenchmarkData data)
+    {
+        return stIntersects(data.outerLineNotInEnvelope, data.geometry);
+    }
+
+    @Benchmark
+    public Object stIntersectsOuterLineNotInEnvelopeSimpleGeometry(BenchmarkData data)
+    {
+        return stIntersects(data.outerLineNotInEnvelope, data.simpleGeometry);
+    }
+
+    @Test
+    public void validateBenchmarkData()
+            throws Exception
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        data.validate();
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private Slice simpleGeometry;
+        private Slice geometry;
+        private Slice innerLine;
+        private Slice crossingLine;
+        private Slice outerLineInEnvelope;
+        private Slice outerLineNotInEnvelope;
+
+        @Setup
+        public void setup()
+                throws IOException
+        {
+            simpleGeometry = stGeometryFromText(utf8Slice("POLYGON ((16.5 54, 16.5 54.1, 16.51 54.1, 16.8 54))"));
+            geometry = stGeometryFromText(utf8Slice(loadPolygon("large_polygon.txt")));
+            innerLine = stGeometryFromText(utf8Slice("LINESTRING (16.6 54.0167, 16.6 54.017)"));
+            crossingLine = stGeometryFromText(utf8Slice("LINESTRING (16.6 53, 16.6 56)"));
+            outerLineInEnvelope = stGeometryFromText(utf8Slice("LINESTRING (16.6667 54.05, 16.8667 54.05)"));
+            outerLineNotInEnvelope = stGeometryFromText(utf8Slice("LINESTRING (16.6667 54.25, 16.8667 54.25)"));
+        }
+
+        public void validate()
+        {
+            validate(simpleGeometry);
+            validate(geometry);
+        }
+
+        public void validate(Slice geometry)
+        {
+            Slice envelope = stEnvelope(geometry);
+
+            // innerLine
+            verify(stIntersects(geometry, innerLine));
+            verify(stContains(geometry, innerLine));
+
+            // crossingLine
+            verify(stIntersects(geometry, crossingLine));
+            verify(!stContains(geometry, crossingLine));
+
+            // outerLineInEnvelope
+            verify(!stIntersects(geometry, outerLineInEnvelope));
+            verify(stIntersects(envelope, outerLineInEnvelope));
+
+            // outerLineNotInEnvelope
+            verify(!stIntersects(geometry, outerLineNotInEnvelope));
+            verify(!stIntersects(envelope, outerLineNotInEnvelope));
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkSTIntersects.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/GeometryBenchmarkUtils.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/GeometryBenchmarkUtils.java
@@ -14,20 +14,22 @@
 package com.facebook.presto.plugin.geospatial;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.net.URL;
 import java.util.List;
+
+import static com.google.common.io.Resources.readLines;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 public class GeometryBenchmarkUtils
 {
     private GeometryBenchmarkUtils() {}
 
-    public static String loadPolygon(String fileName)
+    public static String loadPolygon(String path)
             throws IOException
     {
-        Path filePath = Paths.get(GeometryBenchmarkUtils.class.getClassLoader().getResource(fileName).getPath());
-        List<String> lines = Files.readAllLines(filePath);
+        URL resource = requireNonNull(GeometryBenchmarkUtils.class.getClassLoader().getResource(path), "resource not found: " + path);
+        List<String> lines = readLines(resource, UTF_8);
         String line = lines.get(0);
         String[] parts = line.split("\\|");
         return parts[0];

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -452,6 +452,9 @@ public class TestGeoFunctions
         assertFunction("ST_Intersects(ST_GeometryFromText('MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))'), ST_GeometryFromText('MULTILINESTRING ((3 4, 6 4), (5 0, 5 4))'))", BOOLEAN, true);
         assertFunction("ST_Intersects(ST_GeometryFromText('POLYGON ((1 1, 1 3, 3 3, 3 1))'), ST_GeometryFromText('POLYGON ((4 4, 4 5, 5 5, 5 4))'))", BOOLEAN, false);
         assertFunction("ST_Intersects(ST_GeometryFromText('MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1)), ((0 0, 0 2, 2 2, 2 0)))'), ST_GeometryFromText('POLYGON ((0 1, 3 1, 3 3, 0 3))'))", BOOLEAN, true);
+        assertFunction("ST_Intersects(ST_GeometryFromText('POLYGON ((16.5 54, 16.5 54.1, 16.51 54.1, 16.8 54))'), ST_GeometryFromText('LINESTRING (16.6 53, 16.6 56)'))", BOOLEAN, true);
+        assertFunction("ST_Intersects(ST_GeometryFromText('POLYGON ((16.5 54, 16.5 54.1, 16.51 54.1, 16.8 54))'), ST_GeometryFromText('LINESTRING (16.6667 54.05, 16.8667 54.05)'))", BOOLEAN, false);
+        assertFunction("ST_Intersects(ST_GeometryFromText('POLYGON ((16.5 54, 16.5 54.1, 16.51 54.1, 16.8 54))'), ST_GeometryFromText('LINESTRING (16.6667 54.25, 16.8667 54.25)'))", BOOLEAN, false);
     }
 
     @Test

--- a/src/assembly/tests-with-dependencies.xml
+++ b/src/assembly/tests-with-dependencies.xml
@@ -1,0 +1,37 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>tests-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <unpackOptions>
+                <excludes>
+                    <exclude>META-INF/**</exclude>
+                </excludes>
+            </unpackOptions>
+            <scope>test</scope>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/classes</directory>
+            <outputDirectory>/</outputDirectory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <excludes>
+                <exclude>META-INF/**</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/test-classes</directory>
+            <outputDirectory>/</outputDirectory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>


### PR DESCRIPTION
Try to deserialize and check envelopes first. If envelopes intersect than do the
full deserialization and a fair slow check.

Below are the becnhmark results. Score is a number of operations per second.
Bigger is better.

Original:

```
Benchmark                                                                Mode  Cnt       Score       Error  Units
BenchmarkSTIntersects.stIntersectsCrossingLine                          thrpt   15    3283.622 ±   167.239  ops/s
BenchmarkSTIntersects.stIntersectsCrossingLineSimpleGeometry            thrpt   15  400249.628 ±  6911.584  ops/s
BenchmarkSTIntersects.stIntersectsInnerLine                             thrpt   15    2389.466 ±   108.045  ops/s
BenchmarkSTIntersects.stIntersectsInnerLineSimpleGeometry               thrpt   15  378110.330 ±  5722.562  ops/s
BenchmarkSTIntersects.stIntersectsOuterLineInEnvelope                   thrpt   15    2467.781 ±   165.310  ops/s
BenchmarkSTIntersects.stIntersectsOuterLineInEnvelopeSimpleGeometry     thrpt   15  374974.848 ± 11822.304  ops/s
BenchmarkSTIntersects.stIntersectsOuterLineNotInEnvelope                thrpt   15    5817.151 ±   205.039  ops/s
BenchmarkSTIntersects.stIntersectsOuterLineNotInEnvelopeSimpleGeometry  thrpt   15  766485.338 ± 12150.271  ops/s
```

Modified:

```
Benchmark                                                                Mode  Cnt        Score        Error  Units
BenchmarkSTIntersects.stIntersectsCrossingLine                          thrpt   15     3312.916 ±    182.780  ops/s
BenchmarkSTIntersects.stIntersectsCrossingLineSimpleGeometry            thrpt   15   385701.159 ±  12637.764  ops/s
BenchmarkSTIntersects.stIntersectsInnerLine                             thrpt   15     2425.224 ±    111.010  ops/s
BenchmarkSTIntersects.stIntersectsInnerLineSimpleGeometry               thrpt   15   362100.862 ±   9446.807  ops/s
BenchmarkSTIntersects.stIntersectsOuterLineInEnvelope                   thrpt   15     2378.565 ±    106.855  ops/s
BenchmarkSTIntersects.stIntersectsOuterLineInEnvelopeSimpleGeometry     thrpt   15   359020.076 ±   6955.090  ops/s
BenchmarkSTIntersects.stIntersectsOuterLineNotInEnvelope                thrpt   15  7726620.862 ± 186465.089  ops/s
BenchmarkSTIntersects.stIntersectsOuterLineNotInEnvelopeSimpleGeometry  thrpt   15  7742866.387 ± 156396.092  ops/s
```

For a negative case, when a full deserialization is required to be made
anyway (intersects, evelope intersects) small regression is noticed. ~4% performance
hit for simple geometries, where deserialization time is neligible. And <1% performance
hit for complex geometries, where deserialization takas most of the time.

However for a positive case, when full deserialization is not needed performance gain
is much significant. For the complex geometry case `intersects` operation is 1300 times
faster.