### PR TITLE
Validate null supression in structural blocks

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -479,7 +479,7 @@ public class HivePageSource
                 valueIsNull[i] = arrayBlock.isNull(i);
                 offsets[i + 1] = offsets[i] + arrayBlock.getLength(i);
             }
-            return new ArrayBlock(arrayBlock.getPositionCount(), valueIsNull, offsets, elementsBlock);
+            return ArrayBlock.fromElementBlock(arrayBlock.getPositionCount(), valueIsNull, offsets, elementsBlock);
         }
     }
 
@@ -568,7 +568,7 @@ public class HivePageSource
                 valueIsNull[i] = rowBlock.isNull(i);
                 offsets[i + 1] = offsets[i] + (valueIsNull[i] ? 0 : 1);
             }
-            return new RowBlock(0, rowBlock.getPositionCount(), valueIsNull, offsets, fields);
+            return RowBlock.fromFieldBlocks(rowBlock.getPositionCount(), valueIsNull, offsets, fields);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -175,7 +175,7 @@ public class ParquetReader
         for (int i = 1; i < offsets.length; i++) {
             offsets[i] = offsets[i - 1] + elementOffsets.getInt(i - 1);
         }
-        return new ArrayBlock(batchSize, new boolean[batchSize], offsets, block);
+        return ArrayBlock.fromElementBlock(batchSize, new boolean[batchSize], offsets, block);
     }
 
     public Block readMap(Type type, List<String> path)
@@ -237,7 +237,7 @@ public class ParquetReader
             elementOffsets.add(parameters.size());
             offsets[i] = i;
         }
-        return new RowBlock(0, blockSize, new boolean[blockSize], offsets, blocks);
+        return RowBlock.fromFieldBlocks(blockSize, new boolean[blockSize], offsets, blocks);
     }
 
     public Block readPrimitive(ColumnDescriptor columnDescriptor, Type type)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySubscript.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySubscript.java
@@ -165,7 +165,7 @@ public class BenchmarkArraySubscript
             for (int i = 0; i < offsets.length; i++) {
                 offsets[i] = arraySize * i;
             }
-            return new ArrayBlock(positionCount, new boolean[positionCount], offsets, elementsBlock);
+            return ArrayBlock.fromElementBlock(positionCount, new boolean[positionCount], offsets, elementsBlock);
         }
 
         private static Block createFixWidthValueBlock(int positionCount, int mapSize)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListStreamReader.java
@@ -136,7 +136,7 @@ public class ListStreamReader
         else {
             elements = elementType.createBlockBuilder(new BlockBuilderStatus(), 0).build();
         }
-        ArrayBlock arrayBlock = new ArrayBlock(nextBatchSize, nullVector, offsets, elements);
+        Block arrayBlock = ArrayBlock.fromElementBlock(nextBatchSize, nullVector, offsets, elements);
 
         readOffset = 0;
         nextBatchSize = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
@@ -130,7 +130,7 @@ public class StructStreamReader
         }
 
         // Struct is represented as a row block
-        RowBlock rowBlock = new RowBlock(0, nextBatchSize, nullVector, offsets, blocks);
+        Block rowBlock = RowBlock.fromFieldBlocks(nextBatchSize, nullVector, offsets, blocks);
 
         readOffset = 0;
         nextBatchSize = 0;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.block;
 
+import static com.facebook.presto.spi.block.ArrayBlock.createArrayBlockInternal;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
@@ -70,7 +71,7 @@ public abstract class AbstractArrayBlock
             newPosition++;
         }
         Block newValues = getValues().copyPositions(valuesPositions.elements(), 0, valuesPositions.size());
-        return new ArrayBlock(length, newValueIsNull, newOffsets, newValues);
+        return createArrayBlockInternal(0, length, newValueIsNull, newOffsets, newValues);
     }
 
     @Override
@@ -79,7 +80,7 @@ public abstract class AbstractArrayBlock
         int positionCount = getPositionCount();
         checkValidRegion(positionCount, position, length);
 
