### PR TITLE
Drop tables at the end of testScaleWriters test

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -1522,29 +1522,35 @@ public class TestHiveIntegrationSmokeTest
     @Test
     public void testScaleWriters()
     {
-        // small table that will only have one writer
-        assertUpdate(
-                Session.builder(getSession())
-                        .setSystemProperty("scale_writers", "true")
-                        .setSystemProperty("writer_min_size", "32MB")
-                        .build(),
-                "CREATE TABLE scale_writers_small AS SELECT * FROM tpch.tiny.orders",
-                (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
+        try {
+            // small table that will only have one writer
+            assertUpdate(
+                    Session.builder(getSession())
+                            .setSystemProperty("scale_writers", "true")
+                            .setSystemProperty("writer_min_size", "32MB")
+                            .build(),
+                    "CREATE TABLE scale_writers_small AS SELECT * FROM tpch.tiny.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
 
-        assertEquals(computeActual("SELECT count(DISTINCT \"$path\") FROM scale_writers_small").getOnlyValue(), 1L);
+            assertEquals(computeActual("SELECT count(DISTINCT \"$path\") FROM scale_writers_small").getOnlyValue(), 1L);
 
-        // large table that will scale writers to all machines
-        assertUpdate(
-                Session.builder(getSession())
-                        .setSystemProperty("scale_writers", "true")
-                        .setSystemProperty("writer_min_size", "4MB")
-                        .build(),
-                "CREATE TABLE scale_writers_large WITH (format = 'RCBINARY') AS SELECT * FROM tpch.sf2.orders",
-                (long) computeActual("SELECT count(*) FROM tpch.sf2.orders").getOnlyValue());
+            // large table that will scale writers to all machines
+            assertUpdate(
+                    Session.builder(getSession())
+                            .setSystemProperty("scale_writers", "true")
+                            .setSystemProperty("writer_min_size", "4MB")
+                            .build(),
+                    "CREATE TABLE scale_writers_large WITH (format = 'RCBINARY') AS SELECT * FROM tpch.sf2.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.sf2.orders").getOnlyValue());
 
-        assertEquals(
-                computeActual("SELECT count(DISTINCT \"$path\") FROM scale_writers_large"),
-                computeActual("SELECT count(*) FROM system.runtime.nodes"));
+            assertEquals(
+                    computeActual("SELECT count(DISTINCT \"$path\") FROM scale_writers_large"),
+                    computeActual("SELECT count(*) FROM system.runtime.nodes"));
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS scale_writers_large");
+            assertUpdate("DROP TABLE IF EXISTS scale_writers_small");
+        }
     }
 
     @Test


### PR DESCRIPTION
This follows `testGroupedJoin` example