### PR TITLE
Remove empty constructor to BlockBuilderStatus

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/AccumuloRowSerializer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/AccumuloRowSerializer.java
@@ -16,7 +16,6 @@ package com.facebook.presto.accumulo.serializers;
 import com.facebook.presto.accumulo.Types;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeUtils;
 import com.facebook.presto.spi.type.VarcharType;
@@ -533,7 +532,7 @@ public interface AccumuloRowSerializer
      */
     static Block getBlockFromArray(Type elementType, List<?> array)
     {
-        BlockBuilder builder = elementType.createBlockBuilder(new BlockBuilderStatus(), array.size());
+        BlockBuilder builder = elementType.createBlockBuilder(null, array.size());
         for (Object item : array) {
             writeObject(builder, elementType, item);
         }
@@ -552,7 +551,7 @@ public interface AccumuloRowSerializer
         Type keyType = mapType.getTypeParameters().get(0);
         Type valueType = mapType.getTypeParameters().get(1);
 
-        BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, 1);
         BlockBuilder builder = mapBlockBuilder.beginBlockEntry();
 
         for (Entry<?, ?> entry : map.entrySet()) {

--- a/presto-array/src/test/java/com/facebook/presto/array/TestBlockBigArray.java
+++ b/presto-array/src/test/java/com/facebook/presto/array/TestBlockBigArray.java
@@ -15,7 +15,6 @@ package com.facebook.presto.array;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.IntArrayBlockBuilder;
 import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
@@ -28,7 +27,7 @@ public class TestBlockBigArray
     public void testRetainedSizeWithOverlappingBlocks()
     {
         int entries = 123;
-        BlockBuilder blockBuilder = new IntArrayBlockBuilder(new BlockBuilderStatus(), entries);
+        BlockBuilder blockBuilder = new IntArrayBlockBuilder(null, entries);
         for (int i = 0; i < entries; i++) {
             blockBuilder.writeInt(i);
         }

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHolePageSourceProvider.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHolePageSourceProvider.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.type.FixedWidthType;
@@ -115,10 +114,10 @@ public final class BlackHolePageSourceProvider
 
         BlockBuilder builder;
         if (type instanceof FixedWidthType) {
-            builder = type.createBlockBuilder(new BlockBuilderStatus(), rowsCount);
+            builder = type.createBlockBuilder(null, rowsCount);
         }
         else {
-            builder = type.createBlockBuilder(new BlockBuilderStatus(), rowsCount, slice.length());
+            builder = type.createBlockBuilder(null, rowsCount, slice.length());
         }
 
         for (int i = 0; i < rowsCount; i++) {

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTileFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTileFunctions.java
@@ -25,7 +25,6 @@ import com.esri.core.geometry.ogc.OGCPolygon;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -101,7 +100,7 @@ public class BingTileFunctions
     {
         BingTile tile = BingTile.decode(input);
 
-        BlockBuilder tileBlockBuilder = INTEGER.createBlockBuilder(new BlockBuilderStatus(), 2);
+        BlockBuilder tileBlockBuilder = INTEGER.createBlockBuilder(null, 2);
         INTEGER.writeLong(tileBlockBuilder, tile.getX());
         INTEGER.writeLong(tileBlockBuilder, tile.getY());
 

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -16,7 +16,6 @@ package com.facebook.presto.plugin.geospatial;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -47,7 +46,7 @@ public class TestGeoFunctions
     @Test
     public void testGeometryGetObjectValue()
     {
-        BlockBuilder builder = GEOMETRY.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder builder = GEOMETRY.createBlockBuilder(null, 1);
         GEOMETRY.writeSlice(builder, GeoFunctions.stPoint(1.2, 3.4));
         Block block = builder.build();
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.PageIndexer;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.IntArrayBlockBuilder;
 import com.facebook.presto.spi.type.Type;
@@ -365,7 +364,7 @@ public class HivePageSink
             return null;
         }
 
-        IntArrayBlockBuilder bucketColumnBuilder = new IntArrayBlockBuilder(new BlockBuilderStatus(), page.getPositionCount());
+        IntArrayBlockBuilder bucketColumnBuilder = new IntArrayBlockBuilder(null, page.getPositionCount());
         Page bucketColumnsPage = extractColumns(page, bucketColumns);
         for (int position = 0; position < page.getPositionCount(); position++) {
             int bucket = bucketFunction.getBucket(bucketColumnsPage, position);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.ArrayBlock;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.ColumnarArray;
 import com.facebook.presto.spi.block.ColumnarMap;
 import com.facebook.presto.spi.block.ColumnarRow;
@@ -332,7 +331,7 @@ public class HivePageSource
         @Override
         public Block apply(Block block)
         {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
             for (int i = 0; i < block.getPositionCount(); i++) {
                 if (block.isNull(i)) {
                     blockBuilder.appendNull();
@@ -359,7 +358,7 @@ public class HivePageSource
         @Override
         public Block apply(Block block)
         {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
             for (int i = 0; i < block.getPositionCount(); i++) {
                 if (block.isNull(i)) {
                     blockBuilder.appendNull();
@@ -409,7 +408,7 @@ public class HivePageSource
         @Override
         public Block apply(Block block)
         {
-            BlockBuilder blockBuilder = toType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+            BlockBuilder blockBuilder = toType.createBlockBuilder(null, block.getPositionCount());
             for (int i = 0; i < block.getPositionCount(); i++) {
                 if (block.isNull(i)) {
                     blockBuilder.appendNull();
@@ -438,7 +437,7 @@ public class HivePageSource
         @Override
         public Block apply(Block block)
         {
-            BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+            BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, block.getPositionCount());
             for (int i = 0; i < block.getPositionCount(); i++) {
                 if (block.isNull(i)) {
                     blockBuilder.appendNull();
@@ -534,10 +533,9 @@ public class HivePageSource
             List<HiveType> toFieldTypes = extractStructFieldTypes(toHiveType);
             this.coercers = new Function[toFieldTypes.size()];
             this.nullBlocks = new Block[toFieldTypes.size()];
-            BlockBuilderStatus blockBuilderStatus = new BlockBuilderStatus();
             for (int i = 0; i < coercers.length; i++) {
                 if (i >= fromFieldTypes.size()) {
-                    nullBlocks[i] = toFieldTypes.get(i).getType(typeManager).createBlockBuilder(blockBuilderStatus, 1).appendNull().build();
+                    nullBlocks[i] = toFieldTypes.get(i).getType(typeManager).createBlockBuilder(null, 1).appendNull().build();
                 }
                 else if (!fromFieldTypes.get(i).equals(toFieldTypes.get(i))) {
                     coercers[i] = createCoercer(typeManager, fromFieldTypes.get(i), toFieldTypes.get(i));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -89,7 +88,7 @@ public class OrcFileWriter
 
         ImmutableList.Builder<Block> nullBlocks = ImmutableList.builder();
         for (Type fileColumnType : fileColumnTypes) {
-            BlockBuilder blockBuilder = fileColumnType.createBlockBuilder(new BlockBuilderStatus(), 1, 0);
+            BlockBuilder blockBuilder = fileColumnType.createBlockBuilder(null, 1, 0);
             blockBuilder.appendNull();
             nullBlocks.add(blockBuilder.build());
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriter.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -80,7 +79,7 @@ public class RcFileFileWriter
 
         ImmutableList.Builder<Block> nullBlocks = ImmutableList.builder();
         for (Type fileColumnType : fileColumnTypes) {
-            BlockBuilder blockBuilder = fileColumnType.createBlockBuilder(new BlockBuilderStatus(), 1, 0);
+            BlockBuilder blockBuilder = fileColumnType.createBlockBuilder(null, 1, 0);
             blockBuilder.appendNull();
             nullBlocks.add(blockBuilder.build());
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.LazyBlockLoader;
 import com.facebook.presto.spi.type.Type;
@@ -97,7 +96,7 @@ public class OrcPageSource
             hiveColumnIndexes[columnIndex] = column.getHiveColumnIndex();
 
             if (!recordReader.isColumnPresent(column.getHiveColumnIndex())) {
-                BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), MAX_BATCH_SIZE, NULL_ENTRY_SIZE);
+                BlockBuilder blockBuilder = type.createBlockBuilder(null, MAX_BATCH_SIZE, NULL_ENTRY_SIZE);
                 for (int i = 0; i < MAX_BATCH_SIZE; i++) {
                     blockBuilder.appendNull();
                 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetHiveRecordCursor.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
@@ -773,7 +772,7 @@ public class ParquetHiveRecordCursor
         {
             if (builder == null) {
                 if (nullBuilder == null || (nullBuilder.getPositionCount() >= NULL_BUILDER_POSITIONS_THRESHOLD && nullBuilder.getSizeInBytes() >= NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD)) {
-                    nullBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), NULL_BUILDER_POSITIONS_THRESHOLD);
+                    nullBuilder = rowType.createBlockBuilder(null, NULL_BUILDER_POSITIONS_THRESHOLD);
                 }
                 currentEntryBuilder = nullBuilder.beginBlockEntry();
             }
@@ -908,7 +907,7 @@ public class ParquetHiveRecordCursor
         {
             if (builder == null) {
                 if (nullBuilder == null || (nullBuilder.getPositionCount() >= NULL_BUILDER_POSITIONS_THRESHOLD && nullBuilder.getSizeInBytes() >= NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD)) {
-                    nullBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), NULL_BUILDER_POSITIONS_THRESHOLD);
+                    nullBuilder = arrayType.createBlockBuilder(null, NULL_BUILDER_POSITIONS_THRESHOLD);
                 }
                 currentEntryBuilder = nullBuilder.beginBlockEntry();
             }
@@ -1061,7 +1060,7 @@ public class ParquetHiveRecordCursor
         {
             if (builder == null) {
                 if (nullBuilder == null || (nullBuilder.getPositionCount() >= NULL_BUILDER_POSITIONS_THRESHOLD && nullBuilder.getSizeInBytes() >= NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD)) {
-                    nullBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), NULL_BUILDER_POSITIONS_THRESHOLD);
+                    nullBuilder = mapType.createBlockBuilder(null, NULL_BUILDER_POSITIONS_THRESHOLD);
                 }
                 currentEntryBuilder = nullBuilder.beginBlockEntry();
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetColumnReader.java
@@ -23,7 +23,6 @@ import com.facebook.presto.hive.parquet.dictionary.ParquetDictionary;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
@@ -151,7 +150,7 @@ public abstract class ParquetColumnReader
             throws IOException
     {
         seek();
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, nextBatchSize);
         int valueCount = 0;
         while (valueCount < nextBatchSize) {
             if (page == null) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSource.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.LazyBlockLoader;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
@@ -96,7 +95,7 @@ public class RcFilePageSource
             if (hiveColumnIndexes[columnIndex] >= rcFileReader.getColumnCount()) {
                 // this file may contain fewer fields than what's declared in the schema
                 // this happens when additional columns are added to the hive table after files have been created
-                BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 1, NULL_ENTRY_SIZE);
+                BlockBuilder blockBuilder = type.createBlockBuilder(null, 1, NULL_ENTRY_SIZE);
                 blockBuilder.appendNull();
                 constantBlocks[columnIndex] = blockBuilder.build();
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/SerDeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/SerDeUtils.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive.util;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.CharType;
@@ -183,7 +182,7 @@ public final class SerDeUtils
             currentBuilder = builder.beginBlockEntry();
         }
         else {
-            currentBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), list.size());
+            currentBuilder = elementType.createBlockBuilder(null, list.size());
         }
 
         for (Object element : list) {
@@ -219,7 +218,7 @@ public final class SerDeUtils
         boolean builderSynthesized = false;
         if (builder == null) {
             builderSynthesized = true;
-            builder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
+            builder = type.createBlockBuilder(null, 1);
         }
         currentBuilder = builder.beginBlockEntry();
 
@@ -255,7 +254,7 @@ public final class SerDeUtils
         boolean builderSynthesized = false;
         if (builder == null) {
             builderSynthesized = true;
-            builder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
+            builder = type.createBlockBuilder(null, 1);
         }
         currentBuilder = builder.beginBlockEntry();
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DateType;
@@ -771,7 +770,7 @@ public abstract class AbstractTestHiveFileFormats
                         assertEquals(actualValue, expectedValue, "Wrong value for column " + testColumn.getName());
                     }
                     else {
-                        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
+                        BlockBuilder builder = type.createBlockBuilder(null, 1);
                         type.writeObject(builder, expectedValue);
                         expectedValue = type.getObjectValue(SESSION, builder.build(), 0);
                         assertEquals(actualValue, expectedValue, "Wrong value for column " + testColumn.getName());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
@@ -16,7 +16,6 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -214,7 +213,7 @@ public class TestHiveBucketing
             Object javaValue = javaValues.get(i);
             Type type = hiveTypes.get(i).getType(TYPE_MANAGER);
 
-            BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 3);
+            BlockBuilder blockBuilder = type.createBlockBuilder(null, 3);
             // prepend 2 nulls to make sure position is respected when HiveBucketing function
             blockBuilder.appendNull();
             blockBuilder.appendNull();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/util/TestSerDeUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/util/TestSerDeUtils.java
@@ -16,7 +16,6 @@ package com.facebook.presto.hive.util;
 import com.facebook.presto.block.BlockSerdeUtil;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.RowType;
 import com.google.common.collect.ImmutableList;
@@ -115,54 +114,54 @@ public class TestSerDeUtils
     public void testPrimitiveSlice()
     {
         // boolean
-        Block expectedBoolean = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeByte(1).closeEntry().build();
+        Block expectedBoolean = VARBINARY.createBlockBuilder(null, 1).writeByte(1).closeEntry().build();
         Block actualBoolean = toBinaryBlock(BOOLEAN, true, getInspector(Boolean.class));
         assertBlockEquals(actualBoolean, expectedBoolean);
 
         // byte
-        Block expectedByte = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeByte(5).closeEntry().build();
+        Block expectedByte = VARBINARY.createBlockBuilder(null, 1).writeByte(5).closeEntry().build();
         Block actualByte = toBinaryBlock(TINYINT, (byte) 5, getInspector(Byte.class));
         assertBlockEquals(actualByte, expectedByte);
 
         // short
-        Block expectedShort = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeShort(2).closeEntry().build();
+        Block expectedShort = VARBINARY.createBlockBuilder(null, 1).writeShort(2).closeEntry().build();
         Block actualShort = toBinaryBlock(SMALLINT, (short) 2, getInspector(Short.class));
         assertBlockEquals(actualShort, expectedShort);
 
         // int
-        Block expectedInt = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeInt(1).closeEntry().build();
+        Block expectedInt = VARBINARY.createBlockBuilder(null, 1).writeInt(1).closeEntry().build();
         Block actualInt = toBinaryBlock(INTEGER, 1, getInspector(Integer.class));
         assertBlockEquals(actualInt, expectedInt);
 
         // long
-        Block expectedLong = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeLong(10).closeEntry().build();
+        Block expectedLong = VARBINARY.createBlockBuilder(null, 1).writeLong(10).closeEntry().build();
         Block actualLong = toBinaryBlock(BIGINT, 10L, getInspector(Long.class));
         assertBlockEquals(actualLong, expectedLong);
 
         // float
-        Block expectedFloat = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeInt(floatToRawIntBits(20.0f)).closeEntry().build();
+        Block expectedFloat = VARBINARY.createBlockBuilder(null, 1).writeInt(floatToRawIntBits(20.0f)).closeEntry().build();
         Block actualFloat = toBinaryBlock(REAL, 20.0f, getInspector(Float.class));
         assertBlockEquals(actualFloat, expectedFloat);
 
         // double
-        Block expectedDouble = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeLong(doubleToLongBits(30.12)).closeEntry().build();
+        Block expectedDouble = VARBINARY.createBlockBuilder(null, 1).writeLong(doubleToLongBits(30.12)).closeEntry().build();
         Block actualDouble = toBinaryBlock(DOUBLE, 30.12d, getInspector(Double.class));
         assertBlockEquals(actualDouble, expectedDouble);
 
         // string
-        Block expectedString = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeBytes(utf8Slice("abdd"), 0, 4).closeEntry().build();
+        Block expectedString = VARBINARY.createBlockBuilder(null, 1).writeBytes(utf8Slice("abdd"), 0, 4).closeEntry().build();
         Block actualString = toBinaryBlock(createUnboundedVarcharType(), "abdd", getInspector(String.class));
         assertBlockEquals(actualString, expectedString);
 
         // timestamp
         DateTime dateTime = new DateTime(2008, 10, 28, 16, 7, 15, 0);
-        Block expectedTimestamp = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeLong(dateTime.getMillis()).closeEntry().build();
+        Block expectedTimestamp = VARBINARY.createBlockBuilder(null, 1).writeLong(dateTime.getMillis()).closeEntry().build();
         Block actualTimestamp = toBinaryBlock(BIGINT, new Timestamp(dateTime.getMillis()), getInspector(Timestamp.class));
         assertBlockEquals(actualTimestamp, expectedTimestamp);
 
         // binary
         byte[] byteArray = {81, 82, 84, 85};
-        Block expectedBinary = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1).writeBytes(Slices.wrappedBuffer(byteArray), 0, 4).closeEntry().build();
+        Block expectedBinary = VARBINARY.createBlockBuilder(null, 1).writeBytes(Slices.wrappedBuffer(byteArray), 0, 4).closeEntry().build();
         Block actualBinary = toBinaryBlock(createUnboundedVarcharType(), byteArray, getInspector(byte[].class));
         assertBlockEquals(actualBinary, expectedBinary);
     }
@@ -179,7 +178,7 @@ public class TestSerDeUtils
         com.facebook.presto.spi.type.Type rowType = new RowType(ImmutableList.of(INTEGER, BIGINT), Optional.empty());
         com.facebook.presto.spi.type.Type arrayOfRowType = new RowType(ImmutableList.of(new ArrayType(rowType)), Optional.empty());
         Block actual = toBinaryBlock(arrayOfRowType, listHolder, getInspector(ListHolder.class));
-        BlockBuilder blockBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), 1024);
+        BlockBuilder blockBuilder = rowType.createBlockBuilder(null, 1024);
         rowType.writeObject(blockBuilder, rowBlockOf(ImmutableList.of(INTEGER, BIGINT), 8, 9L));
         rowType.writeObject(blockBuilder, rowBlockOf(ImmutableList.of(INTEGER, BIGINT), 10, 11L));
         Block expected = rowBlockOf(ImmutableList.of(new ArrayType(rowType)), blockBuilder.build());
@@ -317,7 +316,7 @@ public class TestSerDeUtils
 
     private static Block getPrimitiveBlock(com.facebook.presto.spi.type.Type type, Object object, ObjectInspector inspector)
     {
-        BlockBuilder builder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder builder = VARBINARY.createBlockBuilder(null, 1);
         serializeObject(type, builder, object, inspector);
         return builder.build();
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/TransactionsSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/TransactionsSystemTable.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.TypeManager;
@@ -104,7 +103,7 @@ public class TransactionsSystemTable
     private static Block createStringsBlock(List<ConnectorId> values)
     {
         VarcharType varchar = createUnboundedVarcharType();
-        BlockBuilder builder = varchar.createBlockBuilder(new BlockBuilderStatus(), values.size());
+        BlockBuilder builder = varchar.createBlockBuilder(null, values.size());
         for (ConnectorId value : values) {
             if (value == null) {
                 builder.appendNull();

--- a/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CallTask.java
@@ -21,7 +21,6 @@ import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.facebook.presto.spi.procedure.Procedure.Argument;
 import com.facebook.presto.spi.type.Type;
@@ -173,7 +172,7 @@ public class CallTask
 
     private static Object toTypeObjectValue(Session session, Type type, Object value)
     {
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
         writeNativeValue(type, blockBuilder, value);
         return type.getObjectValue(session.toConnectorSession(), blockBuilder, 0);
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/AbstractPropertyManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/AbstractPropertyManager.java
@@ -18,7 +18,6 @@ import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.SemanticException;
@@ -149,7 +148,7 @@ abstract class AbstractPropertyManager
         Object value = evaluateConstantExpression(rewritten, expectedType, metadata, session, parameters);
 
         // convert to object value type of SQL type
-        BlockBuilder blockBuilder = expectedType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = expectedType.createBlockBuilder(null, 1);
         writeNativeValue(expectedType, blockBuilder, value);
         Object objectValue = expectedType.getObjectValue(session.toConnectorSession(), blockBuilder, 0);
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SessionPropertyManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SessionPropertyManager.java
@@ -18,7 +18,6 @@ import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.BigintType;
@@ -230,7 +229,7 @@ public final class SessionPropertyManager
         Object value = evaluateConstantExpression(rewritten, expectedType, metadata, session, parameters);
 
         // convert to object value type of SQL type
-        BlockBuilder blockBuilder = expectedType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = expectedType.createBlockBuilder(null, 1);
         writeNativeValue(expectedType, blockBuilder, value);
         Object objectValue = expectedType.getObjectValue(session.toConnectorSession(), blockBuilder, 0);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ChannelSet.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.google.common.annotations.VisibleForTesting;
@@ -92,7 +91,7 @@ public class ChannelSet
                     isDictionaryAggregationEnabled(operatorContext.getSession()),
                     joinCompiler,
                     this::updateMemoryReservation);
-            this.nullBlockPage = new Page(type.createBlockBuilder(new BlockBuilderStatus(), 1, UNKNOWN.getFixedSize()).appendNull().build());
+            this.nullBlockPage = new Page(type.createBlockBuilder(null, 1, UNKNOWN.getFixedSize()).appendNull().build());
             this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
             this.localMemoryContext = operatorContext.localUserMemoryContext();
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExplainAnalyzeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExplainAnalyzeOperator.java
@@ -22,7 +22,6 @@ import com.facebook.presto.execution.StageInfo;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.ImmutableList;
@@ -174,7 +173,7 @@ public class ExplainAnalyzeOperator
         }
 
         String plan = textDistributedPlan(queryInfo.getOutputStage().get().getSubStages().get(0), functionRegistry, statsCalculator, costCalculator, operatorContext.getSession(), verbose);
-        BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, 1);
         VARCHAR.writeString(builder, plan);
 
         outputConsumed = true;

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupIdOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupIdOperator.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
@@ -82,7 +81,7 @@ public class GroupIdOperator
             // it's easier to create null blocks for every output column even though we only null out some grouping column outputs
             Block[] nullBlocks = new Block[outputTypes.size()];
             for (int i = 0; i < outputTypes.size(); i++) {
-                nullBlocks[i] = outputTypes.get(i).createBlockBuilder(new BlockBuilderStatus(), 1)
+                nullBlocks[i] = outputTypes.get(i).createBlockBuilder(null, 1)
                         .appendNull()
                         .build();
             }
@@ -90,7 +89,7 @@ public class GroupIdOperator
             // create groupid blocks for every group
             Block[] groupIdBlocks = new Block[groupingSetMappings.size()];
             for (int i = 0; i < groupingSetMappings.size(); i++) {
-                BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1);
+                BlockBuilder builder = BIGINT.createBlockBuilder(null, 1);
                 BIGINT.writeLong(builder, i);
                 groupIdBlocks[i] = builder.build();
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashPartitionMaskOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashPartitionMaskOperator.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.ImmutableList;
@@ -193,10 +192,10 @@ public class HashPartitionMaskOperator
         checkState(!finishing, "Operator is finishing");
         checkState(outputPage == null, "Operator still has pending output");
 
-        BlockBuilder activePositions = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), page.getPositionCount());
+        BlockBuilder activePositions = BOOLEAN.createBlockBuilder(null, page.getPositionCount());
         BlockBuilder[] maskBuilders = new BlockBuilder[maskChannels.length];
         for (int i = 0; i < maskBuilders.length; i++) {
-            maskBuilders[i] = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), page.getPositionCount());
+            maskBuilders[i] = BOOLEAN.createBlockBuilder(null, page.getPositionCount());
         }
         for (int position = 0; position < page.getPositionCount(); position++) {
             long rawHash = hashGenerator.hashPosition(position, page);

--- a/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MarkDistinctHash.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.google.common.annotations.VisibleForTesting;
@@ -54,7 +53,7 @@ public class MarkDistinctHash
         return new TransformWork<>(
                 groupByHash.getGroupIds(page),
                 ids -> {
-                    BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), ids.getPositionCount());
+                    BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(null, ids.getPositionCount());
                     for (int i = 0; i < ids.getPositionCount(); i++) {
                         if (ids.getGroupId(i) == nextDistinctId) {
                             BOOLEAN.writeBoolean(blockBuilder, true);

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/ConstantPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/ConstantPageProjection.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -38,7 +37,7 @@ public class ConstantPageProjection
     public ConstantPageProjection(Object value, Type type)
     {
         this.type = type;
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
         writeNativeValue(type, blockBuilder, value);
         this.value = blockBuilder.build();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.relational.RowExpression;
 
@@ -44,7 +43,7 @@ public class GeneratedPageProjection
         this.isDeterministic = isDeterministic;
         this.inputChannels = requireNonNull(inputChannels, "inputChannels is null");
         this.pageProjectionWorkFactory = requireNonNull(pageProjectionWorkFactory, "pageProjectionWorkFactory is null");
-        this.blockBuilder = projection.getType().createBlockBuilder(new BlockBuilderStatus(), 1);
+        this.blockBuilder = projection.getType().createBlockBuilder(null, 1);
     }
 
     @Override
@@ -68,7 +67,7 @@ public class GeneratedPageProjection
     @Override
     public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(null);
         try {
             return (Work<Block>) pageProjectionWorkFactory.invoke(blockBuilder, session, yieldSignal, page, selectedPositions);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InterpretedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InterpretedPageProjection.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.DeterminismEvaluator;
@@ -72,7 +71,7 @@ public class InterpretedPageProjection
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypesFromInput(session, metadata, sqlParser, parameterTypes.build(), rewritten, emptyList());
         this.evaluator = ExpressionInterpreter.expressionInterpreter(rewritten, metadata, session, expressionTypes);
 
-        blockBuilder = evaluator.getType().createBlockBuilder(new BlockBuilderStatus(), 1);
+        blockBuilder = evaluator.getType().createBlockBuilder(null, 1);
     }
 
     @Override
@@ -143,7 +142,7 @@ public class InterpretedPageProjection
             }
 
             result = blockBuilder.build();
-            blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+            blockBuilder = blockBuilder.newBlockBuilderLike(null);
             return true;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatUtils.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.annotation.UsedByGeneratedCode;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 
@@ -27,7 +26,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block appendElement(Type elementType, Block block, long value)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             elementType.appendTo(block, i, blockBuilder);
         }
@@ -40,7 +39,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block appendElement(Type elementType, Block block, boolean value)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             elementType.appendTo(block, i, blockBuilder);
         }
@@ -53,7 +52,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block appendElement(Type elementType, Block block, double value)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             elementType.appendTo(block, i, blockBuilder);
         }
@@ -66,7 +65,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block appendElement(Type elementType, Block block, Slice value)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             elementType.appendTo(block, i, blockBuilder);
         }
@@ -79,7 +78,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block appendElement(Type elementType, Block block, Object value)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             elementType.appendTo(block, i, blockBuilder);
         }
@@ -93,7 +92,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block prependElement(Type elementType, Slice value, Block block)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
 
         elementType.writeSlice(blockBuilder, value);
         for (int i = 0; i < block.getPositionCount(); i++) {
@@ -106,7 +105,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block prependElement(Type elementType, Object value, Block block)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
 
         elementType.writeObject(blockBuilder, value);
         for (int i = 0; i < block.getPositionCount(); i++) {
@@ -119,7 +118,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block prependElement(Type elementType, long value, Block block)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
 
         elementType.writeLong(blockBuilder, value);
         for (int i = 0; i < block.getPositionCount(); i++) {
@@ -132,7 +131,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block prependElement(Type elementType, boolean value, Block block)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
 
         elementType.writeBoolean(blockBuilder, value);
         for (int i = 0; i < block.getPositionCount(); i++) {
@@ -145,7 +144,7 @@ public final class ArrayConcatUtils
     @UsedByGeneratedCode
     public static Block prependElement(Type elementType, double value, Block block)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, block.getPositionCount() + 1);
 
         elementType.writeDouble(blockBuilder, value);
         for (int i = 0; i < block.getPositionCount(); i++) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConstructor.java
@@ -63,7 +63,6 @@ import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantNull;
 import static io.airlift.bytecode.expression.BytecodeExpressions.equal;
-import static io.airlift.bytecode.expression.BytecodeExpressions.newInstance;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Collections.nCopies;
 
@@ -164,7 +163,7 @@ public final class ArrayConstructor
         CallSiteBinder binder = new CallSiteBinder();
 
         BytecodeExpression createBlockBuilder = blockBuilderVariable.set(
-                constantType(binder, elementType).invoke("createBlockBuilder", BlockBuilder.class, newInstance(BlockBuilderStatus.class), constantInt(stackTypes.size())));
+                constantType(binder, elementType).invoke("createBlockBuilder", BlockBuilder.class, constantNull(BlockBuilderStatus.class), constantInt(stackTypes.size())));
         body.append(createBlockBuilder);
 
         for (int i = 0; i < stackTypes.size(); i++) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayDistinctFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayDistinctFunction.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.operator.aggregation.TypedSet;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -51,7 +50,7 @@ public final class ArrayDistinctFunction
         }
 
         TypedSet typedSet = new TypedSet(type, array.getPositionCount(), "array_distinct");
-        BlockBuilder distinctElementBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), array.getPositionCount());
+        BlockBuilder distinctElementBlockBuilder = type.createBlockBuilder(null, array.getPositionCount());
         for (int i = 0; i < array.getPositionCount(); i++) {
             if (!typedSet.contains(array, i)) {
                 typedSet.add(array, i);
@@ -71,7 +70,7 @@ public final class ArrayDistinctFunction
 
         boolean containsNull = false;
         LongSet set = new LongOpenHashSet(array.getPositionCount());
-        BlockBuilder distinctElementBlockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), array.getPositionCount());
+        BlockBuilder distinctElementBlockBuilder = BIGINT.createBlockBuilder(null, array.getPositionCount());
         for (int i = 0; i < array.getPositionCount(); i++) {
             if (array.isNull(i)) {
                 if (!containsNull) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayExceptFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayExceptFunction.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.operator.aggregation.TypedSet;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -43,7 +42,7 @@ public final class ArrayExceptFunction
             return leftArray;
         }
         TypedSet typedSet = new TypedSet(type, leftPositionCount + rightPositionCount, "array_except");
-        BlockBuilder distinctElementBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), leftPositionCount);
+        BlockBuilder distinctElementBlockBuilder = type.createBlockBuilder(null, leftPositionCount);
         for (int i = 0; i < rightPositionCount; i++) {
             typedSet.add(rightArray, i);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -43,7 +42,7 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") FilterLongLambda function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
         for (int position = 0; position < positionCount; position++) {
             Long input = null;
             if (!arrayBlock.isNull(position)) {
@@ -73,7 +72,7 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") FilterDoubleLambda function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
         for (int position = 0; position < positionCount; position++) {
             Double input = null;
             if (!arrayBlock.isNull(position)) {
@@ -103,7 +102,7 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") FilterBooleanLambda function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
         for (int position = 0; position < positionCount; position++) {
             Boolean input = null;
             if (!arrayBlock.isNull(position)) {
@@ -133,7 +132,7 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") FilterSliceLambda function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
         for (int position = 0; position < positionCount; position++) {
             Slice input = null;
             if (!arrayBlock.isNull(position)) {
@@ -163,7 +162,7 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") FilterBlockLambda function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
         for (int position = 0; position < positionCount; position++) {
             Block input = null;
             if (!arrayBlock.isNull(position)) {
@@ -193,7 +192,7 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") FilterVoidLambda function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
         for (int position = 0; position < positionCount; position++) {
             Boolean keep;
             try {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFlattenFunction.java
@@ -20,7 +20,6 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -88,10 +87,10 @@ public class ArrayFlattenFunction
     public static Block flatten(Type type, Type arrayType, Block array)
     {
         if (array.getPositionCount() == 0) {
-            return type.createBlockBuilder(new BlockBuilderStatus(), 0).build();
+            return type.createBlockBuilder(null, 0).build();
         }
 
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), array.getPositionCount(), toIntExact(array.getSizeInBytes() / array.getPositionCount()));
+        BlockBuilder builder = type.createBlockBuilder(null, array.getPositionCount(), toIntExact(array.getSizeInBytes() / array.getPositionCount()));
         for (int i = 0; i < array.getPositionCount(); i++) {
             if (!array.isNull(i)) {
                 Block subArray = (Block) arrayType.getObject(array, i);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFunctions.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.ArrayType;
@@ -32,7 +31,7 @@ public final class ArrayFunctions
     @SqlType("array(unknown)")
     public static Block arrayConstructor()
     {
-        BlockBuilder blockBuilder = new ArrayType(UNKNOWN).createBlockBuilder(new BlockBuilderStatus(), 0);
+        BlockBuilder blockBuilder = new ArrayType(UNKNOWN).createBlockBuilder(null, 0);
         return blockBuilder.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySliceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySliceFunction.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -54,7 +53,7 @@ public final class ArraySliceFunction
         long toIndex = Math.min(fromIndex + length, size + 1);
 
         if (fromIndex >= toIndex || fromIndex < 1) {
-            return type.createBlockBuilder(new BlockBuilderStatus(), 0).build();
+            return type.createBlockBuilder(null, 0).build();
         }
 
         return array.getRegion((int) (fromIndex - 1), (int) (toIndex - fromIndex));

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayUnionFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayUnionFunction.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.operator.aggregation.TypedSet;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -45,7 +44,7 @@ public final class ArrayUnionFunction
         int leftArrayCount = leftArray.getPositionCount();
         int rightArrayCount = rightArray.getPositionCount();
         TypedSet typedSet = new TypedSet(type, leftArrayCount + rightArrayCount, "array_union");
-        BlockBuilder distinctElementBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), leftArrayCount + rightArrayCount);
+        BlockBuilder distinctElementBlockBuilder = type.createBlockBuilder(null, leftArrayCount + rightArrayCount);
         appendTypedArray(leftArray, type, typedSet, distinctElementBlockBuilder);
         appendTypedArray(rightArray, type, typedSet, distinctElementBlockBuilder);
 
@@ -68,7 +67,7 @@ public final class ArrayUnionFunction
         int leftArrayCount = leftArray.getPositionCount();
         int rightArrayCount = rightArray.getPositionCount();
         LongSet set = new LongOpenHashSet(leftArrayCount + rightArrayCount);
-        BlockBuilder distinctElementBlockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), leftArrayCount + rightArrayCount);
+        BlockBuilder distinctElementBlockBuilder = BIGINT.createBlockBuilder(null, leftArrayCount + rightArrayCount);
         AtomicBoolean containsNull = new AtomicBoolean(false);
         appendBigintArray(leftArray, containsNull, set, distinctElementBlockBuilder);
         appendBigintArray(rightArray, containsNull, set, distinctElementBlockBuilder);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/EmptyMapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/EmptyMapConstructor.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -29,7 +28,7 @@ public final class EmptyMapConstructor
 
     public EmptyMapConstructor(@TypeParameter("map(unknown,unknown)") Type mapType)
     {
-        BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, 1);
         mapBlockBuilder.beginBlockEntry();
         mapBlockBuilder.closeEntry();
         emptyMap = ((MapType) mapType).getObject(mapBlockBuilder.build(), 0);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpFunctions.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarFunction;
@@ -203,7 +202,7 @@ public final class JoniRegexpFunctions
     {
         Matcher matcher = pattern.matcher(source.getBytes());
         validateGroup(groupIndex, matcher.getEagerRegion());
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 32);
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 32);
         int group = toIntExact(groupIndex);
 
         int nextStart = 0;
@@ -276,7 +275,7 @@ public final class JoniRegexpFunctions
     public static Block regexpSplit(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) Regex pattern)
     {
         Matcher matcher = pattern.matcher(source.getBytes());
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 32);
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 32);
 
         int lastEnd = 0;
         int nextStart = 0;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToArrayCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToArrayCast.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.StandardTypes;
@@ -96,7 +95,7 @@ public class JsonToArrayCast
             if (jsonParser.getCurrentToken() != START_ARRAY) {
                 throw new JsonCastException(format("Expected a json array, but got %s", jsonParser.getText()));
             }
-            BlockBuilder blockBuilder = arrayType.getElementType().createBlockBuilder(new BlockBuilderStatus(), 20);
+            BlockBuilder blockBuilder = arrayType.getElementType().createBlockBuilder(null, 20);
             while (jsonParser.nextToken() != JsonToken.END_ARRAY) {
                 elementAppender.append(jsonParser, blockBuilder);
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToMapCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToMapCast.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.StandardTypes;
@@ -101,7 +100,7 @@ public class JsonToMapCast
             if (jsonParser.getCurrentToken() != START_OBJECT) {
                 throw new JsonCastException(format("Expected a json object, but got %s", jsonParser.getText()));
             }
-            BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+            BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, 1);
             BlockBuilder singleMapBlockBuilder = mapBlockBuilder.beginBlockEntry();
             HashTable hashTable = new HashTable(mapType.getKeyType(), singleMapBlockBuilder);
             int position = 0;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToRowCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonToRowCast.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.SingleRowBlockWriter;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.RowType;
@@ -111,7 +110,7 @@ public class JsonToRowCast
                 throw new JsonCastException(format("Expected a json array or object, but got %s", jsonParser.getText()));
             }
 
-            BlockBuilder rowBlockBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), 1);
+            BlockBuilder rowBlockBuilder = rowType.createBlockBuilder(null, 1);
             parseJsonToSingleRowBlock(
                     jsonParser,
                     (SingleRowBlockWriter) rowBlockBuilder.beginBlockEntry(),

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapKeys.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapKeys.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -35,7 +34,7 @@ public final class MapKeys
             @TypeParameter("K") Type keyType,
             @SqlType("map(K,V)") Block block)
     {
-        BlockBuilder blockBuilder = keyType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() / 2);
+        BlockBuilder blockBuilder = keyType.createBlockBuilder(null, block.getPositionCount() / 2);
         for (int i = 0; i < block.getPositionCount(); i += 2) {
             keyType.appendTo(block, i, blockBuilder);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToMapCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToMapCast.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
@@ -61,7 +60,7 @@ public final class MapToMapCast
         boolean valueCastRequiresSession = valueCastFunction.type().parameterArray()[0] == ConnectorSession.class;
 
         TypedSet typedSet = new TypedSet(toKeyType, fromMap.getPositionCount() / 2, "map-to-map cast");
-        BlockBuilder keyBlockBuilder = toKeyType.createBlockBuilder(new BlockBuilderStatus(), fromMap.getPositionCount() / 2);
+        BlockBuilder keyBlockBuilder = toKeyType.createBlockBuilder(null, fromMap.getPositionCount() / 2);
         for (int i = 0; i < fromMap.getPositionCount(); i += 2) {
             Object fromKey = readNativeValue(fromKeyType, fromMap, i);
             try {
@@ -85,7 +84,7 @@ public final class MapToMapCast
         }
         Block keyBlock = keyBlockBuilder.build();
 
-        BlockBuilder mapBlockBuilder = toMapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder mapBlockBuilder = toMapType.createBlockBuilder(null, 1);
         BlockBuilder blockBuilder = mapBlockBuilder.beginBlockEntry();
         for (int i = 0; i < fromMap.getPositionCount(); i += 2) {
             if (!typedSet.contains(keyBlock, i / 2)) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapValues.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapValues.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -35,7 +34,7 @@ public final class MapValues
             @TypeParameter("V") Type valueType,
             @SqlType("map(K,V)") Block block)
     {
-        BlockBuilder blockBuilder = valueType.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() / 2);
+        BlockBuilder blockBuilder = valueType.createBlockBuilder(null, block.getPositionCount() / 2);
         for (int i = 0; i < block.getPositionCount(); i += 2) {
             valueType.appendTo(block, i + 1, blockBuilder);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RepeatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RepeatFunction.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlNullable;
@@ -146,7 +145,7 @@ public final class RepeatFunction
     {
         checkCondition(count <= MAX_RESULT_ENTRIES, INVALID_FUNCTION_ARGUMENT, "count argument of repeat function must be less than or equal to 10000");
         checkCondition(count >= 0, INVALID_FUNCTION_ARGUMENT, "count argument of repeat function must be greater than or equal to 0");
-        return type.createBlockBuilder(new BlockBuilderStatus(), toIntExact(count));
+        return type.createBlockBuilder(null, toIntExact(count));
     }
 
     private static Block repeatNullValues(BlockBuilder blockBuilder, long count)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowEqualOperator.java
@@ -18,7 +18,6 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.SqlOperator;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -64,8 +63,8 @@ public class RowEqualOperator
     public static boolean equals(Type rowType, Block leftRow, Block rightRow)
     {
         // TODO: Fix this. It feels very inefficient and unnecessary to wrap and unwrap with Block
-        BlockBuilder leftBlockBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), 1);
-        BlockBuilder rightBlockBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder leftBlockBuilder = rowType.createBlockBuilder(null, 1);
+        BlockBuilder rightBlockBuilder = rowType.createBlockBuilder(null, 1);
         rowType.writeObject(leftBlockBuilder, leftRow);
         rowType.writeObject(rightBlockBuilder, rightRow);
         return rowType.equalTo(leftBlockBuilder.build(), 0, rightBlockBuilder.build(), 0);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowHashCodeOperator.java
@@ -19,7 +19,6 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.SqlOperator;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -63,7 +62,7 @@ public class RowHashCodeOperator
     @UsedByGeneratedCode
     public static long hash(Type rowType, Block block)
     {
-        BlockBuilder blockBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = rowType.createBlockBuilder(null, 1);
         blockBuilder.writeObject(block).closeEntry();
         return rowType.hash(blockBuilder.build(), 0);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
@@ -64,7 +64,7 @@ import static io.airlift.bytecode.Parameter.arg;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantBoolean;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
-import static io.airlift.bytecode.expression.BytecodeExpressions.newInstance;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantNull;
 
 public class RowToRowCast
         extends SqlOperator
@@ -136,7 +136,7 @@ public class RowToRowCast
                 constantType(binder, toType).invoke(
                         "createBlockBuilder",
                         BlockBuilder.class,
-                        newInstance(BlockBuilderStatus.class),
+                        constantNull(BlockBuilderStatus.class),
                         constantInt(1))));
         body.append(singleRowBlockWriter.set(blockBuilder.invoke("beginBlockEntry", BlockBuilder.class)));
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/SequenceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/SequenceFunction.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -100,7 +99,7 @@ public final class SequenceFunction
         int length = toIntExact(diffDate(session, MONTH, start, stop) / step + 1);
         checkMaxEntry(length);
 
-        BlockBuilder blockBuilder = DATE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DATE.createBlockBuilder(null, length);
 
         int value = 0;
         for (int i = 0; i < length; ++i) {
@@ -134,7 +133,7 @@ public final class SequenceFunction
         int length = toIntExact(diffTimestamp(session, MONTH, start, stop) / step + 1);
         checkMaxEntry(length);
 
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
 
         int value = 0;
         for (int i = 0; i < length; ++i) {
@@ -152,7 +151,7 @@ public final class SequenceFunction
         int length = toIntExact((stop - start) / step + 1L);
         checkMaxEntry(length);
 
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, length);
         for (long i = 0, value = start; i < length; ++i, value += step) {
             type.writeLong(blockBuilder, value);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.OperatorType;
@@ -328,7 +327,7 @@ public final class StringFunctions
         checkCondition(limit > 0, INVALID_FUNCTION_ARGUMENT, "Limit must be positive");
         checkCondition(limit <= Integer.MAX_VALUE, INVALID_FUNCTION_ARGUMENT, "Limit is too large");
         checkCondition(delimiter.length() > 0, INVALID_FUNCTION_ARGUMENT, "The delimiter may not be the empty string");
-        BlockBuilder parts = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1, string.length());
+        BlockBuilder parts = VARCHAR.createBlockBuilder(null, 1, string.length());
         // If limit is one, the last and only element is the complete string
         if (limit == 1) {
             VARCHAR.writeSlice(parts, string);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipFunction.java
@@ -22,7 +22,6 @@ import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -114,7 +113,7 @@ public final class ZipFunction
             biggestCardinality = Math.max(biggestCardinality, array.getPositionCount());
         }
         RowType rowType = new RowType(types, Optional.empty());
-        BlockBuilder outputBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), biggestCardinality);
+        BlockBuilder outputBuilder = rowType.createBlockBuilder(null, biggestCardinality);
         for (int outputPosition = 0; outputPosition < biggestCardinality; outputPosition++) {
             BlockBuilder rowBuilder = outputBuilder.beginBlockEntry();
             for (int fieldIndex = 0; fieldIndex < arrays.length; fieldIndex++) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ArrayMapBytecodeExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ArrayMapBytecodeExpression.java
@@ -35,8 +35,8 @@ import java.util.function.Function;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantNull;
 import static io.airlift.bytecode.expression.BytecodeExpressions.lessThan;
-import static io.airlift.bytecode.expression.BytecodeExpressions.newInstance;
 import static io.airlift.bytecode.instruction.VariableInstruction.incrementVariable;
 
 public class ArrayMapBytecodeExpression
@@ -60,7 +60,7 @@ public class ArrayMapBytecodeExpression
         body = new BytecodeBlock();
 
         Variable blockBuilder = scope.declareVariable(BlockBuilder.class, "blockBuilder_" + NEXT_VARIABLE_ID.getAndIncrement());
-        body.append(blockBuilder.set(constantType(binder, toType).invoke("createBlockBuilder", BlockBuilder.class, newInstance(BlockBuilderStatus.class), array.invoke("getPositionCount", int.class))));
+        body.append(blockBuilder.set(constantType(binder, toType).invoke("createBlockBuilder", BlockBuilder.class, constantNull(BlockBuilderStatus.class), array.invoke("getPositionCount", int.class))));
 
         // get element, apply function, and write new element to block builder
         Variable position = scope.declareVariable(int.class, "position_" + NEXT_VARIABLE_ID.getAndIncrement());

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/RowConstructorCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/RowConstructorCodeGenerator.java
@@ -30,7 +30,7 @@ import java.util.List;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
-import static io.airlift.bytecode.expression.BytecodeExpressions.newInstance;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantNull;
 
 public class RowConstructorCodeGenerator
         implements BytecodeGenerator
@@ -50,7 +50,7 @@ public class RowConstructorCodeGenerator
                 constantType(binder, rowType).invoke(
                         "createBlockBuilder",
                         BlockBuilder.class,
-                        newInstance(BlockBuilderStatus.class),
+                        constantNull(BlockBuilderStatus.class),
                         constantInt(1))));
         block.append(singleRowBlockWriter.set(blockBuilder.invoke("beginBlockEntry", BlockBuilder.class)));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RowBlockBuilder;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.ArrayType;
@@ -1165,7 +1164,7 @@ public class ExpressionInterpreter
         protected Object visitArrayConstructor(ArrayConstructor node, Object context)
         {
             Type elementType = ((ArrayType) type(node)).getElementType();
-            BlockBuilder arrayBlockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), node.getValues().size());
+            BlockBuilder arrayBlockBuilder = elementType.createBlockBuilder(null, node.getValues().size());
 
             for (Expression expression : node.getValues()) {
                 Object value = process(expression, context);
@@ -1194,7 +1193,7 @@ public class ExpressionInterpreter
                 return new Row(toExpressions(values, parameterTypes));
             }
             else {
-                BlockBuilder blockBuilder = new RowBlockBuilder(parameterTypes, new BlockBuilderStatus(), 1);
+                BlockBuilder blockBuilder = new RowBlockBuilder(parameterTypes, null, 1);
                 BlockBuilder singleRowBlockWriter = blockBuilder.beginBlockEntry();
                 for (int i = 0; i < cardinality; ++i) {
                     writeNativeValue(parameterTypes.get(i), singleRowBlockWriter, values.get(i));

--- a/presto-main/src/main/java/com/facebook/presto/type/Re2JRegexp.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/Re2JRegexp.java
@@ -16,7 +16,6 @@ package com.facebook.presto.type;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.google.re2j.Matcher;
 import com.google.re2j.Options;
 import com.google.re2j.Pattern;
@@ -94,7 +93,7 @@ public final class Re2JRegexp
         int group = toIntExact(groupIndex);
         validateGroup(group, matcher.groupCount());
 
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 32);
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 32);
         while (true) {
             if (!matcher.find()) {
                 break;
@@ -126,7 +125,7 @@ public final class Re2JRegexp
     public Block split(Slice source)
     {
         Matcher matcher = re2jPattern.matcher(source);
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 32);
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 32);
 
         int lastEnd = 0;
         while (matcher.find()) {

--- a/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigestFunctions.java
@@ -16,7 +16,6 @@ package com.facebook.presto.type.setdigest;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
@@ -91,7 +90,7 @@ public final class SetDigestFunctions
         SetDigest digest = SetDigest.newInstance(slice);
 
         // Maybe use static BlockBuilderStatus in order avoid `new`?
-        BlockBuilder blockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 1);
         BlockBuilder singleMapBlockBuilder = blockBuilder.beginBlockEntry();
         for (Map.Entry<Long, Short> entry : digest.getHashCounts().entrySet()) {
             BIGINT.writeLong(singleMapBlockBuilder, entry.getKey());

--- a/presto-main/src/test/java/com/facebook/presto/RowPageBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/RowPageBuilder.java
@@ -16,7 +16,6 @@ package com.facebook.presto;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 
@@ -48,7 +47,7 @@ public class RowPageBuilder
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         ImmutableList.Builder<BlockBuilder> builders = ImmutableList.builder();
         for (Type type : types) {
-            builders.add(type.createBlockBuilder(new BlockBuilderStatus(), 1));
+            builders.add(type.createBlockBuilder(null, 1));
         }
         this.builders = builders.build();
         checkArgument(!this.builders.isEmpty(), "At least one value info is required");

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -88,7 +88,9 @@ public abstract class AbstractTestBlock
                     retainedSize += ((Slice) field.get(block)).getRetainedSize();
                 }
                 else if (type == BlockBuilderStatus.class) {
-                    retainedSize += BlockBuilderStatus.INSTANCE_SIZE;
+                    if (field.get(block) != null) {
+                        retainedSize += BlockBuilderStatus.INSTANCE_SIZE;
+                    }
                 }
                 else if (type == BlockBuilder.class || type == Block.class) {
                     retainedSize += ((Block) field.get(block)).getRetainedSizeInBytes();
@@ -301,7 +303,7 @@ public abstract class AbstractTestBlock
             assertTrue(block.equals(position, offset, expectedBlock, 0, offset, 3));
             assertEquals(block.compareTo(position, offset, 3, expectedBlock, 0, offset, 3), 0);
 
-            BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1);
+            BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(null, 1);
             block.writeBytesTo(position, offset, 3, blockBuilder);
             blockBuilder.closeEntry();
             Block segment = blockBuilder.build();
@@ -345,7 +347,7 @@ public abstract class AbstractTestBlock
 
     private static Block toSingeValuedBlock(Slice expectedValue)
     {
-        BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1, expectedValue.length());
+        BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(null, 1, expectedValue.length());
         VARBINARY.writeSlice(blockBuilder, expectedValue);
         return blockBuilder.build();
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -15,7 +15,6 @@ package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.ArrayType;
@@ -98,7 +97,7 @@ public final class BlockAssertions
 
     public static Block createStringsBlock(Iterable<String> values)
     {
-        BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, 100);
 
         for (String value : values) {
             if (value == null) {
@@ -120,7 +119,7 @@ public final class BlockAssertions
 
     public static Block createSlicesBlock(Iterable<Slice> values)
     {
-        BlockBuilder builder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = VARBINARY.createBlockBuilder(null, 100);
 
         for (Slice value : values) {
             if (value == null) {
@@ -136,7 +135,7 @@ public final class BlockAssertions
 
     public static Block createStringSequenceBlock(int start, int end)
     {
-        BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, 100);
 
         for (int i = start; i < end; i++) {
             VARCHAR.writeString(builder, String.valueOf(i));
@@ -150,7 +149,7 @@ public final class BlockAssertions
         checkArgument(length > 5, "block must have more than 5 entries");
 
         int dictionarySize = length / 5;
-        BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), dictionarySize);
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, dictionarySize);
         for (int i = start; i < start + dictionarySize; i++) {
             VARCHAR.writeString(builder, String.valueOf(i));
         }
@@ -164,7 +163,7 @@ public final class BlockAssertions
     public static Block createStringArraysBlock(Iterable<? extends Iterable<String>> values)
     {
         ArrayType arrayType = new ArrayType(VARCHAR);
-        BlockBuilder builder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = arrayType.createBlockBuilder(null, 100);
 
         for (Iterable<String> value : values) {
             if (value == null) {
@@ -192,7 +191,7 @@ public final class BlockAssertions
 
     public static Block createBooleansBlock(Iterable<Boolean> values)
     {
-        BlockBuilder builder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = BOOLEAN.createBlockBuilder(null, 100);
 
         for (Boolean value : values) {
             if (value == null) {
@@ -216,7 +215,7 @@ public final class BlockAssertions
     public static Block createShortDecimalsBlock(Iterable<String> values)
     {
         DecimalType shortDecimalType = DecimalType.createDecimalType(1);
-        BlockBuilder builder = shortDecimalType.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = shortDecimalType.createBlockBuilder(null, 100);
 
         for (String value : values) {
             if (value == null) {
@@ -240,7 +239,7 @@ public final class BlockAssertions
     public static Block createLongDecimalsBlock(Iterable<String> values)
     {
         DecimalType longDecimalType = DecimalType.createDecimalType(MAX_SHORT_PRECISION + 1);
-        BlockBuilder builder = longDecimalType.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = longDecimalType.createBlockBuilder(null, 100);
 
         for (String value : values) {
             if (value == null) {
@@ -263,7 +262,7 @@ public final class BlockAssertions
 
     public static Block createIntsBlock(Iterable<Integer> values)
     {
-        BlockBuilder builder = INTEGER.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = INTEGER.createBlockBuilder(null, 100);
 
         for (Integer value : values) {
             if (value == null) {
@@ -285,7 +284,7 @@ public final class BlockAssertions
     // This method makes it easy to create blocks without having to add an L to every value
     public static Block createLongsBlock(int... values)
     {
-        BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = BIGINT.createBlockBuilder(null, 100);
 
         for (int value : values) {
             BIGINT.writeLong(builder, (long) value);
@@ -308,7 +307,7 @@ public final class BlockAssertions
 
     public static Block createTypedLongsBlock(Type type, Iterable<Long> values)
     {
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = type.createBlockBuilder(null, 100);
 
         for (Long value : values) {
             if (value == null) {
@@ -338,7 +337,7 @@ public final class BlockAssertions
         checkArgument(length > 5, "block must have more than 5 entries");
 
         int dictionarySize = length / 5;
-        BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), dictionarySize);
+        BlockBuilder builder = BIGINT.createBlockBuilder(null, dictionarySize);
         for (int i = start; i < start + dictionarySize; i++) {
             BIGINT.writeLong(builder, i);
         }
@@ -387,7 +386,7 @@ public final class BlockAssertions
 
     private static Block createBlockOfReals(Iterable<Float> values)
     {
-        BlockBuilder builder = REAL.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = REAL.createBlockBuilder(null, 100);
         for (Float value : values) {
             if (value == null) {
                 builder.appendNull();
@@ -419,7 +418,7 @@ public final class BlockAssertions
 
     public static Block createDoublesBlock(Iterable<Double> values)
     {
-        BlockBuilder builder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = DOUBLE.createBlockBuilder(null, 100);
 
         for (Double value : values) {
             if (value == null) {
@@ -447,7 +446,7 @@ public final class BlockAssertions
     public static Block createArrayBigintBlock(Iterable<? extends Iterable<Long>> values)
     {
         ArrayType arrayType = new ArrayType(BIGINT);
-        BlockBuilder builder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = arrayType.createBlockBuilder(null, 100);
 
         for (Iterable<Long> value : values) {
             if (value == null) {
@@ -509,14 +508,14 @@ public final class BlockAssertions
 
     public static RunLengthEncodedBlock createRLEBlock(double value, int positionCount)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, 1);
         DOUBLE.writeDouble(blockBuilder, value);
         return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
     }
 
     public static RunLengthEncodedBlock createRLEBlock(long value, int positionCount)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, 1);
         BIGINT.writeLong(blockBuilder, value);
         return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
@@ -15,7 +15,6 @@ package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.ArrayBlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
@@ -112,9 +111,9 @@ public class TestArrayBlock
         for (int i = 0; i < ARRAY_SIZES.length; i++) {
             expectedValues[i] = rand.longs(ARRAY_SIZES[i]).toArray();
         }
-        BlockBuilder emptyBlockBuilder = new ArrayBlockBuilder(BIGINT, new BlockBuilderStatus(), 0, 0);
+        BlockBuilder emptyBlockBuilder = new ArrayBlockBuilder(BIGINT, null, 0, 0);
 
-        BlockBuilder blockBuilder = new ArrayBlockBuilder(BIGINT, new BlockBuilderStatus(), 100, 100);
+        BlockBuilder blockBuilder = new ArrayBlockBuilder(BIGINT, null, 100, 100);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
 
@@ -122,26 +121,26 @@ public class TestArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(null);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
 
     private static BlockBuilder createBlockBuilderWithValues(long[][][] expectedValues)
     {
-        BlockBuilder blockBuilder = new ArrayBlockBuilder(new ArrayBlockBuilder(BIGINT, new BlockBuilderStatus(), 100, 100), new BlockBuilderStatus(), 100);
+        BlockBuilder blockBuilder = new ArrayBlockBuilder(new ArrayBlockBuilder(BIGINT, null, 100, 100), null, 100);
         for (long[][] expectedValue : expectedValues) {
             if (expectedValue == null) {
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder intermediateBlockBuilder = new ArrayBlockBuilder(BIGINT, new BlockBuilderStatus(), 100, 100);
+                BlockBuilder intermediateBlockBuilder = new ArrayBlockBuilder(BIGINT, null, 100, 100);
                 for (int j = 0; j < expectedValue.length; j++) {
                     if (expectedValue[j] == null) {
                         intermediateBlockBuilder.appendNull();
                     }
                     else {
-                        BlockBuilder innerMostBlockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), expectedValue.length);
+                        BlockBuilder innerMostBlockBuilder = BIGINT.createBlockBuilder(null, expectedValue.length);
                         for (long v : expectedValue[j]) {
                             BIGINT.writeLong(innerMostBlockBuilder, v);
                         }
@@ -156,7 +155,7 @@ public class TestArrayBlock
 
     private static BlockBuilder createBlockBuilderWithValues(long[][] expectedValues)
     {
-        BlockBuilder blockBuilder = new ArrayBlockBuilder(BIGINT, new BlockBuilderStatus(), 100, 100);
+        BlockBuilder blockBuilder = new ArrayBlockBuilder(BIGINT, null, 100, 100);
         return writeValues(expectedValues, blockBuilder);
     }
 
@@ -167,7 +166,7 @@ public class TestArrayBlock
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder elementBlockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), expectedValue.length);
+                BlockBuilder elementBlockBuilder = BIGINT.createBlockBuilder(null, expectedValue.length);
                 for (long v : expectedValue) {
                     BIGINT.writeLong(elementBlockBuilder, v);
                 }
@@ -179,13 +178,13 @@ public class TestArrayBlock
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[][] expectedValues)
     {
-        BlockBuilder blockBuilder = new ArrayBlockBuilder(VARCHAR, new BlockBuilderStatus(), 100, 100);
+        BlockBuilder blockBuilder = new ArrayBlockBuilder(VARCHAR, null, 100, 100);
         for (Slice[] expectedValue : expectedValues) {
             if (expectedValue == null) {
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), expectedValue.length);
+                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(null, expectedValue.length);
                 for (Slice v : expectedValue) {
                     VARCHAR.writeSlice(elementBlockBuilder, v);
                 }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestBlockBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestBlockBuilder.java
@@ -16,7 +16,6 @@ package com.facebook.presto.block;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -39,7 +38,7 @@ public class TestBlockBuilder
     @Test
     public void testMultipleValuesWithNull()
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 10);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, 10);
         blockBuilder.appendNull();
         BIGINT.writeLong(blockBuilder, 42);
         blockBuilder.appendNull();
@@ -67,8 +66,8 @@ public class TestBlockBuilder
             BIGINT.writeLong(bigintBlockBuilder, i);
             VARCHAR.writeSlice(varcharBlockBuilder, Slices.utf8Slice("test" + i));
             Block longArrayBlock = new ArrayType(BIGINT)
-                    .createBlockBuilder(new BlockBuilderStatus(), 1)
-                    .writeObject(BIGINT.createBlockBuilder(new BlockBuilderStatus(), 2).writeLong(i).closeEntry().writeLong(i * 2).closeEntry().build())
+                    .createBlockBuilder(null, 1)
+                    .writeObject(BIGINT.createBlockBuilder(null, 2).writeLong(i).closeEntry().writeLong(i * 2).closeEntry().build())
                     .closeEntry();
             arrayBlockBuilder.writeObject(longArrayBlock).closeEntry();
             pageBuilder.declarePosition();

--- a/presto-main/src/test/java/com/facebook/presto/block/TestByteArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestByteArrayBlock.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.ByteArrayBlockBuilder;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -46,9 +45,9 @@ public class TestByteArrayBlock
     public void testLazyBlockBuilderInitialization()
     {
         Slice[] expectedValues = createTestValue(100);
-        BlockBuilder emptyBlockBuilder = new ByteArrayBlockBuilder(new BlockBuilderStatus(), 0);
+        BlockBuilder emptyBlockBuilder = new ByteArrayBlockBuilder(null, 0);
 
-        BlockBuilder blockBuilder = new ByteArrayBlockBuilder(new BlockBuilderStatus(), expectedValues.length);
+        BlockBuilder blockBuilder = new ByteArrayBlockBuilder(null, expectedValues.length);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
 
@@ -56,7 +55,7 @@ public class TestByteArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(null);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
@@ -70,7 +69,7 @@ public class TestByteArrayBlock
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)
     {
-        ByteArrayBlockBuilder blockBuilder = new ByteArrayBlockBuilder(new BlockBuilderStatus(), expectedValues.length);
+        ByteArrayBlockBuilder blockBuilder = new ByteArrayBlockBuilder(null, expectedValues.length);
         writeValues(expectedValues, blockBuilder);
         return blockBuilder;
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestFixedWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestFixedWidthBlock.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
@@ -50,9 +49,9 @@ public class TestFixedWidthBlock
     {
         for (int fixedSize = 0; fixedSize < 20; fixedSize++) {
             Slice[] expectedValues = (Slice[]) alternatingNullValues(createExpectedValues(17, fixedSize));
-            BlockBuilder emptyBlockBuilder = new FixedWidthBlockBuilder(fixedSize, new BlockBuilderStatus(), 0);
+            BlockBuilder emptyBlockBuilder = new FixedWidthBlockBuilder(fixedSize, null, 0);
 
-            BlockBuilder blockBuilder = new FixedWidthBlockBuilder(fixedSize, new BlockBuilderStatus(), expectedValues.length);
+            BlockBuilder blockBuilder = new FixedWidthBlockBuilder(fixedSize, null, expectedValues.length);
             assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
             assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
 
@@ -60,7 +59,7 @@ public class TestFixedWidthBlock
             assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
             assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-            blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+            blockBuilder = blockBuilder.newBlockBuilderLike(null);
             assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
             assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
         }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestIntArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestIntArrayBlock.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.IntArrayBlockBuilder;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
@@ -46,9 +45,9 @@ public class TestIntArrayBlock
     public void testLazyBlockBuilderInitialization()
     {
         Slice[] expectedValues = createTestValue(100);
-        BlockBuilder emptyBlockBuilder = new IntArrayBlockBuilder(new BlockBuilderStatus(), 0);
+        BlockBuilder emptyBlockBuilder = new IntArrayBlockBuilder(null, 0);
 
-        BlockBuilder blockBuilder = new IntArrayBlockBuilder(new BlockBuilderStatus(), expectedValues.length);
+        BlockBuilder blockBuilder = new IntArrayBlockBuilder(null, expectedValues.length);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
 
@@ -56,7 +55,7 @@ public class TestIntArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(null);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
@@ -70,7 +69,7 @@ public class TestIntArrayBlock
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)
     {
-        IntArrayBlockBuilder blockBuilder = new IntArrayBlockBuilder(new BlockBuilderStatus(), expectedValues.length);
+        IntArrayBlockBuilder blockBuilder = new IntArrayBlockBuilder(null, expectedValues.length);
         writeValues(expectedValues, blockBuilder);
         return blockBuilder;
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LongArrayBlockBuilder;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import io.airlift.slice.Slice;
@@ -47,9 +46,9 @@ public class TestLongArrayBlock
     public void testLazyBlockBuilderInitialization()
     {
         Slice[] expectedValues = createTestValue(100);
-        BlockBuilder emptyBlockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 0, 0);
+        BlockBuilder emptyBlockBuilder = new VariableWidthBlockBuilder(null, 0, 0);
 
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), expectedValues.length, 32 * expectedValues.length);
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, expectedValues.length, 32 * expectedValues.length);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
 
@@ -57,7 +56,7 @@ public class TestLongArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(null);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
@@ -71,7 +70,7 @@ public class TestLongArrayBlock
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)
     {
-        LongArrayBlockBuilder blockBuilder = new LongArrayBlockBuilder(new BlockBuilderStatus(), expectedValues.length);
+        LongArrayBlockBuilder blockBuilder = new LongArrayBlockBuilder(null, expectedValues.length);
         writeValues(expectedValues, blockBuilder);
         return blockBuilder;
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
@@ -16,7 +16,6 @@ package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.SingleMapBlock;
 import com.facebook.presto.spi.type.MapType;
 import org.testng.annotations.Test;
@@ -98,7 +97,7 @@ public class TestMapBlock
     private BlockBuilder createBlockBuilderWithValues(Map<String, Long>[] maps)
     {
         MapType mapType = mapType(VARCHAR, BIGINT);
-        BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, 1);
         for (Map<String, Long> map : maps) {
             createBlockBuilderWithValues(map, mapBlockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
@@ -16,7 +16,6 @@ package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RowBlockBuilder;
 import com.facebook.presto.spi.block.SingleRowBlock;
 import com.facebook.presto.spi.type.Type;
@@ -64,7 +63,7 @@ public class TestRowBlock
 
     private BlockBuilder createBlockBuilderWithValues(List<Type> fieldTypes, List<Object>[] rows)
     {
-        BlockBuilder rowBlockBuilder = new RowBlockBuilder(fieldTypes, new BlockBuilderStatus(), 1);
+        BlockBuilder rowBlockBuilder = new RowBlockBuilder(fieldTypes, null, 1);
         for (List<Object> row : rows) {
             if (row == null) {
                 rowBlockBuilder.appendNull();

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
@@ -15,7 +15,6 @@ package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import io.airlift.slice.Slice;
@@ -45,7 +44,7 @@ public class TestRunLengthEncodedBlock
 
     private static Block createSingleValueBlock(Slice expectedValue)
     {
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 1, expectedValue.length());
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, 1, expectedValue.length());
         blockBuilder.writeBytes(expectedValue, 0, expectedValue.length()).closeEntry();
         return blockBuilder.build();
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestShortArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestShortArrayBlock.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.ShortArrayBlockBuilder;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
@@ -46,9 +45,9 @@ public class TestShortArrayBlock
     public void testLazyBlockBuilderInitialization()
     {
         Slice[] expectedValues = createTestValue(100);
-        BlockBuilder emptyBlockBuilder = new ShortArrayBlockBuilder(new BlockBuilderStatus(), 0);
+        BlockBuilder emptyBlockBuilder = new ShortArrayBlockBuilder(null, 0);
 
-        BlockBuilder blockBuilder = new ShortArrayBlockBuilder(new BlockBuilderStatus(), expectedValues.length);
+        BlockBuilder blockBuilder = new ShortArrayBlockBuilder(null, expectedValues.length);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
 
@@ -56,7 +55,7 @@ public class TestShortArrayBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(null);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
@@ -70,7 +69,7 @@ public class TestShortArrayBlock
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)
     {
-        ShortArrayBlockBuilder blockBuilder = new ShortArrayBlockBuilder(new BlockBuilderStatus(), expectedValues.length);
+        ShortArrayBlockBuilder blockBuilder = new ShortArrayBlockBuilder(null, expectedValues.length);
         writeValues(expectedValues, blockBuilder);
         return blockBuilder;
     }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
@@ -15,7 +15,6 @@ package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.VarcharType;
 import io.airlift.slice.Slice;
@@ -64,9 +63,9 @@ public class TestVariableWidthBlock
     public void testLazyBlockBuilderInitialization()
     {
         Slice[] expectedValues = createExpectedValues(100);
-        BlockBuilder emptyBlockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 0, 0);
+        BlockBuilder emptyBlockBuilder = new VariableWidthBlockBuilder(null, 0, 0);
 
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), expectedValues.length, 32 * expectedValues.length);
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, expectedValues.length, 32 * expectedValues.length);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
 
@@ -74,7 +73,7 @@ public class TestVariableWidthBlock
         assertTrue(blockBuilder.getSizeInBytes() > emptyBlockBuilder.getSizeInBytes());
         assertTrue(blockBuilder.getRetainedSizeInBytes() > emptyBlockBuilder.getRetainedSizeInBytes());
 
-        blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+        blockBuilder = blockBuilder.newBlockBuilderLike(null);
         assertEquals(blockBuilder.getSizeInBytes(), emptyBlockBuilder.getSizeInBytes());
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
@@ -84,7 +83,7 @@ public class TestVariableWidthBlock
     {
         int numEntries = 1000;
         VarcharType unboundedVarcharType = createUnboundedVarcharType();
-        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), numEntries, 20 * numEntries);
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, numEntries, 20 * numEntries);
         for (int i = 0; i < numEntries; i++) {
             unboundedVarcharType.writeString(blockBuilder, String.valueOf(ThreadLocalRandom.current().nextLong()));
         }
@@ -114,7 +113,7 @@ public class TestVariableWidthBlock
 
     private static BlockBuilder createBlockBuilderWithValues(Slice[] expectedValues)
     {
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), expectedValues.length, 32 * expectedValues.length);
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, expectedValues.length, 32 * expectedValues.length);
         return writeValues(expectedValues, blockBuilder);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestPageSplitterUtil.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestPageSplitterUtil.java
@@ -16,7 +16,6 @@ package com.facebook.presto.execution;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.testing.MaterializedResult;
@@ -81,7 +80,7 @@ public class TestPageSplitterUtil
         List<Type> types = ImmutableList.of(VARCHAR);
 
         Slice expectedValue = wrappedBuffer("test".getBytes());
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1, expectedValue.length());
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 1, expectedValue.length());
         blockBuilder.writeBytes(expectedValue, 0, expectedValue.length()).closeEntry();
         Block rleBlock = new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
         Page initialPage = new Page(rleBlock);

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
@@ -16,7 +16,6 @@ package com.facebook.presto.execution.buffer;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.DynamicSliceOutput;
@@ -40,7 +39,7 @@ public class TestPagesSerde
     public void testRoundTrip()
     {
         PagesSerde serde = new TestingPagesSerdeFactory().createPagesSerde();
-        BlockBuilder expectedBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 5);
+        BlockBuilder expectedBlockBuilder = VARCHAR.createBlockBuilder(null, 5);
         VARCHAR.writeString(expectedBlockBuilder, "alice");
         VARCHAR.writeString(expectedBlockBuilder, "bob");
         VARCHAR.writeString(expectedBlockBuilder, "charlie");
@@ -63,7 +62,7 @@ public class TestPagesSerde
     @Test
     public void testBigintSerializedSize()
     {
-        BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 5);
+        BlockBuilder builder = BIGINT.createBlockBuilder(null, 5);
 
         // empty page
         Page page = new Page(builder.build());
@@ -86,7 +85,7 @@ public class TestPagesSerde
     @Test
     public void testVarcharSerializedSize()
     {
-        BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 5);
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, 5);
 
         // empty page
         Page page = new Page(builder.build());

--- a/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RowBlockBuilder;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
@@ -158,7 +157,7 @@ public final class OperatorAssertion
         checkArgument(parameterTypes.size() == values.length, "parameterTypes.size(" + parameterTypes.size() + ") does not equal to values.length(" + values.length + ")");
 
         RowType rowType = new RowType(parameterTypes, Optional.empty());
-        BlockBuilder blockBuilder = new RowBlockBuilder(parameterTypes, new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = new RowBlockBuilder(parameterTypes, null, 1);
         BlockBuilder singleRowBlockWriter = blockBuilder.beginBlockEntry();
         for (int i = 0; i < values.length; i++) {
             appendToBlockBuilder(parameterTypes.get(i), values[i], singleRowBlockWriter);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -24,7 +24,6 @@ import com.facebook.presto.operator.aggregation.builder.HashAggregationBuilder;
 import com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.PageBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
@@ -344,7 +343,7 @@ public class TestHashAggregationOperator
     @Test(dataProvider = "hashEnabledAndMemoryLimitForMergeValues")
     public void testHashBuilderResize(boolean hashEnabled, long memoryLimitForMerge, long memoryLimitForMergeWithMemory)
     {
-        BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, 1, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
         VARCHAR.writeSlice(builder, Slices.allocate(200_000)); // this must be larger than DEFAULT_MAX_BLOCK_SIZE, 64K
         builder.build();
 
@@ -418,7 +417,7 @@ public class TestHashAggregationOperator
     @Test(dataProvider = "hashEnabled", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 3MB")
     public void testHashBuilderResizeLimit(boolean hashEnabled)
     {
-        BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, 1, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
         VARCHAR.writeSlice(builder, Slices.allocate(5_000_000)); // this must be larger than DEFAULT_MAX_BLOCK_SIZE, 64K
         builder.build();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestLookupJoinPageBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestLookupJoinPageBuilder.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -38,7 +37,7 @@ public class TestLookupJoinPageBuilder
     public void testPageBuilder()
     {
         int entries = 10_000;
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), entries);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, entries);
         for (int i = 0; i < entries; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }
@@ -159,7 +158,7 @@ public class TestLookupJoinPageBuilder
     @Test
     public void testCrossJoinWithEmptyBuild()
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, 1);
         BIGINT.writeLong(blockBuilder, 0);
         Page page = new Page(blockBuilder.build());
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRealAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRealAverageAggregation.java
@@ -20,7 +20,6 @@ import com.facebook.presto.operator.aggregation.AbstractTestAggregationFunction;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.BeforeClass;
@@ -75,7 +74,7 @@ public class TestRealAverageAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = REAL.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = REAL.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             REAL.writeLong(blockBuilder, floatToRawIntBits((float) i));
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
@@ -17,7 +17,6 @@ import com.facebook.presto.RowPagesBuilder;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
@@ -376,7 +375,7 @@ public class TestRowNumberOperator
 
     private static Block getRowNumberColumn(List<Page> pages)
     {
-        BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), pages.size() * 100);
+        BlockBuilder builder = BIGINT.createBlockBuilder(null, pages.size() * 100);
         for (Page page : pages) {
             int rowNumberChannel = page.getChannelCount() - 1;
             for (int i = 0; i < page.getPositionCount(); i++) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
@@ -18,7 +18,6 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -103,7 +102,7 @@ public abstract class AbstractTestAggregationFunction
         }
         Block[] blocks = new Block[parameterTypes.size()];
         for (int i = 0; i < parameterTypes.size(); i++) {
-            Block nullValueBlock = parameterTypes.get(0).createBlockBuilder(new BlockBuilderStatus(), 1)
+            Block nullValueBlock = parameterTypes.get(0).createBlockBuilder(null, 1)
                     .appendNull()
                     .build();
             blocks[i] = new RunLengthEncodedBlock(nullValueBlock, 10);
@@ -143,7 +142,7 @@ public abstract class AbstractTestAggregationFunction
         for (int i = 0; i < sequenceBlocks.length; i++) {
             int positionCount = sequenceBlocks[i].getPositionCount();
             Type type = types.get(i);
-            BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder blockBuilder = type.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 // append null
                 blockBuilder.appendNull();

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateCountDistinct.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateCountDistinct.java
@@ -17,7 +17,6 @@ import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -166,7 +165,7 @@ public abstract class AbstractTestApproximateCountDistinct
      */
     private static Block createBlock(Type type, List<Object> values)
     {
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), values.size());
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, values.size());
 
         for (Object value : values) {
             Class<?> javaType = type.getJavaType();

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestDecimalAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestDecimalAverageAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDecimal;
 
@@ -32,7 +31,7 @@ public abstract class AbstractTestDecimalAverageAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = getDecimalType().createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = getDecimalType().createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             writeDecimalToBlock(getBigDecimalForCounter(i), blockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestDecimalSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestDecimalSumAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDecimal;
 
@@ -31,7 +30,7 @@ public abstract class AbstractTestDecimalSumAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = getDecimalType().createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = getDecimalType().createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             writeDecimalToBlock(getBigDecimalForCounter(i), blockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
@@ -18,7 +18,6 @@ import com.facebook.presto.operator.GroupByIdBlock;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.google.common.primitives.Ints;
 
@@ -64,28 +63,28 @@ public final class AggregationTestUtils
 
     public static Block getIntermediateBlock(Accumulator accumulator)
     {
-        BlockBuilder blockBuilder = accumulator.getIntermediateType().createBlockBuilder(new BlockBuilderStatus(), 1000);
+        BlockBuilder blockBuilder = accumulator.getIntermediateType().createBlockBuilder(null, 1000);
         accumulator.evaluateIntermediate(blockBuilder);
         return blockBuilder.build();
     }
 
     public static Block getIntermediateBlock(GroupedAccumulator accumulator)
     {
-        BlockBuilder blockBuilder = accumulator.getIntermediateType().createBlockBuilder(new BlockBuilderStatus(), 1000);
+        BlockBuilder blockBuilder = accumulator.getIntermediateType().createBlockBuilder(null, 1000);
         accumulator.evaluateIntermediate(0, blockBuilder);
         return blockBuilder.build();
     }
 
     public static Block getFinalBlock(Accumulator accumulator)
     {
-        BlockBuilder blockBuilder = accumulator.getFinalType().createBlockBuilder(new BlockBuilderStatus(), 1000);
+        BlockBuilder blockBuilder = accumulator.getFinalType().createBlockBuilder(null, 1000);
         accumulator.evaluateFinal(blockBuilder);
         return blockBuilder.build();
     }
 
     public static Block getFinalBlock(GroupedAccumulator accumulator)
     {
-        BlockBuilder blockBuilder = accumulator.getFinalType().createBlockBuilder(new BlockBuilderStatus(), 1000);
+        BlockBuilder blockBuilder = accumulator.getFinalType().createBlockBuilder(null, 1000);
         accumulator.evaluateFinal(0, blockBuilder);
         return blockBuilder.build();
     }
@@ -136,7 +135,7 @@ public final class AggregationTestUtils
         Page[] maskedPages = new Page[pages.length];
         for (int i = 0; i < pages.length; i++) {
             Page page = pages[i];
-            BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), page.getPositionCount());
+            BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(null, page.getPositionCount());
             for (int j = 0; j < page.getPositionCount(); j++) {
                 BOOLEAN.writeBoolean(blockBuilder, maskValue);
             }
@@ -299,7 +298,7 @@ public final class AggregationTestUtils
 
     public static GroupByIdBlock createGroupByIdBlock(int groupId, int positions)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), positions);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, positions);
         for (int i = 0; i < positions; i++) {
             BIGINT.writeLong(blockBuilder, groupId);
         }
@@ -369,7 +368,7 @@ public final class AggregationTestUtils
 
     private static RunLengthEncodedBlock createNullRLEBlock(int positionCount)
     {
-        Block value = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), 1)
+        Block value = BOOLEAN.createBlockBuilder(null, 1)
                 .appendNull()
                 .build();
 
@@ -378,7 +377,7 @@ public final class AggregationTestUtils
 
     public static Object getGroupValue(GroupedAccumulator groupedAggregation, int groupId)
     {
-        BlockBuilder out = groupedAggregation.getFinalType().createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder out = groupedAggregation.getFinalType().createBlockBuilder(null, 1);
         groupedAggregation.evaluateFinal(groupId, out);
         return BlockAssertions.getOnlyValue(groupedAggregation.getFinalType(), out.build());
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkArrayAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkArrayAggregation.java
@@ -18,7 +18,6 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -115,7 +114,7 @@ public class BenchmarkArrayAggregation
 
         private static Block createChannel(int arraySize, Type elementType)
         {
-            BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), arraySize);
+            BlockBuilder blockBuilder = elementType.createBlockBuilder(null, arraySize);
             for (int i = 0; i < arraySize; i++) {
                 if (elementType.getJavaType() == long.class) {
                     elementType.writeLong(blockBuilder, (long) i);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.ArrayType;
 import com.google.common.collect.ImmutableList;
@@ -465,14 +464,14 @@ public class TestApproximatePercentileAggregation
 
     private static RunLengthEncodedBlock createRLEBlock(double percentile, int positionCount)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, 1);
         DOUBLE.writeDouble(blockBuilder, percentile);
         return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
     }
 
     private static RunLengthEncodedBlock createRLEBlock(Iterable<Double> percentiles, int positionCount)
     {
-        BlockBuilder rleBlockBuilder = new ArrayType(DOUBLE).createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder rleBlockBuilder = new ArrayType(DOUBLE).createBlockBuilder(null, 1);
         BlockBuilder arrayBlockBuilder = rleBlockBuilder.beginBlockEntry();
 
         for (double percentile : percentiles) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayAggregation.java
@@ -21,7 +21,6 @@ import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationT
 import com.facebook.presto.operator.aggregation.groupByAggregations.GroupByAggregationTestUtils;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlDate;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
@@ -145,7 +144,7 @@ public class TestArrayAggregation
                 new Signature("array_agg", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature(StandardTypes.BIGINT)));
         GroupedAccumulator groupedAccumulator = bigIntAgg.bind(Ints.asList(new int[] {}), Optional.empty())
                 .createGroupedAccumulator();
-        BlockBuilder blockBuilder = groupedAccumulator.getFinalType().createBlockBuilder(new BlockBuilderStatus(), 1000);
+        BlockBuilder blockBuilder = groupedAccumulator.getFinalType().createBlockBuilder(null, 1000);
 
         groupedAccumulator.evaluateFinal(0, blockBuilder);
         assertTrue(blockBuilder.isNull(0));

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayMaxNAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayMaxNAggregation.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
@@ -39,7 +38,7 @@ public class TestArrayMaxNAggregation
     public static Block createLongArraysBlock(Long[] values)
     {
         ArrayType arrayType = new ArrayType(BIGINT);
-        BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), values.length);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, values.length);
         for (Long value : values) {
             if (value == null) {
                 blockBuilder.appendNull();

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayMinAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayMinAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.google.common.collect.ImmutableList;
 
@@ -31,7 +30,7 @@ public class TestArrayMinAggregation
     public Block[] getSequenceBlocks(int start, int length)
     {
         ArrayType arrayType = new ArrayType(BIGINT);
-        BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             arrayType.writeObject(blockBuilder, arrayBlockOf(BIGINT, i));
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBitwiseAndAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBitwiseAndAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
@@ -32,7 +31,7 @@ public class TestBitwiseAndAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
 
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBitwiseOrAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBitwiseOrAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
@@ -32,7 +31,7 @@ public class TestBitwiseOrAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
 
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBooleanAndAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBooleanAndAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -31,7 +30,7 @@ public class TestBooleanAndAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             // true, false, true, false...
             BOOLEAN.writeBoolean(blockBuilder, i % 2 == 0);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBooleanOrAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestBooleanOrAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -31,7 +30,7 @@ public class TestBooleanOrAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             // false, true, false, true...
             BOOLEAN.writeBoolean(blockBuilder, i % 2 != 0);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -28,7 +27,7 @@ public class TestCountAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountColumnAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountColumnAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestCountColumnAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountIfAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountIfAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestCountIfAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BOOLEAN.writeBoolean(blockBuilder, i % 2 == 0);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountNullAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountNullAggregation.java
@@ -17,7 +17,6 @@ import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.operator.aggregation.state.NullableLongState;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.AggregationState;
 import com.facebook.presto.spi.function.CombineFunction;
@@ -44,7 +43,7 @@ public class TestCountNullAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDateMaxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDateMaxAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.SqlDate;
 import com.facebook.presto.spi.type.StandardTypes;
@@ -29,7 +28,7 @@ public class TestDateMaxAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DateType.DATE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DateType.DATE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DateType.DATE.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDecimalSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDecimalSumAggregation.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.operator.aggregation.state.LongDecimalWithOverflowState;
 import com.facebook.presto.operator.aggregation.state.LongDecimalWithOverflowStateFactory;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic;
@@ -128,7 +127,7 @@ public class TestDecimalSumAggregation
         addToState(state, TWO.pow(126));
 
         assertEquals(state.getOverflow(), 1);
-        DecimalSumAggregation.outputLongDecimal(TYPE, state, new VariableWidthBlockBuilder(new BlockBuilderStatus(), 10, 100));
+        DecimalSumAggregation.outputLongDecimal(TYPE, state, new VariableWidthBlockBuilder(null, 10, 100));
     }
 
     private static void addToState(LongDecimalWithOverflowState state, BigInteger value)

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleAverageAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestDoubleAverageAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleGeometricMeanAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleGeometricMeanAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestDoubleGeometricMeanAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleKurtosisAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleKurtosisAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.Kurtosis;
@@ -30,7 +29,7 @@ public class TestDoubleKurtosisAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleMaxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleMaxAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestDoubleMaxAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleMinAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleMinAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestDoubleMinAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleSkewnessAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleSkewnessAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.Skewness;
@@ -30,7 +29,7 @@ public class TestDoubleSkewnessAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleStdDevAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleStdDevAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
@@ -30,7 +29,7 @@ public class TestDoubleStdDevAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleStdDevPopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleStdDevPopAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
@@ -30,7 +29,7 @@ public class TestDoubleStdDevPopAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleSumAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestDoubleSumAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleVarianceAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleVarianceAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.Variance;
@@ -30,7 +29,7 @@ public class TestDoubleVarianceAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleVariancePopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleVariancePopAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.Variance;
@@ -30,7 +29,7 @@ public class TestDoubleVariancePopAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHistogram.java
@@ -23,7 +23,6 @@ import com.facebook.presto.operator.aggregation.groupByAggregations.GroupByAggre
 import com.facebook.presto.operator.aggregation.histogram.HistogramGroupImplementation;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
@@ -218,7 +217,7 @@ public class TestHistogram
         MapType mapType = mapType(innerMapType, BIGINT);
         InternalAggregationFunction aggregationFunction = getAggregation(mapType.getTypeSignature(), innerMapType.getTypeSignature());
 
-        BlockBuilder builder = innerMapType.createBlockBuilder(new BlockBuilderStatus(), 3);
+        BlockBuilder builder = innerMapType.createBlockBuilder(null, 3);
         innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("a", "b")));
         innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("c", "d")));
         innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("e", "f")));
@@ -235,7 +234,7 @@ public class TestHistogram
         RowType innerRowType = new RowType(ImmutableList.of(BIGINT, DOUBLE), Optional.of(ImmutableList.of("f1", "f2")));
         MapType mapType = mapType(innerRowType, BIGINT);
         InternalAggregationFunction aggregationFunction = getAggregation(mapType.getTypeSignature(), innerRowType.getTypeSignature());
-        BlockBuilder builder = innerRowType.createBlockBuilder(new BlockBuilderStatus(), 3);
+        BlockBuilder builder = innerRowType.createBlockBuilder(null, 3);
         innerRowType.writeObject(builder, toRow(ImmutableList.of(BIGINT, DOUBLE), 1L, 1.0));
         innerRowType.writeObject(builder, toRow(ImmutableList.of(BIGINT, DOUBLE), 2L, 2.0));
         innerRowType.writeObject(builder, toRow(ImmutableList.of(BIGINT, DOUBLE), 3L, 3.0));
@@ -263,7 +262,7 @@ public class TestHistogram
         InternalAggregationFunction function = getInternalDefaultVarCharAggregationn();
         GroupedAccumulator groupedAccumulator = function.bind(Ints.asList(new int[] {}), Optional.empty())
                 .createGroupedAccumulator();
-        BlockBuilder blockBuilder = groupedAccumulator.getFinalType().createBlockBuilder(new BlockBuilderStatus(), 1000);
+        BlockBuilder blockBuilder = groupedAccumulator.getFinalType().createBlockBuilder(null, 1000);
 
         groupedAccumulator.evaluateFinal(0, blockBuilder);
         assertTrue(blockBuilder.isNull(0));

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondAverageAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlIntervalDayTime;
 import com.google.common.collect.ImmutableList;
@@ -31,7 +30,7 @@ public class TestIntervalDayToSecondAverageAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             INTERVAL_DAY_TIME.writeLong(blockBuilder, i * 250);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalDayToSecondSumAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlIntervalDayTime;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +29,7 @@ public class TestIntervalDayToSecondSumAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             INTERVAL_DAY_TIME.writeLong(blockBuilder, i * 1000);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthAverageAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlIntervalYearMonth;
 import com.google.common.collect.ImmutableList;
@@ -32,7 +31,7 @@ public class TestIntervalYearToMonthAverageAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestIntervalYearToMonthSumAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.type.SqlIntervalYearMonth;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +29,7 @@ public class TestIntervalYearToMonthSumAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             INTERVAL_YEAR_MONTH.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongAverageAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestLongAverageAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongDecimalMaxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongDecimalMaxAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.google.common.collect.ImmutableList;
@@ -33,7 +32,7 @@ public class TestLongDecimalMaxAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = LONG_DECIMAL.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = LONG_DECIMAL.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             writeBigDecimal(LONG_DECIMAL, blockBuilder, BigDecimal.valueOf(i));
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongDecimalMinAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongDecimalMinAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.google.common.collect.ImmutableList;
@@ -33,7 +32,7 @@ public class TestLongDecimalMinAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = LONG_DECIMAL.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = LONG_DECIMAL.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             writeBigDecimal(LONG_DECIMAL, blockBuilder, BigDecimal.valueOf(i));
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongGeometricMeanAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongGeometricMeanAggregationFunction.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestLongGeometricMeanAggregationFunction
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             DOUBLE.writeDouble(blockBuilder, (double) i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongKurtosisAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongKurtosisAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.Kurtosis;
@@ -30,7 +29,7 @@ public class TestLongKurtosisAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongMaxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongMaxAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestLongMaxAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongMinAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongMinAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestLongMinAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongSkewnessAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongSkewnessAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.Skewness;
@@ -30,7 +29,7 @@ public class TestLongSkewnessAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongStdDevAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongStdDevAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
@@ -30,7 +29,7 @@ public class TestLongStdDevAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongStdDevPopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongStdDevPopAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
@@ -30,7 +29,7 @@ public class TestLongStdDevPopAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongSumAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestLongSumAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongVarianceAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongVarianceAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.Variance;
@@ -30,7 +29,7 @@ public class TestLongVarianceAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongVariancePopAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestLongVariancePopAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.stat.descriptive.moment.Variance;
@@ -30,7 +29,7 @@ public class TestLongVariancePopAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMapAggAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMapAggAggregation.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
@@ -186,7 +185,7 @@ public class TestMapAggAggregation
                 parseTypeSignature(StandardTypes.DOUBLE),
                 innerMapType.getTypeSignature()));
 
-        BlockBuilder builder = innerMapType.createBlockBuilder(new BlockBuilderStatus(), 3);
+        BlockBuilder builder = innerMapType.createBlockBuilder(null, 3);
         innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("a", "b")));
         innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("c", "d")));
         innerMapType.writeObject(builder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("e", "f")));
@@ -211,7 +210,7 @@ public class TestMapAggAggregation
                 parseTypeSignature(StandardTypes.DOUBLE),
                 innerRowType.getTypeSignature()));
 
-        BlockBuilder builder = innerRowType.createBlockBuilder(new BlockBuilderStatus(), 3);
+        BlockBuilder builder = innerRowType.createBlockBuilder(null, 3);
         innerRowType.writeObject(builder, toRow(ImmutableList.of(INTEGER, DOUBLE), 1L, 1.0));
         innerRowType.writeObject(builder, toRow(ImmutableList.of(INTEGER, DOUBLE), 2L, 2.0));
         innerRowType.writeObject(builder, toRow(ImmutableList.of(INTEGER, DOUBLE), 3L, 3.0));

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeHyperLogLogAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeHyperLogLogAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlVarbinary;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
@@ -35,7 +34,7 @@ public class TestMergeHyperLogLogAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = HYPER_LOG_LOG.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = HYPER_LOG_LOG.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             HyperLogLog hll = HyperLogLog.newInstance(NUMBER_OF_BUCKETS);
             hll.add(i);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealGeometricMeanAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealGeometricMeanAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -30,7 +29,7 @@ public class TestRealGeometricMeanAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = REAL.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = REAL.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             REAL.writeLong(blockBuilder, floatToRawIntBits((float) i));
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealSumAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 
@@ -30,7 +29,7 @@ public class TestRealSumAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = REAL.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = REAL.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             REAL.writeLong(blockBuilder, floatToRawIntBits((float) i));
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestShortDecimalMaxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestShortDecimalMaxAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +29,7 @@ public class TestShortDecimalMaxAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = SHORT_DECIMAL.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = SHORT_DECIMAL.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             SHORT_DECIMAL.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestShortDecimalMinAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestShortDecimalMinAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +29,7 @@ public class TestShortDecimalMinAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = SHORT_DECIMAL.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = SHORT_DECIMAL.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             SHORT_DECIMAL.writeLong(blockBuilder, i);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
@@ -27,7 +27,6 @@ import com.facebook.presto.operator.aggregation.state.StateCompiler;
 import com.facebook.presto.operator.aggregation.state.VarianceState;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.AccumulatorState;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
@@ -75,7 +74,7 @@ public class TestStateCompiler
         state.setLong(2);
         state.setNull(false);
 
-        BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 2);
+        BlockBuilder builder = BIGINT.createBlockBuilder(null, 2);
         serializer.serialize(state, builder);
         state.setNull(true);
         serializer.serialize(state, builder);
@@ -100,7 +99,7 @@ public class TestStateCompiler
 
         state.setLong(2);
 
-        BlockBuilder builder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder builder = BIGINT.createBlockBuilder(null, 1);
         serializer.serialize(state, builder);
 
         Block block = builder.build();
@@ -127,7 +126,7 @@ public class TestStateCompiler
 
         state.setBoolean(true);
 
-        BlockBuilder builder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder builder = BOOLEAN.createBlockBuilder(null, 1);
         serializer.serialize(state, builder);
 
         Block block = builder.build();
@@ -145,7 +144,7 @@ public class TestStateCompiler
 
         state.setByte((byte) 3);
 
-        BlockBuilder builder = TINYINT.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder builder = TINYINT.createBlockBuilder(null, 1);
         serializer.serialize(state, builder);
 
         Block block = builder.build();
@@ -162,14 +161,14 @@ public class TestStateCompiler
         SliceState deserializedState = factory.createSingleState();
 
         state.setSlice(null);
-        BlockBuilder nullBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder nullBlockBuilder = VARCHAR.createBlockBuilder(null, 1);
         serializer.serialize(state, nullBlockBuilder);
         Block nullBlock = nullBlockBuilder.build();
         serializer.deserialize(nullBlock, 0, deserializedState);
         assertEquals(deserializedState.getSlice(), state.getSlice());
 
         state.setSlice(utf8Slice("test"));
-        BlockBuilder builder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, 1);
         serializer.serialize(state, builder);
         Block block = builder.build();
         serializer.deserialize(block, 0, deserializedState);
@@ -188,7 +187,7 @@ public class TestStateCompiler
         singleState.setCount(2);
         singleState.setM2(3);
 
-        BlockBuilder builder = new RowType(ImmutableList.of(BIGINT, DOUBLE, DOUBLE), Optional.empty()).createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder builder = new RowType(ImmutableList.of(BIGINT, DOUBLE, DOUBLE), Optional.empty()).createBlockBuilder(null, 1);
         serializer.serialize(singleState, builder);
 
         Block block = builder.build();
@@ -223,7 +222,7 @@ public class TestStateCompiler
         singleState.setAnotherBlock(mapBlockOf(BIGINT, VARCHAR, ImmutableMap.of(123L, "testBlock")));
 
         BlockBuilder builder = new RowType(ImmutableList.of(BOOLEAN, TINYINT, DOUBLE, INTEGER, BIGINT, mapType, VARBINARY, arrayType, VARBINARY, VARBINARY), Optional.empty())
-                .createBlockBuilder(new BlockBuilderStatus(), 1);
+                .createBlockBuilder(null, 1);
         serializer.serialize(singleState, builder);
 
         Block block = builder.build();
@@ -322,7 +321,7 @@ public class TestStateCompiler
             Block array = createLongsBlock(45);
             retainedSize += array.getRetainedSizeInBytes();
             groupedState.setBlock(array);
-            BlockBuilder mapBlockBuilder = mapType(BIGINT, VARCHAR).createBlockBuilder(new BlockBuilderStatus(), 1);
+            BlockBuilder mapBlockBuilder = mapType(BIGINT, VARCHAR).createBlockBuilder(null, 1);
             BlockBuilder singleMapBlockWriter = mapBlockBuilder.beginBlockEntry();
             BIGINT.writeLong(singleMapBlockWriter, 123L);
             VARCHAR.writeSlice(singleMapBlockWriter, utf8Slice("testBlock"));
@@ -351,7 +350,7 @@ public class TestStateCompiler
             Block array = createLongsBlock(45);
             retainedSize += array.getRetainedSizeInBytes();
             groupedState.setBlock(array);
-            BlockBuilder mapBlockBuilder = mapType(BIGINT, VARCHAR).createBlockBuilder(new BlockBuilderStatus(), 1);
+            BlockBuilder mapBlockBuilder = mapType(BIGINT, VARCHAR).createBlockBuilder(null, 1);
             BlockBuilder singleMapBlockWriter = mapBlockBuilder.beginBlockEntry();
             BIGINT.writeLong(singleMapBlockWriter, 123L);
             VARCHAR.writeSlice(singleMapBlockWriter, utf8Slice("testBlock"));

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedHeap.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedHeap.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -72,13 +71,13 @@ public class TestTypedHeap
 
     private static void test(IntStream inputStream, BlockComparator comparator, PrimitiveIterator.OfInt outputIterator)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), INPUT_SIZE);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, INPUT_SIZE);
         inputStream.forEach(x -> BIGINT.writeLong(blockBuilder, x));
 
         TypedHeap heap = new TypedHeap(comparator, BIGINT, OUTPUT_SIZE);
         heap.addAll(blockBuilder);
 
-        BlockBuilder resultBlockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), OUTPUT_SIZE);
+        BlockBuilder resultBlockBuilder = BIGINT.createBlockBuilder(null, OUTPUT_SIZE);
         heap.popAll(resultBlockBuilder);
 
         Block resultBlock = resultBlockBuilder.build();

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedHistogram.java
@@ -17,7 +17,6 @@ import com.facebook.presto.operator.aggregation.histogram.SingleTypedHistogram;
 import com.facebook.presto.operator.aggregation.histogram.TypedHistogram;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.MapType;
 import org.testng.annotations.Test;
 
@@ -33,7 +32,7 @@ public class TestTypedHistogram
     @Test
     public void testMassive()
     {
-        BlockBuilder inputBlockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 5000);
+        BlockBuilder inputBlockBuilder = BIGINT.createBlockBuilder(null, 5000);
 
         TypedHistogram typedHistogram = new SingleTypedHistogram(BIGINT, 1000);
         IntStream.range(1, 2000)
@@ -46,7 +45,7 @@ public class TestTypedHistogram
         }
 
         MapType mapType = mapType(BIGINT, BIGINT);
-        BlockBuilder out = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder out = mapType.createBlockBuilder(null, 1);
         typedHistogram.serialize(out);
         Block outputBlock = mapType.getObject(out, 0);
         for (int i = 0; i < outputBlock.getPositionCount(); i += 2) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedKeyValueHeap.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedKeyValueHeap.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -80,15 +79,15 @@ public class TestTypedKeyValueHeap
 
     private static void test(IntStream keyInputStream, Stream<String> valueInputStream, BlockComparator comparator, Iterator<String> outputIterator)
     {
-        BlockBuilder keysBlockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), INPUT_SIZE);
-        BlockBuilder valuesBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), INPUT_SIZE);
+        BlockBuilder keysBlockBuilder = BIGINT.createBlockBuilder(null, INPUT_SIZE);
+        BlockBuilder valuesBlockBuilder = VARCHAR.createBlockBuilder(null, INPUT_SIZE);
         keyInputStream.forEach(x -> BIGINT.writeLong(keysBlockBuilder, x));
         valueInputStream.forEach(x -> VARCHAR.writeString(valuesBlockBuilder, x));
 
         TypedKeyValueHeap heap = new TypedKeyValueHeap(comparator, BIGINT, VARCHAR, OUTPUT_SIZE);
         heap.addAll(keysBlockBuilder, valuesBlockBuilder);
 
-        BlockBuilder resultBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), OUTPUT_SIZE);
+        BlockBuilder resultBlockBuilder = VARCHAR.createBlockBuilder(null, OUTPUT_SIZE);
         heap.popAll(resultBlockBuilder);
 
         Block resultBlock = resultBlockBuilder.build();

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
@@ -82,7 +81,7 @@ public class TestTypedSet
     @Test
     public void testGetElementPositionRandom()
     {
-        BlockBuilder keys = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 5);
+        BlockBuilder keys = VARCHAR.createBlockBuilder(null, 5);
         VARCHAR.writeSlice(keys, utf8Slice("hello"));
         VARCHAR.writeSlice(keys, utf8Slice("bye"));
         VARCHAR.writeSlice(keys, utf8Slice("abc"));
@@ -92,7 +91,7 @@ public class TestTypedSet
             set.add(keys, i);
         }
 
-        BlockBuilder values = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 5);
+        BlockBuilder values = VARCHAR.createBlockBuilder(null, 5);
         VARCHAR.writeSlice(values, utf8Slice("bye"));
         VARCHAR.writeSlice(values, utf8Slice("abc"));
         VARCHAR.writeSlice(values, utf8Slice("hello"));

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestUnknownMaxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestUnknownMaxAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.type.UnknownType;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestUnknownMaxAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = UNKNOWN.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = UNKNOWN.createBlockBuilder(null, length);
         for (int i = 0; i < length; i++) {
             blockBuilder.appendNull();
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestUnknownMinAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestUnknownMinAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.type.UnknownType;
 import com.google.common.collect.ImmutableList;
 
@@ -29,7 +28,7 @@ public class TestUnknownMinAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = UNKNOWN.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = UNKNOWN.createBlockBuilder(null, length);
         for (int i = 0; i < length; i++) {
             blockBuilder.appendNull();
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestVarBinaryMaxAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestVarBinaryMaxAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
@@ -33,7 +32,7 @@ public class TestVarBinaryMaxAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(null, length);
         for (int i = 0; i < length; i++) {
             VARBINARY.writeSlice(blockBuilder, Slices.wrappedBuffer(Ints.toByteArray(i)));
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestVarBinaryMinAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestVarBinaryMinAggregation.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
@@ -33,7 +32,7 @@ public class TestVarBinaryMinAggregation
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), length);
+        BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(null, length);
         for (int i = 0; i < length; i++) {
             VARBINARY.writeSlice(blockBuilder, Slices.wrappedBuffer(Ints.toByteArray(i)));
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/groupByAggregations/AggregationTestOutput.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/groupByAggregations/AggregationTestOutput.java
@@ -17,7 +17,6 @@ package com.facebook.presto.operator.aggregation.groupByAggregations;
 import com.facebook.presto.block.BlockAssertions;
 import com.facebook.presto.operator.aggregation.GroupedAccumulator;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import java.util.function.BiConsumer;
 
@@ -54,7 +53,7 @@ public class AggregationTestOutput
 
     private static Object getGroupValue(GroupedAccumulator groupedAggregation, int groupId)
     {
-        BlockBuilder out = groupedAggregation.getFinalType().createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder out = groupedAggregation.getFinalType().createBlockBuilder(null, 1);
         groupedAggregation.evaluateFinal(groupId, out);
         return BlockAssertions.getOnlyValue(groupedAggregation.getFinalType(), out.build());
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/histogram/TestValueStore.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/histogram/TestValueStore.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator.aggregation.histogram;
 import com.facebook.presto.block.BlockAssertions;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.type.TypeUtils;
 import org.testng.annotations.BeforeMethod;
@@ -38,7 +37,7 @@ public class TestValueStore
             throws Exception
     {
         type = VarcharType.createVarcharType(100);
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 100, 10);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 100, 10);
         valueStore = new ValueStore(100, blockBuilder);
         valueStoreSmall = new ValueStore(1, blockBuilder);
         block = BlockAssertions.createStringsBlock("a", "b", "c", "d");

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.LongArrayBlock;
@@ -330,7 +329,7 @@ public class TestDictionaryAwarePageProjection
                 this.yieldSignal = yieldSignal;
                 this.block = page.getBlock(0);
                 this.selectedPositions = selectedPositions;
-                this.blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), selectedPositions.size());
+                this.blockBuilder = BIGINT.createBlockBuilder(null, selectedPositions.size());
             }
 
             @Override
