### PR TITLE
Change Page.getBlocks() not to copy the block array

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
@@ -84,9 +84,12 @@ public class Page
         return retainedSizeInBytes;
     }
 
+    /**
+     * Do not modify the returned array.
+     */
     public Block[] getBlocks()
     {
-        return blocks.clone();
+        return blocks;
     }
 
     public Block getBlock(int channel)


### PR DESCRIPTION
StandardJoinFilterFunction.filter() will call Page.getBlocks() per
each probe. This can cause excessive object creations, especially
when the join condition is not written correctly and causes cross-join
like behavior.