### PR TITLE
Refactor Structural Block and Avoid Building Hash Table when Copying Map Block

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -419,7 +419,7 @@
                                 <argument>-Dmyproperty=myvalue</argument>
                                 <argument>-classpath</argument>
                                 <classpath />
-                                <argument>com.facebook.presto.benchmark.BenchmarkSuite</argument>
+                                <argument>com.facebook.presto</argument>
                             </arguments>
                             <classpathScope>test</classpathScope>
                         </configuration>

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.operator.aggregation.state.DoubleHistogramStateSerializer;
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.AccumulatorState;
 import com.facebook.presto.spi.function.AccumulatorStateMetadata;
@@ -96,13 +95,13 @@ public final class DoubleHistogramAggregation
         }
         else {
             Map<Double, Double> value = state.get().getBuckets();
-            BlockBuilder blockBuilder = DoubleType.DOUBLE.createBlockBuilder(null, value.size() * 2);
+
+            BlockBuilder entryBuilder = out.beginBlockEntry();
             for (Map.Entry<Double, Double> entry : value.entrySet()) {
-                DoubleType.DOUBLE.writeDouble(blockBuilder, entry.getKey());
-                DoubleType.DOUBLE.writeDouble(blockBuilder, entry.getValue());
+                DoubleType.DOUBLE.writeDouble(entryBuilder, entry.getKey());
+                DoubleType.DOUBLE.writeDouble(entryBuilder, entry.getValue());
             }
-            Block block = blockBuilder.build();
-            out.appendStructure(block);
+            out.closeEntry();
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
@@ -102,8 +102,7 @@ public final class DoubleHistogramAggregation
                 DoubleType.DOUBLE.writeDouble(blockBuilder, entry.getValue());
             }
             Block block = blockBuilder.build();
-            out.writeObject(block);
-            out.closeEntry();
+            out.appendStructure(block);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealHistogramAggregation.java
@@ -68,8 +68,7 @@ public class RealHistogramAggregation
                 REAL.writeLong(blockBuilder, floatToRawIntBits(entry.getValue().floatValue()));
             }
             Block block = blockBuilder.build();
-            out.writeObject(block);
-            out.closeEntry();
+            out.appendStructure(block);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/RealHistogramAggregation.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.aggregation;
 
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.AggregationState;
@@ -62,13 +61,12 @@ public class RealHistogramAggregation
         }
         else {
             Map<Double, Double> value = state.get().getBuckets();
-            BlockBuilder blockBuilder = REAL.createBlockBuilder(null, value.size() * 2);
+            BlockBuilder entryBuilder = out.beginBlockEntry();
             for (Map.Entry<Double, Double> entry : value.entrySet()) {
-                REAL.writeLong(blockBuilder, floatToRawIntBits(entry.getKey().floatValue()));
-                REAL.writeLong(blockBuilder, floatToRawIntBits(entry.getValue().floatValue()));
+                REAL.writeLong(entryBuilder, floatToRawIntBits(entry.getKey().floatValue()));
+                REAL.writeLong(entryBuilder, floatToRawIntBits(entry.getValue().floatValue()));
             }
-            Block block = blockBuilder.build();
-            out.appendStructure(block);
+            out.closeEntry();
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
@@ -63,7 +63,7 @@ public class RowHashCodeOperator
     public static long hash(Type rowType, Block block)
     {
         BlockBuilder blockBuilder = rowType.createBlockBuilder(null, 1);
-        blockBuilder.writeObject(block).closeEntry();
+        blockBuilder.appendStructure(block);
         return rowType.hash(blockBuilder.build(), 0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/BenchmarkMapCopy.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BenchmarkMapCopy.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.block;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.type.MapType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.StructuralTestUtil.mapType;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 10)
+@Fork(10)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkMapCopy
+{
+    private static final int POSITIONS = 100_000;
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS)
+    public BlockBuilder benchmarkMapCopy(BenchmarkData data)
+    {
+        Block block = data.getDataBlock();
+        BlockBuilder blockBuilder = data.getBlockBuilder();
+        MapType mapType = mapType(VARCHAR, BIGINT);
+
+        for (int i = 0; i < POSITIONS; i++) {
+            mapType.appendTo(block, i, blockBuilder);
+        }
+
+        return blockBuilder;
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"1", "2", "4", "8", "16"})
+        private int mapSize;
+
+        private Block dataBlock;
+        private BlockBuilder blockBuilder;
+        private BlockBuilderStatus status;
+
+        @Setup
+        public void setup()
+        {
+            MapType mapType = mapType(VARCHAR, BIGINT);
+            blockBuilder = mapType.createBlockBuilder(null, POSITIONS);
+            for (int position = 0; position < POSITIONS; position++) {
+                BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+                for (int i = 0; i < mapSize; i++) {
+                    VARCHAR.writeString(entryBuilder, String.valueOf(ThreadLocalRandom.current().nextInt()));
+                    BIGINT.writeLong(entryBuilder, ThreadLocalRandom.current().nextInt());
+                }
+                blockBuilder.closeEntry();
+            }
+
+            dataBlock = blockBuilder.build();
+        }
+
+        public Block getDataBlock()
+        {
+            return dataBlock;
+        }
+
+        public BlockBuilder getBlockBuilder()
+        {
+            return blockBuilder.newBlockBuilderLike(status);
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkMapCopy().benchmarkMapCopy(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkMapCopy.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
@@ -39,17 +39,19 @@ public class TestArrayBlock
         for (int i = 0; i < ARRAY_SIZES.length; i++) {
             expectedValues[i] = rand.longs(ARRAY_SIZES[i]).toArray();
         }
+
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 1, 3, 4, 7);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 2, 3, 5, 6);
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 3, 4, 7);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 5, 6);
+
         long[][] expectedValuesWithNull = (long[][]) alternatingNullValues(expectedValues);
         BlockBuilder blockBuilderWithNull = createBlockBuilderWithValues(expectedValuesWithNull);