@@ -359,7 +358,7 @@ public class TestDictionaryAwarePageProjection
                     }
                 }
                 result = blockBuilder.build();
-                blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+                blockBuilder = blockBuilder.newBlockBuilderLike(null);
                 return true;
             }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayDistinct.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayDistinct.java
@@ -22,7 +22,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.ArrayType;
@@ -119,7 +118,7 @@ public class BenchmarkArrayDistinct
 
         private static Block createChannel(int positionCount, int arraySize, ArrayType arrayType)
         {
-            BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
                 for (int i = 0; i < arraySize; i++) {
@@ -173,7 +172,7 @@ public class BenchmarkArrayDistinct
         }
 
         TypedSet typedSet = new TypedSet(VARCHAR, array.getPositionCount(), "old_array_distinct");
-        BlockBuilder distinctElementBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), array.getPositionCount());
+        BlockBuilder distinctElementBlockBuilder = VARCHAR.createBlockBuilder(null, array.getPositionCount());
         for (int i = 0; i < array.getPositionCount(); i++) {
             if (!typedSet.contains(array, i)) {
                 typedSet.add(array, i);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
@@ -25,7 +25,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -140,7 +139,7 @@ public class BenchmarkArrayFilter
 
         private static Block createChannel(int positionCount, int arraySize, ArrayType arrayType)
         {
-            BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
                 for (int i = 0; i < arraySize; i++) {
@@ -235,7 +234,7 @@ public class BenchmarkArrayFilter
         public static Block filter(Type type, Block block, MethodHandle function)
         {
             int positionCount = block.getPositionCount();
-            BlockBuilder resultBuilder = type.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder resultBuilder = type.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 Long input = (Long) readNativeValue(type, block, position);
                 Boolean keep;

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayHashCodeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayHashCodeOperator.java
@@ -23,7 +23,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarFunction;
@@ -145,7 +144,7 @@ public class BenchmarkArrayHashCodeOperator
 
         private static Block createChannel(int positionCount, int arraySize, ArrayType arrayType)
         {
-            BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
                 for (int i = 0; i < arraySize; i++) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayJoin.java
@@ -21,7 +21,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.PageFunctionCompiler;
@@ -102,7 +101,7 @@ public class BenchmarkArrayJoin
         {
             ArrayType arrayType = new ArrayType(BIGINT);
 
-            BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
                 for (int i = 0; i < arraySize; i++) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySort.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySort.java
@@ -21,7 +21,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.ArrayType;
@@ -119,7 +118,7 @@ public class BenchmarkArraySort
 
         private static Block createChannel(int positionCount, int arraySize, ArrayType arrayType)
         {
-            BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
                 for (int i = 0; i < arraySize; i++) {
@@ -178,7 +177,7 @@ public class BenchmarkArraySort
             return VARCHAR.compareTo(block, p1, block, p2);
         });
 
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount());
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, block.getPositionCount());
 
         for (int position : positions) {
             VARCHAR.appendTo(block, position, blockBuilder);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySubscript.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySubscript.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.ArrayBlock;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.Type;
@@ -170,7 +169,7 @@ public class BenchmarkArraySubscript
 
         private static Block createFixWidthValueBlock(int positionCount, int mapSize)
         {
-            BlockBuilder valueBlockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), positionCount * mapSize);
+            BlockBuilder valueBlockBuilder = DOUBLE.createBlockBuilder(null, positionCount * mapSize);
             for (int i = 0; i < positionCount * mapSize; i++) {
                 DOUBLE.writeDouble(valueBlockBuilder, ThreadLocalRandom.current().nextDouble());
             }
@@ -180,7 +179,7 @@ public class BenchmarkArraySubscript
         private static Block createVarWidthValueBlock(int positionCount, int mapSize)
         {
             Type valueType = createUnboundedVarcharType();
-            BlockBuilder valueBlockBuilder = valueType.createBlockBuilder(new BlockBuilderStatus(), positionCount * mapSize);
+            BlockBuilder valueBlockBuilder = valueType.createBlockBuilder(null, positionCount * mapSize);
             for (int i = 0; i < positionCount * mapSize; i++) {
                 int wordLength = ThreadLocalRandom.current().nextInt(5, 10);
                 valueType.writeSlice(valueBlockBuilder, utf8Slice(randomString(wordLength)));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayTransform.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayTransform.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
@@ -126,7 +125,7 @@ public class BenchmarkArrayTransform
 
         private static Block createChannel(int positionCount, int arraySize, ArrayType arrayType)
         {
-            BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
                 for (int i = 0; i < arraySize; i++) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToArrayCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToArrayCast.java
@@ -21,7 +21,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
@@ -120,7 +119,7 @@ public class BenchmarkJsonToArrayCast
 
         private static Block createChannel(int positionCount, int mapSize, Type elementType)
         {
-            BlockBuilder blockBuilder = JSON.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder blockBuilder = JSON.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 SliceOutput jsonSlice = new DynamicSliceOutput(20 * mapSize);
                 jsonSlice.appendByte('[');

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToMapCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToMapCast.java
@@ -21,7 +21,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.PageFunctionCompiler;
@@ -120,7 +119,7 @@ public class BenchmarkJsonToMapCast
 
         private static Block createChannel(int positionCount, int mapSize, Type valueType)
         {
-            BlockBuilder blockBuilder = JSON.createBlockBuilder(new BlockBuilderStatus(), positionCount);
+            BlockBuilder blockBuilder = JSON.createBlockBuilder(null, positionCount);
             for (int position = 0; position < positionCount; position++) {
                 SliceOutput jsonSlice = new DynamicSliceOutput(20 * mapSize);
                 jsonSlice.appendByte('{');

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
@@ -21,7 +21,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
@@ -180,7 +179,7 @@ public class BenchmarkMapConcat
 
         private static Block createValueBlock(int positionCount, int mapSize)
         {
-            BlockBuilder valueBlockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), positionCount * mapSize);
+            BlockBuilder valueBlockBuilder = DOUBLE.createBlockBuilder(null, positionCount * mapSize);
             for (int i = 0; i < positionCount * mapSize; i++) {
                 DOUBLE.writeDouble(valueBlockBuilder, ThreadLocalRandom.current().nextDouble());
             }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapSubscript.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapSubscript.java
@@ -21,7 +21,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
@@ -191,7 +190,7 @@ public class BenchmarkMapSubscript
 
         private static Block createFixWidthValueBlock(int positionCount, int mapSize)
         {
-            BlockBuilder valueBlockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), positionCount * mapSize);
+            BlockBuilder valueBlockBuilder = DOUBLE.createBlockBuilder(null, positionCount * mapSize);
             for (int i = 0; i < positionCount * mapSize; i++) {
                 DOUBLE.writeDouble(valueBlockBuilder, ThreadLocalRandom.current().nextDouble());
             }
@@ -201,7 +200,7 @@ public class BenchmarkMapSubscript
         private static Block createVarWidthValueBlock(int positionCount, int mapSize)
         {
             Type valueType = createUnboundedVarcharType();
-            BlockBuilder valueBlockBuilder = valueType.createBlockBuilder(new BlockBuilderStatus(), positionCount * mapSize);
+            BlockBuilder valueBlockBuilder = valueType.createBlockBuilder(null, positionCount * mapSize);
             for (int i = 0; i < positionCount * mapSize; i++) {
                 int wordLength = ThreadLocalRandom.current().nextInt(5, 10);
                 valueType.writeSlice(valueBlockBuilder, utf8Slice(randomString(wordLength)));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformKey.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformKey.java
@@ -22,7 +22,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
@@ -141,7 +140,7 @@ public class BenchmarkTransformKey
 
         private static Block createChannel(int positionCount, MapType mapType, Type elementType)
         {
-            BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+            BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, 1);
             BlockBuilder singleMapBlockWriter = mapBlockBuilder.beginBlockEntry();
             Object value;
             for (int position = 0; position < positionCount; position++) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformValue.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformValue.java
@@ -22,7 +22,6 @@ import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
@@ -154,7 +153,7 @@ public class BenchmarkTransformValue
 
         private static Block createChannel(int positionCount, MapType mapType, Type elementType)
         {
-            BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+            BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, 1);
             BlockBuilder singleMapBlockWriter = mapBlockBuilder.beginBlockEntry();
             Object key;
             Object value;

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonHashTable.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonHashTable.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.util.JsonUtil.HashTable;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
@@ -43,7 +42,7 @@ public class TestJsonHashTable
     {
         Random rand = new Random(SEED);
 
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), NUM_ROUNDS * (NUM_RANDOM_VALUES_IN_ROUND + NUM_EXISTING_VALUES_IN_ROUND));
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, NUM_ROUNDS * (NUM_RANDOM_VALUES_IN_ROUND + NUM_EXISTING_VALUES_IN_ROUND));
         HashTable hashTable = new HashTable(BIGINT, blockBuilder);
         Set<Long> valueSet = new HashSet<>();
         List<Long> valueList = new ArrayList<>();
@@ -79,7 +78,7 @@ public class TestJsonHashTable
     {
         Random rand = new Random(SEED);
 
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), NUM_ROUNDS * (NUM_RANDOM_VALUES_IN_ROUND + NUM_EXISTING_VALUES_IN_ROUND));
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, NUM_ROUNDS * (NUM_RANDOM_VALUES_IN_ROUND + NUM_EXISTING_VALUES_IN_ROUND));
         HashTable hashTable = new HashTable(VARCHAR, blockBuilder);
         Set<Slice> valueSet = new HashSet<>();
         List<Slice> valueList = new ArrayList<>();

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlVarbinary;
 import com.facebook.presto.type.VarbinaryOperators;
 import io.airlift.slice.Slice;
@@ -255,7 +254,7 @@ public class TestVarbinaryFunctions
     {
         Slice data = Slices.wrappedBuffer(ALL_BYTES);
 
-        Block block = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1, ALL_BYTES.length)
+        Block block = VARBINARY.createBlockBuilder(null, 1, ALL_BYTES.length)
                 .writeBytes(data, 0, data.length())
                 .closeEntry()
                 .build();

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestBinaryFileSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestBinaryFileSpiller.java
@@ -20,7 +20,6 @@ import com.facebook.presto.execution.buffer.PagesSerdeFactory;
 import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -100,9 +99,9 @@ public class TestBinaryFileSpiller
     {
         List<Type> types = ImmutableList.of(BIGINT, DOUBLE, VARBINARY);
 
-        BlockBuilder col1 = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1);
-        BlockBuilder col2 = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 1);
-        BlockBuilder col3 = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder col1 = BIGINT.createBlockBuilder(null, 1);
+        BlockBuilder col2 = DOUBLE.createBlockBuilder(null, 1);
+        BlockBuilder col3 = VARBINARY.createBlockBuilder(null, 1);
 
         col1.writeLong(42).closeEntry();
         col2.writeLong(doubleToLongBits(43.0)).closeEntry();

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpiller.java
@@ -20,7 +20,6 @@ import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.operator.PageAssertions;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
@@ -103,9 +102,9 @@ public class TestFileSingleStreamSpiller
 
     private Page buildPage()
     {
-        BlockBuilder col1 = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1);
-        BlockBuilder col2 = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 1);
-        BlockBuilder col3 = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder col1 = BIGINT.createBlockBuilder(null, 1);
+        BlockBuilder col2 = DOUBLE.createBlockBuilder(null, 1);
+        BlockBuilder col3 = VARBINARY.createBlockBuilder(null, 1);
 
         col1.writeLong(42).closeEntry();
         col2.writeLong(doubleToLongBits(43.0)).closeEntry();

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpillerFactory.java
@@ -16,7 +16,6 @@ package com.facebook.presto.spiller;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.type.TypeRegistry;
@@ -107,7 +106,7 @@ public class TestFileSingleStreamSpillerFactory
 
     private Page buildPage()
     {
-        BlockBuilder col1 = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder col1 = BIGINT.createBlockBuilder(null, 1);
         col1.writeLong(42).closeEntry();
         return new Page(col1.build());
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInterpretedPageProjectionFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInterpretedPageProjectionFunction.java
@@ -22,7 +22,6 @@ import com.facebook.presto.operator.project.InterpretedPageProjection;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
@@ -273,7 +272,7 @@ public class TestInterpretedPageProjectionFunction
 
     private static Block createBlock(Type type, Object[] values)
     {
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), values.length);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, values.length);
         for (Object value : values) {
             writeNativeValue(type, blockBuilder, value);
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
@@ -79,7 +78,7 @@ public abstract class AbstractTestType
 
     private Block createAlternatingNullsBlock(Block testBlock)
     {
-        BlockBuilder nullsBlockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), testBlock.getPositionCount());
+        BlockBuilder nullsBlockBuilder = type.createBlockBuilder(null, testBlock.getPositionCount());
         for (int position = 0; position < testBlock.getPositionCount(); position++) {
             if (type.getJavaType() == void.class) {
                 nullsBlockBuilder.appendNull();
@@ -129,7 +128,7 @@ public abstract class AbstractTestType
         assertPositionValue(block.getRegion(0, position + 1), position, expectedStackValue, hash, expectedObjectValue);
         assertPositionValue(block.getRegion(position, block.getPositionCount() - position), 0, expectedStackValue, hash, expectedObjectValue);
 
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
         type.appendTo(block, position, blockBuilder);
         assertPositionValue(blockBuilder.build(), 0, expectedStackValue, hash, expectedObjectValue);
     }
@@ -442,7 +441,7 @@ public abstract class AbstractTestType
 
     private static Block createBlock(Type type, Object value)
     {
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
 
         Class<?> javaType = type.getJavaType();
         if (value == null) {
@@ -514,7 +513,7 @@ public abstract class AbstractTestType
 
     private Block toBlock(Object value)
     {
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
         Class<?> javaType = type.getJavaType();
         if (value == null) {
             blockBuilder.appendNull();

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -119,10 +118,10 @@ public class TestArrayOperators
         writeBlock(actualSliceOutput, actualBlock);
 
         Block expectedBlock = new ArrayType(BIGINT)
-                .createBlockBuilder(new BlockBuilderStatus(), 3)
-                .writeObject(BIGINT.createBlockBuilder(new BlockBuilderStatus(), 2).writeLong(1).closeEntry().writeLong(2).closeEntry().build())
+                .createBlockBuilder(null, 3)
+                .writeObject(BIGINT.createBlockBuilder(null, 2).writeLong(1).closeEntry().writeLong(2).closeEntry().build())
                 .closeEntry()
-                .writeObject(BIGINT.createBlockBuilder(new BlockBuilderStatus(), 1).writeLong(3).closeEntry().build())
+                .writeObject(BIGINT.createBlockBuilder(null, 1).writeLong(3).closeEntry().build())
                 .closeEntry()
                 .build();
         DynamicSliceOutput expectedSliceOutput = new DynamicSliceOutput(100);
@@ -1553,8 +1552,8 @@ public class TestArrayOperators
     private void assertArrayHashOperator(String inputArray, Type elementType, List<Object> elements)
     {
         ArrayType arrayType = new ArrayType(elementType);
-        BlockBuilder arrayArrayBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 1);
-        BlockBuilder arrayBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), elements.size());
+        BlockBuilder arrayArrayBuilder = arrayType.createBlockBuilder(null, 1);
+        BlockBuilder arrayBuilder = elementType.createBlockBuilder(null, elements.size());
         for (Object element : elements) {
             appendToBlockBuilder(elementType, element, arrayBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBigintArrayType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBigintArrayType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
@@ -34,7 +33,7 @@ public class TestBigintArrayType
 
     public static Block createTestBlock(Type arrayType)
     {
-        BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 4);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, 4);
         arrayType.writeObject(blockBuilder, arrayBlockOf(BIGINT, 1, 2));
         arrayType.writeObject(blockBuilder, arrayBlockOf(BIGINT, 1, 2, 3));
         arrayType.writeObject(blockBuilder, arrayBlockOf(BIGINT, 1, 2, 3));
@@ -46,7 +45,7 @@ public class TestBigintArrayType
     protected Object getGreaterValue(Object value)
     {
         Block block = (Block) value;
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             BIGINT.appendTo(block, i, blockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBigintType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBigintType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 
@@ -29,7 +28,7 @@ public class TestBigintType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, 15);
         BIGINT.writeLong(blockBuilder, 1111);
         BIGINT.writeLong(blockBuilder, 1111);
         BIGINT.writeLong(blockBuilder, 1111);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBigintVarcharMapType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBigintVarcharMapType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
 
@@ -36,7 +35,7 @@ public class TestBigintVarcharMapType
 
     public static Block createTestBlock(Type mapType)
     {
-        BlockBuilder blockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 2);
+        BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 2);
         mapType.writeObject(blockBuilder, mapBlockOf(BIGINT, VARCHAR, ImmutableMap.of(1, "hi")));
         mapType.writeObject(blockBuilder, mapBlockOf(BIGINT, VARCHAR, ImmutableMap.of(1, "2", 2, "hello")));
         return blockBuilder.build();

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBooleanType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBooleanType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 
@@ -29,7 +28,7 @@ public class TestBooleanType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(null, 15);
         BOOLEAN.writeBoolean(blockBuilder, true);
         BOOLEAN.writeBoolean(blockBuilder, true);
         BOOLEAN.writeBoolean(blockBuilder, true);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestCharType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestCharType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.CharType;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -34,7 +33,7 @@ public class TestCharType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = CHAR_TYPE.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = CHAR_TYPE.createBlockBuilder(null, 15);
         CHAR_TYPE.writeString(blockBuilder, "apple");
         CHAR_TYPE.writeString(blockBuilder, "apple");
         CHAR_TYPE.writeString(blockBuilder, "apple");

--- a/presto-main/src/test/java/com/facebook/presto/type/TestColorArrayType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestColorArrayType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
@@ -34,7 +33,7 @@ public class TestColorArrayType
 
     public static Block createTestBlock(Type arrayType)
     {
-        BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 4);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, 4);
         arrayType.writeObject(blockBuilder, arrayBlockOf(COLOR, 1, 2));
         arrayType.writeObject(blockBuilder, arrayBlockOf(COLOR, 1, 2, 3));
         arrayType.writeObject(blockBuilder, arrayBlockOf(COLOR, 1, 2, 3));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestColorType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestColorType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.operator.scalar.ColorFunctions.rgb;
 import static com.facebook.presto.type.ColorType.COLOR;
@@ -30,7 +29,7 @@ public class TestColorType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = COLOR.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = COLOR.createBlockBuilder(null, 15);
         COLOR.writeLong(blockBuilder, rgb(1, 1, 1));
         COLOR.writeLong(blockBuilder, rgb(1, 1, 1));
         COLOR.writeLong(blockBuilder, rgb(1, 1, 1));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDateType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDateType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlDate;
 
 import static com.facebook.presto.spi.type.DateType.DATE;
@@ -30,7 +29,7 @@ public class TestDateType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = DATE.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = DATE.createBlockBuilder(null, 15);
         DATE.writeLong(blockBuilder, 1111);
         DATE.writeLong(blockBuilder, 1111);
         DATE.writeLong(blockBuilder, 1111);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDoubleType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDoubleType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 
@@ -29,7 +28,7 @@ public class TestDoubleType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, 15);
         DOUBLE.writeDouble(blockBuilder, 11.11);
         DOUBLE.writeDouble(blockBuilder, 11.11);
         DOUBLE.writeDouble(blockBuilder, 11.11);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIntegerArrayType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIntegerArrayType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
@@ -34,7 +33,7 @@ public class TestIntegerArrayType
 
     public static Block createTestBlock(Type arrayType)
     {
-        BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 4);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, 4);
         arrayType.writeObject(blockBuilder, arrayBlockOf(INTEGER, 1, 2));
         arrayType.writeObject(blockBuilder, arrayBlockOf(INTEGER, 1, 2, 3));
         arrayType.writeObject(blockBuilder, arrayBlockOf(INTEGER, 1, 2, 3));
@@ -46,7 +45,7 @@ public class TestIntegerArrayType
     protected Object getGreaterValue(Object value)
     {
         Block block = (Block) value;
-        BlockBuilder blockBuilder = INTEGER.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = INTEGER.createBlockBuilder(null, block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             INTEGER.appendTo(block, i, blockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIntegerType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIntegerType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 
@@ -29,7 +28,7 @@ public class TestIntegerType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = INTEGER.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = INTEGER.createBlockBuilder(null, 15);
         INTEGER.writeLong(blockBuilder, 1111);
         INTEGER.writeLong(blockBuilder, 1111);
         INTEGER.writeLong(blockBuilder, 1111);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIntegerVarcharMapType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIntegerVarcharMapType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
 
@@ -36,7 +35,7 @@ public class TestIntegerVarcharMapType
 
     public static Block createTestBlock(Type mapType)
     {
-        BlockBuilder blockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 2);
+        BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 2);
         mapType.writeObject(blockBuilder, mapBlockOf(INTEGER, VARCHAR, ImmutableMap.of(1, "hi")));
         mapType.writeObject(blockBuilder, mapBlockOf(INTEGER, VARCHAR, ImmutableMap.of(1, "2", 2, "hello")));
         return blockBuilder.build();

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIntervalDayTimeType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIntervalDayTimeType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 
@@ -29,7 +28,7 @@ public class TestIntervalDayTimeType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(null, 15);
         INTERVAL_DAY_TIME.writeLong(blockBuilder, 1111);
         INTERVAL_DAY_TIME.writeLong(blockBuilder, 1111);
         INTERVAL_DAY_TIME.writeLong(blockBuilder, 1111);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIntervalYearMonthType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIntervalYearMonthType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
 
@@ -29,7 +28,7 @@ public class TestIntervalYearMonthType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = INTERVAL_YEAR_MONTH.createBlockBuilder(null, 15);
         INTERVAL_YEAR_MONTH.writeLong(blockBuilder, 1111);
         INTERVAL_YEAR_MONTH.writeLong(blockBuilder, 1111);
         INTERVAL_YEAR_MONTH.writeLong(blockBuilder, 1111);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestJsonType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestJsonType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
@@ -31,7 +30,7 @@ public class TestJsonType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = JSON.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = JSON.createBlockBuilder(null, 1);
         Slice slice = Slices.utf8Slice("{\"x\":1, \"y\":2}");
         JSON.writeSlice(blockBuilder, slice);
         return blockBuilder.build();

--- a/presto-main/src/test/java/com/facebook/presto/type/TestLongDecimalType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestLongDecimalType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDecimal;
 import io.airlift.slice.Slice;
@@ -53,7 +52,7 @@ public class TestLongDecimalType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = LONG_DECIMAL_TYPE.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = LONG_DECIMAL_TYPE.createBlockBuilder(null, 15);
         writeBigDecimal(LONG_DECIMAL_TYPE, blockBuilder, new BigDecimal("-12345678901234567890.1234567890"));
         writeBigDecimal(LONG_DECIMAL_TYPE, blockBuilder, new BigDecimal("-12345678901234567890.1234567890"));
         writeBigDecimal(LONG_DECIMAL_TYPE, blockBuilder, new BigDecimal("-12345678901234567890.1234567890"));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -913,7 +912,7 @@ public class TestMapOperators
     {
         checkArgument(elements.size() % 2 == 0, "the size of elements should be even number");
         MapType mapType = mapType(keyType, valueType);
-        BlockBuilder mapArrayBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder mapArrayBuilder = mapType.createBlockBuilder(null, 1);
         BlockBuilder singleMapWriter = mapArrayBuilder.beginBlockEntry();
         for (int i = 0; i < elements.size(); i += 2) {
             appendToBlockBuilder(keyType, elements.get(i), singleMapWriter);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRealType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRealType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.spi.type.RealType.REAL;
 import static java.lang.Float.floatToRawIntBits;
@@ -31,7 +30,7 @@ public class TestRealType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = REAL.createBlockBuilder(new BlockBuilderStatus(), 30);
+        BlockBuilder blockBuilder = REAL.createBlockBuilder(null, 30);
         REAL.writeLong(blockBuilder, floatToRawIntBits(11.11F));
         REAL.writeLong(blockBuilder, floatToRawIntBits(11.11F));
         REAL.writeLong(blockBuilder, floatToRawIntBits(11.11F));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -16,7 +16,6 @@ package com.facebook.presto.type;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.function.LiteralParameters;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
@@ -442,7 +441,7 @@ public class TestRowOperators
     {
         checkArgument(types.size() == elements.size(), "types and elements must have the same size");
         RowType rowType = new RowType(types, Optional.empty());
-        BlockBuilder blockBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = rowType.createBlockBuilder(null, 1);
         BlockBuilder singleRowBlockWriter = blockBuilder.beginBlockEntry();
         for (int i = 0; i < types.size(); i++) {
             appendToBlockBuilder(types.get(i), elements.get(i), singleRowBlockWriter);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestShortDecimalType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestShortDecimalType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDecimal;
 
@@ -33,7 +32,7 @@ public class TestShortDecimalType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = SHORT_DECIMAL_TYPE.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = SHORT_DECIMAL_TYPE.createBlockBuilder(null, 15);
         SHORT_DECIMAL_TYPE.writeLong(blockBuilder, -1234);
         SHORT_DECIMAL_TYPE.writeLong(blockBuilder, -1234);
         SHORT_DECIMAL_TYPE.writeLong(blockBuilder, -1234);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RowBlockBuilder;
 import com.facebook.presto.spi.block.SingleRowBlockWriter;
 import com.facebook.presto.spi.type.Type;
@@ -38,7 +37,7 @@ public class TestSimpleRowType
 
     private static Block createTestBlock()
     {
-        RowBlockBuilder blockBuilder = (RowBlockBuilder) TYPE.createBlockBuilder(new BlockBuilderStatus(), 3);
+        RowBlockBuilder blockBuilder = (RowBlockBuilder) TYPE.createBlockBuilder(null, 3);
 
         SingleRowBlockWriter singleRowBlockWriter;
 
@@ -63,7 +62,7 @@ public class TestSimpleRowType
     @Override
     protected Object getGreaterValue(Object value)
     {
-        RowBlockBuilder blockBuilder = (RowBlockBuilder) TYPE.createBlockBuilder(new BlockBuilderStatus(), 1);
+        RowBlockBuilder blockBuilder = (RowBlockBuilder) TYPE.createBlockBuilder(null, 1);
         SingleRowBlockWriter singleRowBlockWriter;
 
         Block block = (Block) value;

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSmallintArrayType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSmallintArrayType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
@@ -34,7 +33,7 @@ public class TestSmallintArrayType
 
     public static Block createTestBlock(Type arrayType)
     {
-        BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 4);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, 4);
         arrayType.writeObject(blockBuilder, arrayBlockOf(SMALLINT, 1, 2));
         arrayType.writeObject(blockBuilder, arrayBlockOf(SMALLINT, 1, 2, 3));
         arrayType.writeObject(blockBuilder, arrayBlockOf(SMALLINT, 1, 2, 3));
@@ -46,7 +45,7 @@ public class TestSmallintArrayType
     protected Object getGreaterValue(Object value)
     {
         Block block = (Block) value;
-        BlockBuilder blockBuilder = SMALLINT.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = SMALLINT.createBlockBuilder(null, block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             SMALLINT.appendTo(block, i, blockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSmallintType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSmallintType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 
@@ -29,7 +28,7 @@ public class TestSmallintType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = SMALLINT.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = SMALLINT.createBlockBuilder(null, 15);
         SMALLINT.writeLong(blockBuilder, 1111);
         SMALLINT.writeLong(blockBuilder, 1111);
         SMALLINT.writeLong(blockBuilder, 1111);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSmallintVarcharMapType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSmallintVarcharMapType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
 
@@ -36,7 +35,7 @@ public class TestSmallintVarcharMapType
 
     public static Block createTestBlock(Type mapType)
     {
-        BlockBuilder blockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 2);
+        BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 2);
         mapType.writeObject(blockBuilder, mapBlockOf(SMALLINT, VARCHAR, ImmutableMap.of(1, "hi")));
         mapType.writeObject(blockBuilder, mapBlockOf(SMALLINT, VARCHAR, ImmutableMap.of(1, "2", 2, "hello")));
         return blockBuilder.build();

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimeType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimeType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlTime;
 
 import static com.facebook.presto.spi.type.TimeType.TIME;
@@ -30,7 +29,7 @@ public class TestTimeType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = TIME.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = TIME.createBlockBuilder(null, 15);
         TIME.writeLong(blockBuilder, 1111);
         TIME.writeLong(blockBuilder, 1111);
         TIME.writeLong(blockBuilder, 1111);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZoneType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZoneType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlTimeWithTimeZone;
 
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
@@ -33,7 +32,7 @@ public class TestTimeWithTimeZoneType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = TIME_WITH_TIME_ZONE.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = TIME_WITH_TIME_ZONE.createBlockBuilder(null, 15);
         TIME_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(1111, getTimeZoneKeyForOffset(0)));
         TIME_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(1111, getTimeZoneKeyForOffset(1)));
         TIME_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(1111, getTimeZoneKeyForOffset(2)));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlTimestamp;
 
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
@@ -30,7 +29,7 @@ public class TestTimestampType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = TIMESTAMP.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = TIMESTAMP.createBlockBuilder(null, 15);
         TIMESTAMP.writeLong(blockBuilder, 1111);
         TIMESTAMP.writeLong(blockBuilder, 1111);
         TIMESTAMP.writeLong(blockBuilder, 1111);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlTimestampWithTimeZone;
 
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
@@ -33,7 +32,7 @@ public class TestTimestampWithTimeZoneType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = TIMESTAMP_WITH_TIME_ZONE.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = TIMESTAMP_WITH_TIME_ZONE.createBlockBuilder(null, 15);
         TIMESTAMP_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(1111, getTimeZoneKeyForOffset(0)));
         TIMESTAMP_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(1111, getTimeZoneKeyForOffset(1)));
         TIMESTAMP_WITH_TIME_ZONE.writeLong(blockBuilder, packDateTimeWithZone(1111, getTimeZoneKeyForOffset(2)));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTinyintArrayType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTinyintArrayType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
@@ -34,7 +33,7 @@ public class TestTinyintArrayType
 
     public static Block createTestBlock(Type arrayType)
     {
-        BlockBuilder blockBuilder = arrayType.createBlockBuilder(new BlockBuilderStatus(), 4);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, 4);
         arrayType.writeObject(blockBuilder, arrayBlockOf(TINYINT, 1, 2));
         arrayType.writeObject(blockBuilder, arrayBlockOf(TINYINT, 1, 2, 3));
         arrayType.writeObject(blockBuilder, arrayBlockOf(TINYINT, 1, 2, 3));
@@ -46,7 +45,7 @@ public class TestTinyintArrayType
     protected Object getGreaterValue(Object value)
     {
         Block block = (Block) value;
-        BlockBuilder blockBuilder = TINYINT.createBlockBuilder(new BlockBuilderStatus(), block.getPositionCount() + 1);
+        BlockBuilder blockBuilder = TINYINT.createBlockBuilder(null, block.getPositionCount() + 1);
         for (int i = 0; i < block.getPositionCount(); i++) {
             TINYINT.appendTo(block, i, blockBuilder);
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTinyintType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTinyintType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 
@@ -29,7 +28,7 @@ public class TestTinyintType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = TINYINT.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = TINYINT.createBlockBuilder(null, 15);
         TINYINT.writeLong(blockBuilder, 111);
         TINYINT.writeLong(blockBuilder, 111);
         TINYINT.writeLong(blockBuilder, 111);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTinyintVarcharMapType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTinyintVarcharMapType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
 
@@ -36,7 +35,7 @@ public class TestTinyintVarcharMapType
 
     public static Block createTestBlock(Type mapType)
     {
-        BlockBuilder blockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 2);
+        BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 2);
         mapType.writeObject(blockBuilder, mapBlockOf(TINYINT, VARCHAR, ImmutableMap.of(1, "hi")));
         mapType.writeObject(blockBuilder, mapBlockOf(TINYINT, VARCHAR, ImmutableMap.of(1, "2", 2, "hello")));
         return blockBuilder.build();

--- a/presto-main/src/test/java/com/facebook/presto/type/TestUnknownType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestUnknownType.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.type;
 
-import com.facebook.presto.spi.block.BlockBuilderStatus;
-
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 
 public class TestUnknownType
@@ -24,7 +22,7 @@ public class TestUnknownType
     {
         super(UNKNOWN,
                 void.class,
-                UNKNOWN.createBlockBuilder(new BlockBuilderStatus(), 3)
+                UNKNOWN.createBlockBuilder(null, 3)
                         .appendNull()
                         .appendNull()
                         .appendNull()

--- a/presto-main/src/test/java/com/facebook/presto/type/TestVarbinaryType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestVarbinaryType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SqlVarbinary;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -32,7 +31,7 @@ public class TestVarbinaryType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = VARBINARY.createBlockBuilder(null, 15);
         VARBINARY.writeSlice(blockBuilder, Slices.utf8Slice("apple"));
         VARBINARY.writeSlice(blockBuilder, Slices.utf8Slice("apple"));
         VARBINARY.writeSlice(blockBuilder, Slices.utf8Slice("apple"));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestVarcharType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestVarcharType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
@@ -31,7 +30,7 @@ public class TestVarcharType
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 15);
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 15);
         VARCHAR.writeString(blockBuilder, "apple");
         VARCHAR.writeString(blockBuilder, "apple");
         VARCHAR.writeString(blockBuilder, "apple");

--- a/presto-main/src/test/java/com/facebook/presto/util/StructuralTestUtil.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/StructuralTestUtil.java
@@ -17,7 +17,6 @@ import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.SqlDecimal;
@@ -49,7 +48,7 @@ public final class StructuralTestUtil
 
     public static Block arrayBlockOf(Type elementType, Object... values)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), values.length);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, values.length);
         for (Object value : values) {
             appendToBlockBuilder(elementType, value, blockBuilder);
         }
@@ -59,7 +58,7 @@ public final class StructuralTestUtil
     public static Block mapBlockOf(Type keyType, Type valueType, Map<?, ?> value)
     {
         MapType mapType = mapType(keyType, valueType);
-        BlockBuilder mapArrayBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder mapArrayBuilder = mapType.createBlockBuilder(null, 1);
         BlockBuilder singleMapWriter = mapArrayBuilder.beginBlockEntry();
         for (Map.Entry<?, ?> entry : value.entrySet()) {
             appendToBlockBuilder(keyType, entry.getKey(), singleMapWriter);

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestEvaluateClassifierPredictions.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestEvaluateClassifierPredictions.java
@@ -22,7 +22,6 @@ import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -52,7 +51,7 @@ public class TestEvaluateClassifierPredictions
                         parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)));
         Accumulator accumulator = aggregation.bind(ImmutableList.of(0, 1), Optional.empty()).createAccumulator();
         accumulator.addInput(getPage());
-        BlockBuilder finalOut = accumulator.getFinalType().createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder finalOut = accumulator.getFinalType().createBlockBuilder(null, 1);
         accumulator.evaluateFinal(finalOut);
         Block block = finalOut.build();
 

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestLearnAggregations.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestLearnAggregations.java
@@ -27,7 +27,6 @@ import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -89,7 +88,7 @@ public class TestLearnAggregations
     private static void assertLearnClassifer(Accumulator accumulator)
     {
         accumulator.addInput(getPage());
-        BlockBuilder finalOut = accumulator.getFinalType().createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder finalOut = accumulator.getFinalType().createBlockBuilder(null, 1);
         accumulator.evaluateFinal(finalOut);
         Block block = finalOut.build();
         Slice slice = accumulator.getFinalType().getSlice(block, 0);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
@@ -21,7 +21,6 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import javax.annotation.Nonnull;
@@ -91,7 +90,7 @@ public class BooleanStreamReader
             }
         }
 
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
@@ -22,7 +22,6 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import javax.annotation.Nonnull;
@@ -92,7 +91,7 @@ public class ByteStreamReader
             }
         }
 
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DecimalStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DecimalStreamReader.java
@@ -23,7 +23,6 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 
@@ -94,7 +93,7 @@ public class DecimalStreamReader
         seekToOffset();
         allocateVectors();
 
-        BlockBuilder builder = decimalType.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder builder = decimalType.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (decimalStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but decimal stream is not present");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
@@ -22,7 +22,6 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import javax.annotation.Nonnull;
@@ -92,7 +91,7 @@ public class DoubleStreamReader
             }
         }
 
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
@@ -22,7 +22,6 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import javax.annotation.Nonnull;
@@ -92,7 +91,7 @@ public class FloatStreamReader
             }
         }
 
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListStreamReader.java
@@ -22,7 +22,6 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.ArrayBlock;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
@@ -134,7 +133,7 @@ public class ListStreamReader
             elements = elementStreamReader.readBlock(elementType);
         }
         else {
-            elements = elementType.createBlockBuilder(new BlockBuilderStatus(), 0).build();
+            elements = elementType.createBlockBuilder(null, 0).build();
         }
         Block arrayBlock = ArrayBlock.fromElementBlock(nextBatchSize, nullVector, offsets, elements);
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryStreamReader.java
@@ -22,7 +22,6 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import javax.annotation.Nonnull;
@@ -147,7 +146,7 @@ public class LongDictionaryStreamReader
             inDictionaryStream.getSetBits(nextBatchSize, inDictionary, nullVector);
         }
 
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         for (int i = 0; i < nextBatchSize; i++) {
             if (nullVector[i]) {
                 builder.appendNull();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
@@ -22,7 +22,6 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import javax.annotation.Nonnull;
@@ -92,7 +91,7 @@ public class LongDirectStreamReader
             }
         }
 
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapStreamReader.java
@@ -21,7 +21,6 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -142,8 +141,8 @@ public class MapStreamReader
             values = valueStreamReader.readBlock(valueType);
         }
         else {
-            keys = keyType.createBlockBuilder(new BlockBuilderStatus(), 0).build();
-            values = valueType.createBlockBuilder(new BlockBuilderStatus(), 1).build();
+            keys = keyType.createBlockBuilder(null, 0).build();
+            values = valueType.createBlockBuilder(null, 1).build();
         }
 
         Block[] keyValueBlock = createKeyValueBlock(nextBatchSize, keys, values, lengthVector);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
