### PR TITLE
Add line_locate_point function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -219,6 +219,13 @@ Accessors
 
     Returns the cardinality of the collection of interior rings of a polygon.
 
+.. function:: line_locate_point(LineString, Point) -> double
+
+    Returns a float between 0 and 1 representing the location of the closest point on
+    the LineString to the given Point, as a fraction of total 2d line length.
+
+    Returns ``null`` if a LineString or a Point is empty of ``null``.
+
 .. function:: geometry_invalid_reason(Geometry) -> varchar
 
     Returns the reason for why the input geometry is not valid.

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryType.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryType.java
@@ -46,6 +46,16 @@ public enum GeometryType
 
     public static GeometryType getForEsriGeometryType(String type)
     {
+        return getForInternalLibraryName(type);
+    }
+
+    public static GeometryType getForJtsGeometryType(String type)
+    {
+        return getForInternalLibraryName(type);
+    }
+
+    private static GeometryType getForInternalLibraryName(String type)
+    {
         requireNonNull(type, "type is null");
         switch (type) {
             case "Point":

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -254,6 +254,21 @@ public class TestGeoFunctions
     }
 
     @Test
+    public void testLineLocatePoint()
+    {
+        assertFunction("line_locate_point(ST_GeometryFromText('LINESTRING (0 0, 0 1)'), ST_Point(0, 0.2))", DOUBLE, 0.2);
+        assertFunction("line_locate_point(ST_GeometryFromText('LINESTRING (0 0, 0 1, 2 1)'), ST_Point(0, 0.2))", DOUBLE, 0.2);
+        assertFunction("line_locate_point(ST_GeometryFromText('LINESTRING (0 0, 0 1, 2 1)'), ST_Point(0.9, 1))", DOUBLE, 1.9);
+        assertFunction("line_locate_point(ST_GeometryFromText('MULTILINESTRING ((0 0, 0 1), (2 2, 4 2))'), ST_Point(3, 1))", DOUBLE, 2.0);
+
+        assertFunction("line_locate_point(ST_GeometryFromText('LINESTRING EMPTY'), ST_Point(0, 1))", DOUBLE, null);
+        assertFunction("line_locate_point(ST_GeometryFromText('LINESTRING (0 0, 0 1, 2 1)'), ST_GeometryFromText('POINT EMPTY'))", DOUBLE, null);
+
+        assertInvalidFunction("line_locate_point(ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))'), ST_Point(0.4, 1))", "First argument to line_locate_point must be a LineString or a MultiLineString. Got: Polygon");
+        assertInvalidFunction("line_locate_point(ST_GeometryFromText('LINESTRING (0 0, 0 1, 2 1)'), ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))'))", "Second argument to line_locate_point must be a Point. Got: Polygon");
+    }
+
+    @Test
     public void testSTMax()
     {
         assertFunction("ST_XMax(ST_GeometryFromText('POINT (1.5 2.5)'))", DOUBLE, 1.5);


### PR DESCRIPTION
`line_locate_point` function returns a float between 0 and 1 representing the location of the closest point on the LineString to the given Point, as a fraction of total 2d line length. It is useful to order points on a "road" LineString to follow the "road".

Here is a corresponding PostGIS function for reference: https://postgis.net/docs/ST_LineLocatePoint.html