### PR TITLE
Cast null to output column types for INSERT

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -817,6 +817,29 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testCastNullToColumnTypes()
+    {
+        String tableName = "test_cast_null_to_column_types";
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(catalog, "orc_optimized_writer_enabled", "true")
+                .build();
+
+        assertUpdate(session, "" +
+                "CREATE TABLE " + tableName + " (" +
+                "  col1 bigint," +
+                "  col2 map(bigint, bigint)," +
+                "  partition_key varchar)" +
+                "WITH (" +
+                "  format = 'ORC', " +
+                "  partitioned_by = ARRAY[ 'partition_key' ] " +
+                ")");
+
+        assertUpdate(session, format("INSERT INTO %s (col1) VALUES (1), (2), (3)", tableName), 3);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testInsertPartitionedBucketedTable()
     {
         testInsertPartitionedBucketedTable(HiveStorageFormat.RCBINARY);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -248,7 +248,8 @@ public class LogicalPlanner
             Symbol output = symbolAllocator.newSymbol(column.getName(), column.getType());
             int index = insert.getColumns().indexOf(columns.get(column.getName()));
             if (index < 0) {
-                assignments.put(output, new NullLiteral());
+                Expression cast = new Cast(new NullLiteral(), column.getType().getTypeSignature().toString());
+                assignments.put(output, cast);
             }
             else {
                 Symbol input = plan.getSymbol(index);


### PR DESCRIPTION
ORC writer uses ColumnarRow/Map/Array to inspect the structure of a
block. The down cast can fail if the input is of unknown type, which by
default creates fixed width blocks that cannot be decoded by either row,
map or array. This can happen when the INSERT misses the output alias.
We force a cast from null to the output column types to workaround this.