@@ -19,7 +19,6 @@ import com.facebook.presto.orc.stream.BooleanInputStream;
 import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RowBlock;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTimeZone;
@@ -113,7 +112,7 @@ public class StructStreamReader
             }
             else {
                 for (int i = 0; i < typeParameters.size(); i++) {
-                    blocks[i] = typeParameters.get(i).createBlockBuilder(new BlockBuilderStatus(), 0).build();
+                    blocks[i] = typeParameters.get(i).createBlockBuilder(null, 0).build();
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampStreamReader.java
@@ -22,7 +22,6 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -119,7 +118,7 @@ public class TimestampStreamReader
             nanosVector = new long[nextBatchSize];
         }
 
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), nextBatchSize);
+        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (secondsStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but seconds stream is not present");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryBuilder.java
@@ -16,10 +16,10 @@ package com.facebook.presto.orc.writer;
 import com.facebook.presto.array.IntBigArray;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import org.openjdk.jol.info.ClassLayout;
 
+import static com.facebook.presto.spi.block.BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
@@ -51,11 +51,10 @@ public class DictionaryBuilder
         checkArgument(expectedSize >= 0, "expectedSize must not be negative");
 
         // todo we can do better
-        BlockBuilderStatus blockBuilderStatus = new BlockBuilderStatus();
-        int expectedEntries = min(expectedSize, blockBuilderStatus.getMaxBlockSizeInBytes() / EXPECTED_BYTES_PER_ENTRY);
+        int expectedEntries = min(expectedSize, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES / EXPECTED_BYTES_PER_ENTRY);
         // it is guaranteed expectedEntries * EXPECTED_BYTES_PER_ENTRY will not overflow
         this.elementBlock = new VariableWidthBlockBuilder(
-                blockBuilderStatus,
+                null,
                 expectedEntries,
                 expectedEntries * EXPECTED_BYTES_PER_ENTRY);
 
@@ -91,7 +90,7 @@ public class DictionaryBuilder
     {
         containsNullElement = false;
         blockPositionByHash.fill(EMPTY_SLOT);
-        elementBlock = elementBlock.newBlockBuilderLike(new BlockBuilderStatus());
+        elementBlock = elementBlock.newBlockBuilderLike(null);
         // first position is always null
         elementBlock.appendNull();
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -21,7 +21,6 @@ import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
@@ -637,7 +636,7 @@ public class OrcTester
                 true,
                 stats);
 
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 1024);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1024);
         while (values.hasNext()) {
             Object value = values.next();
             writeValue(type, blockBuilder, value);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -21,7 +21,6 @@ import com.facebook.presto.orc.stream.OrcInputStream;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
@@ -74,7 +73,7 @@ public class TestOrcWriter
         String[] data = new String[]{"a", "bbbbb", "ccc", "dd", "eeee"};
         Block[] blocks = new Block[data.length];
         int entries = 65536;
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), entries);
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, entries);
         for (int i = 0; i < data.length; i++) {
             byte[] bytes = data[i].getBytes();
             for (int j = 0; j < entries; j++) {
@@ -84,7 +83,7 @@ public class TestOrcWriter
                 blockBuilder.closeEntry();
             }
             blocks[i] = blockBuilder.build();
-            blockBuilder = blockBuilder.newBlockBuilderLike(new BlockBuilderStatus());
+            blockBuilder = blockBuilder.newBlockBuilderLike(null);
         }
 
         writer.write(new Page(blocks));

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileReader.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileReader.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.RcFileWriteValidation.WriteChecksum;
 import com.facebook.presto.rcfile.RcFileWriteValidation.WriteChecksumBuilder;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
