### PR TITLE
Small StreamPreferredProperties cleanups

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -250,7 +250,6 @@ public class AddLocalExchanges
         public PlanWithProperties visitAggregation(AggregationNode node, StreamPreferredProperties parentPreferences)
         {
             StreamPreferredProperties requiredProperties;
-            StreamPreferredProperties preferredChildProperties;
 
             checkState(node.getStep() == AggregationNode.Step.SINGLE, "step of aggregation is expected to be SINGLE, but it is %s", node.getStep());
 
@@ -266,10 +265,7 @@ public class AddLocalExchanges
             }
 
             requiredProperties = parentPreferences.withDefaultParallelism(session).withPartitioning(partitioningRequirement);
-            preferredChildProperties = parentPreferences.withDefaultParallelism(session)
-                    .withPartitioning(partitioningRequirement);
-
-            return planAndEnforceChildren(node, requiredProperties, preferredChildProperties);
+            return planAndEnforceChildren(node, requiredProperties, requiredProperties);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPreferredProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPreferredProperties.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDeriva
 import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.SINGLE;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 class StreamPreferredProperties
@@ -265,7 +266,9 @@ class StreamPreferredProperties
             return any();
         }
 
-        Set<Symbol> common = Sets.intersection(availableSymbols, ImmutableSet.copyOf(partitioningColumns.get()));
+        List<Symbol> common = partitioningColumns.get().stream()
+                .filter(availableSymbols::contains)
+                .collect(toImmutableList());
         if (common.isEmpty()) {
             return any();
         }


### PR DESCRIPTION
One of which is making sure that order of partitioning properties is preserved and deterministic when preferences are constrained.