### PR TITLE
Support bucket number evolution in Hive connector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -303,6 +303,9 @@ public class BackgroundHiveSplitLoader
         // To support custom input formats, we want to call getSplits()
         // on the input format to obtain file splits.
         if (shouldUseFileSplitsFromInputFormat(inputFormat)) {
+            if (tableBucketInfo.isPresent()) {
+                throw new PrestoException(NOT_SUPPORTED, "Presto cannot read bucketed partition in an input format with UseFileSplitsFromInputFormat annotation: " + inputFormat.getClass().getSimpleName());
+            }
             JobConf jobConf = toJobConf(configuration);
             FileInputFormat.setInputPaths(jobConf, path);
             InputSplit[] splits = inputFormat.getSplits(jobConf, 0);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketAdapterRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketAdapterRecordCursor.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import io.airlift.slice.Slice;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.List;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_BUCKET_FILES;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class HiveBucketAdapterRecordCursor
+        implements RecordCursor
+{
+    private final RecordCursor delegate;
+    private final int[] bucketColumnIndices;
+    private final List<Class<?>> javaTypeList;
+    private final List<TypeInfo> typeInfoList;
+    private final int tableBucketCount;
+    private final int partitionBucketCount;
+    private final int bucketToKeep;
+
+    private final Object[] scratch;
+
+    public HiveBucketAdapterRecordCursor(
+            int[] bucketColumnIndices,
+            List<HiveType> bucketColumnHiveTypes,
+            int tableBucketCount,
+            int partitionBucketCount,
+            int bucketToKeep,
+            TypeManager typeManager,
+            RecordCursor delegate)
+    {
+        this.bucketColumnIndices = requireNonNull(bucketColumnIndices, "bucketColumnIndices is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        requireNonNull(bucketColumnHiveTypes, "bucketColumnHiveTypes is null");
+        this.javaTypeList = bucketColumnHiveTypes.stream()
+                .map(HiveType::getTypeSignature)
+                .map(typeManager::getType)
+                .map(Type::getJavaType)
+                .collect(toImmutableList());
+        this.typeInfoList = bucketColumnHiveTypes.stream()
+                .map(HiveType::getTypeInfo)
+                .collect(toImmutableList());
+        this.tableBucketCount = tableBucketCount;
+        this.partitionBucketCount = partitionBucketCount;
+        this.bucketToKeep = bucketToKeep;
+
+        this.scratch = new Object[bucketColumnHiveTypes.size()];
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return delegate.getCompletedBytes();
+    }
+
+    @Override
+    public Type getType(int field)
+    {
+        return delegate.getType(field);
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        while (true) {
+            if (Thread.interrupted()) {
+                // Stop processing if the query has been destroyed.
+                Thread.currentThread().interrupt();
+                throw new PrestoException(GENERIC_INTERNAL_ERROR, "RecordCursor was interrupted");
+            }
+
+            boolean hasNextPosition = delegate.advanceNextPosition();
+            if (!hasNextPosition) {
+                return false;
+            }
+            for (int i = 0; i < scratch.length; i++) {
+                int index = bucketColumnIndices[i];
+                if (delegate.isNull(index)) {
+                    scratch[i] = null;
+                    continue;
+                }
+                Class<?> javaType = javaTypeList.get(i);
+                if (javaType == boolean.class) {
+                    scratch[i] = delegate.getBoolean(index);
+                }
+                else if (javaType == long.class) {
+                    scratch[i] = delegate.getLong(index);
+                }
+                else if (javaType == double.class) {
+                    scratch[i] = delegate.getDouble(index);
+                }
+                else if (javaType == Slice.class) {
+                    scratch[i] = delegate.getSlice(index);
+                }
+                else if (javaType == Block.class) {
+                    scratch[i] = (Block) delegate.getObject(index);
+                }
+                else {
+                    throw new UnsupportedOperationException("unknown java type");
+                }
+            }
+            int bucket = HiveBucketing.getHiveBucket(tableBucketCount, typeInfoList, scratch);
+            if ((bucket - bucketToKeep) % partitionBucketCount != 0) {
+                throw new PrestoException(HIVE_INVALID_BUCKET_FILES, format(
+                        "A row that is supposed to be in bucket %s is encountered. Only rows in bucket %s (modulo %s) are expected",
+                        bucket, bucketToKeep % partitionBucketCount, partitionBucketCount));
+            }
+            if (bucket == bucketToKeep) {
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public boolean getBoolean(int field)
+    {
+        return delegate.getBoolean(field);
+    }
+
+    @Override
+    public long getLong(int field)
+    {
+        return delegate.getLong(field);
+    }
+
+    @Override
+    public double getDouble(int field)
+    {
+        return delegate.getDouble(field);
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        return delegate.getSlice(field);
+    }
+
+    @Override
+    public Object getObject(int field)
+    {
+        return delegate.getObject(field);
+    }
+
+    @Override
+    public boolean isNull(int field)
+    {
+        return delegate.isNull(field);
+    }
+
+    @Override
+    public void close()
+    {
+        delegate.close();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegate.getReadTimeNanos();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return delegate.getSystemMemoryUsage();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketFunction.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketFunction.java
@@ -40,7 +40,7 @@ public class HiveBucketFunction
     @Override
     public int getBucket(Page page, int position)
     {
-        return HiveBucketing.getHiveBucket(typeInfos, page, position, bucketCount);
+        return HiveBucketing.getHiveBucket(bucketCount, typeInfos, page, position);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.Page;
@@ -24,21 +25,11 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
-import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
-import org.apache.hadoop.hive.ql.io.DefaultHivePartitioner;
-import org.apache.hadoop.hive.ql.io.HiveKey;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFHash;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.StructField;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
@@ -48,44 +39,31 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.HiveUtil.getRegularColumnHandles;
-import static com.facebook.presto.hive.HiveUtil.getTableStructFields;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Maps.immutableEntry;
-import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Map.Entry;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
-import static org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
-import static org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
-import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import static org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaBooleanObjectInspector;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteObjectInspector;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaIntObjectInspector;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaLongObjectInspector;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaShortObjectInspector;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
 
 final class HiveBucketing
 {
-    private static final Logger log = Logger.get(HiveBucketing.class);
-
-    private static final Set<PrimitiveCategory> SUPPORTED_TYPES = immutableEnumSet(
-            PrimitiveCategory.BYTE,
-            PrimitiveCategory.SHORT,
-            PrimitiveCategory.INT,
-            PrimitiveCategory.LONG,
-            PrimitiveCategory.BOOLEAN,
-            PrimitiveCategory.STRING);
+    private static final Set<HiveType> SUPPORTED_TYPES_FOR_BUCKET_FILTER = ImmutableSet.of(
+            HiveType.HIVE_BYTE,
+            HiveType.HIVE_SHORT,
+            HiveType.HIVE_INT,
+            HiveType.HIVE_LONG,
+            HiveType.HIVE_BOOLEAN,
+            HiveType.HIVE_STRING);
 
     private HiveBucketing() {}
 
@@ -94,11 +72,28 @@ final class HiveBucketing
         return (getBucketHashCode(types, page, position) & Integer.MAX_VALUE) % bucketCount;
     }
 
+    public static int getHiveBucket(int bucketCount, List<TypeInfo> types, Object[] values)
+    {
+        return (getBucketHashCode(types, values) & Integer.MAX_VALUE) % bucketCount;
+    }
+
     private static int getBucketHashCode(List<TypeInfo> types, Page page, int position)
     {
+        checkArgument(types.size() == page.getChannelCount());
         int result = 0;
         for (int i = 0; i < page.getChannelCount(); i++) {
             int fieldHash = hash(types.get(i), page.getBlock(i), position);
+            result = result * 31 + fieldHash;
+        }
+        return result;
+    }
+
+    private static int getBucketHashCode(List<TypeInfo> types, Object[] values)
+    {
+        checkArgument(types.size() == values.length);
+        int result = 0;
+        for (int i = 0; i < values.length; i++) {
+            int fieldHash = hash(types.get(i), values[i]);
             result = result * 31 + fieldHash;
         }
         return result;
@@ -156,29 +151,95 @@ final class HiveBucketing
                 }
             }
             case LIST: {
-                TypeInfo elementTypeInfo = ((ListTypeInfo) type).getListElementTypeInfo();
                 Block elementsBlock = block.getObject(position, Block.class);
-                int result = 0;
-                for (int i = 0; i < elementsBlock.getPositionCount(); i++) {
-                    result = result * 31 + hash(elementTypeInfo, elementsBlock, i);
-                }
-                return result;
+                return hashOfList((ListTypeInfo) type, elementsBlock);
             }
             case MAP: {
-                MapTypeInfo mapTypeInfo = (MapTypeInfo) type;
-                TypeInfo keyTypeInfo = mapTypeInfo.getMapKeyTypeInfo();
-                TypeInfo valueTypeInfo = mapTypeInfo.getMapValueTypeInfo();
                 Block elementsBlock = block.getObject(position, Block.class);
-                int result = 0;
-                for (int i = 0; i < elementsBlock.getPositionCount(); i += 2) {
-                    result += hash(keyTypeInfo, elementsBlock, i) ^ hash(valueTypeInfo, elementsBlock, i + 1);
-                }
-                return result;
+                return hashOfMap((MapTypeInfo) type, elementsBlock);
             }
             default:
                 // TODO: support more types, e.g. ROW
                 throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory().toString() + ".");
         }
+    }
+
+    private static int hash(TypeInfo type, Object value)
+    {
+        if (value == null) {
+            return 0;
+        }
+
+        switch (type.getCategory()) {
+            case PRIMITIVE: {
+                PrimitiveTypeInfo typeInfo = (PrimitiveTypeInfo) type;
+                PrimitiveCategory primitiveCategory = typeInfo.getPrimitiveCategory();
+                Type prestoType = requireNonNull(HiveType.getPrimitiveType(typeInfo));
+                switch (primitiveCategory) {
+                    case BOOLEAN:
+                        return (boolean) value ? 1 : 0;
+                    case BYTE:
+                        return SignedBytes.checkedCast((long) value);
+                    case SHORT:
+                        return Shorts.checkedCast((long) value);
+                    case INT:
+                        return toIntExact((long) value);
+                    case LONG:
+                        long bigintValue = (long) value;
+                        return (int) ((bigintValue >>> 32) ^ bigintValue);
+                    case FLOAT:
+                        return (int) (long) value;
+                    case DOUBLE:
+                        long doubleValue = doubleToLongBits((double) value);
+                        return (int) ((doubleValue >>> 32) ^ doubleValue);
+                    case STRING:
+                        return hashBytes(0, (Slice) value);
+                    case VARCHAR:
+                        return hashBytes(1, (Slice) value);
+                    case DATE:
+                        // day offset from 1970-01-01
+                        long days = (long) value;
+                        return toIntExact(days);
+                    case TIMESTAMP:
+                        long millisSinceEpoch = (long) value;
+                        // seconds << 30 + nanoseconds
+                        long secondsAndNanos = (Math.floorDiv(millisSinceEpoch, 1000L) << 30) + Math.floorMod(millisSinceEpoch, 1000);
+                        return (int) ((secondsAndNanos >>> 32) ^ secondsAndNanos);
+                    default:
+                        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory.toString() + ".");
+                }
+            }
+            case LIST: {
+                return hashOfList((ListTypeInfo) type, (Block) value);
+            }
+            case MAP: {
+                return hashOfMap((MapTypeInfo) type, (Block) value);
+            }
+            default:
+                // TODO: support more types, e.g. ROW
+                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory().toString() + ".");
+        }
+    }
+
+    private static int hashOfMap(MapTypeInfo type, Block singleMapBlock)
+    {
+        TypeInfo keyTypeInfo = type.getMapKeyTypeInfo();
+        TypeInfo valueTypeInfo = type.getMapValueTypeInfo();
+        int result = 0;
+        for (int i = 0; i < singleMapBlock.getPositionCount(); i += 2) {
+            result += hash(keyTypeInfo, singleMapBlock, i) ^ hash(valueTypeInfo, singleMapBlock, i + 1);
+        }
+        return result;
+    }
+
+    private static int hashOfList(ListTypeInfo type, Block singleListBlock)
+    {
+        TypeInfo elementTypeInfo = type.getListElementTypeInfo();
+        int result = 0;
+        for (int i = 0; i < singleListBlock.getPositionCount(); i++) {
+            result = result * 31 + hash(elementTypeInfo, singleListBlock, i);
+        }
+        return result;
     }
 
     private static int hashBytes(int initialValue, Slice bytes)
@@ -224,9 +285,9 @@ final class HiveBucketing
         if (!bindings.isPresent()) {
             return Optional.empty();
         }
-        Optional<HiveBucketFilter> singleBucket = getHiveBucket(table, bindings.get());
+        OptionalInt singleBucket = getHiveBucket(table, bindings.get());
         if (singleBucket.isPresent()) {
-            return singleBucket;
+            return Optional.of(new HiveBucketFilter(ImmutableSet.of(singleBucket.getAsInt())));
         }
 
         if (!effectivePredicate.getDomains().isPresent()) {
@@ -250,28 +311,22 @@ final class HiveBucketing
         return Optional.of(new HiveBucketFilter(builder.build()));
     }
 
-    private static Optional<HiveBucketFilter> getHiveBucket(Table table, Map<ColumnHandle, NullableValue> bindings)
+    private static OptionalInt getHiveBucket(Table table, Map<ColumnHandle, NullableValue> bindings)
     {
         if (bindings.isEmpty()) {
-            return Optional.empty();
+            return OptionalInt.empty();
         }
 
         List<String> bucketColumns = table.getStorage().getBucketProperty().get().getBucketedBy();
-        Map<String, ObjectInspector> objectInspectors = new HashMap<>();
-
-        // Get column name to object inspector mapping
-        for (StructField field : getTableStructFields(table)) {
-            objectInspectors.put(field.getFieldName(), field.getFieldObjectInspector());
+        Map<String, HiveType> hiveTypes = new HashMap<>();
+        for (Column column : table.getDataColumns()) {
+            hiveTypes.put(column.getName(), column.getType());
         }
 
         // Verify the bucket column types are supported
         for (String column : bucketColumns) {
-            ObjectInspector inspector = objectInspectors.get(column);
-            if ((inspector == null) || (inspector.getCategory() != Category.PRIMITIVE)) {
-                return Optional.empty();
-            }
-            if (!SUPPORTED_TYPES.contains(((PrimitiveObjectInspector) inspector).getPrimitiveCategory())) {
-                return Optional.empty();
+            if (!SUPPORTED_TYPES_FOR_BUCKET_FILTER.contains(hiveTypes.get(column))) {
+                return OptionalInt.empty();
             }
         }
 
@@ -286,91 +341,19 @@ final class HiveBucketing
 
         // Check that we have bindings for all bucket columns
         if (bucketBindings.size() != bucketColumns.size()) {
-            return Optional.empty();
+            return OptionalInt.empty();
         }
 
         // Get bindings of bucket columns
-        ImmutableList.Builder<Entry<ObjectInspector, Object>> columnBindings = ImmutableList.builder();
-        for (String column : bucketColumns) {
-            columnBindings.add(immutableEntry(objectInspectors.get(column), bucketBindings.get(column)));
+        ImmutableList.Builder<TypeInfo> typeInfos = ImmutableList.builder();
+        Object[] values = new Object[bucketColumns.size()];
+        for (int i = 0; i < bucketColumns.size(); i++) {
+            String column = bucketColumns.get(i);
+            typeInfos.add(hiveTypes.get(column).getTypeInfo());
+            values[i] = bucketBindings.get(column);
         }
 
-        return getHiveBucket(columnBindings.build(), table.getStorage().getBucketProperty().get().getBucketCount());
-    }
-
-    @VisibleForTesting
-    static Optional<HiveBucketFilter> getHiveBucket(List<Entry<ObjectInspector, Object>> columnBindings, int bucketCount)
-    {
-        try {
-            @SuppressWarnings("resource")
-            GenericUDFHash udf = new GenericUDFHash();
-            ObjectInspector[] objectInspectors = new ObjectInspector[columnBindings.size()];
-            DeferredObject[] deferredObjects = new DeferredObject[columnBindings.size()];
-
-            int i = 0;
-            for (Entry<ObjectInspector, Object> entry : columnBindings) {
-                objectInspectors[i] = getJavaObjectInspector(entry.getKey());
-                deferredObjects[i] = getJavaDeferredObject(entry.getValue(), entry.getKey());
-                i++;
-            }
-
-            ObjectInspector udfInspector = udf.initialize(objectInspectors);
-            IntObjectInspector inspector = (IntObjectInspector) udfInspector;
-
-            Object result = udf.evaluate(deferredObjects);
-            HiveKey hiveKey = new HiveKey();
-            hiveKey.setHashCode(inspector.get(result));
-
-            int bucketNumber = new DefaultHivePartitioner<>().getBucket(hiveKey, null, bucketCount);
-
-            return Optional.of(new HiveBucketFilter(ImmutableSet.of(bucketNumber)));
-        }
-        catch (HiveException e) {
-            log.debug(e, "Error evaluating bucket number");
-            return Optional.empty();
-        }
-    }
-
-    private static ObjectInspector getJavaObjectInspector(ObjectInspector objectInspector)
-    {
-        checkArgument(objectInspector.getCategory() == Category.PRIMITIVE, "Unsupported object inspector category %s", objectInspector.getCategory());
-        PrimitiveObjectInspector poi = ((PrimitiveObjectInspector) objectInspector);
-        switch (poi.getPrimitiveCategory()) {
-            case BOOLEAN:
-                return javaBooleanObjectInspector;
-            case BYTE:
-                return javaByteObjectInspector;
-            case SHORT:
-                return javaShortObjectInspector;
-            case INT:
-                return javaIntObjectInspector;
-            case LONG:
-                return javaLongObjectInspector;
-            case STRING:
-                return javaStringObjectInspector;
-        }
-        throw new RuntimeException("Unsupported type: " + poi.getPrimitiveCategory());
-    }
-
-    private static DeferredObject getJavaDeferredObject(Object object, ObjectInspector objectInspector)
-    {
-        checkArgument(objectInspector.getCategory() == Category.PRIMITIVE, "Unsupported object inspector category %s", objectInspector.getCategory());
-        PrimitiveObjectInspector poi = ((PrimitiveObjectInspector) objectInspector);
-        switch (poi.getPrimitiveCategory()) {
-            case BOOLEAN:
-                return new DeferredJavaObject(object);
-            case BYTE:
-                return new DeferredJavaObject(((Long) object).byteValue());
-            case SHORT:
-                return new DeferredJavaObject(((Long) object).shortValue());
-            case INT:
-                return new DeferredJavaObject(((Long) object).intValue());
-            case LONG:
-                return new DeferredJavaObject(object);
-            case STRING:
-                return new DeferredJavaObject(((Slice) object).toStringUtf8());
-        }
-        throw new RuntimeException("Unsupported type: " + poi.getPrimitiveCategory());
+        return OptionalInt.of(getHiveBucket(table.getStorage().getBucketProperty().get().getBucketCount(), typeInfos.build(), values));
     }
 
     public static class HiveBucketFilter

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
@@ -89,7 +89,7 @@ final class HiveBucketing
 
     private HiveBucketing() {}
 
-    public static int getHiveBucket(List<TypeInfo> types, Page page, int position, int bucketCount)
+    public static int getHiveBucket(int bucketCount, List<TypeInfo> types, Page page, int position)
     {
         return (getBucketHashCode(types, page, position) & Integer.MAX_VALUE) % bucketCount;
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
@@ -183,6 +183,11 @@ public class HiveColumnHandle
         return new HiveColumnHandle(PATH_COLUMN_NAME, PATH_HIVE_TYPE, PATH_TYPE_SIGNATURE, PATH_COLUMN_INDEX, SYNTHESIZED, Optional.empty());
     }
 
+    /**
+     * The column indicating the bucket id.
+     * When table bucketing differs from partition bucketing, this column indicates
+     * what bucket the row will fall in under the table bucketing scheme.
+     */
     public static HiveColumnHandle bucketColumnHandle()
     {
         return new HiveColumnHandle(BUCKET_COLUMN_NAME, BUCKET_HIVE_TYPE, BUCKET_TYPE_SIGNATURE, BUCKET_COLUMN_INDEX, SYNTHESIZED, Optional.empty());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.HIDDEN;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
@@ -52,7 +52,7 @@ public class HiveColumnHandle
     {
         PARTITION_KEY,
         REGULAR,
-        HIDDEN
+        SYNTHESIZED,
     }
 
     private final String name;
@@ -72,7 +72,7 @@ public class HiveColumnHandle
             @JsonProperty("comment") Optional<String> comment)
     {
         this.name = requireNonNull(name, "name is null");
-        checkArgument(hiveColumnIndex >= 0 || columnType == PARTITION_KEY || columnType == HIDDEN, "hiveColumnIndex is negative");
+        checkArgument(hiveColumnIndex >= 0 || columnType == PARTITION_KEY || columnType == SYNTHESIZED, "hiveColumnIndex is negative");
         this.hiveColumnIndex = hiveColumnIndex;
         this.hiveType = requireNonNull(hiveType, "hiveType is null");
         this.typeName = requireNonNull(typeSignature, "type is null");
@@ -105,7 +105,7 @@ public class HiveColumnHandle
 
     public boolean isHidden()
     {
-        return columnType == HIDDEN;
+        return columnType == SYNTHESIZED;
     }
 
     public ColumnMetadata getColumnMetadata(TypeManager typeManager)
@@ -175,17 +175,17 @@ public class HiveColumnHandle
         // plan-time support for row-by-row delete so that planning doesn't fail. This is why we need
         // rowid handle. Note that in Hive connector, rowid handle is not implemented beyond plan-time.
 
-        return new HiveColumnHandle(UPDATE_ROW_ID_COLUMN_NAME, HIVE_LONG, BIGINT.getTypeSignature(), -1, HIDDEN, Optional.empty());
+        return new HiveColumnHandle(UPDATE_ROW_ID_COLUMN_NAME, HIVE_LONG, BIGINT.getTypeSignature(), -1, SYNTHESIZED, Optional.empty());
     }
 
     public static HiveColumnHandle pathColumnHandle()
     {
-        return new HiveColumnHandle(PATH_COLUMN_NAME, PATH_HIVE_TYPE, PATH_TYPE_SIGNATURE, PATH_COLUMN_INDEX, HIDDEN, Optional.empty());
+        return new HiveColumnHandle(PATH_COLUMN_NAME, PATH_HIVE_TYPE, PATH_TYPE_SIGNATURE, PATH_COLUMN_INDEX, SYNTHESIZED, Optional.empty());
     }
 
     public static HiveColumnHandle bucketColumnHandle()
     {
-        return new HiveColumnHandle(BUCKET_COLUMN_NAME, BUCKET_HIVE_TYPE, BUCKET_TYPE_SIGNATURE, BUCKET_COLUMN_INDEX, HIDDEN, Optional.empty());
+        return new HiveColumnHandle(BUCKET_COLUMN_NAME, BUCKET_HIVE_TYPE, BUCKET_TYPE_SIGNATURE, BUCKET_COLUMN_INDEX, SYNTHESIZED, Optional.empty());
     }
 
     public static boolean isPathColumnHandle(HiveColumnHandle column)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1311,7 +1311,8 @@ public class HiveMetadata
                                 getPartitionsAsList(hivePartitionResult),
                                 hivePartitionResult.getCompactEffectivePredicate(),
                                 hivePartitionResult.getEnforcedConstraint(),
-                                hivePartitionResult.getBucketHandle())),
+                                hivePartitionResult.getBucketHandle(),
+                                hivePartitionResult.getBucketFilter())),
                 hivePartitionResult.getUnenforcedConstraint()));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -98,9 +98,9 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.hive.HiveBucketing.getHiveBucketHandle;
 import static com.facebook.presto.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
