### PR TITLE
Increase max arguments to zip function to 5

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipFunction.java
@@ -47,7 +47,7 @@ public final class ZipFunction
         extends SqlScalarFunction
 {
     public static final int MIN_ARITY = 2;
-    public static final int MAX_ARITY = 4;
+    public static final int MAX_ARITY = 5;
     public static final ZipFunction[] ZIP_FUNCTIONS;
 
     private static final MethodHandle METHOD_HANDLE = methodHandle(ZipFunction.class, "zip", List.class, Block[].class);


### PR DESCRIPTION
There was a user request to increase the number of arrays that can be
passed to the zip function.