### PR TITLE
Remove unused preGeneratedExpressions variables

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeGeneratorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeGeneratorContext.java
@@ -34,7 +34,6 @@ public class BytecodeGeneratorContext
     private final CallSiteBinder callSiteBinder;
     private final CachedInstanceBinder cachedInstanceBinder;
     private final FunctionRegistry registry;
-    private final PreGeneratedExpressions preGeneratedExpressions;
     private final Variable wasNull;
 
     public BytecodeGeneratorContext(
@@ -42,8 +41,7 @@ public class BytecodeGeneratorContext
             Scope scope,
             CallSiteBinder callSiteBinder,
             CachedInstanceBinder cachedInstanceBinder,
-            FunctionRegistry registry,
-            PreGeneratedExpressions preGeneratedExpressions)
+            FunctionRegistry registry)
     {
         requireNonNull(rowExpressionCompiler, "bytecodeGenerator is null");
         requireNonNull(cachedInstanceBinder, "cachedInstanceBinder is null");
@@ -56,7 +54,6 @@ public class BytecodeGeneratorContext
         this.callSiteBinder = callSiteBinder;
         this.cachedInstanceBinder = cachedInstanceBinder;
         this.registry = registry;
-        this.preGeneratedExpressions = preGeneratedExpressions;
         this.wasNull = scope.getVariable("wasNull");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -137,14 +137,13 @@ public class JoinFilterFunctionCompiler
         PreGeneratedExpressions preGeneratedExpressions = generateMethodsForLambdaAndTry(classDefinition, callSiteBinder, cachedInstanceBinder, leftBlocksSize, filter);
         generateFilterMethod(classDefinition, callSiteBinder, cachedInstanceBinder, preGeneratedExpressions, filter, leftBlocksSize, sessionField);
 
-        generateConstructor(classDefinition, sessionField, cachedInstanceBinder, preGeneratedExpressions);
+        generateConstructor(classDefinition, sessionField, cachedInstanceBinder);
     }
 
     private static void generateConstructor(
             ClassDefinition classDefinition,
             FieldDefinition sessionField,
-            CachedInstanceBinder cachedInstanceBinder,
-            PreGeneratedExpressions preGeneratedExpressions)
+            CachedInstanceBinder cachedInstanceBinder)
     {
         Parameter sessionParameter = arg("session", ConnectorSession.class);
         MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC), sessionParameter);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/RowExpressionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/RowExpressionCompiler.java
@@ -143,8 +143,7 @@ public class RowExpressionCompiler
                     context.getScope(),
                     callSiteBinder,
                     cachedInstanceBinder,
-                    registry,
-                    preGeneratedExpressions);
+                    registry);
 
             return generator.generateExpression(call.getSignature(), generatorContext, call.getType(), call.getArguments());
         }
@@ -215,8 +214,7 @@ public class RowExpressionCompiler
                     context.getScope(),
                     callSiteBinder,
                     cachedInstanceBinder,
-                    registry,
-                    preGeneratedExpressions);
+                    registry);
 
             return generateLambda(
                     generatorContext,


### PR DESCRIPTION
preGeneratedExpressions used to be required in more places
to compile lambda and try expressions.