### PR TITLE
Analyze query before enqueuing

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -424,6 +424,7 @@ public class SqlQueryManager
                 queryInfo = execution.getQueryInfo();
                 queryMonitor.queryCreatedEvent(queryInfo);
                 queryMonitor.queryCompletedEvent(queryInfo);
+                stats.queryQueued();
                 stats.queryStarted();
                 stats.queryStopped();
                 stats.queryFinished(queryInfo);


### PR DESCRIPTION
This helps catch semantic and access control errors much sooner.
Otherwise, queries can queue for a long time only to fail with
trivial errors.