### PR TITLE
Expose "$partitions" system tables for partitioned Hive tables

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveMetastoreModule;
 import com.facebook.presto.hive.s3.HiveS3Module;
 import com.facebook.presto.hive.security.HiveSecurityModule;
+import com.facebook.presto.hive.security.PartitionsAwareAccessControl;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
@@ -118,7 +119,7 @@ public class HiveConnectorFactory
             ConnectorNodePartitioningProvider connectorDistributionProvider = injector.getInstance(ConnectorNodePartitioningProvider.class);
             HiveSessionProperties hiveSessionProperties = injector.getInstance(HiveSessionProperties.class);
             HiveTableProperties hiveTableProperties = injector.getInstance(HiveTableProperties.class);
-            ConnectorAccessControl accessControl = injector.getInstance(ConnectorAccessControl.class);
+            ConnectorAccessControl accessControl = new PartitionsAwareAccessControl(injector.getInstance(ConnectorAccessControl.class));
 
             return new HiveConnector(
                     lifeCycleManager,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -79,6 +79,7 @@ import org.joda.time.DateTimeZone;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -98,6 +99,7 @@ import static com.facebook.presto.hive.HiveColumnHandle.PATH_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveColumnHandle.updateRowIdHandle;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_COLUMN_ORDER_MISMATCH;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CONCURRENT_MODIFICATION_DETECTED;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_EXCEEDED_PARTITION_LIMIT;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TIMEZONE_MISMATCH;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
@@ -189,6 +191,7 @@ public class HiveMetadata
     private final TypeTranslator typeTranslator;
     private final String prestoVersion;
     private final HiveStatisticsProvider hiveStatisticsProvider;
+    private final int maxPartitions;
 
     public HiveMetadata(
             SemiTransactionalHiveMetastore metastore,
@@ -205,7 +208,8 @@ public class HiveMetadata
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
             TypeTranslator typeTranslator,
             String prestoVersion,
-            HiveStatisticsProvider hiveStatisticsProvider)
+            HiveStatisticsProvider hiveStatisticsProvider,
+            int maxPartitions)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
 
@@ -223,6 +227,8 @@ public class HiveMetadata
         this.typeTranslator = requireNonNull(typeTranslator, "typeTranslator is null");
         this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
         this.hiveStatisticsProvider = requireNonNull(hiveStatisticsProvider, "hiveStatisticsProvider is null");
+        checkArgument(maxPartitions >= 1, "maxPartitions must be at least 1");
+        this.maxPartitions = maxPartitions;
     }
 
     public SemiTransactionalHiveMetastore getMetastore()
@@ -393,12 +399,37 @@ public class HiveMetadata
         if (!isStatisticsEnabled(session)) {
             return EMPTY_STATISTICS;
         }
-        List<HivePartition> hivePartitions = partitionManager.getPartitions(metastore, tableHandle, constraint).getPartitions();
+        List<HivePartition> hivePartitions = getPartitionsAsList(tableHandle, constraint);
         Map<String, ColumnHandle> tableColumns = getColumnHandles(session, tableHandle)
                 .entrySet().stream()
                 .filter(entry -> !((HiveColumnHandle) entry.getValue()).isHidden())
                 .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
         return hiveStatisticsProvider.getTableStatistics(session, tableHandle, hivePartitions, tableColumns);
+    }
+
+    private List<HivePartition> getPartitionsAsList(ConnectorTableHandle tableHandle, Constraint<ColumnHandle> constraint)
+    {
+        HivePartitionResult partitions = partitionManager.getPartitions(metastore, tableHandle, constraint);
+        return getPartitionsAsList(partitions);
+    }
+
+    private List<HivePartition> getPartitionsAsList(HivePartitionResult partitions)
+    {
+        ImmutableList.Builder<HivePartition> partitionList = ImmutableList.builder();
+        int count = 0;
+        Iterator<HivePartition> iterator = partitions.getPartitions();
+        while (iterator.hasNext()) {
+            HivePartition partition = iterator.next();
+            if (count == maxPartitions) {
+                throw new PrestoException(HIVE_EXCEEDED_PARTITION_LIMIT, format(
+                        "Query over table '%s' can potentially read more than %s partitions",
+                        partition.getTableName(),
+                        maxPartitions));
+            }
+            partitionList.add(partition);
+            count++;
+        }
+        return partitionList.build();
     }
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
@@ -1177,7 +1208,7 @@ public class HiveMetadata
                         new HiveTableLayoutHandle(
                                 handle.getSchemaTableName(),
                                 ImmutableList.copyOf(hivePartitionResult.getPartitionColumns()),
-                                hivePartitionResult.getPartitions(),
+                                getPartitionsAsList(hivePartitionResult),
                                 hivePartitionResult.getCompactEffectivePredicate(),
                                 hivePartitionResult.getEnforcedConstraint(),
                                 hivePartitionResult.getBucketHandle())),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -39,6 +39,7 @@ public class HiveMetadataFactory
     private final boolean writesToNonManagedTablesEnabled;
     private final boolean createsOfNonManagedTablesEnabled;
     private final long perTransactionCacheMaximumSize;