-        assertBlock(blockBuilderWithNull, expectedValuesWithNull);
-        assertBlock(blockBuilderWithNull.build(), expectedValuesWithNull);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), 0, 1, 5, 6, 7, 10, 11, 12, 15);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), 2, 3, 4, 9, 13, 14);
+        assertBlock(blockBuilderWithNull, () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+        assertBlock(blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 5, 6, 7, 10, 11, 12, 15);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 4, 9, 13, 14);
     }
 
     @Test
@@ -62,17 +64,20 @@ public class TestArrayBlock
                 expectedValues[i][j] = Slices.utf8Slice(String.format("%d.%d", i, j));
             }
         }
+
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 1, 3, 4, 7);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 2, 3, 5, 6);
+
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 3, 4, 7);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 5, 6);
+
         Slice[][] expectedValuesWithNull = (Slice[][]) alternatingNullValues(expectedValues);
         BlockBuilder blockBuilderWithNull = createBlockBuilderWithValues(expectedValuesWithNull);
-        assertBlock(blockBuilderWithNull, expectedValuesWithNull);
-        assertBlock(blockBuilderWithNull.build(), expectedValuesWithNull);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), 0, 1, 5, 6, 7, 10, 11, 12, 15);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), 2, 3, 4, 9, 13, 14);
+        assertBlock(blockBuilderWithNull, () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+        assertBlock(blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 5, 6, 7, 10, 11, 12, 15);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 4, 9, 13, 14);
     }
 
     @Test
@@ -90,17 +95,20 @@ public class TestArrayBlock
                 }
             }
         }
+
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 1, 3, 4, 7);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 2, 3, 5, 6);
+
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 3, 4, 7);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 5, 6);
+
         long[][][] expectedValuesWithNull = (long[][][]) alternatingNullValues(expectedValues);
         BlockBuilder blockBuilderWithNull = createBlockBuilderWithValues(expectedValuesWithNull);
-        assertBlock(blockBuilderWithNull, expectedValuesWithNull);
-        assertBlock(blockBuilderWithNull.build(), expectedValuesWithNull);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), 0, 1, 5, 6, 7, 10, 11, 12, 15);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), 2, 3, 4, 9, 13, 14);
+        assertBlock(blockBuilderWithNull, () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+        assertBlock(blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 5, 6, 7, 10, 11, 12, 15);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 4, 9, 13, 14);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
@@ -144,10 +144,10 @@ public class TestArrayBlock
                         for (long v : expectedValue[j]) {
                             BIGINT.writeLong(innerMostBlockBuilder, v);
                         }
-                        intermediateBlockBuilder.writeObject(innerMostBlockBuilder.build()).closeEntry();
+                        intermediateBlockBuilder.appendStructure(innerMostBlockBuilder.build());
                     }
                 }
-                blockBuilder.writeObject(intermediateBlockBuilder.build()).closeEntry();
+                blockBuilder.appendStructure(intermediateBlockBuilder.build());
             }
         }
         return blockBuilder;
@@ -170,7 +170,7 @@ public class TestArrayBlock
                 for (long v : expectedValue) {
                     BIGINT.writeLong(elementBlockBuilder, v);
                 }
-                blockBuilder.writeObject(elementBlockBuilder).closeEntry();
+                blockBuilder.appendStructure(elementBlockBuilder);
             }
         }
         return blockBuilder;
@@ -188,7 +188,7 @@ public class TestArrayBlock
                 for (Slice v : expectedValue) {
                     VARCHAR.writeSlice(elementBlockBuilder, v);
                 }
-                blockBuilder.writeObject(elementBlockBuilder.build()).closeEntry();
+                blockBuilder.appendStructure(elementBlockBuilder.build());
             }
         }
         return blockBuilder;

--- a/presto-main/src/test/java/com/facebook/presto/block/TestBlockBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestBlockBuilder.java
@@ -67,9 +67,8 @@ public class TestBlockBuilder
             VARCHAR.writeSlice(varcharBlockBuilder, Slices.utf8Slice("test" + i));
             Block longArrayBlock = new ArrayType(BIGINT)
                     .createBlockBuilder(null, 1)
-                    .writeObject(BIGINT.createBlockBuilder(null, 2).writeLong(i).closeEntry().writeLong(i * 2).closeEntry().build())
-                    .closeEntry();
-            arrayBlockBuilder.writeObject(longArrayBlock).closeEntry();
+                    .appendStructure(BIGINT.createBlockBuilder(null, 2).writeLong(i).closeEntry().writeLong(i * 2).closeEntry().build());
+            arrayBlockBuilder.appendStructure(longArrayBlock);
             pageBuilder.declarePosition();
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/block/TestByteArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestByteArrayBlock.java
@@ -38,7 +38,7 @@ public class TestByteArrayBlock
     {
         Slice[] expectedValues = (Slice[]) alternatingNullValues(createTestValue(17));
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 2, 4, 6, 7, 9, 10, 16);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 2, 4, 6, 7, 9, 10, 16);
     }
 
     @Test
@@ -63,8 +63,8 @@ public class TestByteArrayBlock
     private void assertFixedWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
     }
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestFixedWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestFixedWidthBlock.java
@@ -40,7 +40,7 @@ public class TestFixedWidthBlock
         for (int fixedSize = 0; fixedSize < 20; fixedSize++) {
             Slice[] expectedValues = (Slice[]) alternatingNullValues(createExpectedValues(17, fixedSize));
             BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues, fixedSize);
