### PR TITLE
Optimize the ST_Intersection function for envelopes

### DIFF
--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometrySerde.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometrySerde.java
@@ -145,6 +145,14 @@ public class GeometrySerde
         }
     }
 
+    public static GeometryType deserializeType(Slice shape)
+    {
+        requireNonNull(shape, "shape is null");
+        BasicSliceInput input = shape.getInput();
+        verify(input.available() > 0);
+        return GeometryType.getForCode(input.readByte());
+    }
+
     public static OGCGeometry deserialize(Slice shape)
     {
         requireNonNull(shape, "shape is null");

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryType.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryType.java
@@ -23,7 +23,8 @@ public enum GeometryType
     MULTI_LINE_STRING(3, true),
     POLYGON(4, false),
     MULTI_POLYGON(5, true),
-    GEOMETRY_COLLECTION(6, true);
+    GEOMETRY_COLLECTION(6, true),
+    ENVELOPE(7, false);
 
     private final int code;
     private final boolean multitype;
@@ -84,6 +85,8 @@ public enum GeometryType
                 return MULTI_POLYGON;
             case 6:
                 return GEOMETRY_COLLECTION;
+            case 7:
+                return ENVELOPE;
             default:
                 throw new IllegalArgumentException("Invalid type code: " + code);
         }

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/JtsGeometrySerde.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/JtsGeometrySerde.java
@@ -72,6 +72,8 @@ public class JtsGeometrySerde
                 return readPolygon(input, true);
             case GEOMETRY_COLLECTION:
                 return readGeometryCollection(input);
+            case ENVELOPE:
+                return readEnvelope(input);
             default:
                 throw new UnsupportedOperationException("Unexpected type: " + type);
         }
@@ -204,6 +206,23 @@ public class JtsGeometrySerde
             geometries.add(readGeometry(input, type));
         }
         return GEOMETRY_FACTORY.createGeometryCollection(geometries.toArray(new Geometry[0]));
+    }
+
+    private static Geometry readEnvelope(SliceInput input)
+    {
+        verify(input.available() > 0);
+        double xMin = input.readDouble();
+        double yMin = input.readDouble();
+        double xMax = input.readDouble();
+        double yMax = input.readDouble();
+
+        Coordinate[] coordinates = new Coordinate[5];
+        coordinates[0] = new Coordinate(xMin, yMin);
+        coordinates[1] = new Coordinate(xMin, yMax);
+        coordinates[2] = new Coordinate(xMax, yMax);
+        coordinates[3] = new Coordinate(xMax, yMin);
+        coordinates[4] = coordinates[0];
+        return GEOMETRY_FACTORY.createPolygon(coordinates);
     }
 
     private static void skipEsriType(SliceInput input)

--- a/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/TestGeometrySerialization.java
+++ b/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/TestGeometrySerialization.java
@@ -24,7 +24,16 @@ import org.testng.annotations.Test;
 import static com.esri.core.geometry.ogc.OGCGeometry.createFromEsriGeometry;
 import static com.facebook.presto.geospatial.GeometrySerde.deserialize;
 import static com.facebook.presto.geospatial.GeometrySerde.deserializeEnvelope;
+import static com.facebook.presto.geospatial.GeometrySerde.deserializeType;
 import static com.facebook.presto.geospatial.GeometrySerde.serialize;
+import static com.facebook.presto.geospatial.GeometryType.ENVELOPE;
+import static com.facebook.presto.geospatial.GeometryType.GEOMETRY_COLLECTION;
+import static com.facebook.presto.geospatial.GeometryType.LINE_STRING;
+import static com.facebook.presto.geospatial.GeometryType.MULTI_LINE_STRING;
+import static com.facebook.presto.geospatial.GeometryType.MULTI_POINT;
+import static com.facebook.presto.geospatial.GeometryType.MULTI_POLYGON;
+import static com.facebook.presto.geospatial.GeometryType.POINT;
+import static com.facebook.presto.geospatial.GeometryType.POLYGON;
 import static org.testng.Assert.assertEquals;
 
 public class TestGeometrySerialization