@@ -428,7 +427,7 @@ public class RcFileReader
 
         if (columnIndex >= columns.length) {
             Type type = readColumns.get(columnIndex);
-            Block nullBlock = type.createBlockBuilder(new BlockBuilderStatus(), 1, 0).appendNull().build();
+            Block nullBlock = type.createBlockBuilder(null, 1, 0).appendNull().build();
             return new RunLengthEncodedBlock(nullBlock, currentChunkRowCount);
         }
 

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/BinaryEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/BinaryEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -66,7 +65,7 @@ public class BinaryEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/BlockEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/BlockEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
@@ -68,7 +67,7 @@ public abstract class BlockEncoding
         int size = columnData.rowCount();
 
         Slice slice = columnData.getSlice();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
         for (int i = 0; i < size; i++) {
             int length = columnData.getLength(i);
             if (length > 0) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/BooleanEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/BooleanEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -56,7 +55,7 @@ public class BooleanEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/ByteEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/ByteEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -56,7 +55,7 @@ public class ByteEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/DateEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/DateEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -58,7 +57,7 @@ public class DateEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/DecimalEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/DecimalEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
@@ -76,7 +75,7 @@ public class DecimalEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/DoubleEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/DoubleEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -56,7 +55,7 @@ public class DoubleEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/FloatEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/FloatEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -56,7 +55,7 @@ public class FloatEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/LongEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/LongEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -57,7 +56,7 @@ public class LongEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/ShortEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/ShortEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -56,7 +55,7 @@ public class ShortEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/StringEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/StringEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -71,7 +70,7 @@ public class StringEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/TimestampEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/TimestampEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -62,7 +61,7 @@ public class TimestampEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/BinaryEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/BinaryEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -70,7 +69,7 @@ public class BinaryEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/BlockEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/BlockEncoding.java
@@ -18,7 +18,6 @@ import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.rcfile.RcFileCorruptionException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -61,7 +60,7 @@ public abstract class BlockEncoding
         int size = columnData.rowCount();
 
         Slice slice = columnData.getSlice();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
         for (int i = 0; i < size; i++) {
             int length = columnData.getLength(i);
             int offset = columnData.getOffset(i);

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/BooleanEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/BooleanEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -72,7 +71,7 @@ public class BooleanEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/DateEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/DateEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -79,7 +78,7 @@ public class DateEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/DecimalEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/DecimalEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
@@ -80,7 +79,7 @@ public class DecimalEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/DoubleEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/DoubleEncoding.java
@@ -18,7 +18,6 @@ import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.rcfile.RcFileCorruptionException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -71,7 +70,7 @@ public class DoubleEncoding
             throws RcFileCorruptionException
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/FloatEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/FloatEncoding.java
@@ -18,7 +18,6 @@ import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.rcfile.RcFileCorruptionException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -71,7 +70,7 @@ public class FloatEncoding
             throws RcFileCorruptionException
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/LongEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/LongEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -71,7 +70,7 @@ public class LongEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/StringEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/StringEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -75,7 +74,7 @@ public class StringEncoding
         }
 
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/TimestampEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/text/TimestampEncoding.java
@@ -17,7 +17,6 @@ import com.facebook.presto.rcfile.ColumnData;
 import com.facebook.presto.rcfile.EncodeOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -94,7 +93,7 @@ public class TimestampEncoding
     public Block decodeColumn(ColumnData columnData)
     {
         int size = columnData.rowCount();
-        BlockBuilder builder = type.createBlockBuilder(new BlockBuilderStatus(), size);
+        BlockBuilder builder = type.createBlockBuilder(null, size);
 
         Slice slice = columnData.getSlice();
         for (int i = 0; i < size; i++) {

--- a/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
@@ -21,7 +21,6 @@ import com.facebook.presto.rcfile.text.TextRcFileEncoding;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
@@ -668,7 +667,7 @@ public class RcFileTester
                 new DataSize(100, KILOBYTE),   // use a smaller size to create more row groups
                 new DataSize(200, KILOBYTE),
                 true);
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 1024);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1024);
         while (values.hasNext()) {
             Object value = values.next();
             writeValue(type, blockBuilder, value);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilderStatus.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilderStatus.java
@@ -18,7 +18,6 @@ import org.openjdk.jol.info.ClassLayout;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-import static com.facebook.presto.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -31,13 +30,6 @@ public class BlockBuilderStatus
     private final int maxBlockSizeInBytes;
 
     private int currentSize;
-
-    public BlockBuilderStatus()
-    {
-        // When this constructor is used, this class has no observable internal state (except getMaxBlockSizeInBytes).
-        // TODO: this constructor essentially constructs a black hole. This constructor and all its usage should probably be removed.
-        this(new PageBuilderStatus(DEFAULT_MAX_PAGE_SIZE_IN_BYTES, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES), DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
-    }
 
     BlockBuilderStatus(PageBuilderStatus pageBuilderStatus, int maxBlockSizeInBytes)
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -67,7 +67,7 @@ public class FixedWidthBlockBuilder
         initialized = true;
         Slice slice = Slices.allocate(fixedSize * positionCount);
 
-        this.blockBuilderStatus = new BlockBuilderStatus();
+        this.blockBuilderStatus = null;
         this.sliceOutput = slice.getOutput();
 
         this.valueIsNull = Slices.allocate(positionCount).getOutput();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Utils.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Utils.java
@@ -15,7 +15,6 @@ package com.facebook.presto.spi.predicate;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.Type;
 
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
@@ -32,7 +31,7 @@ public final class Utils
         if (object != null && !Primitives.wrap(type.getJavaType()).isInstance(object)) {
             throw new IllegalArgumentException(String.format("Object '%s' does not match type %s", object, type.getJavaType()));
         }
-        BlockBuilder blockBuilder = type.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
         writeNativeValue(type, blockBuilder, object);
         return blockBuilder.build();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
@@ -125,7 +125,7 @@ public abstract class AbstractIntType
     @Override
     public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
-        return new IntArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
+        return new IntArrayBlockBuilder(null, positionCount);
     }
 
     public static long hash(int value)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
@@ -123,7 +123,7 @@ public abstract class AbstractLongType
     @Override
     public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
-        return new LongArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
+        return new LongArrayBlockBuilder(null, positionCount);
     }
 
     public static long hash(long value)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