-import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.HIDDEN;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.hive.HiveColumnHandle.PATH_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveColumnHandle.updateRowIdHandle;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_COLUMN_ORDER_MISMATCH;
@@ -1576,7 +1576,7 @@ public class HiveMetadata
                 columnType = PARTITION_KEY;
             }
             else if (column.isHidden()) {
-                columnType = HIDDEN;
+                columnType = SYNTHESIZED;
             }
             else {
                 columnType = REGULAR;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartition.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartition.java
@@ -18,11 +18,9 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.facebook.presto.hive.HiveBucketing.HiveBucket;
 import static java.util.Objects.requireNonNull;
 
 public class HivePartition
@@ -32,23 +30,20 @@ public class HivePartition
     private final SchemaTableName tableName;
     private final String partitionId;
     private final Map<ColumnHandle, NullableValue> keys;
-    private final List<HiveBucket> buckets;
 
-    public HivePartition(SchemaTableName tableName, List<HiveBucket> buckets)
+    public HivePartition(SchemaTableName tableName)
     {
-        this(tableName, UNPARTITIONED_ID, ImmutableMap.of(), buckets);
+        this(tableName, UNPARTITIONED_ID, ImmutableMap.of());
     }
 
     public HivePartition(
             SchemaTableName tableName,
             String partitionId,
-            Map<ColumnHandle, NullableValue> keys,
-            List<HiveBucket> buckets)
+            Map<ColumnHandle, NullableValue> keys)
     {
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.partitionId = requireNonNull(partitionId, "partitionId is null");
         this.keys = ImmutableMap.copyOf(requireNonNull(keys, "keys is null"));
-        this.buckets = requireNonNull(buckets, "bucket number is null");
     }
 
     public SchemaTableName getTableName()