+    private final int maxPartitions;
     private final ExtendedHiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final HivePartitionManager partitionManager;
@@ -78,6 +79,7 @@ public class HiveMetadataFactory
                 hiveClientConfig.getWritesToNonManagedTablesEnabled(),
                 hiveClientConfig.getCreatesOfNonManagedTablesEnabled(),
                 hiveClientConfig.getPerTransactionMetastoreCacheMaximumSize(),
+                hiveClientConfig.getMaxPartitionsPerScan(),
                 typeManager,
                 locationService,
                 tableParameterCodec,
@@ -99,6 +101,7 @@ public class HiveMetadataFactory
             boolean writesToNonManagedTablesEnabled,
             boolean createsOfNonManagedTablesEnabled,
             long perTransactionCacheMaximumSize,
+            int maxPartitions,
             TypeManager typeManager,
             LocationService locationService,
             TableParameterCodec tableParameterCodec,
@@ -124,6 +127,7 @@ public class HiveMetadataFactory
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
         this.typeTranslator = requireNonNull(typeTranslator, "typeTranslator is null");
         this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
+        this.maxPartitions = maxPartitions;
 
         if (!allowCorruptWritesForTesting && !timeZone.equals(DateTimeZone.getDefault())) {
             log.warn("Hive writes are disabled. " +
@@ -158,6 +162,7 @@ public class HiveMetadataFactory
                 partitionUpdateCodec,
                 typeTranslator,
                 prestoVersion,
-                new MetastoreHiveStatisticsProvider(typeManager, metastore, timeZone));
+                new MetastoreHiveStatisticsProvider(typeManager, metastore, timeZone),
+                maxPartitions);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -61,7 +61,6 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.hive.HiveBucketing.HiveBucket;
 import static com.facebook.presto.hive.HiveBucketing.getHiveBucketHandle;
 import static com.facebook.presto.hive.HiveBucketing.getHiveBucketNumbers;
-import static com.facebook.presto.hive.HiveErrorCode.HIVE_EXCEEDED_PARTITION_LIMIT;
 import static com.facebook.presto.hive.HiveUtil.getPartitionKeyColumnHandles;
 import static com.facebook.presto.hive.HiveUtil.parsePartitionValue;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
@@ -80,7 +79,6 @@ public class HivePartitionManager
 
     private final DateTimeZone timeZone;
     private final boolean assumeCanonicalPartitionKeys;
-    private final int maxPartitions;
     private final int domainCompactionThreshold;
     private final TypeManager typeManager;
 
@@ -93,7 +91,6 @@ public class HivePartitionManager
                 typeManager,
                 hiveClientConfig.getDateTimeZone(),
                 hiveClientConfig.isAssumeCanonicalPartitionKeys(),
-                hiveClientConfig.getMaxPartitionsPerScan(),
                 hiveClientConfig.getDomainCompactionThreshold());
     }
 
@@ -101,13 +98,10 @@ public class HivePartitionManager
             TypeManager typeManager,
             DateTimeZone timeZone,
             boolean assumeCanonicalPartitionKeys,
-            int maxPartitions,
             int domainCompactionThreshold)
     {
         this.timeZone = requireNonNull(timeZone, "timeZone is null");
         this.assumeCanonicalPartitionKeys = assumeCanonicalPartitionKeys;
-        checkArgument(maxPartitions >= 1, "maxPartitions must be at least 1");
-        this.maxPartitions = maxPartitions;
         checkArgument(domainCompactionThreshold >= 1, "domainCompactionThreshold must be at least 1");
         this.domainCompactionThreshold = domainCompactionThreshold;
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -147,28 +141,17 @@ public class HivePartitionManager
 
         List<String> partitionNames = getFilteredPartitionNames(metastore, tableName, partitionColumns, effectivePredicate);
 
-        // do a final pass to filter based on fields that could not be used to filter the partitions
-        int partitionCount = 0;
-        ImmutableList.Builder<HivePartition> partitions = ImmutableList.builder();
-        for (String partitionName : partitionNames) {
-            Optional<Map<ColumnHandle, NullableValue>> values = parseValuesAndFilterPartition(partitionName, partitionColumns, partitionTypes, constraint);
-
-            if (values.isPresent()) {
-                if (partitionCount == maxPartitions) {
-                    throw new PrestoException(HIVE_EXCEEDED_PARTITION_LIMIT, format(
-                            "Query over table '%s' can potentially read more than %s partitions",
-                            hiveTableHandle.getSchemaTableName(),
-                            maxPartitions));
-                }
-                partitionCount++;
-                partitions.add(new HivePartition(tableName, partitionName, values.get(), buckets));
-            }
-        }
+        Iterable<HivePartition> partitionsIterable = () -> partitionNames.stream()
+                // Apply extra filters which could not be done by getFilteredPartitionNames
+                .map(partitionName -> parseValuesAndFilterPartition(tableName, partitionName, partitionColumns, partitionTypes, constraint, buckets))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .iterator();
 
         // All partition key domains will be fully evaluated, so we don't need to include those
         TupleDomain<ColumnHandle> remainingTupleDomain = TupleDomain.withColumnDomains(Maps.filterKeys(effectivePredicate.getDomains().get(), not(Predicates.in(partitionColumns))));
         TupleDomain<ColumnHandle> enforcedTupleDomain = TupleDomain.withColumnDomains(Maps.filterKeys(effectivePredicate.getDomains().get(), Predicates.in(partitionColumns)));
-        return new HivePartitionResult(partitionColumns, partitions.build(), compactEffectivePredicate, remainingTupleDomain, enforcedTupleDomain, hiveBucketHandle);
+        return new HivePartitionResult(partitionColumns, partitionsIterable, compactEffectivePredicate, remainingTupleDomain, enforcedTupleDomain, hiveBucketHandle);
     }
 
     private static TupleDomain<HiveColumnHandle> toCompactTupleDomain(TupleDomain<ColumnHandle> effectivePredicate, int threshold)