@@ -62,7 +62,7 @@ public final class BooleanType
     @Override
     public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
-        return new ByteArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
+        return new ByteArrayBlockBuilder(null, positionCount);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -133,7 +133,7 @@ public final class DoubleType
     @Override
     public final BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
-        return new LongArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
+        return new LongArrayBlockBuilder(null, positionCount);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -63,7 +63,7 @@ final class ShortDecimalType
     @Override
     public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
-        return new LongArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
+        return new LongArrayBlockBuilder(null, positionCount);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
@@ -65,7 +65,7 @@ public final class SmallintType
     @Override
     public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
-        return new ShortArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
+        return new ShortArrayBlockBuilder(null, positionCount);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
@@ -65,7 +65,7 @@ public final class TinyintType
     @Override
     public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
     {
-        return new ByteArrayBlockBuilder(new BlockBuilderStatus(), positionCount);
+        return new ByteArrayBlockBuilder(null, positionCount);
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestPage.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestPage.java
@@ -15,7 +15,6 @@ package com.facebook.presto.spi;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.DictionaryId;
 import io.airlift.slice.DynamicSliceOutput;
@@ -74,7 +73,7 @@ public class TestPage
         DictionaryBlock commonSourceIdBlock1 = new DictionaryBlock(positionCount, dictionary1, commonDictionaryIds, commonSourceId);
 
         // second dictionary block is "length(firstColumn)"
-        BlockBuilder dictionary2 = BIGINT.createBlockBuilder(new BlockBuilderStatus(), dictionary1.getPositionCount());
+        BlockBuilder dictionary2 = BIGINT.createBlockBuilder(null, dictionary1.getPositionCount());
         for (Slice expectedValue : dictionaryValues1) {
             BIGINT.writeLong(dictionary2, expectedValue.length());
         }
@@ -106,7 +105,7 @@ public class TestPage
     public void testGetPositions()
     {
         int entries = 10;
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), entries);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, entries);
         for (int i = 0; i < entries; i++) {
             BIGINT.writeLong(blockBuilder, i);
         }