@@ -64,11 +59,6 @@ public class HivePartition
     public Map<ColumnHandle, NullableValue> getKeys()
     {
         return keys;
-    }
-
-    public List<HiveBucket> getBuckets()
-    {
-        return buckets;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionResult.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionResult.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HiveBucketing.HiveBucketFilter;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 
@@ -38,6 +39,7 @@ public class HivePartitionResult
     private final TupleDomain<ColumnHandle> unenforcedConstraint;
     private final TupleDomain<ColumnHandle> enforcedConstraint;
     private final Optional<HiveBucketHandle> bucketHandle;
+    private final Optional<HiveBucketFilter> bucketFilter;
 
     public HivePartitionResult(
             List<HiveColumnHandle> partitionColumns,
@@ -45,7 +47,8 @@ public class HivePartitionResult
             TupleDomain<? extends ColumnHandle> compactEffectivePredicate,
             TupleDomain<ColumnHandle> unenforcedConstraint,
             TupleDomain<ColumnHandle> enforcedConstraint,
-            Optional<HiveBucketHandle> bucketHandle)
+            Optional<HiveBucketHandle> bucketHandle,
+            Optional<HiveBucketFilter> bucketFilter)
     {
         this.partitionColumns = requireNonNull(partitionColumns, "partitionColumns is null");
         this.partitions = requireNonNull(partitions, "partitions is null");
@@ -53,6 +56,7 @@ public class HivePartitionResult
         this.unenforcedConstraint = requireNonNull(unenforcedConstraint, "unenforcedConstraint is null");
         this.enforcedConstraint = requireNonNull(enforcedConstraint, "enforcedConstraint is null");
         this.bucketHandle = requireNonNull(bucketHandle, "bucketHandle is null");
+        this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
     }
 
     public List<HiveColumnHandle> getPartitionColumns()