@@ -151,6 +160,27 @@ public class TestGeometrySerialization
         assertDeserializeEnvelope("GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (2 7), LINESTRING (4 6, 7 10)), POINT (3 7), LINESTRING (4 6, 7 10))", new Envelope(2, 6, 7, 10));
     }
 
+    @Test
+    public void testDeserializeType()
+    {
+        assertDeserializeType("POINT (1 2)", POINT);
+        assertDeserializeType("POINT EMPTY", POINT);
+        assertDeserializeType("MULTIPOINT (20 20, 25 25)", MULTI_POINT);
+        assertDeserializeType("MULTIPOINT EMPTY", MULTI_POINT);
+        assertDeserializeType("LINESTRING (1 1, 5 1, 6 2))", LINE_STRING);
+        assertDeserializeType("LINESTRING EMPTY", LINE_STRING);
+        assertDeserializeType("MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))", MULTI_LINE_STRING);
+        assertDeserializeType("MULTILINESTRING EMPTY", MULTI_LINE_STRING);
+        assertDeserializeType("POLYGON ((0 0, 0 4, 4 0))", POLYGON);
+        assertDeserializeType("POLYGON EMPTY", POLYGON);
+        assertDeserializeType("MULTIPOLYGON (((0 0 , 0 2, 2 2, 2 0)), ((2 2, 2 4, 4 4, 4 2)))", MULTI_POLYGON);
+        assertDeserializeType("MULTIPOLYGON EMPTY", MULTI_POLYGON);
+        assertDeserializeType("GEOMETRYCOLLECTION (POINT (3 7), LINESTRING (4 6, 7 10))", GEOMETRY_COLLECTION);
+        assertDeserializeType("GEOMETRYCOLLECTION EMPTY", GEOMETRY_COLLECTION);
+
+        assertEquals(deserializeType(serialize(new Envelope(1, 2, 3, 4))), ENVELOPE);
+    }
+
     private static void testSerialization(String wkt)
     {
         testEsriSerialization(wkt);
@@ -203,6 +233,11 @@ public class TestGeometrySerialization
     private static void assertDeserializeEnvelope(String geometry, Envelope expectedEnvelope)
     {
         assertEquals(deserializeEnvelope(geometryFromText(geometry)), expectedEnvelope);
+    }
+
+    private static void assertDeserializeType(String wkt, GeometryType expectedType)
+    {
+        assertEquals(deserializeType(geometryFromText(wkt)), expectedType);
     }
 
     private static void assertGeometryEquals(OGCGeometry actual, OGCGeometry expected)

--- a/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/TestGeometrySerialization.java
+++ b/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/TestGeometrySerialization.java
@@ -21,6 +21,7 @@ import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.testng.annotations.Test;
 
+import static com.esri.core.geometry.ogc.OGCGeometry.createFromEsriGeometry;
 import static com.facebook.presto.geospatial.GeometrySerde.deserialize;
 import static com.facebook.presto.geospatial.GeometrySerde.deserializeEnvelope;
 import static com.facebook.presto.geospatial.GeometrySerde.serialize;
@@ -119,6 +120,21 @@ public class TestGeometrySerialization
         testSerialization("GEOMETRYCOLLECTION (POINT EMPTY)");
         testSerialization("GEOMETRYCOLLECTION EMPTY");
         testSerialization("GEOMETRYCOLLECTION (MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20))), GEOMETRYCOLLECTION (MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)))))");
+    }
+
+    @Test
+    public void testEnvelope()
+    {
+        testEnvelopeSerialization(new Envelope(0, 0, 1, 1));
+        testEnvelopeSerialization(new Envelope(1, 2, 3, 4));
+        testEnvelopeSerialization(new Envelope(10101, -2.05, -3e5, 0));
+    }
+
+    private void testEnvelopeSerialization(Envelope envelope)
+    {
+        assertEquals(deserialize(serialize(envelope)), createFromEsriGeometry(envelope, null));
+        assertEquals(deserializeEnvelope(serialize(envelope)), envelope);
+        assertEquals(JtsGeometrySerde.serialize(JtsGeometrySerde.deserialize(serialize(envelope))), serialize(createFromEsriGeometry(envelope, null)));
     }
 
     @Test

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -70,7 +70,7 @@ import static org.locationtech.jts.simplify.TopologyPreservingSimplifier.simplif
 public final class GeoFunctions
 {
     private static final Joiner OR_JOINER = Joiner.on(" or ");
-    private static final Slice EMPTY_POLYGON = serialize(createFromEsriGeometry(new Polygon(), null));
+    private static final Slice EMPTY_POLYGON = serialize(new OGCPolygon(new Polygon(), null));
     private static final Slice EMPTY_MULTIPOINT = serialize(createFromEsriGeometry(new MultiPoint(), null, true));
     private static final double EARTH_RADIUS_KM = 6371.01;
 

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -482,7 +482,7 @@ public final class GeoFunctions
         if (envelope == null) {
             return EMPTY_POLYGON;
         }
-        return serialize(createFromEsriGeometry(envelope, null));
+        return serialize(envelope);
     }
 
     @Description("Returns the Geometry value that represents the point set difference of two geometries")

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -123,7 +123,6 @@ public final class GeoFunctions
         return serialize(geometryFromText(input));
     }
 
