### PR TITLE
Fix NPE in ShardCleaner when running on Java 9

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardCleaner.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardCleaner.java
@@ -495,7 +495,12 @@ public class ShardCleaner
             }
 
             try {
-                result.add(queue.poll(remainingNanos, NANOSECONDS));
+                T element = queue.poll(remainingNanos, NANOSECONDS);
+                // adding a null element causes a NPE later on when removeAll()
+                // is called with the result as an argument in cleanBackupShards()
+                if (element != null) {
+                    result.add(element);
+                }
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
Java 9 is behaving differently than Java 8 when removing an `ArrayList` with `null` elements from a `ConcurrentHashSet`. Below snippet runs fine on Java 8 while it throws a NPE on Java 9.

```
public static void main(String[] args)
{
    Set<UUID> processing = newConcurrentHashSet();
    Collection<UUID> result = new ArrayList<>();
    result.add(null);
    result.add(UUID.randomUUID());
    System.out.println(result);
     processing.add(UUID.randomUUID());
    processing.removeAll(result);
}
```

```
2018-03-22T16:32:56.003-0700    ERROR   shard-cleaner-1 com.facebook.presto.raptor.metadata.ShardCleaner        Error cleaning backup shards
java.lang.NullPointerException
        at java.base/java.util.concurrent.ConcurrentHashMap.replaceNode(ConcurrentHashMap.java:1121)
        at java.base/java.util.concurrent.ConcurrentHashMap.remove(ConcurrentHashMap.java:1112)
        at java.base/java.util.concurrent.ConcurrentHashMap$KeySetView.remove(ConcurrentHashMap.java:4644)
        at java.base/java.util.concurrent.ConcurrentHashMap$CollectionView.removeAll(ConcurrentHashMap.java:4581)
        at java.base/java.util.concurrent.ConcurrentHashMap$KeySetView.removeAll(ConcurrentHashMap.java:4611)
        at java.base/java.util.Collections$SetFromMap.removeAll(Collections.java:5504)
        at com.facebook.presto.raptor.metadata.ShardCleaner.cleanBackupShards(ShardCleaner.java:473)
        at com.facebook.presto.raptor.metadata.ShardCleaner.runBackupCleanup(ShardCleaner.java:270)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514)
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:300)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.base/java.lang.Thread.run(Thread.java:844)
```