@@ -83,5 +87,10 @@ public class HivePartitionResult
     public Optional<HiveBucketHandle> getBucketHandle()
     {
         return bucketHandle;
+    }
+
+    public Optional<HiveBucketFilter> getBucketFilter()
+    {
+        return bucketFilter;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordCursor.java
@@ -25,6 +25,8 @@ import org.joda.time.DateTimeZone;
 
 import java.util.List;
 
+import static com.facebook.presto.hive.HivePageSourceProvider.ColumnMappingKind.PREFILLED;
+import static com.facebook.presto.hive.HivePageSourceProvider.ColumnMappingKind.REGULAR;
 import static com.facebook.presto.hive.HiveUtil.bigintPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.booleanPartitionKey;
 import static com.facebook.presto.hive.HiveUtil.charPartitionKey;
@@ -98,7 +100,7 @@ public class HiveRecordCursor
         for (int columnIndex = 0; columnIndex < size; columnIndex++) {
             ColumnMapping columnMapping = columnMappings.get(columnIndex);
 
-            if (columnMapping.isPrefilled()) {
+            if (columnMapping.getKind() == PREFILLED) {
                 String columnValue = columnMapping.getPrefilledValue();
                 byte[] bytes = columnValue.getBytes(UTF_8);
 
@@ -177,7 +179,7 @@ public class HiveRecordCursor
     public boolean getBoolean(int field)
     {
         ColumnMapping columnMapping = columnMappings.get(field);
-        if (!columnMapping.isPrefilled()) {
+        if (columnMapping.getKind() == REGULAR) {
             return delegate.getBoolean(columnMapping.getIndex());
         }
         return booleans[field];
@@ -187,7 +189,7 @@ public class HiveRecordCursor
     public long getLong(int field)
     {
         ColumnMapping columnMapping = columnMappings.get(field);
-        if (!columnMapping.isPrefilled()) {
+        if (columnMapping.getKind() == REGULAR) {
             return delegate.getLong(columnMapping.getIndex());
         }
         return longs[field];
@@ -197,7 +199,7 @@ public class HiveRecordCursor
     public double getDouble(int field)
     {
         ColumnMapping columnMapping = columnMappings.get(field);
-        if (!columnMapping.isPrefilled()) {
+        if (columnMapping.getKind() == REGULAR) {
             return delegate.getDouble(columnMapping.getIndex());
         }
         return doubles[field];
@@ -207,7 +209,7 @@ public class HiveRecordCursor
     public Slice getSlice(int field)
     {
         ColumnMapping columnMapping = columnMappings.get(field);
-        if (!columnMapping.isPrefilled()) {
+        if (columnMapping.getKind() == REGULAR) {
             return delegate.getSlice(columnMapping.getIndex());
         }
         return slices[field];
@@ -217,7 +219,7 @@ public class HiveRecordCursor
     public Object getObject(int field)
     {
         ColumnMapping columnMapping = columnMappings.get(field);
-        if (!columnMapping.isPrefilled()) {
+        if (columnMapping.getKind() == REGULAR) {
             return delegate.getObject(columnMapping.getIndex());
         }
         return objects[field];
@@ -227,7 +229,7 @@ public class HiveRecordCursor
     public boolean isNull(int field)
     {
         ColumnMapping columnMapping = columnMappings.get(field);
-        if (!columnMapping.isPrefilled()) {
+        if (columnMapping.getKind() == REGULAR) {
             return delegate.isNull(columnMapping.getIndex());
         }
         return nulls[field];

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 
@@ -46,7 +48,8 @@ public class HiveSplit
     private final TupleDomain<HiveColumnHandle> effectivePredicate;
     private final OptionalInt bucketNumber;
     private final boolean forceLocalScheduling;
-    private final Map<Integer, HiveType> columnCoercions;
+    private final Map<Integer, HiveType> columnCoercions; // key: hiveColumnIndex
+    private final Optional<BucketConversion> bucketConversion;
 
     @JsonCreator
     public HiveSplit(
@@ -63,7 +66,8 @@ public class HiveSplit
             @JsonProperty("bucketNumber") OptionalInt bucketNumber,
             @JsonProperty("forceLocalScheduling") boolean forceLocalScheduling,
             @JsonProperty("effectivePredicate") TupleDomain<HiveColumnHandle> effectivePredicate,
-            @JsonProperty("columnCoercions") Map<Integer, HiveType> columnCoercions)
+            @JsonProperty("columnCoercions") Map<Integer, HiveType> columnCoercions,
+            @JsonProperty("bucketConversion") Optional<BucketConversion> bucketConversion)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(length >= 0, "length must be positive");
@@ -78,6 +82,7 @@ public class HiveSplit
         requireNonNull(bucketNumber, "bucketNumber is null");
         requireNonNull(effectivePredicate, "tupleDomain is null");
         requireNonNull(columnCoercions, "columnCoercions is null");
+        requireNonNull(bucketConversion, "bucketConversion is null");
 
         this.database = database;
         this.table = table;
@@ -93,6 +98,7 @@ public class HiveSplit
         this.forceLocalScheduling = forceLocalScheduling;
         this.effectivePredicate = effectivePredicate;
         this.columnCoercions = columnCoercions;
+        this.bucketConversion = bucketConversion;
     }
 
     @JsonProperty
@@ -180,6 +186,12 @@ public class HiveSplit
         return columnCoercions;
     }
 
+    @JsonProperty
+    public Optional<BucketConversion> getBucketConversion()
+    {
+        return bucketConversion;
+    }
+
     @Override
     public boolean isRemotelyAccessible()
     {
@@ -212,5 +224,63 @@ public class HiveSplit
                 .addValue(fileSize)
                 .addValue(effectivePredicate)
                 .toString();
+    }
+
+    public static class BucketConversion
+    {
+        private final int tableBucketCount;
+        private final int partitionBucketCount;
+        private final List<HiveColumnHandle> bucketColumnNames;
+        // bucketNumber is needed, but can be found in bucketNumber field of HiveSplit.
+
+        @JsonCreator
+        public BucketConversion(
+                @JsonProperty("tableBucketCount") int tableBucketCount,
+                @JsonProperty("partitionBucketCount") int partitionBucketCount,
+                @JsonProperty("bucketColumnHandles") List<HiveColumnHandle> bucketColumnHandles)
+        {
+            this.tableBucketCount = tableBucketCount;
+            this.partitionBucketCount = partitionBucketCount;
+            this.bucketColumnNames = requireNonNull(bucketColumnHandles, "bucketColumnHandles is null");
+        }
+
+        @JsonProperty
+        public int getTableBucketCount()
+        {
+            return tableBucketCount;
+        }
+
+        @JsonProperty
+        public int getPartitionBucketCount()
+        {
+            return partitionBucketCount;
+        }
+
+        @JsonProperty
+        public List<HiveColumnHandle> getBucketColumnHandles()
+        {
+            return bucketColumnNames;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BucketConversion that = (BucketConversion) o;
+            return tableBucketCount == that.tableBucketCount &&
+                    partitionBucketCount == that.partitionBucketCount &&
+                    Objects.equals(bucketColumnNames, that.bucketColumnNames);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(tableBucketCount, partitionBucketCount, bucketColumnNames);
+        }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.hive;
 
-import com.facebook.presto.hive.HiveBucketing.HiveBucket;
+import com.facebook.presto.hive.HiveBucketing.HiveBucketFilter;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
@@ -179,7 +179,7 @@ public class HiveSplitManager
         }
 
         // get buckets from first partition (arbitrary)
-        List<HiveBucket> buckets = partition.getBuckets();
+        Optional<HiveBucketFilter> bucketFilter = layout.getBucketFilter();
 
         // validate bucket bucketed execution
         Optional<HiveBucketHandle> bucketHandle = layout.getBucketHandle();
@@ -196,7 +196,7 @@ public class HiveSplitManager
                 table,
                 hivePartitions,
                 layout.getCompactEffectivePredicate(),
-                createBucketSplitInfo(bucketHandle, buckets),
+                createBucketSplitInfo(bucketHandle, bucketFilter),
                 session,
                 hdfsEnvironment,
                 namenodeStats,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -336,15 +336,19 @@ public class HiveSplitManager
                                 hivePartition.getTableName(),
                                 hivePartition.getPartitionId()));
                     }
-                    if (!bucketProperty.equals(partitionBucketProperty)) {
+                    int tableBucketCount = bucketProperty.get().getBucketCount();
+                    int partitionBucketCount = partitionBucketProperty.get().getBucketCount();
+                    List<String> tableBucketColumns = bucketProperty.get().getBucketedBy();
+                    List<String> partitionBucketColumns = partitionBucketProperty.get().getBucketedBy();
+                    if (!tableBucketColumns.equals(partitionBucketColumns) || !isBucketCountCompatible(tableBucketCount, partitionBucketCount)) {
                         throw new PrestoException(HIVE_PARTITION_SCHEMA_MISMATCH, format(
-                                "Hive table (%s) bucketing (columns=%s, buckets=%s) does not match partition (%s) bucketing (columns=%s, buckets=%s)",
+                                "Hive table (%s) bucketing (columns=%s, buckets=%s) is not compatible with partition (%s) bucketing (columns=%s, buckets=%s)",
                                 hivePartition.getTableName(),
-                                bucketProperty.get().getBucketedBy(),
-                                bucketProperty.get().getBucketCount(),
+                                tableBucketColumns,
+                                tableBucketCount,
                                 hivePartition.getPartitionId(),
-                                partitionBucketProperty.get().getBucketedBy(),
-                                partitionBucketProperty.get().getBucketCount()));
+                                partitionBucketColumns,
+                                partitionBucketCount));
                     }
                 }
 
@@ -354,6 +358,22 @@ public class HiveSplitManager
             return results.build();
         });
         return concat(partitionBatches);
+    }
+
+    private static boolean isBucketCountCompatible(int tableBucketCount, int partitionBucketCount)
+    {
+        checkArgument(tableBucketCount > 0 && partitionBucketCount > 0);
+        int larger = Math.max(tableBucketCount, partitionBucketCount);
+        int smaller = Math.min(tableBucketCount, partitionBucketCount);
+        if (larger % smaller != 0) {
+            // must be evenly divisible
+            return false;
+        }
+        if (Integer.bitCount(larger / smaller) != 1) {
+            // ratio must be power of two
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -366,7 +366,8 @@ class HiveSplitSource
                         internalSplit.getBucketNumber(),
                         internalSplit.isForceLocalScheduling(),
                         (TupleDomain<HiveColumnHandle>) compactEffectivePredicate,
-                        transformValues(internalSplit.getColumnCoercions(), HiveTypeName::toHiveType)));
+                        transformValues(internalSplit.getColumnCoercions(), HiveTypeName::toHiveType),
+                        internalSplit.getBucketConversion()));
                 internalSplit.increaseStart(splitBytes);
 
                 if (internalSplit.isDone()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HiveBucketing.HiveBucketFilter;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.SchemaTableName;
@@ -36,6 +37,7 @@ public final class HiveTableLayoutHandle
     private final TupleDomain<? extends ColumnHandle> compactEffectivePredicate;
     private final TupleDomain<ColumnHandle> promisedPredicate;
     private final Optional<HiveBucketHandle> bucketHandle;
+    private final Optional<HiveBucketFilter> bucketFilter;
 
     @JsonCreator
     public HiveTableLayoutHandle(
@@ -43,7 +45,8 @@ public final class HiveTableLayoutHandle
             @JsonProperty("partitionColumns") List<ColumnHandle> partitionColumns,
             @JsonProperty("compactEffectivePredicate") TupleDomain<ColumnHandle> compactEffectivePredicate,
             @JsonProperty("promisedPredicate") TupleDomain<ColumnHandle> promisedPredicate,
-            @JsonProperty("bucketHandle") Optional<HiveBucketHandle> bucketHandle)
+            @JsonProperty("bucketHandle") Optional<HiveBucketHandle> bucketHandle,
+            @JsonProperty("bucketFilter") Optional<HiveBucketFilter> bucketFilter)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "table is null");
         this.partitionColumns = ImmutableList.copyOf(requireNonNull(partitionColumns, "partitionColumns is null"));
@@ -51,6 +54,7 @@ public final class HiveTableLayoutHandle
         this.partitions = null;
         this.promisedPredicate = requireNonNull(promisedPredicate, "promisedPredicate is null");
         this.bucketHandle = requireNonNull(bucketHandle, "bucketHandle is null");
+        this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
     }
 
     public HiveTableLayoutHandle(
@@ -59,7 +63,8 @@ public final class HiveTableLayoutHandle
             List<HivePartition> partitions,
             TupleDomain<? extends ColumnHandle> compactEffectivePredicate,
             TupleDomain<ColumnHandle> promisedPredicate,
-            Optional<HiveBucketHandle> bucketHandle)
+            Optional<HiveBucketHandle> bucketHandle,
+            Optional<HiveBucketFilter> bucketFilter)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "table is null");
         this.partitionColumns = ImmutableList.copyOf(requireNonNull(partitionColumns, "partitionColumns is null"));
@@ -67,6 +72,7 @@ public final class HiveTableLayoutHandle
         this.compactEffectivePredicate = requireNonNull(compactEffectivePredicate, "compactEffectivePredicate is null");
         this.promisedPredicate = requireNonNull(promisedPredicate, "promisedPredicate is null");
         this.bucketHandle = requireNonNull(bucketHandle, "bucketHandle is null");
+        this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
     }
 
     @JsonProperty
@@ -108,6 +114,12 @@ public final class HiveTableLayoutHandle
     public Optional<HiveBucketHandle> getBucketHandle()
     {
         return bucketHandle;
+    }
+
+    @JsonProperty
+    public Optional<HiveBucketFilter> getBucketFilter()
+    {
+        return bucketFilter;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HiveSplit.BucketConversion;
 import com.facebook.presto.spi.HostAddress;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -22,6 +23,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 
@@ -54,6 +56,7 @@ public class InternalHiveSplit
     private final boolean splittable;
     private final boolean forceLocalScheduling;
     private final Map<Integer, HiveTypeName> columnCoercions;
+    private final Optional<BucketConversion> bucketConversion;
 
     private long start;
     private int currentBlockIndex;
@@ -70,7 +73,8 @@ public class InternalHiveSplit
             OptionalInt bucketNumber,
             boolean splittable,
             boolean forceLocalScheduling,
-            Map<Integer, HiveTypeName> columnCoercions)
+            Map<Integer, HiveTypeName> columnCoercions,
+            Optional<BucketConversion> bucketConversion)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(end >= 0, "length must be positive");
@@ -82,6 +86,7 @@ public class InternalHiveSplit
         requireNonNull(blocks, "blocks is null");
         requireNonNull(bucketNumber, "bucketNumber is null");
         requireNonNull(columnCoercions, "columnCoercions is null");
+        requireNonNull(bucketConversion, "bucketConversion is null");
 
         this.partitionName = partitionName;
         this.path = path;
@@ -95,6 +100,7 @@ public class InternalHiveSplit
         this.splittable = splittable;
         this.forceLocalScheduling = forceLocalScheduling;
         this.columnCoercions = ImmutableMap.copyOf(columnCoercions);
+        this.bucketConversion = bucketConversion;
     }
 
     public String getPath()
@@ -150,6 +156,11 @@ public class InternalHiveSplit
     public Map<Integer, HiveTypeName> getColumnCoercions()
     {
         return columnCoercions;
+    }
+
+    public Optional<BucketConversion> getBucketConversion()
+    {
+        return bucketConversion;
     }
 
     public InternalHiveBlock currentBlock()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.util;
 
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.HivePartitionKey;
+import com.facebook.presto.hive.HiveSplit.BucketConversion;
 import com.facebook.presto.hive.HiveTypeName;
 import com.facebook.presto.hive.InternalHiveSplit;
 import com.facebook.presto.hive.InternalHiveSplit.InternalHiveBlock;
@@ -55,6 +56,7 @@ public class InternalHiveSplitFactory
     private final List<HivePartitionKey> partitionKeys;
     private final Optional<Domain> pathDomain;
     private final Map<Integer, HiveTypeName> columnCoercions;
+    private final Optional<BucketConversion> bucketConversion;
     private final boolean forceLocalScheduling;
 
     public InternalHiveSplitFactory(
@@ -65,6 +67,7 @@ public class InternalHiveSplitFactory
             List<HivePartitionKey> partitionKeys,
             TupleDomain<HiveColumnHandle> effectivePredicate,
             Map<Integer, HiveTypeName> columnCoercions,
+            Optional<BucketConversion> bucketConversion,
             boolean forceLocalScheduling)
     {
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
@@ -74,6 +77,7 @@ public class InternalHiveSplitFactory
         this.partitionKeys = requireNonNull(partitionKeys, "partitionKeys is null");
         pathDomain = getPathDomain(requireNonNull(effectivePredicate, "effectivePredicate is null"));
         this.columnCoercions = requireNonNull(columnCoercions, "columnCoercions is null");
+        this.bucketConversion = requireNonNull(bucketConversion, "bucketConversion is null");
         this.forceLocalScheduling = forceLocalScheduling;
     }
 
@@ -178,7 +182,8 @@ public class InternalHiveSplitFactory
                 bucketNumber,
                 splittable,
                 forceLocalScheduling && allBlocksHaveRealAddress(blocks),
