### PR TITLE
Improve local aggregation parallelism

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -217,9 +217,7 @@ public class AddExchanges
         {
             Set<Symbol> partitioningRequirement = ImmutableSet.copyOf(node.getGroupingKeys());
 
-            boolean preferSingleNode = (node.hasEmptyGroupingSet() && !node.hasNonEmptyGroupingSet()) ||
-                    (node.hasDefaultOutput() && !node.isDecomposable(metadata.getFunctionRegistry()));
-
+            boolean preferSingleNode = node.hasSingleNodeExecutionPreference(metadata.getFunctionRegistry());
             PreferredProperties preferredProperties = preferSingleNode ? PreferredProperties.undistributed() : PreferredProperties.any();
 
             if (!node.getGroupingKeys().isEmpty()) {
@@ -235,14 +233,6 @@ public class AddExchanges
             }
 
             if (preferSingleNode) {
-                // For queries with only empty grouping sets like
-                //
-                // SELECT count(*) FROM lineitem;
-                //
-                // there is no need for distributed aggregation. Single node FINAL aggregation will suffice,
-                // since all input have to be aggregated into one line output.
-                //
-                // If aggregation must produce default output and it is not decomposable, we can not distribute it
                 child = withDerivedProperties(
                         gatheringExchange(idAllocator.getNextId(), REMOTE, child.getNode()),
                         child.getProperties());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
@@ -197,6 +197,21 @@ public class AggregationNode
                         .allMatch(entry -> !entry.getValue().getCall().getOrderBy().isPresent());
     }
 
+    public boolean hasSingleNodeExecutionPreference(FunctionRegistry functionRegistry)
+    {
+        // There are two kinds of aggregations the have single node execution preference:
+        //
+        // 1. aggregations with only empty grouping sets like
+        //
+        // SELECT count(*) FROM lineitem;
+        //
+        // there is no need for distributed aggregation. Single node FINAL aggregation will suffice,
+        // since all input have to be aggregated into one line output.
+        //
+        // 2. aggregations that must produce default output and are not decomposable, we can not distribute them.
+        return (hasEmptyGroupingSet() && !hasNonEmptyGroupingSet()) || (hasDefaultOutput() && !isDecomposable(functionRegistry));
+    }
+
     public enum Step
     {
         PARTIAL(true, true),


### PR DESCRIPTION
local exchange type for aggregation can be governed by similar rules as remote exchange. See `com/facebook/presto/sql/planner/optimizations/AddExchanges.java:251`