-    @SqlNullable
     @Description("Returns the Well-Known Text (WKT) representation of the geometry")
     @ScalarFunction("ST_AsText")
     @SqlType(StandardTypes.VARCHAR)

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkEnvelopeIntersection.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkEnvelopeIntersection.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import io.airlift.slice.Slice;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.geospatial.GeometrySerde.deserialize;
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stEnvelope;
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stGeometryFromText;
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stIntersection;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkEnvelopeIntersection
+{
+    @Benchmark
+    public Slice envelopes(BenchmarkData data)
+    {
+        return stIntersection(data.envelope, data.otherEnvelope);
+    }
+
+    @Benchmark
+    public Slice geometries(BenchmarkData data)
+    {
+        return stIntersection(data.geometry, data.otherGeometry);
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private Slice envelope;
+        private Slice otherEnvelope;
+
+        private Slice geometry;
+        private Slice otherGeometry;
+
+        @Setup
+        public void setup()
+        {
+            geometry = stGeometryFromText(utf8Slice("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"));
+            otherGeometry = stGeometryFromText(utf8Slice("POLYGON ((0.5 0.5, 0.5 1.5, 1.5 1.5, 1.5 0.5, 0.5 0.5))"));
+            envelope = stEnvelope(geometry);
+            otherEnvelope = stEnvelope(otherGeometry);
+        }
+    }
+
+    @Test
+    public void validate()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        BenchmarkEnvelopeIntersection benchmark = new BenchmarkEnvelopeIntersection();
+        assertEquals(deserialize(benchmark.envelopes(data)), deserialize(benchmark.geometries(data)));
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkEnvelopeIntersection.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
@@ -131,8 +131,8 @@ public class TestBingTileFunctions
     @Test
     public void testBingTilePolygon()
     {
-        assertFunction("ST_AsText(bing_tile_polygon(bing_tile('123030123010121')))", VARCHAR, "POLYGON ((59.996337890625 30.12612436422458, 59.996337890625 30.11662158281937, 60.00732421875 30.11662158281937, 60.00732421875 30.12612436422458, 59.996337890625 30.12612436422458))");
-        assertFunction("ST_AsText(ST_Centroid(bing_tile_polygon(bing_tile('123030123010121'))))", VARCHAR, "POINT (60.00183104425149 30.121372968273892)");
+        assertFunction("ST_AsText(bing_tile_polygon(bing_tile('123030123010121')))", VARCHAR, "POLYGON ((59.996337890625 30.11662158281937, 60.00732421875 30.11662158281937, 60.00732421875 30.12612436422458, 59.996337890625 30.12612436422458, 59.996337890625 30.11662158281937))");
+        assertFunction("ST_AsText(ST_Centroid(bing_tile_polygon(bing_tile('123030123010121'))))", VARCHAR, "POINT (60.0018310442288 30.121372968273892)");
 
         // Check bottom right corner of a stack of tiles at different zoom levels
         assertFunction("ST_AsText(apply(bing_tile_polygon(bing_tile(1, 1, 1)), g -> ST_Point(ST_XMax(g), ST_YMin(g))))", VARCHAR, "POINT (180 -85.05112877980659)");

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -362,7 +362,7 @@ public class TestGeoFunctions
     public void testSTEnvelope()
     {
         assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('MULTIPOINT (1 2, 2 4, 3 6, 4 8)')))", VARCHAR, "POLYGON ((1 2, 4 2, 4 8, 1 8, 1 2))");
-        assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('LINESTRING EMPTY')))", VARCHAR, "MULTIPOLYGON EMPTY");
+        assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('LINESTRING EMPTY')))", VARCHAR, "POLYGON EMPTY");
         assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('LINESTRING (1 1, 2 2, 1 3)')))", VARCHAR, "POLYGON ((1 1, 2 1, 2 3, 1 3, 1 1))");
         assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('LINESTRING (8 4, 5 7)')))", VARCHAR, "POLYGON ((5 4, 8 4, 8 7, 5 7, 5 4))");
         assertFunction("ST_AsText(ST_Envelope(ST_GeometryFromText('MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))')))", VARCHAR, "POLYGON ((1 1, 5 1, 5 4, 1 4, 1 1))");

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -415,6 +415,21 @@ public class TestGeoFunctions
         assertFunction("ST_AsText(ST_Intersection(ST_GeometryFromText('MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1)), ((0 0, 0 2, 2 2, 2 0)))'), ST_GeometryFromText('POLYGON ((0 1, 3 1, 3 3, 0 3))')))", VARCHAR, "GEOMETRYCOLLECTION (LINESTRING (1 1, 2 1), MULTIPOLYGON (((0 1, 1 1, 1 2, 0 2, 0 1)), ((2 1, 3 1, 3 3, 1 3, 1 2, 2 2, 2 1))))");
         assertFunction("ST_AsText(ST_Intersection(ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))'), ST_GeometryFromText('LINESTRING (2 0, 2 3)')))", VARCHAR, "LINESTRING (2 1, 2 3)");
         assertFunction("ST_AsText(ST_Intersection(ST_GeometryFromText('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'), ST_GeometryFromText('LINESTRING (0 0, 1 -1, 1 2)')))", VARCHAR, "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (1 0, 1 1))");
