### PR TITLE
Construct the error message lazily in MathFunctions::widthBucket

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -1180,7 +1180,9 @@ public final class MathFunctions
             index = (lower + upper) / 2;
             bin = DOUBLE.getDouble(bins, index);
 
-            checkCondition(isFinite(bin), INVALID_FUNCTION_ARGUMENT, format("Bin value must be finite, got %s", bin));
+            if (!isFinite(bin)) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Bin value must be finite, got " + bin);
+            }
 
             if (operand < bin) {
                 upper = index;


### PR DESCRIPTION
Otherwise, it may have noticeable performance impact.

```
"20180321_093108_15763_3p2xy.3.476-343-54479" #54479 prio=5 os_prio=0 tid=0x00007ef3c01724a0 nid=0x11ea7 runnable [0x00007eed5cb8d000]
   java.lang.Thread.State: RUNNABLE
        at jdk.internal.math.FloatingDecimal$BinaryToASCIIBuffer.access$100(java.base@9.0.1/FloatingDecimal.java:259)
        at jdk.internal.math.FloatingDecimal.getBinaryToASCIIConverter(java.base@9.0.1/FloatingDecimal.java:1785)
        at jdk.internal.math.FloatingDecimal.getBinaryToASCIIConverter(java.base@9.0.1/FloatingDecimal.java:1738)
        at jdk.internal.math.FloatingDecimal.toJavaFormatString(java.base@9.0.1/FloatingDecimal.java:70)
        at java.lang.Double.toString(java.base@9.0.1/Double.java:204)
        at java.lang.Double.toString(java.base@9.0.1/Double.java:661)
        at java.util.Formatter$FormatSpecifier.printString(java.base@9.0.1/Formatter.java:2939)
        at java.util.Formatter$FormatSpecifier.print(java.base@9.0.1/Formatter.java:2816)
        at java.util.Formatter.format(java.base@9.0.1/Formatter.java:2581)
        at java.util.Formatter.format(java.base@9.0.1/Formatter.java:2517)
        at java.lang.String.format(java.base@9.0.1/String.java:2747)
        at com.facebook.presto.operator.scalar.MathFunctions.widthBucket(MathFunctions.java:1183)
        at java.lang.invoke.LambdaForm$DMH/1965282721.invokeStatic_DL_J(java.base@9.0.1/LambdaForm$DMH)
        at java.lang.invoke.LambdaForm$MH/1796448928.linkToTargetMethod(java.base@9.0.1/LambdaForm$MH)
        at com.facebook.presto.$gen.PageProjectionWork_20180321_093108_15763_3p2xy_3_2_39874.evaluate(Unknown Source)
        at com.facebook.presto.$gen.PageProjectionWork_20180321_093108_15763_3p2xy_3_2_39874.process(Unknown Source)
        at com.facebook.presto.operator.project.PageProcessor$PositionsPageProcessorIterator.processBatch(PageProcessor.java:275)
        at com.facebook.presto.operator.project.PageProcessor$PositionsPageProcessorIterator.computeNext(PageProcessor.java:180)
        at com.facebook.presto.operator.project.PageProcessor$PositionsPageProcessorIterator.computeNext(PageProcessor.java:127)
        at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:145)
        at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:140)
        at com.facebook.presto.operator.project.PageProcessorOutput.hasNext(PageProcessorOutput.java:49)
        at com.facebook.presto.operator.project.MergingPageOutput.getOutput(MergingPageOutput.java:110)
        at com.facebook.presto.operator.ScanFilterAndProjectOperator.processPageSource(ScanFilterAndProjectOperator.java:295)
        at com.facebook.presto.operator.ScanFilterAndProjectOperator.getOutput(ScanFilterAndProjectOperator.java:234)
        at com.facebook.presto.operator.Driver.processInternal(Driver.java:379)
        at com.facebook.presto.operator.Driver.lambda$processFor$8(Driver.java:278)
        at com.facebook.presto.operator.Driver$$Lambda$1461/899648547.get(Unknown Source)
        at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:645)
        at com.facebook.presto.operator.Driver.processFor(Driver.java:272)
        at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:975)
        at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:162)
        at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:492)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@9.0.1/ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@9.0.1/ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(java.base@9.0.1/Thread.java:844)
```