### PR TITLE
Fix computing averages in WindowOperatorStats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowOperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowOperatorStats.java
@@ -53,13 +53,13 @@ class WindowOperatorStats
                 .filter(windowInfo -> windowInfo.getTotalRowsCount() > 0)
                 .mapToLong(DriverWindowInfo::getNumberOfIndexes)
                 .average()
-                .getAsDouble();
+                .orElse(Double.NaN);
 
         double averageNumberOfRows = info.getWindowInfos().stream()
                 .filter(windowInfo -> windowInfo.getTotalRowsCount() > 0)
                 .mapToLong(DriverWindowInfo::getTotalRowsCount)
                 .average()
-                .getAsDouble();
+                .orElse(Double.NaN);
 
         for (DriverWindowInfo driverWindowInfo : info.getWindowInfos()) {
             long driverTotalRowsCount = driverWindowInfo.getTotalRowsCount();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowOperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/WindowOperatorStats.java
@@ -50,13 +50,13 @@ class WindowOperatorStats
         long totalPartitionsCount = 0;
 
         double averageNumberOfIndexes = info.getWindowInfos().stream()
-                .filter(windowInfo -> windowInfo.getTotalRowsCount() > 0)
+                .filter(WindowOperatorStats::isMeaningful)
                 .mapToLong(DriverWindowInfo::getNumberOfIndexes)
                 .average()
                 .orElse(Double.NaN);
 
         double averageNumberOfRows = info.getWindowInfos().stream()
-                .filter(windowInfo -> windowInfo.getTotalRowsCount() > 0)
+                .filter(WindowOperatorStats::isMeaningful)
                 .mapToLong(DriverWindowInfo::getTotalRowsCount)
                 .average()
                 .orElse(Double.NaN);
@@ -92,6 +92,35 @@ class WindowOperatorStats
                 totalPartitionsCount,
                 activeDrivers,
                 totalDrivers);
+    }
+
+    private static boolean isMeaningful(DriverWindowInfo windowInfo)
+    {
+        // We are filtering out windowInfos without rows.
+        //
+        // The idea was to distinguish two types of problems:
+        //
+        // Data skew (should be visible in ExchangeOperator stats), e.g. when one partition is significantly larger than others.
+        // In such case, WindowOperator will be inefficient because parallelism will go down.
+        // Problems in WindowOperator execution itself.
+        // If you included empty indexes in WO stats, the active WO stats would be overwhelmed by data skew problems.
+        // Imagine situation when all data is in one partition (processed by 8 local WOs) but you have 1024 WOs total in plan
+        // (128 nodes are idling till 1 node finishes processing WO).
+        //
+        // In such case you care how efficiently the only occupied 8 local operators were working (how many times index was rebuilt, how big it was etc,
+        // did everyone get the same index or maybe there was some skew which could be prevent on the operator level etc.).
+        // If you included all 127 remaining idling nodes in the average, the problems with running operators would be not visible
+        // (in most cases you'd see the average values very low, no matter how well active operators are doing).
+        //
+        // So, in other words, it's to make stats more granular:
+        // if you're looking for data distribution skew, keep an eye on ExchangeOperator stats.
+        // If you're debugging execution of WO, focus on relevant stats for WOs.
+        //
+        // Keep in mind, though, that WO stats are very low level and tightly coupled to implementation.
+        // They don't make sense to DBA, if he doesn't know execution engine and implementation of WOs.
+        // It's mostly to help driving window function improvements by better understanding why some queries are slower than others.
+
+        return windowInfo.getTotalRowsCount() > 0;
     }
 
     private WindowOperatorStats(

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -293,6 +293,8 @@ public abstract class AbstractTestDistributedQueries
     public void testExplainAnalyzeVerbose()
     {
         assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT * FROM orders");
+        assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT rank() OVER (PARTITION BY orderkey ORDER BY clerk DESC) FROM orders");
+        assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT rank() OVER (PARTITION BY orderkey ORDER BY clerk DESC) FROM orders WHERE orderkey < 0");
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "EXPLAIN ANALYZE only supported for statements that are queries")

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -289,6 +289,12 @@ public abstract class AbstractTestDistributedQueries
         assertExplainAnalyze("EXPLAIN ANALYZE SHOW SESSION");
     }
 
+    @Test
+    public void testExplainAnalyzeVerbose()
+    {
+        assertExplainAnalyze("EXPLAIN ANALYZE VERBOSE SELECT * FROM orders");
+    }
+
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "EXPLAIN ANALYZE only supported for statements that are queries")
     public void testExplainAnalyzeDDL()
     {


### PR DESCRIPTION
The code failed if all the `WindowInfo` objects we iterated over had `getTotalRowsCount() == 0`.
This change fixes the behaviour but I am not exactly sure why we need the `.filter(windowInfo -> windowInfo.getTotalRowsCount() > 0)` alltogether.
@arhimondr can you take a look if this is a proper fix and if original code is right?

cc: @findepi 