+
+        // test intersection of envelopes
+        assertEnvelopeIntersection("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))", "POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))", "POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))");
+        assertEnvelopeIntersection("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))", "POLYGON ((-1 4, 1 4, 1 6, -1 6, -1 4))", "POLYGON ((0 4, 1 4, 1 5, 0 5, 0 4))");
+        assertEnvelopeIntersection("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))", "POLYGON ((1 4, 2 4, 2 6, 1 6, 1 4))", "POLYGON ((1 4, 2 4, 2 5, 1 5, 1 4))");
+        assertEnvelopeIntersection("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))", "POLYGON ((4 4, 6 4, 6 6, 4 6, 4 4))", "POLYGON ((4 4, 5 4, 5 5, 4 5, 4 4))");
+        assertEnvelopeIntersection("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))", "POLYGON ((10 10, 11 10, 11 11, 10 11, 10 10))", "POLYGON EMPTY");
+        assertEnvelopeIntersection("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))", "POLYGON ((-1 -1, 0 -1, 0 1, -1 1, -1 -1))", "LINESTRING (0 0, 0 1)");
+        assertEnvelopeIntersection("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))", "POLYGON ((1 -1, 2 -1, 2 0, 1 0, 1 -1))", "LINESTRING (1 0, 2 0)");
+        assertEnvelopeIntersection("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))", "POLYGON ((-1 -1, 0 -1, 0 0, -1 0, -1 -1))", "POINT (0 0)");
+    }
+
+    private void assertEnvelopeIntersection(String envelope, String otherEnvelope, String intersection)
+    {
+        assertFunction("ST_AsText(ST_Intersection(ST_Envelope(ST_GeometryFromText('" + envelope + "')), ST_Envelope(ST_GeometryFromText('" + otherEnvelope + "'))))", VARCHAR, intersection);
     }
 
     @Test


### PR DESCRIPTION
Optimized version is 400 times faster.

```
Benchmark                                 Mode  Cnt      Score      Error  Units
BenchmarkEnvelopeIntersection.envelopes   avgt   20    128.189 ±    9.407  ns/op
BenchmarkEnvelopeIntersection.geometries  avgt   20  58120.260 ± 9739.057  ns/op
```
