### PR TITLE
Add peak per-node total memory usage to QueryStats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/query/QueryMonitor.java
@@ -214,6 +214,7 @@ public class QueryMonitor
                                     Optional.ofNullable(queryStats.getDistributedPlanningTime()).map(duration -> ofMillis(duration.toMillis())),
                                     queryStats.getPeakUserMemoryReservation().toBytes(),
                                     queryStats.getPeakTotalMemoryReservation().toBytes(),
+                                    queryStats.getPeakTaskTotalMemory().toBytes(),
                                     queryStats.getRawInputDataSize().toBytes(),
                                     queryStats.getRawInputPositions(),
                                     queryStats.getOutputDataSize().toBytes(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
@@ -77,11 +77,12 @@ public class MemoryTrackingRemoteTaskFactory
         {
             long currentUserMemory = newStatus.getMemoryReservation().toBytes();
             long currentSystemMemory = newStatus.getSystemMemoryReservation().toBytes();
+            long currentTotalMemory = currentUserMemory + currentSystemMemory;
             long deltaUserMemoryInBytes = currentUserMemory - previousUserMemory;
-            long deltaTotalMemoryInBytes = (currentUserMemory + currentSystemMemory) - (previousUserMemory + previousSystemMemory);
+            long deltaTotalMemoryInBytes = currentTotalMemory - (previousUserMemory + previousSystemMemory);
             previousUserMemory = currentUserMemory;
             previousSystemMemory = currentSystemMemory;
-            stateMachine.updateMemoryUsage(deltaUserMemoryInBytes, deltaTotalMemoryInBytes);
+            stateMachine.updateMemoryUsage(deltaUserMemoryInBytes, deltaTotalMemoryInBytes, currentTotalMemory);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -66,6 +66,7 @@ public class QueryStats
     private final DataSize userMemoryReservation;
     private final DataSize peakUserMemoryReservation;
     private final DataSize peakTotalMemoryReservation;
+    private final DataSize peakTaskTotalMemory;
 
     private final boolean scheduled;
     private final Duration totalScheduledTime;
@@ -115,6 +116,7 @@ public class QueryStats
         this.userMemoryReservation = null;
         this.peakUserMemoryReservation = null;
         this.peakTotalMemoryReservation = null;
+        this.peakTaskTotalMemory = null;
         this.scheduled = false;
         this.totalScheduledTime = null;
         this.totalCpuTime = null;
@@ -161,6 +163,7 @@ public class QueryStats
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
             @JsonProperty("peakTotalMemoryReservation") DataSize peakTotalMemoryReservation,
+            @JsonProperty("peakTaskTotalMemory") DataSize peakTaskTotalMemory,
 
             @JsonProperty("scheduled") boolean scheduled,
             @JsonProperty("totalScheduledTime") Duration totalScheduledTime,
@@ -219,6 +222,7 @@ public class QueryStats
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
         this.peakTotalMemoryReservation = requireNonNull(peakTotalMemoryReservation, "peakTotalMemoryReservation is null");
+        this.peakTaskTotalMemory = requireNonNull(peakTaskTotalMemory, "peakTaskTotalMemory is null");
         this.scheduled = scheduled;
         this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
         this.totalCpuTime = requireNonNull(totalCpuTime, "totalCpuTime is null");
@@ -391,6 +395,12 @@ public class QueryStats
     public DataSize getPeakTotalMemoryReservation()
     {
         return peakTotalMemoryReservation;
+    }
+
+    @JsonProperty
+    public DataSize getPeakTaskTotalMemory()
+    {
+        return peakTaskTotalMemory;
     }
 
     @JsonProperty

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -131,6 +131,7 @@ public class MockQueryExecution
                         new DataSize(18, BYTE),
                         new DataSize(19, BYTE),
                         new DataSize(20, BYTE),
+                        new DataSize(21, BYTE),
 
                         true,
                         new Duration(20, NANOSECONDS),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -275,6 +275,32 @@ public class TestQueryStateMachine
         assertTrue(queryStats.getTotalPlanningTime().toMillis() == 500);
     }
 
+    @Test
+    public void testUpdateMemoryUsage()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+
+        stateMachine.updateMemoryUsage(5, 10, 3);
+        assertEquals(stateMachine.getPeakUserMemoryInBytes(), 5);
+        assertEquals(stateMachine.getPeakTotalMemoryInBytes(), 10);
+        assertEquals(stateMachine.getPeakTaskTotalMemory(), 3);
+
+        stateMachine.updateMemoryUsage(0, 0, 2);
+        assertEquals(stateMachine.getPeakUserMemoryInBytes(), 5);
+        assertEquals(stateMachine.getPeakTotalMemoryInBytes(), 10);
+        assertEquals(stateMachine.getPeakTaskTotalMemory(), 3);
+
+        stateMachine.updateMemoryUsage(1, 1, 5);
+        assertEquals(stateMachine.getPeakUserMemoryInBytes(), 6);
+        assertEquals(stateMachine.getPeakTotalMemoryInBytes(), 11);
+        assertEquals(stateMachine.getPeakTaskTotalMemory(), 5);
+
+        stateMachine.updateMemoryUsage(3, 3, 2);
+        assertEquals(stateMachine.getPeakUserMemoryInBytes(), 9);
+        assertEquals(stateMachine.getPeakTotalMemoryInBytes(), 14);
+        assertEquals(stateMachine.getPeakTaskTotalMemory(), 5);
+    }
+
     private static void assertFinalState(QueryStateMachine stateMachine, QueryState expectedState)
     {
         assertFinalState(stateMachine, expectedState, null);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -156,6 +156,7 @@ public class TestQueryStats
             new DataSize(18, BYTE),
             new DataSize(19, BYTE),
             new DataSize(20, BYTE),
+            new DataSize(21, BYTE),
 
             true,
             new Duration(20, NANOSECONDS),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -74,6 +74,7 @@ public class TestBasicQueryInfo
                                 DataSize.valueOf("21GB"),
                                 DataSize.valueOf("22GB"),
                                 DataSize.valueOf("23GB"),
+                                DataSize.valueOf("24GB"),
                                 true,
                                 Duration.valueOf("23m"),
                                 Duration.valueOf("24m"),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -121,6 +121,7 @@ public class TestQueryStateInfo
                         DataSize.valueOf("21GB"),
                         DataSize.valueOf("22GB"),
                         DataSize.valueOf("23GB"),
+                        DataSize.valueOf("24GB"),
                         true,
                         Duration.valueOf("23m"),
                         Duration.valueOf("24m"),

--- a/presto-product-tests/src/test/resources/com/facebook/presto/tests/querystats/single_query_info_response.json
+++ b/presto-product-tests/src/test/resources/com/facebook/presto/tests/querystats/single_query_info_response.json
@@ -43,6 +43,7 @@
     "totalMemoryReservation": "0B",
     "peakUserMemoryReservation": "0B",
     "peakTotalMemoryReservation": "0B",
+    "peakTaskTotalMemory": "0B",
     "totalScheduledTime": "1.22ms",
     "totalCpuTime": "1.19ms",
     "totalUserTime": "0.00ns",

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
@@ -30,6 +30,7 @@ public class QueryStatistics
     private final long peakUserMemoryBytes;
     // peak of user + system memory
     private final long peakTotalNonRevocableMemoryBytes;
+    private final long peakTaskTotalMemory;
     private final long totalBytes;
     private final long totalRows;
     private final long outputBytes;
@@ -56,6 +57,7 @@ public class QueryStatistics
             Optional<Duration> distributedPlanningTime,
             long peakUserMemoryBytes,
             long peakTotalNonRevocableMemoryBytes,
+            long peakTaskTotalMemory,
             long totalBytes,
             long totalRows,
             long outputBytes,
@@ -76,6 +78,7 @@ public class QueryStatistics
         this.distributedPlanningTime = requireNonNull(distributedPlanningTime, "distributedPlanningTime is null");
         this.peakUserMemoryBytes = peakUserMemoryBytes;
         this.peakTotalNonRevocableMemoryBytes = peakTotalNonRevocableMemoryBytes;
+        this.peakTaskTotalMemory = peakTaskTotalMemory;
         this.totalBytes = totalBytes;
         this.totalRows = totalRows;
         this.outputBytes = outputBytes;
@@ -123,6 +126,11 @@ public class QueryStatistics
     public long getPeakTotalNonRevocableMemoryBytes()
     {
         return peakTotalNonRevocableMemoryBytes;
+    }
+
+    public long peakTaskTotalMemory()
+    {
+        return peakTaskTotalMemory;
     }
 
     public long getTotalBytes()


### PR DESCRIPTION
To enforce limits against the total memory usage we need to know the
max total memory a particular query uses across the nodes.

Needed for setting limits when https://github.com/prestodb/presto/pull/10121 is merged.