### PR TITLE
Restore predicate pushdown switch in TPCH connector

### DIFF
--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchConnectorFactory.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchConnectorFactory.java
@@ -35,6 +35,7 @@ public class TpchConnectorFactory
     public static final String TPCH_COLUMN_NAMING_PROPERTY = "tpch.column-naming";
 
     private final int defaultSplitsPerNode;
+    private final boolean predicatePushdownEnabled;
 
     public TpchConnectorFactory()
     {
@@ -43,7 +44,13 @@ public class TpchConnectorFactory
 
     public TpchConnectorFactory(int defaultSplitsPerNode)
     {
+        this(defaultSplitsPerNode, true);
+    }
+
+    public TpchConnectorFactory(int defaultSplitsPerNode, boolean predicatePushdownEnabled)
+    {
         this.defaultSplitsPerNode = defaultSplitsPerNode;
+        this.predicatePushdownEnabled = predicatePushdownEnabled;
     }
 
     @Override
@@ -76,7 +83,7 @@ public class TpchConnectorFactory
             @Override
             public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
             {
-                return new TpchMetadata(connectorId, columnNaming);
+                return new TpchMetadata(connectorId, columnNaming, predicatePushdownEnabled);
             }
 
             @Override


### PR DESCRIPTION
This reverts removal of predicate pushdown switch in TPCH connector.
Additionally, this uses the switch also when querying table statistics,
so that TPCH connector can mimic a partitioned table (or not).