-            assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 2, 4, 6, 7, 9, 10, 16);
+            assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 2, 4, 6, 7, 9, 10, 16);
         }
     }
 
@@ -68,8 +68,8 @@ public class TestFixedWidthBlock
     private void assertFixedWithValues(Slice[] expectedValues, int fixedSize)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues, fixedSize);
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
     }
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues, int fixedSize)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestIntArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestIntArrayBlock.java
@@ -38,7 +38,7 @@ public class TestIntArrayBlock
     {
         Slice[] expectedValues = (Slice[]) alternatingNullValues(createTestValue(17));
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 2, 4, 6, 7, 9, 10, 16);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 2, 4, 6, 7, 9, 10, 16);
     }
 
     @Test
@@ -63,8 +63,8 @@ public class TestIntArrayBlock
     private void assertFixedWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
     }
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
@@ -39,7 +39,7 @@ public class TestLongArrayBlock
     {
         Slice[] expectedValues = (Slice[]) alternatingNullValues(createTestValue(17));
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 2, 4, 6, 7, 9, 10, 16);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 2, 4, 6, 7, 9, 10, 16);
     }
 
     @Test
@@ -64,8 +64,8 @@ public class TestLongArrayBlock
     private void assertFixedWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
     }
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
@@ -64,34 +64,34 @@ public class TestMapBlock
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
 
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
-        assertBlockFilteredPositions(expectedValues, blockBuilder, 0, 1, 3, 4, 7);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 1, 3, 4, 7);
-        assertBlockFilteredPositions(expectedValues, blockBuilder, 2, 3, 5, 6);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 2, 3, 5, 6);
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlockFilteredPositions(expectedValues, blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 3, 4, 7);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 3, 4, 7);
+        assertBlockFilteredPositions(expectedValues, blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 5, 6);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 5, 6);
 
         Block block = createBlockWithValuesFromKeyValueBlock(expectedValues);
 
-        assertBlock(block, expectedValues);
-        assertBlockFilteredPositions(expectedValues, block, 0, 1, 3, 4, 7);
-        assertBlockFilteredPositions(expectedValues, block, 2, 3, 5, 6);
+        assertBlock(block, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlockFilteredPositions(expectedValues, block, () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 3, 4, 7);
+        assertBlockFilteredPositions(expectedValues, block, () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 5, 6);
 
         Map<String, Long>[] expectedValuesWithNull = (Map<String, Long>[]) alternatingNullValues(expectedValues);
         BlockBuilder blockBuilderWithNull = createBlockBuilderWithValues(expectedValuesWithNull);
 
-        assertBlock(blockBuilderWithNull, expectedValuesWithNull);
-        assertBlock(blockBuilderWithNull.build(), expectedValuesWithNull);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull, 0, 1, 5, 6, 7, 10, 11, 12, 15);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), 0, 1, 5, 6, 7, 10, 11, 12, 15);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull, 2, 3, 4, 9, 13, 14);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), 2, 3, 4, 9, 13, 14);
+        assertBlock(blockBuilderWithNull, () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+        assertBlock(blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull, () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 5, 6, 7, 10, 11, 12, 15);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 5, 6, 7, 10, 11, 12, 15);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull, () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 4, 9, 13, 14);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockBuilderWithNull.build(), () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 4, 9, 13, 14);
 
         Block blockWithNull = createBlockWithValuesFromKeyValueBlock(expectedValuesWithNull);
 
-        assertBlock(blockWithNull, expectedValuesWithNull);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockWithNull, 0, 1, 5, 6, 7, 10, 11, 12, 15);
-        assertBlockFilteredPositions(expectedValuesWithNull, blockWithNull, 2, 3, 4, 9, 13, 14);
+        assertBlock(blockWithNull, () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockWithNull, () -> blockBuilder.newBlockBuilderLike(null), 0, 1, 5, 6, 7, 10, 11, 12, 15);
+        assertBlockFilteredPositions(expectedValuesWithNull, blockWithNull, () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 4, 9, 13, 14);
     }
 
     private BlockBuilder createBlockBuilderWithValues(Map<String, Long>[] maps)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
@@ -53,12 +53,12 @@ public class TestRowBlock
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(fieldTypes, expectedValues);
 
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
 
         IntArrayList positionList = generatePositionList(expectedValues.length, expectedValues.length / 2);
-        assertBlockFilteredPositions(expectedValues, blockBuilder, positionList.toIntArray());
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), positionList.toIntArray());
+        assertBlockFilteredPositions(expectedValues, blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), positionList.toIntArray());
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), positionList.toIntArray());
     }
 
     private BlockBuilder createBlockBuilderWithValues(List<Type> fieldTypes, List<Object>[] rows)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
@@ -39,7 +39,7 @@ public class TestRunLengthEncodedBlock
         for (int position = 0; position < positionCount; position++) {
             expectedValues[position] = expectedValue;
         }
-        assertBlock(block, expectedValues);
+        assertBlock(block, TestRunLengthEncodedBlock::createBlockBuilder, expectedValues);
     }
 
     private static Block createSingleValueBlock(Slice expectedValue)
@@ -47,5 +47,10 @@ public class TestRunLengthEncodedBlock
         BlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, 1, expectedValue.length());
         blockBuilder.writeBytes(expectedValue, 0, expectedValue.length()).closeEntry();
         return blockBuilder.build();
+    }
+
+    private static BlockBuilder createBlockBuilder()
+    {
+        return new VariableWidthBlockBuilder(null, 1, 1);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestShortArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestShortArrayBlock.java
@@ -38,7 +38,7 @@ public class TestShortArrayBlock
     {
         Slice[] expectedValues = (Slice[]) alternatingNullValues(createTestValue(17));
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 2, 4, 6, 7, 9, 10, 16);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 2, 4, 6, 7, 9, 10, 16);
     }
 
     @Test
