### PR TITLE
Prevent NullPointerException in PartitionedLookupSourceFactory

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -256,6 +256,10 @@ public final class PartitionedLookupSourceFactory
             checkState(partitionsSet == partitions.length, "Not all set yet");
             checkState(this.lookupSourceSupplier == null, "Already supplied");
 
+            if (partitionsNoLongerNeeded.isDone()) {
+                return;
+            }
+
             if (partitionsSet != 1) {
                 List<Supplier<LookupSource>> partitions = ImmutableList.copyOf(this.partitions);
                 this.lookupSourceSupplier = createPartitionedLookupSourceSupplier(partitions, hashChannelTypes, outer);


### PR DESCRIPTION
When query is aborted and `PartitionedLookupSourceFactory` gets
destroyed before `HashBuilderOperator` is stopped, then
`PartitionedLookupSourceFactory.freePartitions()` may have been called
before `lendPartitionLookupSource()` (and `supplyLookupSources()`) are
called.  When this happened, `PartitionedLookupSourceFactory.partitions`
would have null entries, leading to `NullPointerException` in
`supplyLookupSources()`.

Fixes #10238