### PR TITLE
Allow listing missing schemas in Accumulo

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/metadata/ZooKeeperMetadataManager.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/metadata/ZooKeeperMetadataManager.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.json.ObjectMapperProvider;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -33,9 +34,9 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.ZOOKEEPER_ERROR;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.zookeeper.KeeperException.Code.NONODE;
@@ -105,30 +106,22 @@ public class ZooKeeperMetadataManager
     public Set<String> getTableNames(String schema)
     {
         String schemaPath = getSchemaPath(schema);
-        boolean exists;
         try {
-            exists = curator.checkExists().forPath(schemaPath) != null;
+            if (curator.checkExists().forPath(schemaPath) == null) {
+                return ImmutableSet.of();
+            }
         }
         catch (Exception e) {
             throw new PrestoException(ZOOKEEPER_ERROR, "Error checking if schema exists", e);
         }
 
-        if (exists) {
-            try {
-                Set<String> tables = new HashSet<>();
-                tables.addAll(
-                        curator.getChildren().forPath(schemaPath)
-                                .stream()
-                                .filter(x -> isAccumuloTable(new SchemaTableName(schema, x)))
-                                .collect(Collectors.toList()));
-                return tables;
-            }
-            catch (Exception e) {
-                throw new PrestoException(ZOOKEEPER_ERROR, "Error fetching schemas", e);
-            }
+        try {
+            return curator.getChildren().forPath(schemaPath).stream()
+                    .filter(x -> isAccumuloTable(new SchemaTableName(schema, x)))
+                    .collect(toImmutableSet());
         }
-        else {
-            throw new PrestoException(ZOOKEEPER_ERROR, "No metadata for schema" + schema);
+        catch (Exception e) {
+            throw new PrestoException(ZOOKEEPER_ERROR, "Error fetching schemas", e);
         }
     }
 
@@ -154,30 +147,22 @@ public class ZooKeeperMetadataManager
     public Set<String> getViewNames(String schema)
     {
         String schemaPath = getSchemaPath(schema);
-        boolean exists;
         try {
-            exists = curator.checkExists().forPath(schemaPath) != null;
+            if (curator.checkExists().forPath(schemaPath) == null) {
+                return ImmutableSet.of();
+            }
         }
         catch (Exception e) {
             throw new PrestoException(ZOOKEEPER_ERROR, "Error checking if schema exists", e);
         }
 
-        if (exists) {
-            try {
-                Set<String> tables = new HashSet<>();
-                tables.addAll(
-                        curator.getChildren().forPath(schemaPath)
-                                .stream()
-                                .filter(x -> isAccumuloView(new SchemaTableName(schema, x)))
-                                .collect(Collectors.toList()));
-                return tables;
-            }
-            catch (Exception e) {
-                throw new PrestoException(ZOOKEEPER_ERROR, "Error fetching schemas", e);
-            }
+        try {
+            return curator.getChildren().forPath(schemaPath).stream()
+                    .filter(x -> isAccumuloView(new SchemaTableName(schema, x)))
+                    .collect(toImmutableSet());
         }
-        else {
-            throw new PrestoException(ZOOKEEPER_ERROR, "No metadata for schema " + schema);
+        catch (Exception e) {
+            throw new PrestoException(ZOOKEEPER_ERROR, "Error fetching schemas", e);
         }
     }
 


### PR DESCRIPTION
The schema name passed to listing APIs is merely a hint.
Implementations are expected to succeed whether or not it exists.