@@ -63,8 +63,8 @@ public class TestShortArrayBlock
     private void assertFixedWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
     }
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
@@ -56,7 +56,7 @@ public class TestVariableWidthBlock
     {
         Slice[] expectedValues = (Slice[]) alternatingNullValues(createExpectedValues(100));
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), 0, 2, 4, 6, 7, 9, 10, 16);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 2, 4, 6, 7, 9, 10, 16);
     }
 
     @Test
@@ -107,8 +107,8 @@ public class TestVariableWidthBlock
     private void assertVariableWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
-        assertBlock(blockBuilder, expectedValues);
-        assertBlock(blockBuilder.build(), expectedValues);
+        assertBlock(blockBuilder, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+        assertBlock(blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
     }
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
@@ -246,7 +246,6 @@ public class BenchmarkArrayFilter
                 }
                 if (TRUE.equals(keep)) {
                     block.writePositionTo(position, resultBuilder);
-                    resultBuilder.closeEntry();
                 }
             }
             return resultBuilder.build();

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -118,10 +118,8 @@ public class TestArrayOperators
 
         Block expectedBlock = new ArrayType(BIGINT)
                 .createBlockBuilder(null, 3)
-                .writeObject(BIGINT.createBlockBuilder(null, 2).writeLong(1).closeEntry().writeLong(2).closeEntry().build())
-                .closeEntry()
-                .writeObject(BIGINT.createBlockBuilder(null, 1).writeLong(3).closeEntry().build())
-                .closeEntry()
+                .appendStructure(BIGINT.createBlockBuilder(null, 2).writeLong(1).closeEntry().writeLong(2).closeEntry().build())
+                .appendStructure(BIGINT.createBlockBuilder(null, 1).writeLong(3).closeEntry().build())
                 .build();
         DynamicSliceOutput expectedSliceOutput = new DynamicSliceOutput(100);
         writeBlock(expectedSliceOutput, expectedBlock);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -145,9 +145,9 @@ public abstract class AbstractArrayBlock
             }
             else {
                 getValues().writePositionTo(i, entryBuilder);
-                entryBuilder.closeEntry();
             }
         }
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -136,18 +136,7 @@ public abstract class AbstractArrayBlock
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         checkReadablePosition(position);
-        BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
-        int startValueOffset = getOffset(position);
-        int endValueOffset = getOffset(position + 1);
-        for (int i = startValueOffset; i < endValueOffset; i++) {
-            if (getValues().isNull(i)) {
-                entryBuilder.appendNull();
-            }
-            else {
-                getValues().writePositionTo(i, entryBuilder);
-            }
-        }
-        blockBuilder.closeEntry();
+        blockBuilder.appendStructureInternal(this, position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
@@ -141,6 +141,7 @@ public abstract class AbstractFixedWidthBlock
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         writeBytesTo(position, 0, getSliceLength(position), blockBuilder);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -224,16 +224,15 @@ public abstract class AbstractMapBlock
             }
             else {
                 getKeys().writePositionTo(i, entryBuilder);
-                entryBuilder.closeEntry();
             }
             if (getValues().isNull(i)) {
                 entryBuilder.appendNull();
             }
             else {
                 getValues().writePositionTo(i, entryBuilder);
-                entryBuilder.closeEntry();
             }
         }
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -215,24 +215,7 @@ public abstract class AbstractMapBlock
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         checkReadablePosition(position);
-        BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
-        int startValueOffset = getOffset(position);
-        int endValueOffset = getOffset(position + 1);
-        for (int i = startValueOffset; i < endValueOffset; i++) {
-            if (getKeys().isNull(i)) {
-                entryBuilder.appendNull();
-            }
-            else {
-                getKeys().writePositionTo(i, entryBuilder);
-            }
-            if (getValues().isNull(i)) {
-                entryBuilder.appendNull();
-            }
-            else {
-                getValues().writePositionTo(i, entryBuilder);
-            }
-        }
-        blockBuilder.closeEntry();
+        blockBuilder.appendStructureInternal(this, position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -157,9 +157,9 @@ public abstract class AbstractRowBlock
             }
             else {
                 getFieldBlocks()[i].writePositionTo(fieldBlockOffset, entryBuilder);
-                entryBuilder.closeEntry();
             }
         }
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -149,17 +149,7 @@ public abstract class AbstractRowBlock
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         checkReadablePosition(position);
-        BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
-        int fieldBlockOffset = getFieldBlockOffset(position);
-        for (int i = 0; i < numFields; i++) {
-            if (getFieldBlocks()[i].isNull(fieldBlockOffset)) {
-                entryBuilder.appendNull();
-            }
-            else {
-                getFieldBlocks()[i].writePositionTo(fieldBlockOffset, entryBuilder);
-            }
-        }
-        blockBuilder.closeEntry();
+        blockBuilder.appendStructureInternal(this, position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
@@ -124,6 +124,7 @@ public abstract class AbstractVariableWidthBlock
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         writeBytesTo(position, 0, getSliceLength(position), blockBuilder);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -152,7 +152,6 @@ public class ArrayBlockBuilder
             }
             else {
                 block.writePositionTo(i, values);
-                values.closeEntry();
             }
         }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -139,14 +139,13 @@ public class ArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder appendStructure(Object value)