-                columnCoercions));
+                columnCoercions,
+                bucketConversion));
     }
 
     private static void checkBlocks(List<InternalHiveBlock> blocks, long start, long length)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -109,6 +109,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +119,8 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 import static com.facebook.presto.hive.AbstractTestHiveClient.TransactionDeleteInsertTestTag.COMMIT;
 import static com.facebook.presto.hive.AbstractTestHiveClient.TransactionDeleteInsertTestTag.ROLLBACK_AFTER_APPEND_PAGE;
@@ -126,8 +129,10 @@ import static com.facebook.presto.hive.AbstractTestHiveClient.TransactionDeleteI
 import static com.facebook.presto.hive.AbstractTestHiveClient.TransactionDeleteInsertTestTag.ROLLBACK_AFTER_FINISH_INSERT;
 import static com.facebook.presto.hive.AbstractTestHiveClient.TransactionDeleteInsertTestTag.ROLLBACK_AFTER_SINK_FINISH;
 import static com.facebook.presto.hive.AbstractTestHiveClient.TransactionDeleteInsertTestTag.ROLLBACK_RIGHT_AWAY;
+import static com.facebook.presto.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveColumnHandle.bucketColumnHandle;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_SCHEMA_MISMATCH;
 import static com.facebook.presto.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
@@ -180,6 +185,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.testing.MaterializedResult.materializeSourceDataStream;
@@ -188,10 +194,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.uniqueIndex;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.Sets.difference;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
@@ -400,6 +408,7 @@ public abstract class AbstractTestHiveClient
     protected SchemaTableName tableBucketedDoubleFloat;
     protected SchemaTableName tablePartitionSchemaChange;
     protected SchemaTableName tablePartitionSchemaChangeNonCanonical;
+    protected SchemaTableName tableBucketEvolution;
 
     protected String invalidClientId;
     protected ConnectorTableHandle invalidTableHandle;
@@ -460,6 +469,7 @@ public abstract class AbstractTestHiveClient
         tableBucketedDoubleFloat = new SchemaTableName(database, "presto_test_bucketed_by_double_float");
         tablePartitionSchemaChange = new SchemaTableName(database, "presto_test_partition_schema_change");
         tablePartitionSchemaChangeNonCanonical = new SchemaTableName(database, "presto_test_partition_schema_change_non_canonical");
+        tableBucketEvolution = new SchemaTableName(database, "presto_test_bucket_evolution");
 
         invalidClientId = "hive";
         invalidTableHandle = new HiveTableHandle(database, INVALID_TABLE);
@@ -908,14 +918,7 @@ public abstract class AbstractTestHiveClient
         // alter the table schema
         try (Transaction transaction = newTransaction()) {
             ConnectorSession session = newSession();
-            PrincipalPrivileges principalPrivileges = new PrincipalPrivileges(
-                    ImmutableMultimap.<String, HivePrivilegeInfo>builder()
-                            .put(session.getUser(), new HivePrivilegeInfo(HivePrivilege.SELECT, true))
-                            .put(session.getUser(), new HivePrivilegeInfo(HivePrivilege.INSERT, true))
-                            .put(session.getUser(), new HivePrivilegeInfo(HivePrivilege.UPDATE, true))
-                            .put(session.getUser(), new HivePrivilegeInfo(HivePrivilege.DELETE, true))
-                            .build(),
-                    ImmutableMultimap.of());
+            PrincipalPrivileges principalPrivileges = testingPrincipalPrivilege(session.getUser());
             Table oldTable = transaction.getMetastore(schemaName).getTable(schemaName, tableName).get();
             HiveTypeTranslator hiveTypeTranslator = new HiveTypeTranslator();
             List<Column> dataColumns = tableAfter.stream()
@@ -1388,6 +1391,134 @@ public abstract class AbstractTestHiveClient
             MaterializedResult result = readTable(transaction, tableHandle, columnHandles, session, TupleDomain.fromFixedValues(bindings), OptionalInt.of(32), Optional.empty());
             assertEquals(result.getRowCount(), 100);
         }
+    }
+
+    @Test
+    public void testBucketedTableEvolution()
+            throws Exception
+    {
+        for (HiveStorageFormat storageFormat : createTableFormats) {
+            SchemaTableName temporaryBucketEvolutionTable = temporaryTable("bucket_evolution");
+            try {
+                doTestBucketedTableEvolution(storageFormat, temporaryBucketEvolutionTable);
+            }
+            finally {
+                dropTable(temporaryBucketEvolutionTable);
+            }
+        }
+    }
+
+    private void doTestBucketedTableEvolution(HiveStorageFormat storageFormat, SchemaTableName tableName)
+            throws Exception
+    {
+        int rowCount = 100;
+
+        //
+        // Produce a table with 8 buckets.
+        // The table has 3 partitions of 3 different bucket count (4, 8, 16).
+        createEmptyTable(
+                tableName,
+                storageFormat,
+                ImmutableList.of(
+                        new Column("id", HIVE_LONG, Optional.empty()),
+                        new Column("name", HIVE_STRING, Optional.empty())),
+                ImmutableList.of(new Column("pk", HIVE_STRING, Optional.empty())),
+                Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 4)));
+        // write a 4-bucket partition
+        MaterializedResult.Builder bucket4Builder = MaterializedResult.resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR);
+        IntStream.range(0, rowCount).forEach(i -> bucket4Builder.row((long) i, String.valueOf(i), "four"));
+        insertData(tableName, bucket4Builder.build());
+        // write a 16-bucket partition
+        alterBucketProperty(tableName, Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 16)));
+        MaterializedResult.Builder bucket16Builder = MaterializedResult.resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR);
+        IntStream.range(0, rowCount).forEach(i -> bucket16Builder.row((long) i, String.valueOf(i), "sixteen"));
+        insertData(tableName, bucket16Builder.build());
+        // write an 8-bucket partition
+        alterBucketProperty(tableName, Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 8)));
+        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR);
+        IntStream.range(0, rowCount).forEach(i -> bucket8Builder.row((long) i, String.valueOf(i), "eight"));
+        insertData(tableName, bucket8Builder.build());
+
+        try (Transaction transaction = newTransaction()) {
+            ConnectorMetadata metadata = transaction.getMetadata();
+            ConnectorSession session = newSession();
+
+            ConnectorTableHandle tableHandle = getTableHandle(metadata, tableName);
+
+            // read entire table
+            List<ColumnHandle> columnHandles = ImmutableList.<ColumnHandle>builder()
+                    .addAll(metadata.getColumnHandles(session, tableHandle).values())
+                    .build();
+            MaterializedResult result = readTable(
+                    transaction,
+                    tableHandle,
+                    columnHandles,
+                    session,
+                    TupleDomain.all(),
+                    OptionalInt.empty(),
+                    Optional.empty());
+            assertBucketTableEvolutionResult(result, columnHandles, ImmutableSet.of(0, 1, 2, 3, 4, 5, 6, 7), rowCount);
+
+            // read single bucket (table/logical bucket)
+            result = readTable(
+                    transaction,
+                    tableHandle,
+                    columnHandles,
+                    session,
+                    TupleDomain.fromFixedValues(ImmutableMap.of(bucketColumnHandle(), NullableValue.of(INTEGER, 6L))),
+                    OptionalInt.empty(),
+                    Optional.empty());
+            assertBucketTableEvolutionResult(result, columnHandles, ImmutableSet.of(6), rowCount);
+
+            // read single bucket, without selecting the bucketing column (i.e. id column)
+            columnHandles = ImmutableList.<ColumnHandle>builder()
+                    .addAll(metadata.getColumnHandles(session, tableHandle).values().stream()
+                            .filter(columnHandle -> !"id".equals(((HiveColumnHandle) columnHandle).getName()))
+                            .collect(toImmutableList()))
+                    .build();
+            result = readTable(
+                    transaction,
+                    tableHandle,
+                    columnHandles,
+                    session,
+                    TupleDomain.fromFixedValues(ImmutableMap.of(bucketColumnHandle(), NullableValue.of(INTEGER, 6L))),
+                    OptionalInt.empty(),
+                    Optional.empty());
+            assertBucketTableEvolutionResult(result, columnHandles, ImmutableSet.of(6), rowCount);
+        }
+    }
+
+    private static void assertBucketTableEvolutionResult(MaterializedResult result, List<ColumnHandle> columnHandles, Set<Integer> bucketIds, int rowCount)
+    {
+        // Assert that only elements in the specified bucket shows up, and each element shows up 3 times.
+        int bucketCount = 8;
+        Set<Long> expectedIds = LongStream.range(0, rowCount)
+                .filter(x -> bucketIds.contains(toIntExact(x % bucketCount)))
+                .boxed()
+                .collect(toImmutableSet());
+
+        // assert that content from all three buckets are the same
+        Map<String, Integer> columnIndex = indexColumns(columnHandles);
+        OptionalInt idColumnIndex = columnIndex.containsKey("id") ? OptionalInt.of(columnIndex.get("id")) : OptionalInt.empty();
+        int nameColumnIndex = columnIndex.get("name");
+        int bucketColumnIndex = columnIndex.get(BUCKET_COLUMN_NAME);
+        Map<Long, Integer> idCount = new HashMap<>();
+        for (MaterializedRow row : result.getMaterializedRows()) {
+            String name = (String) row.getField(nameColumnIndex);
+            int bucket = (int) row.getField(bucketColumnIndex);
+            idCount.compute(Long.parseLong(name), (key, oldValue) -> oldValue == null ? 1 : oldValue + 1);
+            assertEquals(bucket, Integer.parseInt(name) % bucketCount);
+            if (idColumnIndex.isPresent()) {
+                long id = (long) row.getField(idColumnIndex.getAsInt());
+                assertEquals(Integer.parseInt(name), id);
+            }
+        }
+        assertEquals(
+                (int) idCount.values().stream()
+                        .distinct()
+                        .collect(onlyElement()),
+                3);
+        assertEquals(idCount.keySet(), expectedIds);
     }
 
     private void assertTableIsBucketed(ConnectorTableHandle tableHandle)
@@ -1882,7 +2013,7 @@ public abstract class AbstractTestHiveClient
         ConnectorSession session = newSession();
         String schemaName = schemaTableName.getSchemaName();
         String tableName = schemaTableName.getTableName();
