### PR TITLE
Fix ordinal_position when adding new column

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
@@ -445,11 +445,10 @@ public class RaptorMetadata
         RaptorTableHandle table = (RaptorTableHandle) tableHandle;
 
         // Always add new columns to the end.
-        // TODO: This needs to be updated when we support dropping columns.
         List<TableColumn> existingColumns = dao.listTableColumns(table.getSchemaName(), table.getTableName());
         TableColumn lastColumn = existingColumns.get(existingColumns.size() - 1);
         long columnId = lastColumn.getColumnId() + 1;
-        int ordinalPosition = existingColumns.size();
+        int ordinalPosition = lastColumn.getOrdinalPosition() + 1;
 
         String type = column.getType().getTypeSignature().toString();
         daoTransaction(dbi, MetadataDao.class, dao -> {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
@@ -33,7 +33,7 @@ public interface MetadataDao
 
     String TABLE_COLUMN_SELECT = "" +
             "SELECT t.schema_name, t.table_name,\n" +
-            "  c.column_id, c.column_name, c.data_type,\n" +
+            "  c.column_id, c.column_name, c.data_type, c.ordinal_position,\n" +
             "  c.bucket_ordinal_position, c.sort_ordinal_position,\n" +
             "  t.temporal_column_id = c.column_id AS temporal\n" +
             "FROM tables t\n" +

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/TableColumn.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/TableColumn.java
@@ -38,16 +38,18 @@ public class TableColumn
     private final String columnName;
     private final Type dataType;
     private final long columnId;
+    private final int ordinalPosition;
     private final OptionalInt bucketOrdinal;
     private final OptionalInt sortOrdinal;
     private final boolean temporal;
 
-    public TableColumn(SchemaTableName table, String columnName, Type dataType, long columnId, OptionalInt bucketOrdinal, OptionalInt sortOrdinal, boolean temporal)
+    public TableColumn(SchemaTableName table, String columnName, Type dataType, long columnId, int ordinalPosition, OptionalInt bucketOrdinal, OptionalInt sortOrdinal, boolean temporal)
     {
         this.table = requireNonNull(table, "table is null");
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.dataType = requireNonNull(dataType, "dataType is null");
         this.columnId = columnId;
+        this.ordinalPosition = ordinalPosition;
         this.bucketOrdinal = requireNonNull(bucketOrdinal, "bucketOrdinal is null");
         this.sortOrdinal = requireNonNull(sortOrdinal, "sortOrdinal is null");
         this.temporal = temporal;
@@ -71,6 +73,11 @@ public class TableColumn
     public long getColumnId()
     {
         return columnId;
+    }
+
+    public int getOrdinalPosition()
+    {
+        return ordinalPosition;
     }
 
     public OptionalInt getBucketOrdinal()
@@ -137,6 +144,7 @@ public class TableColumn
                     r.getString("column_name"),
                     type,
                     r.getLong("column_id"),
+                    r.getInt("ordinal_position"),
                     getOptionalInt(r, "bucket_ordinal_position"),
                     getOptionalInt(r, "sort_ordinal_position"),
                     r.getBoolean("temporal"));


### PR DESCRIPTION
Use the `max(ordinal_position)  + 1` as the `ordinal_position` value for newly added columns.