+    public BlockBuilder appendStructure(Block block)
     {
         if (currentEntryOpened) {
             throw new IllegalStateException("Expected current entry to be closed but was opened");
         }
         currentEntryOpened = true;
 
-        Block block = (Block) value;
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (block.isNull(i)) {
                 values.appendNull();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -139,11 +139,12 @@ public class ArrayBlockBuilder
     }
 
     @Override
-    public BlockBuilder writeObject(Object value)
+    public BlockBuilder appendStructure(Object value)
     {
         if (currentEntryOpened) {
             throw new IllegalStateException("Expected current entry to be closed but was opened");
         }
+        currentEntryOpened = true;
 
         Block block = (Block) value;
         for (int i = 0; i < block.getPositionCount(); i++) {
@@ -156,7 +157,7 @@ public class ArrayBlockBuilder
             }
         }
 
-        currentEntryOpened = true;
+        closeEntry();
         return this;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -160,6 +160,31 @@ public class ArrayBlockBuilder
     }
 
     @Override
+    public BlockBuilder appendStructureInternal(Block block, int position)
+    {
+        if (!(block instanceof AbstractArrayBlock)) {
+            throw new IllegalArgumentException();
+        }
+
+        AbstractArrayBlock arrayBlock = (AbstractArrayBlock) block;
+        BlockBuilder entryBuilder = beginBlockEntry();
+
+        int startValueOffset = arrayBlock.getOffset(position);
+        int endValueOffset = arrayBlock.getOffset(position + 1);
+        for (int i = startValueOffset; i < endValueOffset; i++) {
+            if (arrayBlock.getValues().isNull(i)) {
+                entryBuilder.appendNull();
+            }
+            else {
+                arrayBlock.getValues().writePositionTo(i, entryBuilder);
+            }
+        }
+
+        closeEntry();
+        return this;
+    }
+
+    @Override
     public SingleArrayBlockWriter beginBlockEntry()
     {
         if (currentEntryOpened) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -110,7 +110,7 @@ public interface Block
     }
 
     /**
-     * Appends the value at {@code position} to {@code blockBuilder}.
+     * Appends the value at {@code position} to {@code blockBuilder} and close the entry.
      */
     void writePositionTo(int position, BlockBuilder blockBuilder);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
@@ -95,6 +95,15 @@ public interface BlockBuilder
     }
 
     /**
+     * Do not use this interface outside block package.
+     * Instead, use Block.writePositionTo(BlockBuilder, position)
+     */
+    default BlockBuilder appendStructureInternal(Block block, int position)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
      * Builds the block. This method can be called multiple times.
      */
     Block build();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
@@ -59,14 +59,6 @@ public interface BlockBuilder
     }
 
     /**
-     * Write an object to the current entry;
-     */
-    default BlockBuilder writeObject(Object value)
-    {
-        throw new UnsupportedOperationException(getClass().getName());
-    }
-
-    /**
      * Return a writer to the current entry. The caller can operate on the returned caller to incrementally build the object. This is generally more efficient than
      * building the object elsewhere and call writeObject afterwards because a large chunk of memory could potentially be unnecessarily copied in this process.
      */
@@ -93,6 +85,14 @@ public interface BlockBuilder
      * Appends a null value to the block.
      */
     BlockBuilder appendNull();
+
+    /**
+     * Append a struct to the block and close the entry.
+     */
+    default BlockBuilder appendStructure(Object value)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
 
     /**
      * Builds the block. This method can be called multiple times.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
@@ -89,7 +89,7 @@ public interface BlockBuilder
     /**
      * Append a struct to the block and close the entry.
      */