-        PrincipalPrivileges privileges = new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of());
+        PrincipalPrivileges privileges = testingPrincipalPrivilege(session.getUser());
         Path targetPath;
         try {
             try (Transaction transaction = newTransaction()) {
@@ -3310,7 +3441,13 @@ public abstract class AbstractTestHiveClient
                 .collect(toList());
     }
 
-    protected void createEmptyTable(SchemaTableName schemaTableName, HiveStorageFormat hiveStorageFormat, List<Column> columns, List<Column> partitionColumns)
+    private void createEmptyTable(SchemaTableName schemaTableName, HiveStorageFormat hiveStorageFormat, List<Column> columns, List<Column> partitionColumns)
+            throws Exception
+    {
+        createEmptyTable(schemaTableName, hiveStorageFormat, columns, partitionColumns, Optional.empty());
+    }
+
+    private void createEmptyTable(SchemaTableName schemaTableName, HiveStorageFormat hiveStorageFormat, List<Column> columns, List<Column> partitionColumns, Optional<HiveBucketProperty> bucketProperty)
             throws Exception
     {
         Path targetPath;
@@ -3340,16 +3477,10 @@ public abstract class AbstractTestHiveClient
             tableBuilder.getStorageBuilder()
                     .setLocation(targetPath.toString())
                     .setStorageFormat(StorageFormat.create(hiveStorageFormat.getSerDe(), hiveStorageFormat.getInputFormat(), hiveStorageFormat.getOutputFormat()))
+                    .setBucketProperty(bucketProperty)
                     .setSerdeParameters(ImmutableMap.of());
 
-            PrincipalPrivileges principalPrivileges = new PrincipalPrivileges(
-                    ImmutableMultimap.<String, HivePrivilegeInfo>builder()
-                            .put(tableOwner, new HivePrivilegeInfo(HivePrivilege.SELECT, true))
-                            .put(tableOwner, new HivePrivilegeInfo(HivePrivilege.INSERT, true))
-                            .put(tableOwner, new HivePrivilegeInfo(HivePrivilege.UPDATE, true))
-                            .put(tableOwner, new HivePrivilegeInfo(HivePrivilege.DELETE, true))
-                            .build(),
-                    ImmutableMultimap.of());
+            PrincipalPrivileges principalPrivileges = testingPrincipalPrivilege(tableOwner);
             transaction.getMetastore(schemaName).createTable(session, tableBuilder.build(), principalPrivileges, Optional.empty(), true);
 
             transaction.commit();
@@ -3358,6 +3489,38 @@ public abstract class AbstractTestHiveClient
         HdfsContext context = new HdfsContext(newSession(), schemaTableName.getSchemaName(), schemaTableName.getTableName());
         List<String> targetDirectoryList = listDirectory(context, targetPath);
         assertEquals(targetDirectoryList, ImmutableList.of());
+    }
+
+    private void alterBucketProperty(SchemaTableName schemaTableName, Optional<HiveBucketProperty> bucketProperty)
+    {
+        try (Transaction transaction = newTransaction()) {
+            ConnectorSession session = newSession();
+
+            String tableOwner = session.getUser();
+            String schemaName = schemaTableName.getSchemaName();
+            String tableName = schemaTableName.getTableName();
+
+            Optional<Table> table = transaction.getMetastore(schemaName).getTable(schemaName, tableName);
+            Table.Builder tableBuilder = Table.builder(table.get());
+            tableBuilder.getStorageBuilder().setBucketProperty(bucketProperty);
+            PrincipalPrivileges principalPrivileges = testingPrincipalPrivilege(tableOwner);
+            // hack: replaceView can be used as replaceTable despite its name
+            transaction.getMetastore(schemaName).replaceView(schemaName, tableName, tableBuilder.build(), principalPrivileges);
+
+            transaction.commit();
+        }
+    }
+
+    private PrincipalPrivileges testingPrincipalPrivilege(String tableOwner)
+    {
+        return new PrincipalPrivileges(
+                ImmutableMultimap.<String, HivePrivilegeInfo>builder()
+                        .put(tableOwner, new HivePrivilegeInfo(HivePrivilege.SELECT, true))
+                        .put(tableOwner, new HivePrivilegeInfo(HivePrivilege.INSERT, true))
+                        .put(tableOwner, new HivePrivilegeInfo(HivePrivilege.UPDATE, true))
+                        .put(tableOwner, new HivePrivilegeInfo(HivePrivilege.DELETE, true))
+                        .build(),
+                ImmutableMultimap.of());
     }
 
     private List<String> listDirectory(HdfsContext context, Path path)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -466,9 +466,10 @@ public abstract class AbstractTestHiveClient
         invalidTableLayoutHandle = new HiveTableLayoutHandle(
                 invalidTable,
                 ImmutableList.of(),
-                ImmutableList.of(new HivePartition(invalidTable, "unknown", ImmutableMap.of(), ImmutableList.of())),
+                ImmutableList.of(new HivePartition(invalidTable, "unknown", ImmutableMap.of())),
                 TupleDomain.all(),
                 TupleDomain.all(),
+                Optional.empty(),
                 Optional.empty());
 
         dsColumn = new HiveColumnHandle("ds", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), -1, PARTITION_KEY, Optional.empty());
@@ -485,37 +486,33 @@ public abstract class AbstractTestHiveClient
                                 .put(dsColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("2012-12-29")))
                                 .put(fileFormatColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("textfile")))
                                 .put(dummyColumn, NullableValue.of(INTEGER, 1L))
-                                .build(),
-                        ImmutableList.of()))
+                                .build()))
                 .add(new HivePartition(tablePartitionFormat,
                         "ds=2012-12-29/file_format=sequencefile/dummy=2",
                         ImmutableMap.<ColumnHandle, NullableValue>builder()
                                 .put(dsColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("2012-12-29")))
                                 .put(fileFormatColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("sequencefile")))
                                 .put(dummyColumn, NullableValue.of(INTEGER, 2L))
-                                .build(),
-                        ImmutableList.of()))
+                                .build()))
                 .add(new HivePartition(tablePartitionFormat,
                         "ds=2012-12-29/file_format=rctext/dummy=3",
                         ImmutableMap.<ColumnHandle, NullableValue>builder()
                                 .put(dsColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("2012-12-29")))
                                 .put(fileFormatColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("rctext")))
                                 .put(dummyColumn, NullableValue.of(INTEGER, 3L))
-                                .build(),
-                        ImmutableList.of()))
+                                .build()))
                 .add(new HivePartition(tablePartitionFormat,
                         "ds=2012-12-29/file_format=rcbinary/dummy=4",
                         ImmutableMap.<ColumnHandle, NullableValue>builder()
                                 .put(dsColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("2012-12-29")))
                                 .put(fileFormatColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("rcbinary")))
                                 .put(dummyColumn, NullableValue.of(INTEGER, 4L))
-                                .build(),
-                        ImmutableList.of()))
+                                .build()))
                 .build();
         partitionCount = partitions.size();
         tupleDomain = TupleDomain.fromFixedValues(ImmutableMap.of(dsColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice("2012-12-29"))));
         tableLayout = new ConnectorTableLayout(
-                new HiveTableLayoutHandle(tablePartitionFormat, partitionColumns, partitions, tupleDomain, tupleDomain, Optional.empty()),
+                new HiveTableLayoutHandle(tablePartitionFormat, partitionColumns, partitions, tupleDomain, tupleDomain, Optional.empty(), Optional.empty()),
                 Optional.empty(),
                 TupleDomain.withColumnDomains(ImmutableMap.of(
                         dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
@@ -541,8 +538,8 @@ public abstract class AbstractTestHiveClient
                                 fileFormatColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("rcbinary"))), false),
                                 dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 4L)), false)))))),
                 ImmutableList.of());
-        List<HivePartition> unpartitionedPartitions = ImmutableList.of(new HivePartition(tableUnpartitioned, ImmutableList.of()));
-        unpartitionedTableLayout = new ConnectorTableLayout(new HiveTableLayoutHandle(tableUnpartitioned, ImmutableList.of(), unpartitionedPartitions, TupleDomain.all(), TupleDomain.all(), Optional.empty()));
+        List<HivePartition> unpartitionedPartitions = ImmutableList.of(new HivePartition(tableUnpartitioned));
+        unpartitionedTableLayout = new ConnectorTableLayout(new HiveTableLayoutHandle(tableUnpartitioned, ImmutableList.of(), unpartitionedPartitions, TupleDomain.all(), TupleDomain.all(), Optional.empty(), Optional.empty()));
         timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZoneId));
     }
 
@@ -1010,7 +1007,6 @@ public abstract class AbstractTestHiveClient
             assertEquals(actualPartition.getPartitionId(), expectedPartition.getPartitionId());
             assertEquals(actualPartition.getKeys(), expectedPartition.getKeys());
             assertEquals(actualPartition.getTableName(), expectedPartition.getTableName());
-            assertEquals(actualPartition.getBuckets(), expectedPartition.getBuckets());
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HiveBucketing.HiveBucketFilter;
+import com.facebook.presto.hive.HiveColumnHandle.ColumnType;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.StorageFormat;
@@ -25,6 +27,7 @@ import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.stats.CounterStat;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.conf.Configuration;
@@ -48,7 +51,6 @@ import java.util.Optional;
 import java.util.concurrent.Executor;
 
 import static com.facebook.presto.hive.BackgroundHiveSplitLoader.BucketSplitInfo.createBucketSplitInfo;
-import static com.facebook.presto.hive.HiveBucketing.HiveBucket;
 import static com.facebook.presto.hive.HiveColumnHandle.pathColumnHandle;
 import static com.facebook.presto.hive.HiveTestUtils.SESSION;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
@@ -56,6 +58,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveUtil.getRegularColumnHandles;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -90,6 +93,8 @@ public class TestBackgroundHiveSplitLoader
 
     private static final List<Column> PARTITION_COLUMNS = ImmutableList.of(
             new Column("partitionColumn", HIVE_INT, Optional.empty()));
+    private static final List<HiveColumnHandle> BUCKET_COLUMN_HANDLES = ImmutableList.of(
+            new HiveColumnHandle("col1", HIVE_INT, INTEGER.getTypeSignature(), 0, ColumnType.REGULAR, Optional.empty()));
 
     private static final Optional<HiveBucketProperty> BUCKET_PROPERTY = Optional.of(
             new HiveBucketProperty(ImmutableList.of("col1"), BUCKET_COUNT));
@@ -133,11 +138,9 @@ public class TestBackgroundHiveSplitLoader
         BackgroundHiveSplitLoader backgroundHiveSplitLoader = backgroundHiveSplitLoader(
                 TEST_FILES,
                 RETURNED_PATH_DOMAIN,
-                ImmutableList.of(
-                        new HiveBucket(0, BUCKET_COUNT),
-                        new HiveBucket(1, BUCKET_COUNT)),
+                Optional.of(new HiveBucketFilter(ImmutableSet.of(0, 1))),
                 PARTITIONED_TABLE,
-                Optional.empty());
+                Optional.of(new HiveBucketHandle(BUCKET_COLUMN_HANDLES, BUCKET_COUNT)));
 
         HiveSplitSource hiveSplitSource = hiveSplitSource(backgroundHiveSplitLoader, RETURNED_PATH_DOMAIN);
         backgroundHiveSplitLoader.start(hiveSplitSource);