-        return new ArrayBlock(
+        return createArrayBlockInternal(
                 position + getOffsetBase(),
                 length,
                 getValueIsNull(),
@@ -115,7 +116,7 @@ public abstract class AbstractArrayBlock
         if (newValues == getValues() && newOffsets == getOffsets() && newValueIsNull == getValueIsNull()) {
             return this;
         }
-        return new ArrayBlock(length, newValueIsNull, newOffsets, newValues);
+        return createArrayBlockInternal(0, length, newValueIsNull, newOffsets, newValues);
     }
 
     @Override
@@ -158,7 +159,8 @@ public abstract class AbstractArrayBlock
         int valueLength = getOffset(position + 1) - startValueOffset;
         Block newValues = getValues().copyRegion(startValueOffset, valueLength);
 
-        return new ArrayBlock(
+        return createArrayBlockInternal(
+                0,
                 1,
                 new boolean[] {isNull(position)},
                 new int[] {0, valueLength},

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -23,6 +23,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
+import static com.facebook.presto.spi.block.MapBlock.createMapBlockInternal;
 import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractMapBlock
@@ -120,7 +121,7 @@ public abstract class AbstractMapBlock
 
         Block newKeys = getKeys().copyPositions(entriesPositions.elements(), 0, entriesPositions.size());
         Block newValues = getValues().copyPositions(entriesPositions.elements(), 0, entriesPositions.size());
-        return new MapBlock(0, length, newMapIsNull, newOffsets, newKeys, newValues, newHashTable, keyType, keyBlockNativeEquals, keyNativeHashCode);
+        return createMapBlockInternal(0, length, newMapIsNull, newOffsets, newKeys, newValues, newHashTable, keyType, keyBlockNativeEquals, keyNativeHashCode);
     }
 
     @Override
@@ -129,7 +130,7 @@ public abstract class AbstractMapBlock
         int positionCount = getPositionCount();
         checkValidRegion(positionCount, position, length);
 
-        return new MapBlock(
+        return createMapBlockInternal(
                 position + getOffsetBase(),
                 length,
                 getMapIsNull(),
@@ -176,7 +177,7 @@ public abstract class AbstractMapBlock
         if (newKeys == getKeys() && newValues == getValues() && newOffsets == getOffsets() && newMapIsNull == getMapIsNull() && newHashTable == getHashTables()) {
             return this;
         }
-        return new MapBlock(
+        return createMapBlockInternal(
                 0,
                 length,
                 newMapIsNull,
@@ -247,7 +248,7 @@ public abstract class AbstractMapBlock
         Block newValues = getValues().copyRegion(startValueOffset, valueLength);
         int[] newHashTable = Arrays.copyOfRange(getHashTables(), startValueOffset * HASH_MULTIPLIER, endValueOffset * HASH_MULTIPLIER);
 
-        return new MapBlock(
+        return createMapBlockInternal(
                 0,
                 1,
                 new boolean[] {isNull(position)},

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -18,6 +18,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
+import static com.facebook.presto.spi.block.RowBlock.createRowBlockInternal;
 
 public abstract class AbstractRowBlock
         implements Block
@@ -81,7 +82,7 @@ public abstract class AbstractRowBlock
         for (int i = 0; i < numFields; i++) {
             newBlocks[i] = getFieldBlocks()[i].copyPositions(fieldBlockPositions.elements(), 0, fieldBlockPositions.size());
         }
-        return new RowBlock(0, length, newRowIsNull, newOffsets, newBlocks);
+        return createRowBlockInternal(0, length, newRowIsNull, newOffsets, newBlocks);
     }
 
     @Override
@@ -90,7 +91,7 @@ public abstract class AbstractRowBlock
         int positionCount = getPositionCount();
         checkValidRegion(positionCount, position, length);
 
-        return new RowBlock(position + getOffsetBase(), length, getRowIsNull(), getFieldBlockOffsets(), getFieldBlocks());
+        return createRowBlockInternal(position + getOffsetBase(), length, getRowIsNull(), getFieldBlockOffsets(), getFieldBlocks());
     }
 
     @Override
@@ -130,7 +131,7 @@ public abstract class AbstractRowBlock
         if (arraySame(newBlocks, getFieldBlocks()) && newOffsets == getFieldBlockOffsets() && newRowIsNull == getRowIsNull()) {
             return this;
         }
-        return new RowBlock(0, length, newRowIsNull, newOffsets, newBlocks);
+        return createRowBlockInternal(0, length, newRowIsNull, newOffsets, newBlocks);
     }
 
     @Override
@@ -176,7 +177,7 @@ public abstract class AbstractRowBlock
         boolean[] newRowIsNull = new boolean[] {isNull(position)};
         int[] newOffsets = new int[] {0, fieldBlockLength};
 
-        return new RowBlock(0, 1, newRowIsNull, newOffsets, newBlocks);
+        return createRowBlockInternal(0, 1, newRowIsNull, newOffsets, newBlocks);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlock.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class ArrayBlock
@@ -34,35 +35,70 @@ public class ArrayBlock
     private volatile long sizeInBytes;
     private final long retainedSizeInBytes;
 
-    public ArrayBlock(int positionCount, boolean[] valueIsNull, int[] offsets, Block values)
+    /**
+     * Create an array block directly from columnar nulls, values, and offsets into the values.
+     * A null array must have no entries.
+     */
+    public static Block fromElementBlock(int positionCount, boolean[] valueIsNull, int[] arrayOffset, Block values)
     {
-        this(0, positionCount, valueIsNull, offsets, values);
+        validateConstructorArguments(0, positionCount, valueIsNull, arrayOffset, values);
+        // for performance reasons per element checks are only performed on the public construction
+        for (int i = 0; i < positionCount; i++) {
+            int offset = arrayOffset[i];
+            int length = arrayOffset[i + 1] - offset;
+            if (length < 0) {
+                throw new IllegalArgumentException(format("Offset is not monotonically ascending. offsets[%s]=%s, offsets[%s]=%s", i, arrayOffset[i], i + 1, arrayOffset[i + 1]));
+            }
+            if (valueIsNull[i] && length != 0) {
+                throw new IllegalArgumentException("A null array must have zero entries");
+            }
+        }
+        return new ArrayBlock(0, positionCount, valueIsNull, arrayOffset, values);
     }
 
-    ArrayBlock(int arrayOffset, int positionCount, boolean[] valueIsNull, int[] offsets, Block values)
+    /**
+     * Create an array block directly without per element validations.
+     */
+    static ArrayBlock createArrayBlockInternal(int arrayOffset, int positionCount, boolean[] valueIsNull, int[] offsets, Block values)
+    {
+        validateConstructorArguments(arrayOffset, positionCount, valueIsNull, offsets, values);
+        return new ArrayBlock(arrayOffset, positionCount, valueIsNull, offsets, values);
+    }
+
+    private static void validateConstructorArguments(int arrayOffset, int positionCount, boolean[] valueIsNull, int[] offsets, Block values)
     {
         if (arrayOffset < 0) {
             throw new IllegalArgumentException("arrayOffset is negative");
         }
-        this.arrayOffset = arrayOffset;
 
         if (positionCount < 0) {
             throw new IllegalArgumentException("positionCount is negative");
         }
-        this.positionCount = positionCount;
 
         requireNonNull(valueIsNull, "valueIsNull is null");
         if (valueIsNull.length - arrayOffset < positionCount) {
             throw new IllegalArgumentException("isNull length is less than positionCount");
         }
-        this.valueIsNull = valueIsNull;
 
         requireNonNull(offsets, "offsets is null");
         if (offsets.length - arrayOffset < positionCount + 1) {
             throw new IllegalArgumentException("offsets length is less than positionCount");
         }
-        this.offsets = offsets;
 
+        requireNonNull(values, "values is null");
+    }
+
+    /**
+     * Use createArrayBlockInternal or fromElementBlock instead of this method.  The caller of this method is assumed to have
+     * validated the arguments with validateConstructorArguments.
+     */
+    private ArrayBlock(int arrayOffset, int positionCount, boolean[] valueIsNull, int[] offsets, Block values)
+    {
+        // caller must check arguments with validateConstructorArguments
+        this.arrayOffset = arrayOffset;
+        this.positionCount = positionCount;
+        this.valueIsNull = valueIsNull;
+        this.offsets = offsets;
         this.values = requireNonNull(values);
 
         sizeInBytes = -1;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.function.BiConsumer;
 
+import static com.facebook.presto.spi.block.ArrayBlock.createArrayBlockInternal;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
@@ -236,7 +237,7 @@ public class ArrayBlockBuilder
         if (currentEntryOpened) {
             throw new IllegalStateException("Current entry must be closed before the block can be built");
         }
-        return new ArrayBlock(positionCount, valueIsNull, offsets, values.build());
+        return createArrayBlockInternal(0, positionCount, valueIsNull, offsets, values.build());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockEncoding.java
@@ -18,6 +18,8 @@ import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 
+import static com.facebook.presto.spi.block.ArrayBlock.createArrayBlockInternal;
+
 public class ArrayBlockEncoding
         implements BlockEncoding
 {
@@ -68,7 +70,7 @@ public class ArrayBlockEncoding
         int[] offsets = new int[positionCount + 1];
         sliceInput.readBytes(Slices.wrappedIntArray(offsets));
         boolean[] valueIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
-        return new ArrayBlock(positionCount, valueIsNull, offsets, values);
+        return createArrayBlockInternal(0, positionCount, valueIsNull, offsets, values);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
@@ -197,6 +197,9 @@ public class MapBlock
             if (keyCount < 0) {
                 throw new IllegalArgumentException(format("Offset is not monotonically ascending. offsets[%s]=%s, offsets[%s]=%s", i, offsets[i], i + 1, offsets[i + 1]));
             }
+            if (mapIsNull[i] && keyCount != 0) {
+                throw new IllegalArgumentException("A null map must have zero entries");
+            }
             buildHashTable(keyBlock, keyOffset, keyCount, keyBlockHashCode, hashTables, keyOffset * HASH_MULTIPLIER, keyCount * HASH_MULTIPLIER);
         }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.spi.block.MapBlock.createMapBlockInternal;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -240,7 +241,7 @@ public class MapBlockBuilder
         if (currentEntryOpened) {
             throw new IllegalStateException("Current entry must be closed before the block can be built");
         }
-        return new MapBlock(
+        return createMapBlockInternal(
                 0,
                 positionCount,
                 mapIsNull,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
@@ -24,6 +24,7 @@ import io.airlift.slice.SliceOutput;
 import java.lang.invoke.MethodHandle;
 
 import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
+import static com.facebook.presto.spi.block.MapBlock.createMapBlockInternal;
 import static com.facebook.presto.spi.block.MethodHandleUtil.compose;
 import static com.facebook.presto.spi.block.MethodHandleUtil.nativeValueGetter;
 import static io.airlift.slice.Slices.wrappedIntArray;
@@ -105,7 +106,7 @@ public class MapBlockEncoding
         int[] offsets = new int[positionCount + 1];
         sliceInput.readBytes(wrappedIntArray(offsets));
         boolean[] mapIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
-        return new MapBlock(0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTable, keyType, keyBlockNativeEquals, keyNativeHashCode);
+        return createMapBlockInternal(0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTable, keyType, keyBlockNativeEquals, keyNativeHashCode);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.spi.block.RowBlock.createRowBlockInternal;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -201,7 +202,7 @@ public class RowBlockBuilder
         for (int i = 0; i < numFields; i++) {
             fieldBlocks[i] = fieldBlockBuilders[i].build();
         }
-        return new RowBlock(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
+        return createRowBlockInternal(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
+import static com.facebook.presto.spi.block.RowBlock.createRowBlockInternal;
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static java.util.Objects.requireNonNull;
 
@@ -80,7 +81,7 @@ public class RowBlockEncoding
         int[] fieldBlockOffsets = new int[positionCount + 1];
         sliceInput.readBytes(wrappedIntArray(fieldBlockOffsets));
         boolean[] rowIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
-        return new RowBlock(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
+        return createRowBlockInternal(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -234,7 +234,7 @@ public class MapType
         return "map(" + keyType.getDisplayName() + ", " + valueType.getDisplayName() + ")";
     }
 
-    public MapBlock createBlockFromKeyValue(boolean[] mapIsNull, int[] offsets, Block keyBlock, Block valueBlock)
+    public Block createBlockFromKeyValue(boolean[] mapIsNull, int[] offsets, Block keyBlock, Block valueBlock)
     {
         return MapBlock.fromKeyValueBlock(
                 mapIsNull,

--- a/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/datatypes/PrestoThriftBigintArray.java
+++ b/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/datatypes/PrestoThriftBigintArray.java
@@ -93,7 +93,7 @@ public final class PrestoThriftBigintArray
         checkArgument(desiredType.getTypeParameters().size() == 1 && BIGINT.equals(desiredType.getTypeParameters().get(0)),
                 "type doesn't match: %s", desiredType);
         int numberOfRecords = numberOfRecords();
-        return new ArrayBlock(
+        return ArrayBlock.fromElementBlock(
                 numberOfRecords,
                 nulls == null ? new boolean[numberOfRecords] : nulls,
                 calculateOffsets(sizes, nulls, numberOfRecords),


### PR DESCRIPTION
Structural blocks assume that null map, array, and rows have no entries
in the nested blocks.  If nested blocks do have entries exceptions or
incorrect results can occur.  There are no known uses of this behavior,
and this change ensures none are added in the future.