-    default BlockBuilder appendStructure(Object value)
+    default BlockBuilder appendStructure(Block value)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -119,6 +119,7 @@ public class ByteArrayBlock
     {
         checkReadablePosition(position);
         blockBuilder.writeByte(values[position + arrayOffset]);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -179,6 +179,7 @@ public class ByteArrayBlockBuilder
     {
         checkReadablePosition(position);
         blockBuilder.writeByte(values[position]);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -119,6 +119,7 @@ public class IntArrayBlock
     {
         checkReadablePosition(position);
         blockBuilder.writeInt(values[position + arrayOffset]);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -180,6 +180,7 @@ public class IntArrayBlockBuilder
     {
         checkReadablePosition(position);
         blockBuilder.writeInt(values[position]);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -166,6 +166,7 @@ public class LongArrayBlock
     {
         checkReadablePosition(position);
         blockBuilder.writeLong(values[position + arrayOffset]);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -227,6 +227,7 @@ public class LongArrayBlockBuilder
     {
         checkReadablePosition(position);
         blockBuilder.writeLong(values[position]);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -282,14 +282,12 @@ public class MapBlockBuilder
             }
             else {
                 block.writePositionTo(i, keyBlockBuilder);
-                keyBlockBuilder.closeEntry();
             }
             if (block.isNull(i + 1)) {
                 valueBlockBuilder.appendNull();
             }
             else {
                 block.writePositionTo(i + 1, valueBlockBuilder);
-                valueBlockBuilder.closeEntry();
             }
         }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -262,14 +262,16 @@ public class MapBlockBuilder
     }
 
     @Override
-    public BlockBuilder appendStructure(Object value)
+    public BlockBuilder appendStructure(Block block)
     {
+        if (!(block instanceof SingleMapBlock)) {
+            throw new IllegalArgumentException("Expected SingleMapBlock");
+        }
         if (currentEntryOpened) {
             throw new IllegalStateException("Expected current entry to be closed but was opened");
         }
         currentEntryOpened = true;
 
-        Block block = (Block) value;
         int blockPositionCount = block.getPositionCount();
         if (blockPositionCount % 2 != 0) {
             throw new IllegalArgumentException(format("block position count is not even: %s", blockPositionCount));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -296,6 +296,39 @@ public class MapBlockBuilder
     }
 
     @Override
+    public BlockBuilder appendStructureInternal(Block block, int position)
+    {
+        if (!(block instanceof AbstractMapBlock)) {
+            throw new IllegalArgumentException("Expected AbstractMapBlock");
+        }
+        if (currentEntryOpened) {
+            throw new IllegalStateException("Expected current entry to be closed but was opened");
+        }
+        currentEntryOpened = true;
+
+        AbstractMapBlock mapBlock = (AbstractMapBlock) block;
+        int startValueOffset = mapBlock.getOffset(position);
+        int endValueOffset = mapBlock.getOffset(position + 1);
+        for (int i = startValueOffset; i < endValueOffset; i++) {
+            if (mapBlock.getKeys().isNull(i)) {
+                keyBlockBuilder.appendNull();
+            }
+            else {
+                mapBlock.getKeys().writePositionTo(i, keyBlockBuilder);
+            }
+            if (mapBlock.getValues().isNull(i)) {
+                valueBlockBuilder.appendNull();
+            }
+            else {
+                mapBlock.getValues().writePositionTo(i, valueBlockBuilder);
+            }
+        }
+
+        closeEntry();
+        return this;
+    }
+
+    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         int newSize = calculateBlockResetSize(getPositionCount());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -272,22 +272,23 @@ public class MapBlockBuilder
         }
         currentEntryOpened = true;
 
-        int blockPositionCount = block.getPositionCount();
+        SingleMapBlock singleMapBlock = (SingleMapBlock) block;
+        int blockPositionCount = singleMapBlock.getPositionCount();
         if (blockPositionCount % 2 != 0) {
             throw new IllegalArgumentException(format("block position count is not even: %s", blockPositionCount));
         }
         for (int i = 0; i < blockPositionCount; i += 2) {
-            if (block.isNull(i)) {
+            if (singleMapBlock.isNull(i)) {
                 throw new IllegalArgumentException("Map keys must not be null");
             }
             else {
-                block.writePositionTo(i, keyBlockBuilder);
+                singleMapBlock.writePositionTo(i, keyBlockBuilder);
             }
-            if (block.isNull(i + 1)) {
+            if (singleMapBlock.isNull(i + 1)) {
                 valueBlockBuilder.appendNull();
             }
             else {
-                block.writePositionTo(i + 1, valueBlockBuilder);
+                singleMapBlock.writePositionTo(i + 1, valueBlockBuilder);
             }
         }
 
@@ -311,7 +312,7 @@ public class MapBlockBuilder
         int endValueOffset = mapBlock.getOffset(position + 1);
         for (int i = startValueOffset; i < endValueOffset; i++) {
             if (mapBlock.getKeys().isNull(i)) {
-                keyBlockBuilder.appendNull();
+                throw new IllegalArgumentException("Map keys must not be null");
             }
             else {
                 mapBlock.getKeys().writePositionTo(i, keyBlockBuilder);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -262,7 +262,7 @@ public class MapBlockBuilder
     }
 
     @Override
-    public BlockBuilder writeObject(Object value)
+    public BlockBuilder appendStructure(Object value)
     {
         if (currentEntryOpened) {
             throw new IllegalStateException("Expected current entry to be closed but was opened");
@@ -290,6 +290,8 @@ public class MapBlockBuilder
                 valueBlockBuilder.closeEntry();
             }
         }
+
+        closeEntry();
         return this;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
@@ -212,14 +212,16 @@ public class RowBlockBuilder
     }
 
     @Override
-    public BlockBuilder appendStructure(Object value)
+    public BlockBuilder appendStructure(Block block)
     {
+        if (!(block instanceof AbstractSingleRowBlock)) {
+            throw new IllegalStateException("Expected AbstractSingleRowBlock");
+        }
         if (currentEntryOpened) {
             throw new IllegalStateException("Expected current entry to be closed but was opened");
         }
         currentEntryOpened = true;
 
-        Block block = (Block) value;
         int blockPositionCount = block.getPositionCount();
         if (blockPositionCount != numFields) {
             throw new IllegalArgumentException(format("block position count (%s) is not equal to number of fields (%s)", blockPositionCount, numFields));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
@@ -212,7 +212,7 @@ public class RowBlockBuilder
     }
 
     @Override
-    public BlockBuilder writeObject(Object value)
+    public BlockBuilder appendStructure(Object value)
     {
         if (currentEntryOpened) {
             throw new IllegalStateException("Expected current entry to be closed but was opened");
@@ -233,6 +233,8 @@ public class RowBlockBuilder
                 fieldBlockBuilders[i].closeEntry();
             }
         }
+
+        closeEntry();
         return this;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
@@ -240,6 +240,30 @@ public class RowBlockBuilder
     }
 
     @Override
+    public BlockBuilder appendStructureInternal(Block block, int position)
+    {
+        if (!(block instanceof AbstractRowBlock)) {
+            throw new IllegalArgumentException();
+        }
+
+        AbstractRowBlock rowBlock = (AbstractRowBlock) block;
+        BlockBuilder entryBuilder = this.beginBlockEntry();
+
+        int fieldBlockOffset = rowBlock.getFieldBlockOffset(position);
+        for (int i = 0; i < rowBlock.numFields; i++) {
+            if (rowBlock.getFieldBlocks()[i].isNull(fieldBlockOffset)) {
+                entryBuilder.appendNull();
+            }
+            else {
+                rowBlock.getFieldBlocks()[i].writePositionTo(fieldBlockOffset, entryBuilder);
+            }
+        }
+
+        closeEntry();
+        return this;
+    }
+
+    @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         int newSize = calculateBlockResetSize(getPositionCount());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
@@ -232,7 +232,6 @@ public class RowBlockBuilder
             }
             else {
                 block.writePositionTo(i, fieldBlockBuilders[i]);
-                fieldBlockBuilders[i].closeEntry();
             }
         }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -119,6 +119,7 @@ public class ShortArrayBlock
     {
         checkReadablePosition(position);
         blockBuilder.writeShort(values[position + arrayOffset]);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -180,6 +180,7 @@ public class ShortArrayBlockBuilder
     {
         checkReadablePosition(position);
         blockBuilder.writeShort(values[position]);
+        blockBuilder.closeEntry();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
@@ -106,6 +106,14 @@ public class SingleArrayBlockWriter
     }
 
     @Override
+    public BlockBuilder appendStructureInternal(Block block, int position)
+    {
+        blockBuilder.appendStructureInternal(block, position);
+        entryAdded();
+        return this;
+    }
+
+    @Override
     public BlockBuilder beginBlockEntry()
     {
         return blockBuilder.beginBlockEntry();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
@@ -98,9 +98,9 @@ public class SingleArrayBlockWriter
     }
 
     @Override
-    public BlockBuilder appendStructure(Object value)
+    public BlockBuilder appendStructure(Block block)
     {
-        blockBuilder.appendStructure(value);
+        blockBuilder.appendStructure(block);
         entryAdded();
         return this;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
@@ -98,9 +98,10 @@ public class SingleArrayBlockWriter
     }
 
     @Override
-    public BlockBuilder writeObject(Object value)
+    public BlockBuilder appendStructure(Object value)
     {
-        blockBuilder.writeObject(value);
+        blockBuilder.appendStructure(value);
+        entryAdded();
         return this;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
@@ -141,14 +141,15 @@ public class SingleMapBlockWriter
     }
 
     @Override
-    public BlockBuilder writeObject(Object value)
+    public BlockBuilder appendStructure(Object value)
     {
         if (writeToValueNext) {
-            valueBlockBuilder.writeObject(value);
+            valueBlockBuilder.appendStructure(value);
         }
         else {
-            keyBlockBuilder.writeObject(value);
+            keyBlockBuilder.appendStructure(value);
         }
+        entryAdded();
         return this;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
@@ -141,13 +141,13 @@ public class SingleMapBlockWriter
     }
 
     @Override
-    public BlockBuilder appendStructure(Object value)
+    public BlockBuilder appendStructure(Block block)
     {
         if (writeToValueNext) {
-            valueBlockBuilder.appendStructure(value);
+            valueBlockBuilder.appendStructure(block);
         }
         else {
-            keyBlockBuilder.appendStructure(value);
+            keyBlockBuilder.appendStructure(block);
         }
         entryAdded();
         return this;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
@@ -154,6 +154,19 @@ public class SingleMapBlockWriter
     }
 
     @Override
+    public BlockBuilder appendStructureInternal(Block block, int position)
+    {
+        if (writeToValueNext) {
+            valueBlockBuilder.appendStructureInternal(block, position);
+        }
+        else {
+            keyBlockBuilder.appendStructureInternal(block, position);
+        }
+        entryAdded();
+        return this;
+    }
+
+    @Override
     public BlockBuilder beginBlockEntry()
     {
         BlockBuilder result;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
@@ -147,6 +147,15 @@ public class SingleRowBlockWriter
     }
 
     @Override
+    public BlockBuilder appendStructureInternal(Block block, int position)
+    {
+        checkFieldIndexToWrite();
+        fieldBlockBuilders[currentFieldIndexToWrite].appendStructureInternal(block, position);
+        entryAdded();
+        return this;
+    }
+
+    @Override
     public BlockBuilder beginBlockEntry()
     {
         checkFieldIndexToWrite();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
@@ -138,10 +138,10 @@ public class SingleRowBlockWriter
     }
 
     @Override
-    public BlockBuilder appendStructure(Object value)
+    public BlockBuilder appendStructure(Block block)
     {
         checkFieldIndexToWrite();
-        fieldBlockBuilders[currentFieldIndexToWrite].appendStructure(value);
+        fieldBlockBuilders[currentFieldIndexToWrite].appendStructure(block);
         entryAdded();
         return this;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
@@ -138,10 +138,11 @@ public class SingleRowBlockWriter
     }
 
     @Override
-    public BlockBuilder writeObject(Object value)
+    public BlockBuilder appendStructure(Object value)
     {
         checkFieldIndexToWrite();
-        fieldBlockBuilders[currentFieldIndexToWrite].writeObject(value);
+        fieldBlockBuilders[currentFieldIndexToWrite].appendStructure(value);
+        entryAdded();
         return this;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
@@ -187,7 +187,7 @@ public class ArrayType
     @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
-        blockBuilder.appendStructure(value);
+        blockBuilder.appendStructure((Block) value);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
@@ -187,7 +187,7 @@ public class ArrayType
     @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
-        blockBuilder.writeObject(value).closeEntry();
+        blockBuilder.appendStructure(value);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
@@ -156,7 +156,6 @@ public class ArrayType
         }
         else {
             block.writePositionTo(position, blockBuilder);
-            blockBuilder.closeEntry();
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -219,7 +219,7 @@ public class MapType
         if (!(value instanceof SingleMapBlock)) {
             throw new IllegalArgumentException("Maps must be represented with SingleMapBlock");
         }
-        blockBuilder.appendStructure(value);
+        blockBuilder.appendStructure((Block) value);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -203,7 +203,6 @@ public class MapType
         }
         else {
             block.writePositionTo(position, blockBuilder);
-            blockBuilder.closeEntry();
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -219,7 +219,7 @@ public class MapType
         if (!(value instanceof SingleMapBlock)) {
             throw new IllegalArgumentException("Maps must be represented with SingleMapBlock");
         }
-        blockBuilder.writeObject(value).closeEntry();
+        blockBuilder.appendStructure(value);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
@@ -144,7 +144,7 @@ public class RowType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeObject(block.getObject(position, Block.class));
+            block.writePositionTo(position, blockBuilder);
             blockBuilder.closeEntry();
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
@@ -158,7 +158,7 @@ public class RowType
     @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
-        blockBuilder.appendStructure(value);
+        blockBuilder.appendStructure((Block) value);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
@@ -158,7 +158,7 @@ public class RowType
     @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
-        blockBuilder.writeObject(value).closeEntry();
+        blockBuilder.appendStructure(value);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
@@ -145,7 +145,6 @@ public class RowType
         }
         else {
             block.writePositionTo(position, blockBuilder);
-            blockBuilder.closeEntry();
         }
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestArrayBlockBuilder.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestArrayBlockBuilder.java
@@ -69,6 +69,6 @@ public class TestArrayBlockBuilder
         BlockBuilder blockBuilder = new ArrayBlockBuilder(BIGINT, null, EXPECTED_ENTRY_COUNT);
         BlockBuilder elementBlockWriter = blockBuilder.beginBlockEntry();
         elementBlockWriter.writeLong(45).closeEntry();
-        blockBuilder.writeObject(new FixedWidthBlockBuilder(8, 4).writeLong(123).closeEntry().build()).closeEntry();
+        blockBuilder.appendStructure(new FixedWidthBlockBuilder(8, 4).writeLong(123).closeEntry().build());
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarArray.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarArray.java
@@ -123,7 +123,7 @@ public class TestColumnarArray
                         VARCHAR.writeSlice(elementBlockBuilder, v);
                     }
                 }
-                blockBuilder.writeObject(elementBlockBuilder.build()).closeEntry();
+                blockBuilder.appendStructure(elementBlockBuilder.build());
             }
         }
         return blockBuilder;

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarMap.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarMap.java
@@ -130,21 +130,22 @@ public class TestColumnarMap
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(null, expectedMap.length);
+                BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+                VARCHAR.createBlockBuilder(null, expectedMap.length);
                 for (Slice[] entry : expectedMap) {
                     Slice key = entry[0];
                     assertNotNull(key);
-                    VARCHAR.writeSlice(elementBlockBuilder, key);
+                    VARCHAR.writeSlice(entryBuilder, key);
 
                     Slice value = entry[1];
                     if (value == null) {
-                        elementBlockBuilder.appendNull();
+                        entryBuilder.appendNull();
                     }
                     else {
-                        VARCHAR.writeSlice(elementBlockBuilder, value);
+                        VARCHAR.writeSlice(entryBuilder, value);
                     }
                 }
