### PR TITLE
Do not use Streams in Block/Pages implementations

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
@@ -267,9 +267,8 @@ public class Page
     {
         requireNonNull(retainedPositions, "retainedPositions is null");
 
-        Block[] blocks = Arrays.stream(getBlocks())
-                .map(block -> block.getPositions(retainedPositions, offset, length))
-                .toArray(Block[]::new);
+        Block[] blocks = new Block[this.blocks.length];
+        Arrays.setAll(blocks, i -> this.blocks[i].getPositions(retainedPositions, offset, length));
         return new Page(length, blocks);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
@@ -26,7 +26,6 @@ import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
 import static com.facebook.presto.spi.block.BlockUtil.compactSlice;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.util.Arrays.stream;
 
 public class VariableWidthBlock
         extends AbstractVariableWidthBlock
@@ -134,9 +133,10 @@ public class VariableWidthBlock
     {
         checkArrayRange(positions, offset, length);
 
-        int finalLength = stream(positions, offset, offset + length)
-                .map(this::getSliceLength)
-                .sum();
+        int finalLength = 0;
+        for (int i = offset; i < offset + length; i++) {
+            finalLength += getSliceLength(positions[i]);
+        }
         SliceOutput newSlice = Slices.allocate(finalLength).getOutput();
         int[] newOffsets = new int[length + 1];
         boolean[] newValueIsNull = new boolean[length];

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -39,7 +39,6 @@ import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.min;
-import static java.util.Arrays.stream;
 
 public class VariableWidthBlockBuilder
         extends AbstractVariableWidthBlock
@@ -140,9 +139,10 @@ public class VariableWidthBlockBuilder
     {
         checkArrayRange(positions, offset, length);
 
-        int finalLength = stream(positions, offset, offset + length)
-                .map(this::getSliceLength)
-                .sum();
+        int finalLength = 0;
+        for (int i = offset; i < offset + length; i++) {
+            finalLength += getSliceLength(positions[i]);
+        }
         SliceOutput newSlice = Slices.allocate(finalLength).getOutput();
         int[] newOffsets = new int[length + 1];
         boolean[] newValueIsNull = new boolean[length];


### PR DESCRIPTION
While Streams often offer more readable code, they have certain
performance implications and therefore should be avoided in execution.