@@ -190,15 +173,21 @@ public class HivePartitionManager
         return TupleDomain.withColumnDomains(builder.build());
     }
 
-    private Optional<Map<ColumnHandle, NullableValue>> parseValuesAndFilterPartition(String partitionName, List<HiveColumnHandle> partitionColumns, List<Type> partitionTypes, Constraint<ColumnHandle> constraint)
+    private Optional<HivePartition> parseValuesAndFilterPartition(
+            SchemaTableName tableName,
+            String partitionId,
+            List<HiveColumnHandle> partitionColumns,
+            List<Type> partitionColumnTypes,
+            Constraint<ColumnHandle> constraint,
+            List<HiveBucket> buckets)
     {
-        List<String> partitionValues = extractPartitionKeyValues(partitionName);
+        List<String> keys = extractPartitionKeyValues(partitionId);
 
         Map<ColumnHandle, Domain> domains = constraint.getSummary().getDomains().get();
         ImmutableMap.Builder<ColumnHandle, NullableValue> builder = ImmutableMap.builder();
         for (int i = 0; i < partitionColumns.size(); i++) {
             HiveColumnHandle column = partitionColumns.get(i);
-            NullableValue parsedValue = parsePartitionValue(partitionName, partitionValues.get(i), partitionTypes.get(i), timeZone);
+            NullableValue parsedValue = parsePartitionValue(partitionId, keys.get(i), partitionColumnTypes.get(i), timeZone);
 
             Domain allowedDomain = domains.get(column);
             if (allowedDomain != null && !allowedDomain.includesNullableValue(parsedValue.getValue())) {
@@ -212,7 +201,7 @@ public class HivePartitionManager
             return Optional.empty();
         }
 
-        return Optional.of(values);
+        return Optional.of(new HivePartition(tableName, partitionId, values, buckets));
     }
 
     private Table getTable(SemiTransactionalHiveMetastore metastore, SchemaTableName tableName)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionResult.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionResult.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 public class HivePartitionResult
 {
     private final List<HiveColumnHandle> partitionColumns;
-    private final List<HivePartition> partitions;
+    private final Iterable<HivePartition> partitions;
     private final TupleDomain<? extends ColumnHandle> compactEffectivePredicate;
     private final TupleDomain<ColumnHandle> unenforcedConstraint;
     private final TupleDomain<ColumnHandle> enforcedConstraint;
@@ -40,7 +41,7 @@ public class HivePartitionResult
 
     public HivePartitionResult(
             List<HiveColumnHandle> partitionColumns,
-            List<HivePartition> partitions,
+            Iterable<HivePartition> partitions,
             TupleDomain<? extends ColumnHandle> compactEffectivePredicate,
             TupleDomain<ColumnHandle> unenforcedConstraint,
             TupleDomain<ColumnHandle> enforcedConstraint,
@@ -59,9 +60,9 @@ public class HivePartitionResult
         return partitionColumns;
     }
 
-    public List<HivePartition> getPartitions()
+    public Iterator<HivePartition> getPartitions()
     {
-        return partitions;
+        return partitions.iterator();
     }
 
     public TupleDomain<? extends ColumnHandle> getCompactEffectivePredicate()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/PartitionsAwareAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/PartitionsAwareAccessControl.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.security;
+
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.security.AccessDeniedException;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
+
+import java.util.Set;
+
+import static com.facebook.presto.hive.HiveMetadata.getSourceTableNameForPartitionsTable;
+import static com.facebook.presto.hive.HiveMetadata.isPartitionsSystemTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
+import static java.util.Objects.requireNonNull;
+
+public class PartitionsAwareAccessControl
+        implements ConnectorAccessControl
+{
+    private final ConnectorAccessControl delegate;
+
+    public PartitionsAwareAccessControl(ConnectorAccessControl delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public void checkCanCreateSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        delegate.checkCanCreateSchema(transactionHandle, identity, schemaName);
+    }
+
+    @Override
+    public void checkCanDropSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        delegate.checkCanDropSchema(transactionHandle, identity, schemaName);
+    }
+
+    @Override
+    public void checkCanRenameSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName, String newSchemaName)
+    {
+        delegate.checkCanRenameSchema(transactionHandle, identity, schemaName, newSchemaName);
+    }
+
+    @Override
+    public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
+    {
+        delegate.checkCanShowSchemas(transactionHandle, identity);
+    }
+
+    @Override
+    public Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
+    {
+        return delegate.filterSchemas(transactionHandle, identity, schemaNames);
+    }
+
+    @Override
+    public void checkCanCreateTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        delegate.checkCanCreateTable(transactionHandle, identity, tableName);
+    }
+
+    @Override
+    public void checkCanDropTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        delegate.checkCanDropTable(transactionHandle, identity, tableName);
+    }
+
+    @Override
+    public void checkCanRenameTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, SchemaTableName newTableName)
+    {
+        delegate.checkCanRenameTable(transactionHandle, identity, tableName, newTableName);
+    }
+
+    @Override
+    public void checkCanShowTablesMetadata(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        delegate.checkCanShowTablesMetadata(transactionHandle, identity, schemaName);
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
+    {
+        return delegate.filterTables(transactionHandle, identity, tableNames);
+    }
+
+    @Override
+    public void checkCanAddColumn(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        delegate.checkCanAddColumn(transactionHandle, identity, tableName);
+    }
+
+    @Override
+    public void checkCanDropColumn(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        delegate.checkCanDropColumn(transactionHandle, identity, tableName);
+    }
+
+    @Override
+    public void checkCanRenameColumn(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        delegate.checkCanRenameColumn(transactionHandle, identity, tableName);
+    }
+
+    @Override
+    public void checkCanSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        if (isPartitionsSystemTable(tableName)) {
+            try {
+                checkCanSelectFromTable(transactionHandle, identity, getSourceTableNameForPartitionsTable(tableName));
+                return;
+            }
+            catch (AccessDeniedException e) {
+                denySelectTable(tableName.toString());
+            }
+        }
+        delegate.checkCanSelectFromTable(transactionHandle, identity, tableName);
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        delegate.checkCanInsertIntoTable(transactionHandle, identity, tableName);
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        delegate.checkCanDeleteFromTable(transactionHandle, identity, tableName);
+    }
+
+    @Override
+    public void checkCanCreateView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
+    {
+        delegate.checkCanCreateView(transactionHandle, identity, viewName);
+    }
+
+    @Override
+    public void checkCanDropView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
+    {
+        delegate.checkCanDropView(transactionHandle, identity, viewName);
+    }
+
+    @Override
+    public void checkCanSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
+    {
+        delegate.checkCanSelectFromView(transactionHandle, identity, viewName);
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
+    {
+        delegate.checkCanCreateViewWithSelectFromTable(transactionHandle, identity, tableName);
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
+    {
+        delegate.checkCanCreateViewWithSelectFromView(transactionHandle, identity, viewName);
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, String propertyName)
+    {
+        delegate.checkCanSetCatalogSessionProperty(identity, propertyName);
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(ConnectorTransactionHandle transactionHandle, Identity identity, Privilege privilege, SchemaTableName tableName, String grantee, boolean withGrantOption)
+    {
+        delegate.checkCanGrantTablePrivilege(transactionHandle, identity, privilege, tableName, grantee, withGrantOption);
+    }
+
+    @Override
+    public void checkCanRevokeTablePrivilege(ConnectorTransactionHandle transactionHandle, Identity identity, Privilege privilege, SchemaTableName tableName, String revokee, boolean grantOptionFor)
+    {
+        delegate.checkCanRevokeTablePrivilege(transactionHandle, identity, privilege, tableName, revokee, grantOptionFor);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -589,6 +589,7 @@ public abstract class AbstractTestHiveClient
                 false,
                 true,
                 1000,
+                new HiveClientConfig().getMaxPartitionsPerScan(),
                 TYPE_MANAGER,
                 locationService,
                 new TableParameterCodec(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1185,17 +1185,24 @@ public class TestHiveIntegrationSmokeTest
             assertUpdate(session, insertPartitions, 100);
         }
 
-        // verify can show partitions
+        // we are not constrained by hive.max-partitions-per-scan when listing partitions
         assertQuery(
                 session,
                 "SHOW PARTITIONS FROM " + tableName + " WHERE part > 490 and part <= 500",
                 "VALUES 491, 492, 493, 494, 495, 496, 497, 498, 499, 500");
+
         assertQuery(
                 session,
                 "SHOW PARTITIONS FROM " + tableName + " WHERE part < 0",
                 "SELECT null WHERE false");
 
-        // using $partitions system table we are not constrained by hive.max-partitions-per-scan
+        assertQuery(
+                session,
+                "SHOW PARTITIONS FROM " + tableName,
+                "VALUES " + LongStream.range(0, 1200)
+                        .mapToObj(String::valueOf)
+                        .collect(joining(",")));
+
         assertQuery(
                 session,
                 "SELECT * FROM \"" + tableName + "$partitions\"",

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/DelegatingSystemTablesProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/DelegatingSystemTablesProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SystemTable;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.MoreCollectors.toOptional;
+import static java.util.Objects.requireNonNull;
+
+public class DelegatingSystemTablesProvider
+        implements SystemTablesProvider
+{
+    private final List<SystemTablesProvider> delegates;
+
+    public DelegatingSystemTablesProvider(SystemTablesProvider... delegates)
+    {
+        this(ImmutableList.copyOf(delegates));
+    }
+
+    public DelegatingSystemTablesProvider(List<SystemTablesProvider> delegates)
+    {
+        requireNonNull(delegates, "delegates is null");
+        checkArgument(delegates.size() >= 1, "empty delegates");
+        this.delegates = ImmutableList.copyOf(delegates);
+    }
+
+    @Override
+    public Set<SystemTable> listSystemTables(ConnectorSession session)
+    {
+        return delegates.stream()
+                .flatMap(delegate -> delegate.listSystemTables(session).stream())
+                .collect(toImmutableSet());
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        return delegates.stream()
+                .map(delegate -> delegate.getSystemTable(session, tableName))
+                .filter(Optional::isPresent)
+                // this ensures there is 0 or 1 element in stream
+                .map(Optional::get)
+                .collect(toOptional());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/MetadataBasedSystemTablesProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/MetadataBasedSystemTablesProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.FullConnectorSession;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.QualifiedObjectName;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SystemTable;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.SystemTable.Distribution.SINGLE_COORDINATOR;
+import static java.util.Objects.requireNonNull;
+
+public class MetadataBasedSystemTablesProvider
+        implements SystemTablesProvider
+{
+    private final Metadata metadata;
+    private final String catalogName;
+
+    public MetadataBasedSystemTablesProvider(Metadata metadata, String catalogName)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+    }
+
+    @Override
+    public Set<SystemTable> listSystemTables(ConnectorSession session)
+    {
+        return ImmutableSet.of();
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        Optional<SystemTable> systemTable = metadata.getSystemTable(
+                ((FullConnectorSession) session).getSession(),
+                new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName()));
+
+        // dynamic system tables require access to the transaction and thus can only run on the current coordinator
+        if (systemTable.isPresent() && systemTable.get().getDistribution() != SINGLE_COORDINATOR) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Distribution for dynamic system table must be " + SINGLE_COORDINATOR);
+        }
+
+        return systemTable;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/StaticSystemTablesProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/StaticSystemTablesProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SystemTable;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.function.Function.identity;
+
+public class StaticSystemTablesProvider
+        implements SystemTablesProvider
+{
+    private final Set<SystemTable> systemTables;
+    private final Map<SchemaTableName, SystemTable> systemTablesMap;
+
+    public StaticSystemTablesProvider(Set<SystemTable> systemTables)
+    {
+        this.systemTables = ImmutableSet.copyOf(systemTables);
+        this.systemTablesMap = systemTables.stream()
+                .collect(toImmutableMap(
+                        table -> table.getTableMetadata().getTable(),
+                        identity()));
+    }
+
+    @Override
+    public Set<SystemTable> listSystemTables(ConnectorSession session)
+    {
+        return systemTables;
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        return Optional.ofNullable(systemTablesMap.get(tableName));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnector.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnector.java
@@ -44,6 +44,15 @@ public class SystemConnector
             Set<SystemTable> tables,
             Function<TransactionId, ConnectorTransactionHandle> transactionHandleFunction)
     {
+        this(connectorId, nodeManager, new StaticSystemTablesProvider(tables), transactionHandleFunction);
+    }
+
+    public SystemConnector(
+            ConnectorId connectorId,
+            InternalNodeManager nodeManager,
+            SystemTablesProvider tables,
+            Function<TransactionId, ConnectorTransactionHandle> transactionHandleFunction)
+    {
         requireNonNull(connectorId, "connectorId is null");
         requireNonNull(nodeManager, "nodeManager is null");
         requireNonNull(tables, "tables is null");

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemPageSourceProvider.java
@@ -37,24 +37,22 @@ import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Maps.uniqueIndex;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class SystemPageSourceProvider
         implements ConnectorPageSourceProvider
 {
-    private final Map<SchemaTableName, SystemTable> tables;
+    private final SystemTablesProvider tables;
 
-    public SystemPageSourceProvider(Set<SystemTable> tables)
+    public SystemPageSourceProvider(SystemTablesProvider tables)
     {
-        this.tables = uniqueIndex(tables, table -> table.getTableMetadata().getTable());
+        this.tables = requireNonNull(tables, "tables is null");
     }
 
     @Override
@@ -64,9 +62,10 @@ public class SystemPageSourceProvider
         SystemTransactionHandle systemTransaction = (SystemTransactionHandle) transactionHandle;
         SystemSplit systemSplit = (SystemSplit) split;
         SchemaTableName tableName = systemSplit.getTableHandle().getSchemaTableName();
-        SystemTable systemTable = tables.get(tableName);
+        SystemTable systemTable = tables.getSystemTable(session, tableName)
+                // table might disappear in the meantime
+                .orElseThrow(() -> new PrestoException(NOT_FOUND, format("Table %s not found", tableName)));
 
-        checkArgument(systemTable != null, "Table %s does not exist", tableName);
         List<ColumnMetadata> tableColumns = systemTable.getTableMetadata().getColumns();
 
         Map<String, Integer> columnsByName = new HashMap<>();

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesMetadata.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutResult;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
@@ -32,44 +33,35 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.connector.system.SystemColumnHandle.toSystemColumnHandles;
 import static com.facebook.presto.metadata.MetadataUtil.findColumnMetadata;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
 
 public class SystemTablesMetadata
         implements ConnectorMetadata
 {
     private final ConnectorId connectorId;
-    private final Map<SchemaTableName, ConnectorTableMetadata> tables;
 
-    public SystemTablesMetadata(ConnectorId connectorId, Set<SystemTable> tables)
+    private final SystemTablesProvider tables;
+
+    public SystemTablesMetadata(ConnectorId connectorId, SystemTablesProvider tables)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId");
-        this.tables = tables.stream()
-                .map(SystemTable::getTableMetadata)
-                .collect(toMap(ConnectorTableMetadata::getTable, identity()));
-    }
-
-    private SystemTableHandle checkTableHandle(ConnectorTableHandle tableHandle)
-    {
-        SystemTableHandle systemTableHandle = (SystemTableHandle) tableHandle;
-        checkArgument(tables.containsKey(systemTableHandle.getSchemaTableName()));
-        return systemTableHandle;
+        this.tables = requireNonNull(tables, "tables is null");
     }
 
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
-        return tables.keySet().stream()
-                .map(SchemaTableName::getSchemaName)
+        return tables.listSystemTables(session).stream()
+                .map(table -> table.getTableMetadata().getTable().getSchemaName())
                 .distinct()
                 .collect(toImmutableList());
     }
@@ -77,7 +69,8 @@ public class SystemTablesMetadata
     @Override
     public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
-        if (!tables.containsKey(tableName)) {
+        Optional<SystemTable> table = tables.getSystemTable(session, tableName);
+        if (!table.isPresent()) {
             return null;
         }
         return SystemTableHandle.fromSchemaTableName(connectorId, tableName);
@@ -100,27 +93,23 @@ public class SystemTablesMetadata
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        SystemTableHandle systemTableHandle = checkTableHandle(tableHandle);
-        return tables.get(systemTableHandle.getSchemaTableName());
+        return checkAndGetTable(session, tableHandle).getTableMetadata();
     }
 
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, String schemaNameOrNull)
     {
-        if (schemaNameOrNull == null) {
-            return ImmutableList.copyOf(tables.keySet());
-        }
-
-        return tables.keySet().stream()
-                .filter(table -> table.getSchemaName().equals(schemaNameOrNull))
+        return tables.listSystemTables(session).stream()
+                .map(SystemTable::getTableMetadata)
+                .map(ConnectorTableMetadata::getTable)
+                .filter(table -> schemaNameOrNull == null || table.getSchemaName().equals(schemaNameOrNull))
                 .collect(toImmutableList());
     }
 
     @Override
     public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
     {
-        SystemTableHandle systemTableHandle = checkTableHandle(tableHandle);
-        ConnectorTableMetadata tableMetadata = tables.get(systemTableHandle.getSchemaTableName());
+        ConnectorTableMetadata tableMetadata = checkAndGetTable(session, tableHandle).getTableMetadata();
 
         String columnName = ((SystemColumnHandle) columnHandle).getColumnName();
 
@@ -132,9 +121,16 @@ public class SystemTablesMetadata
     @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        SystemTableHandle systemTableHandle = checkTableHandle(tableHandle);
+        ConnectorTableMetadata tableMetadata = checkAndGetTable(session, tableHandle).getTableMetadata();
+        return toSystemColumnHandles(((SystemTableHandle) tableHandle).getConnectorId(), tableMetadata);
+    }
 
-        return toSystemColumnHandles(systemTableHandle.getConnectorId(), tables.get(systemTableHandle.getSchemaTableName()));
+    private SystemTable checkAndGetTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        SystemTableHandle systemTableHandle = (SystemTableHandle) tableHandle;
+        return tables.getSystemTable(session, systemTableHandle.getSchemaTableName())
+                // table might disappear in the meantime
+                .orElseThrow(() -> new PrestoException(NOT_FOUND, format("Table %s not found", systemTableHandle.getSchemaTableName())));
     }
 
     @Override
@@ -142,9 +138,10 @@ public class SystemTablesMetadata
     {
         requireNonNull(prefix, "prefix is null");
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> builder = ImmutableMap.builder();
-        for (Entry<SchemaTableName, ConnectorTableMetadata> entry : tables.entrySet()) {
-            if (prefix.matches(entry.getKey())) {
-                builder.put(entry.getKey(), entry.getValue().getColumns());
+        for (SystemTable table : tables.listSystemTables(session)) {
+            ConnectorTableMetadata tableMetadata = table.getTableMetadata();
+            if (prefix.matches(tableMetadata.getTable())) {
+                builder.put(tableMetadata.getTable(), tableMetadata.getColumns());
             }
         }
         return builder.build();

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemTablesProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SystemTable;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface SystemTablesProvider
+{
+    Set<SystemTable> listSystemTables(ConnectorSession session);
+
+    /**
+     * Resolves table name. Returns {@link Optional#empty()} if table is not found.
+     * Some tables which are not part of set returned by {@link #listSystemTables(ConnectorSession)}
+     * can still be validly resolved.
+     */
+    Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName);
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/CatalogMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/CatalogMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.metadata;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -99,14 +100,13 @@ public class CatalogMetadata
         throw new IllegalArgumentException("Unknown connector id: " + connectorId);
     }
 
-    public ConnectorId getConnectorId(QualifiedObjectName table)
+    public ConnectorId getConnectorId(Session session, QualifiedObjectName table)
     {
         if (table.getSchemaName().equals(INFORMATION_SCHEMA_NAME)) {
             return informationSchemaId;
         }
 
-        // system tables does not need a connector session
-        if (systemTables.getTableHandle(null, table.asSchemaTableName()) != null) {
+        if (systemTables.getTableHandle(session.toConnectorSession(systemTablesId), table.asSchemaTableName()) != null) {
             return systemTablesId;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableIdentity;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
@@ -64,6 +65,8 @@ public interface Metadata
      * Returns a table handle for the specified table name.
      */
     Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName);
+
+    Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName);
 
     List<TableLayoutResult> getLayouts(Session session, TableHandle tableHandle, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns);
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -297,7 +297,7 @@ public class MetadataManager
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, table.getCatalogName());
         if (catalog.isPresent()) {
             CatalogMetadata catalogMetadata = catalog.get();
-            ConnectorId connectorId = catalogMetadata.getConnectorId(table);
+            ConnectorId connectorId = catalogMetadata.getConnectorId(session, table);
             ConnectorMetadata metadata = catalogMetadata.getMetadataFor(connectorId);
 
             ConnectorTableHandle tableHandle = metadata.getTableHandle(session.toConnectorSession(connectorId), table.asSchemaTableName());
@@ -802,7 +802,7 @@ public class MetadataManager
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, viewName.getCatalogName());
         if (catalog.isPresent()) {
             CatalogMetadata catalogMetadata = catalog.get();
-            ConnectorId connectorId = catalogMetadata.getConnectorId(viewName);
+            ConnectorId connectorId = catalogMetadata.getConnectorId(session, viewName);
             ConnectorMetadata metadata = catalogMetadata.getMetadataFor(connectorId);
 
             Map<SchemaTableName, ConnectorViewDefinition> views = metadata.getViews(

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingSession.java
@@ -16,6 +16,7 @@ package com.facebook.presto.testing;
 import com.facebook.presto.Session;
 import com.facebook.presto.Session.SessionBuilder;
 import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.connector.system.StaticSystemTablesProvider;
 import com.facebook.presto.connector.system.SystemTablesMetadata;
 import com.facebook.presto.execution.QueryIdGenerator;
 import com.facebook.presto.metadata.Catalog;
@@ -87,7 +88,7 @@ public final class TestingSession
             @Override
             public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
             {
-                return new SystemTablesMetadata(new ConnectorId("test_session_connector"), ImmutableSet.of());
+                return new SystemTablesMetadata(new ConnectorId("test_session_connector"), new StaticSystemTablesProvider(ImmutableSet.of()));
             }
 
             @Override

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.ColumnIdentity;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableIdentity;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
@@ -93,6 +94,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/InMemoryRecordSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/InMemoryRecordSet.java
@@ -41,7 +41,7 @@ public class InMemoryRecordSet
     private final List<Type> types;
     private final Iterable<? extends List<?>> records;
 
-    public InMemoryRecordSet(Collection<? extends Type> types, Collection<? extends List<?>> records)
+    public InMemoryRecordSet(Collection<? extends Type> types, Iterable<? extends List<?>> records)
     {
         this.types = Collections.unmodifiableList(new ArrayList<>(types));
         this.records = records;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTablePrefix.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTablePrefix.java
@@ -66,6 +66,14 @@ public class SchemaTablePrefix
         return tableName == null || tableName.equals(schemaTableName.getTableName());
     }
 
+    public SchemaTableName toSchemaTableName()
+    {
+        if (schemaName == null || tableName == null) {
+            throw new IllegalStateException("both schemaName and tableName must be set");
+        }
+        return new SchemaTableName(schemaName, tableName);
+    }
+
     @Override
     public int hashCode()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableIdentity;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
@@ -73,6 +74,17 @@ public interface ConnectorMetadata
      * Returns a table handle for the specified table name, or null if the connector does not contain the table.
      */
     ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName);
+
+    /**
+     * Returns the system table for the specified table name, if one exists.
+     * The system tables handled via {@link #getSystemTable} differ form those returned by {@link Connector#getSystemTables()}.
+     * The former mechanism allows dynamic resolution of system tables, while the latter is
+     * based on static list of system tables built during startup.
+     */
+    default Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        return Optional.empty();
+    }
 
     /**
      * Return a list of table layouts that satisfy the given constraint.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableIdentity;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
@@ -118,6 +119,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getTableHandle(session, tableName);
+        }
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSystemTable(session, tableName);
         }
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -160,7 +160,7 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails("SHOW PARTITIONS FROM orders", "line 1:1: Table does not have partition columns: \\S+\\.orders");
         assertQueryFails("SHOW PARTITIONS FROM orders WHERE orderkey < 10", "line 1:1: Table does not have partition columns: \\S+\\.orders");
-        assertQueryFails("SHOW PARTITIONS FROM orders WHERE invalid_column < 10", "line 1:35: Column 'invalid_column' cannot be resolved");
+        assertQueryFails("SHOW PARTITIONS FROM orders WHERE invalid_column < 10", "line 1:1: Table does not have partition columns: \\S+\\.orders");
         assertQueryFails("SHOW PARTITIONS FROM orders LIMIT 2", "line 1:1: Table does not have partition columns: \\S+\\.orders");
     }
 

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
@@ -208,8 +208,17 @@ public class ThriftMetadata
 
     private PrestoThriftNullableTableMetadata getTableMetadata(SchemaTableName schemaTableName)
     {
+        // treat invalid names as not found
+        PrestoThriftSchemaTableName name;
         try {
-            return client.get().getTableMetadata(new PrestoThriftSchemaTableName(schemaTableName));
+            name = new PrestoThriftSchemaTableName(schemaTableName);
+        }
+        catch (IllegalArgumentException e) {
+            return new PrestoThriftNullableTableMetadata(null);
+        }
+
+        try {
+            return client.get().getTableMetadata(name);
         }
         catch (PrestoThriftServiceException | TException e) {
             throw toPrestoException(e);


### PR DESCRIPTION
@electrum, @findepi 
**Please just do high level review to validate if approach is generally OK**

This is an try to workaround the problem with listing Hive partitions when there are more of them than configuration set hard limit.
We decided that want to try approach when for each partitioned Hive table we expose a counterpart system table (suffixed with `$partitions`) which 
will expose all the partitioning keys.

This PR achieves that by exposing new `Optional<SystemTable> ConnectorMetadata.getSystemTable()` method.
The method is then plugged to per-connector SystemMemory connector via `SystemTablesProvider` (which used to be just `List<SystemTable>` before).
The `SystemTablesProvider` is responsible for listing and resolving system tables.
The used implementation is provided with `List<SystemTable>` (for sake of static system tables) and `Metadata` which is used to delegate calls to `ConnectorMetadata.getSystemTable` for dynamic ones.

The approach generally seems to work but please let me know what you think about it.

One limitation I see with current implementation is that we are only listing the static system tables. This leads to some weirdnesses. E.g you will get empty table when query `SHOW COLUMNS FROM "table$partitions"`, because it is rewritten to `information_schema` query which depends on fact that queried tables are listed via `ConnectorMedata.listTables`. 
Potentially this can be extended by adding `ConnectorMetadata.listSystemTables` method. Yet for Hive we cannot cheaply test if table is partitioned or not (I think).
And without that check it gets problematic if the `$partitions` table is queried for table which is not actually partitioned as we do not have any columns to return. But generally it should be doable - we just need to think about what is exact expected behaviour.

Edit: addressed limitation with `Use SystemTablesProvider.getSystemTable in listTableColumns` commit.