-                blockBuilder.appendStructure(elementBlockBuilder.build());
+                blockBuilder.closeEntry();
             }
         }
         return blockBuilder;

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarMap.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarMap.java
@@ -144,7 +144,7 @@ public class TestColumnarMap
                         VARCHAR.writeSlice(elementBlockBuilder, value);
                     }
                 }
-                blockBuilder.writeObject(elementBlockBuilder.build()).closeEntry();
+                blockBuilder.appendStructure(elementBlockBuilder.build());
             }
         }
         return blockBuilder;

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarRow.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarRow.java
@@ -118,16 +118,16 @@ public class TestColumnarRow
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(null, expectedValue.length);
+                BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
                 for (Slice v : expectedValue) {
                     if (v == null) {
-                        elementBlockBuilder.appendNull();
+                        entryBuilder.appendNull();
                     }
                     else {
-                        VARCHAR.writeSlice(elementBlockBuilder, v);
+                        VARCHAR.writeSlice(entryBuilder, v);
                     }
                 }
-                blockBuilder.appendStructure(elementBlockBuilder.build());
+                blockBuilder.closeEntry();
             }
         }
         return blockBuilder;

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarRow.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarRow.java
@@ -127,7 +127,7 @@ public class TestColumnarRow
                         VARCHAR.writeSlice(elementBlockBuilder, v);
                     }
                 }