@@ -153,7 +156,7 @@ public class TestBackgroundHiveSplitLoader
         BackgroundHiveSplitLoader backgroundHiveSplitLoader = backgroundHiveSplitLoader(
                 TEST_FILES,
                 RETURNED_PATH_DOMAIN,
-                ImmutableList.of(),
+                Optional.empty(),
                 PARTITIONED_TABLE,
                 Optional.of(
                         new HiveBucketHandle(
@@ -224,7 +227,7 @@ public class TestBackgroundHiveSplitLoader
         return backgroundHiveSplitLoader(
                 files,
                 tupleDomain,
-                ImmutableList.of(),
+                Optional.empty(),
                 SIMPLE_TABLE,
                 Optional.empty());
     }
@@ -232,14 +235,14 @@ public class TestBackgroundHiveSplitLoader
     private static BackgroundHiveSplitLoader backgroundHiveSplitLoader(
             List<LocatedFileStatus> files,
             TupleDomain<HiveColumnHandle> compactEffectivePredicate,
-            List<HiveBucket> hiveBuckets,
+            Optional<HiveBucketFilter> hiveBucketFilter,
             Table table,
             Optional<HiveBucketHandle> bucketHandle)
     {
         List<HivePartitionMetadata> hivePartitionMetadatas =
                 ImmutableList.of(
                         new HivePartitionMetadata(
-                                new HivePartition(new SchemaTableName("testSchema", "table_name"), ImmutableList.of()),
+                                new HivePartition(new SchemaTableName("testSchema", "table_name")),
                                 Optional.empty(),
                                 ImmutableMap.of()));
 
@@ -250,7 +253,7 @@ public class TestBackgroundHiveSplitLoader
                 table,
                 hivePartitionMetadatas,
                 compactEffectivePredicate,
-                createBucketSplitInfo(bucketHandle, hiveBuckets),
+                createBucketSplitInfo(bucketHandle, hiveBucketFilter),
                 connectorSession,
                 new TestingHdfsEnvironment(),
                 new NamenodeStats(),
@@ -269,7 +272,7 @@ public class TestBackgroundHiveSplitLoader
                 SIMPLE_TABLE,
                 createPartitionMetadataWithOfflinePartitions(),
                 TupleDomain.all(),
-                createBucketSplitInfo(Optional.empty(), ImmutableList.of()),
+                createBucketSplitInfo(Optional.empty(), Optional.empty()),
                 connectorSession,
                 new TestingHdfsEnvironment(),
                 new NamenodeStats(),
@@ -295,7 +298,7 @@ public class TestBackgroundHiveSplitLoader
                 switch (position) {
                     case 0:
                         return new HivePartitionMetadata(
-                                new HivePartition(new SchemaTableName("testSchema", "table_name"), ImmutableList.of()),
+                                new HivePartition(new SchemaTableName("testSchema", "table_name")),
                                 Optional.empty(),
                                 ImmutableMap.of());
                     case 1:

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
@@ -221,7 +221,7 @@ public class TestHiveBucketing
             blockListBuilder.add(block);
         }
         ImmutableList<Block> blockList = blockListBuilder.build();
-        return HiveBucketing.getHiveBucket(hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2, bucketCount);
+        return HiveBucketing.getHiveBucket(bucketCount, hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2);
     }
 
     public static int getHiveBucket(List<Entry<ObjectInspector, Object>> columnBindings, int bucketCount)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.hive;
 
-import com.facebook.presto.hive.HiveBucketing.HiveBucketFilter;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -21,7 +20,6 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.airlift.slice.Slices;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -46,54 +44,17 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
+import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Maps.immutableEntry;
-import static io.airlift.slice.Slices.utf8Slice;
-import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.toIntExact;
 import static java.util.Arrays.asList;
 import static java.util.Map.Entry;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaBooleanObjectInspector;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaLongObjectInspector;
-import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestHiveBucketing
 {
-    @Test
-    public void testHashingBooleanLong()
-    {
-        List<Entry<ObjectInspector, Object>> bindings = ImmutableList.<Entry<ObjectInspector, Object>>builder()
-                .add(entry(javaBooleanObjectInspector, true))
-                .add(entry(javaLongObjectInspector, 123L))
-                .build();
-
-        Optional<HiveBucketFilter> bucket = HiveBucketing.getHiveBucket(bindings, 32);
-        assertTrue(bucket.isPresent());
-        assertEquals(bucket.get().getBucketsToKeep(), ImmutableSet.of(26));
-    }
-
-    @Test
-    public void testHashingString()
-    {
-        List<Entry<ObjectInspector, Object>> bindings = ImmutableList.<Entry<ObjectInspector, Object>>builder()
-                .add(entry(javaStringObjectInspector, utf8Slice("sequencefile test")))
-                .build();
-
-        Optional<HiveBucketFilter> bucket = HiveBucketing.getHiveBucket(bindings, 32);
-        assertTrue(bucket.isPresent());
-        assertEquals(bucket.get().getBucketsToKeep(), ImmutableSet.of(21));
-    }
-
-    private static Entry<ObjectInspector, Object> entry(ObjectInspector inspector, Object value)
-    {
-        return immutableEntry(inspector, value);
-    }
-
     @Test
     public void testHashingCompare()
             throws Exception
@@ -167,14 +128,14 @@ public class TestHiveBucketing
                 asList(null, ImmutableList.of((short) 5, (short) 8, (short) 13), null, ImmutableMap.of("key", 123L), null));
     }
 
-    private static void assertBucketEquals(String hiveTypeStrings, Object javaValues)
+    private static void assertBucketEquals(String hiveTypeStrings, Object hiveValues)
             throws HiveException
     {
         // Use asList to allow nulls
-        assertBucketEquals(ImmutableList.of(hiveTypeStrings), asList(javaValues));
+        assertBucketEquals(ImmutableList.of(hiveTypeStrings), asList(hiveValues));
     }
 
-    private static void assertBucketEquals(List<String> hiveTypeStrings, List<Object> javaValues)
+    private static void assertBucketEquals(List<String> hiveTypeStrings, List<Object> hiveValues)
             throws HiveException
     {
         List<HiveType> hiveTypes = hiveTypeStrings.stream()
@@ -185,18 +146,18 @@ public class TestHiveBucketing
                 .collect(toImmutableList());
 
         for (int bucketCount : new int[] {1, 2, 500, 997}) {
-            int actual = computeActual(hiveTypeStrings, javaValues, bucketCount, hiveTypes, hiveTypeInfos);
-            int expected = computeExpected(hiveTypeStrings, javaValues, bucketCount, hiveTypeInfos);
+            int actual = computeActual(hiveTypeStrings, hiveValues, bucketCount, hiveTypes, hiveTypeInfos);
+            int expected = computeExpected(hiveTypeStrings, hiveValues, bucketCount, hiveTypeInfos);
             assertEquals(actual, expected);
         }
     }
 
-    private static int computeExpected(List<String> hiveTypeStrings, List<Object> javaValues, int bucketCount, List<TypeInfo> hiveTypeInfos)
+    private static int computeExpected(List<String> hiveTypeStrings, List<Object> hiveValues, int bucketCount, List<TypeInfo> hiveTypeInfos)
             throws HiveException
     {
         ImmutableList.Builder<Entry<ObjectInspector, Object>> columnBindingsBuilder = ImmutableList.builder();
         for (int i = 0; i < hiveTypeStrings.size(); i++) {
-            Object javaValue = javaValues.get(i);
+            Object javaValue = hiveValues.get(i);
 
             columnBindingsBuilder.add(Maps.immutableEntry(
                     TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(hiveTypeInfos.get(i)),
@@ -205,23 +166,29 @@ public class TestHiveBucketing
         return getHiveBucket(columnBindingsBuilder.build(), bucketCount);
     }
 
-    private static int computeActual(List<String> hiveTypeStrings, List<Object> javaValues, int bucketCount, List<HiveType> hiveTypes, List<TypeInfo> hiveTypeInfos)
+    private static int computeActual(List<String> hiveTypeStrings, List<Object> hiveValues, int bucketCount, List<HiveType> hiveTypes, List<TypeInfo> hiveTypeInfos)
     {
         ImmutableList.Builder<Block> blockListBuilder = ImmutableList.builder();
+        Object[] nativeContainerValues = new Object[hiveValues.size()];
         for (int i = 0; i < hiveTypeStrings.size(); i++) {
-            Object javaValue = javaValues.get(i);
+            Object hiveValue = hiveValues.get(i);
             Type type = hiveTypes.get(i).getType(TYPE_MANAGER);
 
             BlockBuilder blockBuilder = type.createBlockBuilder(null, 3);
             // prepend 2 nulls to make sure position is respected when HiveBucketing function
             blockBuilder.appendNull();
             blockBuilder.appendNull();
-            appendToBlockBuilder(type, javaValue, blockBuilder);
+            appendToBlockBuilder(type, hiveValue, blockBuilder);
             Block block = blockBuilder.build();
             blockListBuilder.add(block);
+
+            nativeContainerValues[i] = toNativeContainerValue(type, hiveValue);
         }
         ImmutableList<Block> blockList = blockListBuilder.build();
-        return HiveBucketing.getHiveBucket(bucketCount, hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2);
+        int result1 = HiveBucketing.getHiveBucket(bucketCount, hiveTypeInfos, new Page(blockList.toArray(new Block[blockList.size()])), 2);
+        int result2 = HiveBucketing.getHiveBucket(bucketCount, hiveTypeInfos, nativeContainerValues);
+        assertEquals(result1, result2, "Overloads of getHiveBucket produced different result");
+        return result1;
     }
 
     public static int getHiveBucket(List<Entry<ObjectInspector, Object>> columnBindings, int bucketCount)
@@ -254,82 +221,76 @@ public class TestHiveBucketing
         return new DefaultHivePartitioner<>().getBucket(hiveKey, null, bucketCount);
     }
 
-    /**
-     * @param element java representation of the element (e.g. int, double, List, Date, String) to be added
-     */
-    public static void appendToBlockBuilder(Type type, Object element, BlockBuilder blockBuilder)
+    private static Object toNativeContainerValue(Type type, Object hiveValue)
     {
         String typeBase = type.getTypeSignature().getBase();
-        if (element == null) {
-            blockBuilder.appendNull();
-            return;
+        if (hiveValue == null) {
+            return null;
         }
         switch (typeBase) {
             case StandardTypes.ARRAY: {
+                BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
                 BlockBuilder subBlockBuilder = blockBuilder.beginBlockEntry();
-                for (Object subElement : (Iterable<?>) element) {
+                for (Object subElement : (Iterable<?>) hiveValue) {
                     appendToBlockBuilder(type.getTypeParameters().get(0), subElement, subBlockBuilder);
                 }
                 blockBuilder.closeEntry();
-                break;
+                return type.getObject(blockBuilder, 0);
             }
             case StandardTypes.ROW: {
+                BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
                 BlockBuilder subBlockBuilder = blockBuilder.beginBlockEntry();
                 int field = 0;
-                for (Object subElement : (Iterable<?>) element) {
+                for (Object subElement : (Iterable<?>) hiveValue) {
                     appendToBlockBuilder(type.getTypeParameters().get(field), subElement, subBlockBuilder);
                     field++;
                 }
                 blockBuilder.closeEntry();
-                break;
+                return type.getObject(blockBuilder, 0);
             }
             case StandardTypes.MAP: {
+                BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
                 BlockBuilder subBlockBuilder = blockBuilder.beginBlockEntry();
-                for (Entry<?, ?> entry : ((Map<?, ?>) element).entrySet()) {
+                for (Entry<?, ?> entry : ((Map<?, ?>) hiveValue).entrySet()) {
                     appendToBlockBuilder(type.getTypeParameters().get(0), entry.getKey(), subBlockBuilder);
                     appendToBlockBuilder(type.getTypeParameters().get(1), entry.getValue(), subBlockBuilder);
                 }
                 blockBuilder.closeEntry();
-                break;
+                return type.getObject(blockBuilder, 0);
             }
             case StandardTypes.BOOLEAN:
-                type.writeBoolean(blockBuilder, (Boolean) element);
-                break;
+                return hiveValue;
             case StandardTypes.TINYINT:
-                type.writeLong(blockBuilder, ((Number) element).byteValue());
-                break;
+                return (long) (byte) hiveValue;
             case StandardTypes.SMALLINT:
-                type.writeLong(blockBuilder, ((Number) element).shortValue());
-                break;
+                return (long) (short) hiveValue;
             case StandardTypes.INTEGER:
-                type.writeLong(blockBuilder, ((Number) element).intValue());
-                break;
+                return (long) (int) hiveValue;
             case StandardTypes.BIGINT:
-                type.writeLong(blockBuilder, ((Number) element).longValue());
-                break;
+                return hiveValue;
             case StandardTypes.REAL:
-                type.writeLong(blockBuilder, floatToRawIntBits(((Number) element).floatValue()));
-                break;
+                return (long) Float.floatToRawIntBits((float) hiveValue);
             case StandardTypes.DOUBLE:
-                type.writeDouble(blockBuilder, ((Number) element).doubleValue());
-                break;
+                return hiveValue;
             case StandardTypes.VARCHAR:
-                type.writeSlice(blockBuilder, Slices.utf8Slice(element.toString()));
-                break;
+                return Slices.utf8Slice(hiveValue.toString());
             case StandardTypes.DATE:
-                long daysSinceEpochInLocalZone = ((Date) element).toLocalDate().toEpochDay();
-                assertEquals(daysSinceEpochInLocalZone, DateWritable.dateToDays((Date) element));
-                type.writeLong(blockBuilder, daysSinceEpochInLocalZone);
-                break;
+                long daysSinceEpochInLocalZone = ((Date) hiveValue).toLocalDate().toEpochDay();
+                assertEquals(daysSinceEpochInLocalZone, DateWritable.dateToDays((Date) hiveValue));
+                return daysSinceEpochInLocalZone;
             case StandardTypes.TIMESTAMP:
-                Instant instant = ((Timestamp) element).toInstant();
+                Instant instant = ((Timestamp) hiveValue).toInstant();
                 long epochSecond = instant.getEpochSecond();
                 int nano = instant.getNano();
                 assertEquals(nano % 1_000_000, 0);
-                type.writeLong(blockBuilder, epochSecond * 1000 + nano / 1_000_000);
-                break;
+                return epochSecond * 1000 + nano / 1_000_000;
             default:
                 throw new UnsupportedOperationException("unknown type");
         }
+    }
+
+    private static void appendToBlockBuilder(Type type, Object hiveValue, BlockBuilder blockBuilder)
+    {
+        writeNativeValue(type, blockBuilder, toNativeContainerValue(type, hiveValue));
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketing.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HiveBucketing.HiveBucketFilter;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -20,6 +21,7 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.airlift.slice.Slices;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -46,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.hive.HiveBucketing.HiveBucket;
 import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Maps.immutableEntry;
@@ -71,10 +72,9 @@ public class TestHiveBucketing
                 .add(entry(javaLongObjectInspector, 123L))
                 .build();
 
-        Optional<HiveBucket> bucket = HiveBucketing.getHiveBucket(bindings, 32);
+        Optional<HiveBucketFilter> bucket = HiveBucketing.getHiveBucket(bindings, 32);
         assertTrue(bucket.isPresent());
-        assertEquals(bucket.get().getBucketCount(), 32);
-        assertEquals(bucket.get().getBucketNumber(), 26);
+        assertEquals(bucket.get().getBucketsToKeep(), ImmutableSet.of(26));
     }
 
     @Test
@@ -84,10 +84,9 @@ public class TestHiveBucketing
                 .add(entry(javaStringObjectInspector, utf8Slice("sequencefile test")))
                 .build();
 
-        Optional<HiveBucket> bucket = HiveBucketing.getHiveBucket(bindings, 32);
+        Optional<HiveBucketFilter> bucket = HiveBucketing.getHiveBucket(bindings, 32);
         assertTrue(bucket.isPresent());
-        assertEquals(bucket.get().getBucketCount(), 32);
-        assertEquals(bucket.get().getBucketNumber(), 21);
+        assertEquals(bucket.get().getBucketsToKeep(), ImmutableSet.of(21));
     }
 
     private static Entry<ObjectInspector, Object> entry(ObjectInspector inspector, Object value)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
@@ -46,6 +46,12 @@ public class TestHiveClientFileMetastore
     }
 
     @Override
+    public void testBucketedTableEvolution()
+    {
+        // FileHiveMetastore only supports replaceTable() for views
+    }
+
+    @Override
     public void testTransactionDeleteInsert()
     {
         // FileHiveMetastore has various incompatibilities

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -678,7 +678,8 @@ public class TestHiveFileFormats
                 partitionKeys,
                 DateTimeZone.getDefault(),
                 TYPE_MANAGER,
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                Optional.empty());
 
         RecordCursor cursor = ((RecordPageSource) pageSource.get()).getCursor();
 
@@ -722,7 +723,8 @@ public class TestHiveFileFormats
                 partitionKeys,
                 DateTimeZone.getDefault(),
                 TYPE_MANAGER,
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                Optional.empty());
 
         assertTrue(pageSource.isPresent());
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
@@ -45,7 +45,7 @@ public class TestHiveMetadata
             partitions.add(new HivePartition(
                     new SchemaTableName("test", "test"),
                     Integer.toString(i),
-                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i)))), ImmutableList.of()));
+                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i))))));
         }
 
         createPredicate(ImmutableList.of(TEST_COLUMN_HANDLE), partitions.build());
