### PR TITLE
Fix current_date when session zone had gap at 1970-01-01 00:00:00

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -27,6 +27,7 @@ import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeField;
 import org.joda.time.Days;
+import org.joda.time.LocalDate;
 import org.joda.time.chrono.ISOChronology;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -86,9 +87,8 @@ public final class DateTimeFunctions
 
         // It is ok for this method to use the Object interfaces because it is constant folded during
         // plan optimization
-        DateTime currentDateTime = new DateTime(session.getStartTime(), chronology).withTimeAtStartOfDay();
-        DateTime baseDateTime = new DateTime(1970, 1, 1, 0, 0, chronology).withTimeAtStartOfDay();
-        return Days.daysBetween(baseDateTime, currentDateTime).getDays();
+        LocalDate currentDate = new DateTime(session.getStartTime(), chronology).toLocalDate();
+        return Days.daysBetween(new LocalDate(1970, 1, 1), currentDate).getDays();
     }
 
     @Description("current time with time zone")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -120,8 +120,10 @@ public abstract class TestDateTimeFunctionsBase
     public void testCurrentDateTimezone()
     {
         TimeZoneKey kievTimeZoneKey = getTimeZoneKey("Europe/Kiev");
+        TimeZoneKey bahiaBanderasTimeZoneKey = getTimeZoneKey("America/Bahia_Banderas"); // The zone has 'gap' on 1970-01-01
         for (long instant = new DateTime(2000, 6, 15, 0, 0).getMillis(); instant < new DateTime(2016, 6, 15, 0, 0).getMillis(); instant += TimeUnit.HOURS.toMillis(1)) {
             assertCurrentDateAtInstant(kievTimeZoneKey, instant);
+            assertCurrentDateAtInstant(bahiaBanderasTimeZoneKey, instant);
             assertCurrentDateAtInstant(TIME_ZONE_KEY, instant);
         }
     }


### PR DESCRIPTION
Computation done by the implementation of `current_date` was failing if
session zone had a gap at 1970-01-01 00:00:00. This commit changes the
APIs used so that the code works in those cases too.

This problem was found thanks to https://github.com/prestodb/presto/pull/10128