-                blockBuilder.writeObject(elementBlockBuilder.build()).closeEntry();
+                blockBuilder.appendStructure(elementBlockBuilder.build());
             }
         }
         return blockBuilder;


### PR DESCRIPTION
Benchmark:

Before
```
Benchmark                          (mapSize)  Mode  Cnt     Score    Error  Units
BenchmarkMapCopy.benchmarkMapCopy          1  avgt  100   141.925 ±  0.830  ns/op
BenchmarkMapCopy.benchmarkMapCopy          2  avgt  100   277.466 ±  2.169  ns/op
BenchmarkMapCopy.benchmarkMapCopy          4  avgt  100   541.838 ±  5.143  ns/op
BenchmarkMapCopy.benchmarkMapCopy          8  avgt  100  1127.118 ± 39.768  ns/op
BenchmarkMapCopy.benchmarkMapCopy         16  avgt  100  2212.371 ± 84.363  ns/op
```

After
```
Benchmark                          (mapSize)  Mode  Cnt     Score    Error  Units
BenchmarkMapCopy.benchmarkMapCopy          1  avgt  100    89.487 ±  0.736  ns/op
BenchmarkMapCopy.benchmarkMapCopy          2  avgt  100   157.988 ±  1.185  ns/op
BenchmarkMapCopy.benchmarkMapCopy          4  avgt  100   291.660 ±  1.935  ns/op
BenchmarkMapCopy.benchmarkMapCopy          8  avgt  100   589.937 ± 23.140  ns/op
BenchmarkMapCopy.benchmarkMapCopy         16  avgt  100  1178.167 ± 45.828  ns/op
```

It's 37% to 48% improvement.