### PR TITLE
Change WEIGHTED_FAIR to use FCFS to pick between winners

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -525,12 +525,8 @@ public class TestResourceGroups
             group2Queries = fillGroupTo(group2, group2Queries, 4);
         }
 
-        // group 1 should run approximately 1/2 the number of queries of group 2
-        BinomialDistribution binomial = new BinomialDistribution(2000, 1.0 / 3.0);
-        int lowerBound = binomial.inverseCumulativeProbability(0.000001);
-        int upperBound = binomial.inverseCumulativeProbability(0.999999);
-
-        assertBetweenInclusive(group1Ran, lowerBound, upperBound);
+        assertEquals(group1Ran, 1000);
+        assertEquals(group1Ran, 1000);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -387,7 +387,7 @@ public class TestResourceGroups
     }
 
     @Test(timeOut = 10_000)
-    public void testWeightedSharesScheduling()
+    public void testWeightedFairScheduling()
     {
         RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
@@ -430,7 +430,7 @@ public class TestResourceGroups
     }
 
     @Test(timeOut = 10_000)
-    public void testWeightedSharesSchedulingEqualWeights()
+    public void testWeightedFairSchedulingEqualWeights()
     {
         RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
@@ -489,7 +489,7 @@ public class TestResourceGroups
     }
 
     @Test(timeOut = 10_000)
-    public void testWeightedSharesNoStarvation()
+    public void testWeightedFairSchedulingNoStarvation()
     {
         RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestWeightedFairQueue.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestWeightedFairQueue.java
@@ -14,10 +14,8 @@
 package com.facebook.presto.execution.resourceGroups;
 
 import com.facebook.presto.execution.resourceGroups.WeightedFairQueue.Usage;
-import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.testng.annotations.Test;
 
-import static io.airlift.testing.Assertions.assertBetweenInclusive;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -82,11 +80,7 @@ public class TestWeightedFairQueue
             }
         }
 
-        BinomialDistribution binomial = new BinomialDistribution(1000, 2.0 / 3.0);
-        int lowerBound = binomial.inverseCumulativeProbability(0.000001);
-        int upperBound = binomial.inverseCumulativeProbability(0.999999);
-
-        assertBetweenInclusive(count1, lowerBound, upperBound);
-        assertBetweenInclusive((1000 - count2), lowerBound, upperBound);
+        assertEquals(count1, 500);
+        assertEquals(count2, 500);
     }
 }


### PR DESCRIPTION
This mechanism also guarantees no starvation, is easier to understand
and more deterministic, and leads to shorter queue sizes overall.