@@ -153,7 +152,7 @@ public class TestPage
 
     private static Block createSlicesBlock(Slice[] values)
     {
-        BlockBuilder builder = VARBINARY.createBlockBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder builder = VARBINARY.createBlockBuilder(null, 100);
 
         for (Slice value : values) {
             verify(value != null);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestArrayBlockBuilder.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestArrayBlockBuilder.java
@@ -53,7 +53,7 @@ public class TestArrayBlockBuilder
     public void testRetainedSizeInBytes()
     {
         int expectedEntries = 1000;
-        BlockBuilder arrayBlockBuilder = new ArrayBlockBuilder(BIGINT, new BlockBuilderStatus(), expectedEntries);
+        BlockBuilder arrayBlockBuilder = new ArrayBlockBuilder(BIGINT, null, expectedEntries);
         long initialRetainedSize = arrayBlockBuilder.getRetainedSizeInBytes();
         for (int i = 0; i < expectedEntries; i++) {
             BlockBuilder arrayElementBuilder = arrayBlockBuilder.beginBlockEntry();
@@ -66,7 +66,7 @@ public class TestArrayBlockBuilder
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Expected current entry to be closed but was opened")
     public void testConcurrentWriting()
     {
-        BlockBuilder blockBuilder = new ArrayBlockBuilder(BIGINT, new BlockBuilderStatus(), EXPECTED_ENTRY_COUNT);
+        BlockBuilder blockBuilder = new ArrayBlockBuilder(BIGINT, null, EXPECTED_ENTRY_COUNT);
         BlockBuilder elementBlockWriter = blockBuilder.beginBlockEntry();
         elementBlockWriter.writeLong(45).closeEntry();
         blockBuilder.writeObject(new FixedWidthBlockBuilder(8, 4).writeLong(123).closeEntry().build()).closeEntry();

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockRetainedSizeBreakdown.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockRetainedSizeBreakdown.java
@@ -37,7 +37,7 @@ public class TestBlockRetainedSizeBreakdown
     @Test
     public void testArrayBlock()
     {
-        BlockBuilder arrayBlockBuilder = new ArrayBlockBuilder(BIGINT, new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        BlockBuilder arrayBlockBuilder = new ArrayBlockBuilder(BIGINT, null, EXPECTED_ENTRIES);
         for (int i = 0; i < EXPECTED_ENTRIES; i++) {
             BlockBuilder arrayElementBuilder = arrayBlockBuilder.beginBlockEntry();
             writeNativeValue(BIGINT, arrayElementBuilder, castIntegerToObject(i, BIGINT));
@@ -49,7 +49,7 @@ public class TestBlockRetainedSizeBreakdown
     @Test
     public void testByteArrayBlock()
     {
-        BlockBuilder blockBuilder = new ByteArrayBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        BlockBuilder blockBuilder = new ByteArrayBlockBuilder(null, EXPECTED_ENTRIES);
         for (int i = 0; i < EXPECTED_ENTRIES; i++) {
             blockBuilder.writeByte(i);
         }
@@ -70,7 +70,7 @@ public class TestBlockRetainedSizeBreakdown
     @Test
     public void testFixedWidthBlock()
     {
-        BlockBuilder blockBuilder = new FixedWidthBlockBuilder(8, new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        BlockBuilder blockBuilder = new FixedWidthBlockBuilder(8, null, EXPECTED_ENTRIES);
         writeEntries(EXPECTED_ENTRIES, blockBuilder, DOUBLE);
         checkRetainedSize(blockBuilder.build(), true);
     }
@@ -78,7 +78,7 @@ public class TestBlockRetainedSizeBreakdown
     @Test
     public void testIntArrayBlock()
     {
-        BlockBuilder blockBuilder = new IntArrayBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        BlockBuilder blockBuilder = new IntArrayBlockBuilder(null, EXPECTED_ENTRIES);
         writeEntries(EXPECTED_ENTRIES, blockBuilder, INTEGER);
         checkRetainedSize(blockBuilder.build(), false);
     }
@@ -86,7 +86,7 @@ public class TestBlockRetainedSizeBreakdown
     @Test
     public void testLongArrayBlock()
     {
-        BlockBuilder blockBuilder = new LongArrayBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        BlockBuilder blockBuilder = new LongArrayBlockBuilder(null, EXPECTED_ENTRIES);
         writeEntries(EXPECTED_ENTRIES, blockBuilder, BIGINT);
         checkRetainedSize(blockBuilder.build(), false);
     }
@@ -94,7 +94,7 @@ public class TestBlockRetainedSizeBreakdown
     @Test
     public void testRunLengthEncodedBlock()
     {
-        BlockBuilder blockBuilder = new LongArrayBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = new LongArrayBlockBuilder(null, 1);
         writeEntries(1, blockBuilder, BIGINT);
         checkRetainedSize(new RunLengthEncodedBlock(blockBuilder.build(), 1), false);
     }
@@ -102,7 +102,7 @@ public class TestBlockRetainedSizeBreakdown
     @Test
     public void testShortArrayBlock()
     {
-        BlockBuilder blockBuilder = new ShortArrayBlockBuilder(new BlockBuilderStatus(), EXPECTED_ENTRIES);
+        BlockBuilder blockBuilder = new ShortArrayBlockBuilder(null, EXPECTED_ENTRIES);
         for (int i = 0; i < EXPECTED_ENTRIES; i++) {
             blockBuilder.writeShort(i);
         }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarArray.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarArray.java
@@ -108,13 +108,13 @@ public class TestColumnarArray
 
     public static BlockBuilder createBlockBuilderWithValues(Slice[][] expectedValues)
     {
-        BlockBuilder blockBuilder = new ArrayBlockBuilder(VARCHAR, new BlockBuilderStatus(), 100, 100);
+        BlockBuilder blockBuilder = new ArrayBlockBuilder(VARCHAR, null, 100, 100);
         for (Slice[] expectedValue : expectedValues) {
             if (expectedValue == null) {
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), expectedValue.length);
+                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(null, expectedValue.length);
                 for (Slice v : expectedValue) {
                     if (v == null) {
                         elementBlockBuilder.appendNull();

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarMap.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarMap.java
@@ -124,13 +124,13 @@ public class TestColumnarMap
 
     public static BlockBuilder createBlockBuilderWithValues(Slice[][][] expectedValues)
     {
-        BlockBuilder blockBuilder = createMapBuilder(new BlockBuilderStatus(), 100);
+        BlockBuilder blockBuilder = createMapBuilder(100);
         for (Slice[][] expectedMap : expectedValues) {
             if (expectedMap == null) {
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), expectedMap.length);
+                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(null, expectedMap.length);
                 for (Slice[] entry : expectedMap) {
                     Slice key = entry[0];
                     assertNotNull(key);
@@ -150,7 +150,7 @@ public class TestColumnarMap
         return blockBuilder;
     }
 
-    private static BlockBuilder createMapBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    private static BlockBuilder createMapBuilder(int expectedEntries)
     {
         return new MapBlockBuilder(
                 VARCHAR,
@@ -158,7 +158,7 @@ public class TestColumnarMap
                 MethodHandleUtil.methodHandle(Slice.class, "equals", Object.class).asType(MethodType.methodType(boolean.class, Slice.class, Slice.class)),
                 MethodHandleUtil.methodHandle(Slice.class, "hashCode").asType(MethodType.methodType(long.class, Slice.class)),
                 MethodHandleUtil.methodHandle(TestColumnarMap.class, "blockVarcharHashCode", Block.class, int.class),
-                blockBuilderStatus,
+                null,
                 expectedEntries);
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarRow.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestColumnarRow.java
@@ -112,13 +112,13 @@ public class TestColumnarRow
 
     public static BlockBuilder createBlockBuilderWithValues(Slice[][] expectedValues)
     {
-        BlockBuilder blockBuilder = createBlockBuilder(new BlockBuilderStatus(), 100, 100);
+        BlockBuilder blockBuilder = createBlockBuilder(null, 100, 100);
         for (Slice[] expectedValue : expectedValues) {
             if (expectedValue == null) {
                 blockBuilder.appendNull();
             }
             else {
-                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), expectedValue.length);
+                BlockBuilder elementBlockBuilder = VARCHAR.createBlockBuilder(null, expectedValue.length);
                 for (Slice v : expectedValue) {
                     if (v == null) {
                         elementBlockBuilder.appendNull();

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestDictionaryBlockEncoding.java
@@ -30,7 +30,7 @@ public class TestDictionaryBlockEncoding
         int positionCount = 40;
 
         // build dictionary
-        BlockBuilder dictionaryBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 4);
+        BlockBuilder dictionaryBuilder = VARCHAR.createBlockBuilder(null, 4);
         VARCHAR.writeString(dictionaryBuilder, "alice");
         VARCHAR.writeString(dictionaryBuilder, "bob");
         VARCHAR.writeString(dictionaryBuilder, "charlie");

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockEncoding.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockEncoding.java
@@ -26,7 +26,7 @@ public class TestVariableWidthBlockEncoding
     @Test
     public void testRoundTrip()
     {
-        BlockBuilder expectedBlockBuilder = VARCHAR.createBlockBuilder(new BlockBuilderStatus(), 4);
+        BlockBuilder expectedBlockBuilder = VARCHAR.createBlockBuilder(null, 4);
         VARCHAR.writeString(expectedBlockBuilder, "alice");
         VARCHAR.writeString(expectedBlockBuilder, "bob");
         VARCHAR.writeString(expectedBlockBuilder, "charlie");

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestLongDecimalType.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestLongDecimalType.java
@@ -15,7 +15,6 @@ package com.facebook.presto.spi.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
@@ -62,7 +61,7 @@ public class TestLongDecimalType
     private Block decimalAsBlock(String value)
     {
         Slice slice = encodeScaledValue(new BigDecimal(value));
-        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(new BlockBuilderStatus(), 1, slice.length());
+        BlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, 1, slice.length());
         TYPE.writeSlice(blockBuilder, slice);
         return blockBuilder.build();
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StructuralTestUtil.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StructuralTestUtil.java
@@ -17,7 +17,6 @@ import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.MapType;
@@ -86,7 +85,7 @@ public final class StructuralTestUtil
 
     public static Block arrayBlockOf(Type elementType, Object... values)
     {
-        BlockBuilder blockBuilder = elementType.createBlockBuilder(new BlockBuilderStatus(), 1024);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, 1024);
         for (Object value : values) {
             appendToBlockBuilder(elementType, value, blockBuilder);
         }
@@ -96,7 +95,7 @@ public final class StructuralTestUtil
     public static Block mapBlockOf(Type keyType, Type valueType, Object key, Object value)
     {
         MapType mapType = mapType(keyType, valueType);
-        BlockBuilder blockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 10);
+        BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 10);
         BlockBuilder singleMapBlockWriter = blockBuilder.beginBlockEntry();
         appendToBlockBuilder(keyType, key, singleMapBlockWriter);
         appendToBlockBuilder(valueType, value, singleMapBlockWriter);
@@ -108,7 +107,7 @@ public final class StructuralTestUtil
     {
         checkArgument(keys.length == values.length, "keys/values must have the same length");
         MapType mapType = mapType(keyType, valueType);
-        BlockBuilder blockBuilder = mapType.createBlockBuilder(new BlockBuilderStatus(), 10);
+        BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 10);
         BlockBuilder singleMapBlockWriter = blockBuilder.beginBlockEntry();
         for (int i = 0; i < keys.length; i++) {
             Object key = keys[i];
@@ -123,7 +122,7 @@ public final class StructuralTestUtil
     public static Block rowBlockOf(List<Type> parameterTypes, Object... values)
     {
         RowType rowType = new RowType(parameterTypes, Optional.empty());
-        BlockBuilder blockBuilder = rowType.createBlockBuilder(new BlockBuilderStatus(), 1);
+        BlockBuilder blockBuilder = rowType.createBlockBuilder(null, 1);
         BlockBuilder singleRowBlockWriter = blockBuilder.beginBlockEntry();
         for (int i = 0; i < values.length; i++) {
             appendToBlockBuilder(parameterTypes.get(i), values[i], singleRowBlockWriter);

--- a/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftBlock.java
+++ b/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftBlock.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.drift.annotations.ThriftConstructor;
@@ -324,7 +323,7 @@ public final class PrestoThriftBlock
     private static Block convertColumnToBlock(RecordSet recordSet, int columnIndex, int positions)
     {
         Type type = recordSet.getColumnTypes().get(columnIndex);
-        BlockBuilder output = type.createBlockBuilder(new BlockBuilderStatus(), positions);
+        BlockBuilder output = type.createBlockBuilder(null, positions);
         Class<?> javaType = type.getJavaType();
         RecordCursor cursor = recordSet.cursor();
         for (int position = 0; position < positions; position++) {

--- a/presto-thrift-connector-api/src/test/java/com/facebook/presto/connector/thrift/api/TestReadWrite.java
+++ b/presto-thrift-connector-api/src/test/java/com/facebook/presto/connector/thrift/api/TestReadWrite.java
@@ -17,7 +17,6 @@ import com.facebook.presto.operator.index.PageRecordSet;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
@@ -179,7 +178,7 @@ public class TestReadWrite
 
     private static Block generateColumn(ColumnDefinition column, Random random, int records)
     {
-        BlockBuilder builder = column.getType().createBlockBuilder(new BlockBuilderStatus(), records);
+        BlockBuilder builder = column.getType().createBlockBuilder(null, records);
         for (int i = 0; i < records; i++) {
             if (random.nextDouble() < NULL_FRACTION) {
                 builder.appendNull();

--- a/presto-thrift-connector-api/src/test/java/com/facebook/presto/connector/thrift/api/datatypes/TestPrestoThriftBigint.java
+++ b/presto-thrift-connector-api/src/test/java/com/facebook/presto/connector/thrift/api/datatypes/TestPrestoThriftBigint.java
@@ -16,7 +16,6 @@ package com.facebook.presto.connector.thrift.api.datatypes;
 import com.facebook.presto.connector.thrift.api.PrestoThriftBlock;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -164,7 +163,7 @@ public class TestPrestoThriftBigint
 
     private static Block longBlock(Integer... values)
     {
-        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(new BlockBuilderStatus(), values.length);
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, values.length);
         for (Integer value : values) {
             if (value == null) {
                 blockBuilder.appendNull();


### PR DESCRIPTION
When this constructor is used, this class has no observable
internal state, and this constructor essentially constructs
a black hole.

Since BlockBuilder now allows taking null as BlockBuilderStatus,
this constructor and all its usage should probably be removed.