@@ -60,7 +60,7 @@ public class TestHiveMetadata
             partitions.add(new HivePartition(
                     new SchemaTableName("test", "test"),
                     Integer.toString(i),
-                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR)), ImmutableList.of()));
+                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR))));
         }
 
         createPredicate(ImmutableList.of(TEST_COLUMN_HANDLE), partitions.build());
@@ -75,13 +75,13 @@ public class TestHiveMetadata
             partitions.add(new HivePartition(
                     new SchemaTableName("test", "test"),
                     Integer.toString(i),
-                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i)))), ImmutableList.of()));
+                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i))))));
         }
 
         partitions.add(new HivePartition(
                 new SchemaTableName("test", "test"),
                 "null",
-                ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR)), ImmutableList.of()));
+                ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR))));
 
         createPredicate(ImmutableList.of(TEST_COLUMN_HANDLE), partitions.build());
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -209,7 +209,22 @@ public class TestHivePageSink
         splitProperties.setProperty(SERIALIZATION_LIB, config.getHiveStorageFormat().getSerDe());
         splitProperties.setProperty("columns", Joiner.on(',').join(getColumnHandles().stream().map(HiveColumnHandle::getName).collect(toList())));
         splitProperties.setProperty("columns.types", Joiner.on(',').join(getColumnHandles().stream().map(HiveColumnHandle::getHiveType).map(hiveType -> hiveType.getHiveTypeName().toString()).collect(toList())));
-        HiveSplit split = new HiveSplit(SCHEMA_NAME, TABLE_NAME, "", "file:///" + outputFile.getAbsolutePath(), 0, outputFile.length(), outputFile.length(), splitProperties, ImmutableList.of(), ImmutableList.of(), OptionalInt.empty(), false, TupleDomain.all(), ImmutableMap.of());
+        HiveSplit split = new HiveSplit(
+                SCHEMA_NAME,
+                TABLE_NAME,
+                "",
+                "file:///" + outputFile.getAbsolutePath(),
+                0,
+                outputFile.length(),
+                outputFile.length(),
+                splitProperties,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                OptionalInt.empty(),
+                false,
+                TupleDomain.all(),
+                ImmutableMap.of(),
+                Optional.empty());
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config), getDefaultHiveRecordCursorProvider(config), getDefaultHiveDataStreamFactories(config), TYPE_MANAGER);
         return provider.createPageSource(transaction, getSession(config), split, ImmutableList.copyOf(getColumnHandles()));
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.hive.HiveColumnHandle.ColumnType;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.google.common.collect.ImmutableList;
@@ -20,10 +21,13 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 
+import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static org.testng.Assert.assertEquals;
 
 public class TestHiveSplit
@@ -45,7 +49,7 @@ public class TestHiveSplit
                 "partitionId",
                 "path",
                 42,
-                88,
+                87,
                 88,
                 schema,
                 partitionKeys,
@@ -53,7 +57,11 @@ public class TestHiveSplit
                 OptionalInt.empty(),
                 true,
                 TupleDomain.all(),
-                ImmutableMap.of(1, HIVE_STRING));
+                ImmutableMap.of(1, HIVE_STRING),
+                Optional.of(new HiveSplit.BucketConversion(
+                        32,
+                        16,
+                        ImmutableList.of(new HiveColumnHandle("col", HIVE_LONG, BIGINT.getTypeSignature(), 5, ColumnType.REGULAR, Optional.of("comment"))))));
 
         String json = codec.toJson(expected);
         HiveSplit actual = codec.fromJson(json);
@@ -69,6 +77,7 @@ public class TestHiveSplit
         assertEquals(actual.getPartitionKeys(), expected.getPartitionKeys());
         assertEquals(actual.getAddresses(), expected.getAddresses());
         assertEquals(actual.getColumnCoercions(), expected.getColumnCoercions());
+        assertEquals(actual.getBucketConversion(), expected.getBucketConversion());
         assertEquals(actual.isForceLocalScheduling(), expected.isForceLocalScheduling());
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -27,6 +27,7 @@ import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -222,7 +223,8 @@ public class TestHiveSplitSource
                 OptionalInt.empty(),
                 true,
                 false,
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                Optional.empty());
         int testSplitSizeInBytes = testSplit.getEstimatedSizeInBytes();
 
         int maxSplitCount = toIntExact(maxOutstandingSplitsSize.toBytes()) / testSplitSizeInBytes;
@@ -282,7 +284,8 @@ public class TestHiveSplitSource
                     OptionalInt.empty(),
                     true,
                     false,
-                    ImmutableMap.of());
+                    ImmutableMap.of(),
+                    Optional.empty());
         }
 
         private static Properties properties(String key, String value)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -470,7 +470,8 @@ public class TestOrcPageSourceMemoryTracking
                     partitionKeys,
                     DateTimeZone.UTC,
                     TYPE_MANAGER,
-                    ImmutableMap.of())
+                    ImmutableMap.of(),
+                    Optional.empty())
                     .get();
         }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -200,6 +200,13 @@ public class LazyBlock
     }
 
     @Override
+    public Block getPositions(int[] positions, int offset, int length)
+    {
+        assureLoaded();
+        return block.getPositions(positions, offset, length);
+    }
+
+    @Override
     public Block copyPositions(int[] positions, int offset, int length)
     {
         assureLoaded();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -97,6 +97,16 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public Block getPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+        for (int i = offset; i < offset + length; i++) {
+            checkValidPosition(positions[i], positionCount);
+        }
+        return new RunLengthEncodedBlock(value, length);
+    }
+
+    @Override
     public Block copyPositions(int[] positions, int offset, int length)
     {
         checkArrayRange(positions, offset, length);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorPageSourceProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorPageSourceProvider.java
@@ -22,5 +22,8 @@ import java.util.List;
 
 public interface ConnectorPageSourceProvider
 {
+    /**
+     * @param columns columns that should show up in the output page, in this order
+     */
     ConnectorPageSource createPageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorSplit split, List<ColumnHandle> columns);
 }


### PR DESCRIPTION
This allows mismatch between partition bucket count and table bucket count
if the ratio is a power of two.
