### PR TITLE
Move CLI_ARGUMENTS to docker compose files

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -40,10 +40,7 @@ function run_in_application_runner_container() {
 }
 
 function check_presto() {
-  run_in_application_runner_container \
-    java -jar "/docker/volumes/presto-cli/presto-cli-executable.jar" \
-    ${CLI_ARGUMENTS} \
-    --execute "SHOW CATALOGS" | grep -iq hive
+  run_in_application_runner_container /docker/volumes/conf/docker/files/presto-cli.sh --execute "SHOW CATALOGS" | grep -iq hive
 }
 
 function run_product_tests() {
@@ -126,17 +123,6 @@ if [[ "$ENVIRONMENT" == "multinode" ]]; then
    PRESTO_SERVICES="${PRESTO_SERVICES} presto-worker"
 elif [[ "$ENVIRONMENT" == "multinode-tls" ]]; then
    PRESTO_SERVICES="${PRESTO_SERVICES} presto-worker-1 presto-worker-2"
-fi
-
-CLI_ARGUMENTS="--server presto-master:8080"
-if [[ "$ENVIRONMENT" == "singlenode-ldap" ]]; then
-    CLI_ARGUMENTS="--server https://presto-master:8443 --keystore-path /etc/openldap/certs/coordinator.jks --keystore-password testldap"
-fi
-if [[ "$ENVIRONMENT" == "multinode-tls" || "$ENVIRONMENT" == *kerberos* ]]; then
-    CLI_ARGUMENTS="--server https://presto-master.docker.cluster:7778 --keystore-path /docker/volumes/conf/presto/etc/docker.cluster.jks --keystore-password 123456"
-fi
-if [[ "$ENVIRONMENT" == *kerberos* ]]; then
-    CLI_ARGUMENTS="${CLI_ARGUMENTS} --krb5-config-path /etc/krb5.conf --krb5-principal presto-client/presto-master.docker.cluster@LABS.TERADATA.COM --krb5-keytab-path /etc/presto/conf/presto-client.keytab --krb5-remote-service-name presto-server --krb5-disable-remote-service-hostname-canonicalization"
 fi
 
 # check docker and docker compose installation

--- a/presto-product-tests/conf/docker/common/kerberos.yml
+++ b/presto-product-tests/conf/docker/common/kerberos.yml
@@ -23,3 +23,4 @@ services:
     image: '${HADOOP_BASE_IMAGE}-kerberized:${DOCKER_IMAGES_VERSION}'
     environment:
       - TEMPTO_PROFILE_CONFIG_FILE=/docker/volumes/conf/tempto/tempto-configuration-for-docker-kerberos.yaml
+      - CLI_ARGUMENTS=--server https://presto-master.docker.cluster:7778 --keystore-path /docker/volumes/conf/presto/etc/docker.cluster.jks --keystore-password 123456 --krb5-config-path /etc/krb5.conf --krb5-principal presto-client/presto-master.docker.cluster@LABS.TERADATA.COM --krb5-keytab-path /etc/presto/conf/presto-client.keytab --krb5-remote-service-name presto-server --krb5-disable-remote-service-hostname-canonicalization

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -50,3 +50,4 @@ services:
     environment:
       - PRESTO_JDBC_DRIVER_CLASS
       - TEMPTO_EXTRA_CONFIG_FILE
+      - CLI_ARGUMENTS=--server presto-master:8080

--- a/presto-product-tests/conf/docker/files/presto-cli.sh
+++ b/presto-product-tests/conf/docker/files/presto-cli.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+java -jar /docker/volumes/presto-cli/presto-cli-executable.jar ${CLI_ARGUMENTS} "$@"

--- a/presto-product-tests/conf/docker/multinode-tls/docker-compose.yml
+++ b/presto-product-tests/conf/docker/multinode-tls/docker-compose.yml
@@ -47,3 +47,4 @@ services:
   application-runner:
     environment:
       - TEMPTO_PROFILE_CONFIG_FILE=/docker/volumes/conf/tempto/tempto-configuration-for-docker-tls.yaml
+      - CLI_ARGUMENTS=--server https://presto-master.docker.cluster:7778 --keystore-path /docker/volumes/conf/presto/etc/docker.cluster.jks --keystore-password 123456

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     image: 'prestodb/centos6-oj8-openldap:${DOCKER_IMAGES_VERSION}'
     environment:
       - TEMPTO_PROFILE_CONFIG_FILE=/docker/volumes/conf/tempto/tempto-configuration-for-docker-ldap.yaml
+      - CLI_ARGUMENTS=--server https://presto-master:8443 --keystore-path /etc/openldap/certs/coordinator.jks --keystore-password testldap
 
   ldapserver:
     image: 'prestodb/centos6-oj8-openldap:${DOCKER_IMAGES_VERSION}'


### PR DESCRIPTION
Move CLI_ARGUMENTS to docker compose files

That way configuration related to given environment is stored in this
environment configuration files not in a script which is just using that
environment.

Also that way it is easier to use Presto cli manually to connect to presto in
environment specific Presto server by something like:
./conf/docker/singlenode-kerberos-hdfs-impersonation/compose.sh run
application-runner /docker/volumes/conf/docker/files/presto-cli.sh
