### PR TITLE
Improve queries on information_schema.columns with filter on table_schema

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaConnector.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaConnector.java
@@ -39,7 +39,7 @@ public class InformationSchemaConnector
         requireNonNull(nodeManager, "nodeManager is null");
         requireNonNull(metadata, "metadata is null");
 
-        this.metadata = new InformationSchemaMetadata(catalogName);
+        this.metadata = new InformationSchemaMetadata(catalogName, metadata);
         this.splitManager = new InformationSchemaSplitManager(nodeManager);
         this.pageSourceProvider = new InformationSchemaPageSourceProvider(metadata, accessControl);
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -42,8 +42,7 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.compose;
-import static com.google.common.base.Predicates.equalTo;
-import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -145,7 +144,9 @@ public class InformationSchemaMetadata
             return ImmutableList.copyOf(TABLES.keySet());
         }
 
-        return ImmutableList.copyOf(filter(TABLES.keySet(), compose(equalTo(schemaNameOrNull), SchemaTableName::getSchemaName)));
+        return TABLES.keySet().stream()
+                .filter(compose(schemaNameOrNull::equals, SchemaTableName::getSchemaName))
+                .collect(toImmutableList());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -13,6 +13,11 @@
  */
 package com.facebook.presto.connector.informationSchema;
 
+import com.facebook.presto.FullConnectorSession;
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.QualifiedObjectName;
+import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorSession;
@@ -25,14 +30,23 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.EquatableValueSet;
+import com.facebook.presto.spi.predicate.NullableValue;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.metadata.MetadataUtil.SchemaMetadataBuilder.schemaMetadataBuilder;
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
@@ -43,6 +57,8 @@ import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharTyp
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.compose;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.slice.Slices.utf8Slice;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -99,11 +115,18 @@ public class InformationSchemaMetadata
                     .build())
             .build();
 
-    private final String catalogName;
+    private static final InformationSchemaColumnHandle CATALOG_COLUMN_HANDLE = new InformationSchemaColumnHandle("table_catalog");
+    private static final InformationSchemaColumnHandle SCHEMA_COLUMN_HANDLE = new InformationSchemaColumnHandle("table_schema");
+    private static final InformationSchemaColumnHandle TABLE_NAME_COLUMN_HANDLE = new InformationSchemaColumnHandle("table_name");
+    private static final int MAX_PREFIXES_COUNT = 100;
 
-    public InformationSchemaMetadata(String catalogName)
+    private final String catalogName;
+    private final Metadata metadata;
+
+    public InformationSchemaMetadata(String catalogName, Metadata metadata)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
     private InformationSchemaTableHandle checkTableHandle(ConnectorTableHandle tableHandle)
@@ -190,9 +213,115 @@ public class InformationSchemaMetadata
     @Override
     public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
     {
-        InformationSchemaTableHandle handle = (InformationSchemaTableHandle) table;
-        ConnectorTableLayout layout = new ConnectorTableLayout(new InformationSchemaTableLayoutHandle(handle, constraint.getSummary()));
+        if (constraint.getSummary().isNone()) {
+            return ImmutableList.of();
+        }
+
+        InformationSchemaTableHandle handle = checkTableHandle(table);
+
+        Set<QualifiedTablePrefix> prefixes = calculatePrefixesWithSchemaName(session, constraint.getSummary(), constraint.predicate());
+        if (isTablesEnumeratingTable(handle.getSchemaTableName())) {
+            Set<QualifiedTablePrefix> tablePrefixes = calculatePrefixesWithTableName(session, prefixes, constraint.getSummary(), constraint.predicate());
+            // in case of high number of prefixes it is better to populate all data and then filter
+            if (tablePrefixes.size() <= MAX_PREFIXES_COUNT) {
+                prefixes = tablePrefixes;
+            }
+        }
+        if (prefixes.size() > MAX_PREFIXES_COUNT) {
+            // in case of high number of prefixes it is better to populate all data and then filter
+            prefixes = ImmutableSet.of(new QualifiedTablePrefix(catalogName));
+        }
+
+        ConnectorTableLayout layout = new ConnectorTableLayout(new InformationSchemaTableLayoutHandle(handle, prefixes));
         return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
+    }
+
+    private boolean isTablesEnumeratingTable(SchemaTableName schemaTableName)
+    {
+        return ImmutableSet.of(TABLE_COLUMNS, TABLE_TABLES, TABLE_TABLES, TABLE_TABLE_PRIVILEGES).contains(schemaTableName);
+    }
+
+    private Set<QualifiedTablePrefix> calculatePrefixesWithSchemaName(
+            ConnectorSession connectorSession,
+            TupleDomain<ColumnHandle> constraint,
+            Predicate<Map<ColumnHandle, NullableValue>> predicate)
+    {
+        Optional<Set<String>> schemas = filterString(constraint, SCHEMA_COLUMN_HANDLE);
+        if (schemas.isPresent()) {
+            return schemas.get().stream()
+                    .map(schema -> new QualifiedTablePrefix(catalogName, schema))
+                    .collect(toImmutableSet());
+        }
+
+        Session session = ((FullConnectorSession) connectorSession).getSession();
+        return metadata.listSchemaNames(session, catalogName).stream()
+                .filter(schema -> predicate.test(schemaAsFixedValues(schema)))
+                .map(schema -> new QualifiedTablePrefix(catalogName, schema))
+                .collect(toImmutableSet());
+    }
+
+    public Set<QualifiedTablePrefix> calculatePrefixesWithTableName(
+            ConnectorSession connectorSession,
+            Set<QualifiedTablePrefix> prefixes,
+            TupleDomain<ColumnHandle> constraint,
+            Predicate<Map<ColumnHandle, NullableValue>> predicate)
+    {
+        Session session = ((FullConnectorSession) connectorSession).getSession();
+
+        Optional<Set<String>> tables = filterString(constraint, TABLE_NAME_COLUMN_HANDLE);
+        if (tables.isPresent()) {
+            return prefixes.stream()
+                    .flatMap(prefix -> tables.get().stream()
+                            .map(table -> new QualifiedObjectName(catalogName, prefix.getSchemaName().get(), table)))
+                    .filter(objectName -> metadata.getTableHandle(session, objectName).isPresent() || metadata.getView(session, objectName).isPresent())
+                    .map(QualifiedObjectName::asQualifiedTablePrefix)
+                    .collect(toImmutableSet());
+        }
+
+        return prefixes.stream()
+                .flatMap(prefix -> Stream.concat(
+                        metadata.listTables(session, prefix).stream(),
+                        metadata.listViews(session, prefix).stream()))
+                .filter(objectName -> predicate.test(asFixedValues(objectName)))
+                .map(QualifiedObjectName::asQualifiedTablePrefix)
+                .collect(toImmutableSet());
+    }
+
+    private <T> Optional<Set<String>> filterString(TupleDomain<T> constraint, T column)
+    {
+        if (constraint.isNone()) {
+            return Optional.of(ImmutableSet.of());
+        }
+
+        Domain domain = constraint.getDomains().get().get(column);
+        if (domain == null) {
+            return Optional.empty();
+        }
+
+        if (domain.isSingleValue()) {
+            return Optional.of(ImmutableSet.of(((Slice) domain.getSingleValue()).toStringUtf8()));
+        }
+        else if (domain.getValues() instanceof EquatableValueSet) {
+            Collection<Object> values = ((EquatableValueSet) domain.getValues()).getValues();
+            return Optional.of(values.stream()
+                    .map(Slice.class::cast)
+                    .map(Slice::toStringUtf8)
+                    .collect(toImmutableSet()));
+        }
+        return Optional.empty();
+    }
+
+    private Map<ColumnHandle, NullableValue> schemaAsFixedValues(String schema)
+    {
+        return ImmutableMap.of(SCHEMA_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(schema)));
+    }
+
+    private Map<ColumnHandle, NullableValue> asFixedValues(QualifiedObjectName objectName)
+    {
+        return ImmutableMap.of(
+                CATALOG_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(objectName.getCatalogName())),
+                SCHEMA_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(objectName.getSchemaName())),
+                TABLE_NAME_COLUMN_HANDLE, new NullableValue(createUnboundedVarcharType(), utf8Slice(objectName.getObjectName())));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -38,7 +38,6 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -201,7 +200,7 @@ public class InformationSchemaPageSourceProvider
     {
         InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_VIEWS));
         for (QualifiedTablePrefix prefix : prefixes) {
-            for (Entry<QualifiedObjectName, ViewDefinition> entry : getViews(session, prefix).entrySet()) {
+            for (Entry<QualifiedObjectName, ViewDefinition> entry : metadata.getViews(session, prefix).entrySet()) {
                 table.add(
                         entry.getKey().getCatalogName(),
                         entry.getKey().getSchemaName(),
@@ -210,11 +209,6 @@ public class InformationSchemaPageSourceProvider
             }
         }
         return table.build();
-    }
-
-    private Map<QualifiedObjectName, ViewDefinition> getViews(Session session, QualifiedTablePrefix prefix)
-    {
-        return metadata.getViews(session, prefix);
     }
 
     private InternalTable buildSchemata(Session session, String catalogName)

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -32,17 +32,14 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrivilegeInfo;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.Slice;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.TABLE_COLUMNS;
@@ -56,10 +53,8 @@ import static com.facebook.presto.metadata.MetadataListing.listTableColumns;
 import static com.facebook.presto.metadata.MetadataListing.listTablePrivileges;
 import static com.facebook.presto.metadata.MetadataListing.listTables;
 import static com.facebook.presto.metadata.MetadataListing.listViews;
-import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.collect.Sets.union;
 import static java.lang.String.format;
-import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class InformationSchemaPageSourceProvider
@@ -105,116 +100,121 @@ public class InformationSchemaPageSourceProvider
         requireNonNull(columns, "columns is null");
 
         InformationSchemaTableHandle handle = split.getTableHandle();
-        Map<String, NullableValue> filters = split.getFilters();
+        Set<QualifiedTablePrefix> prefixes = split.getPrefixes();
 
-        return getInformationSchemaTable(session, handle.getCatalogName(), handle.getSchemaTableName(), filters);
+        return getInformationSchemaTable(session, handle.getCatalogName(), handle.getSchemaTableName(), prefixes);
     }
 
-    public InternalTable getInformationSchemaTable(Session session, String catalog, SchemaTableName table, Map<String, NullableValue> filters)
+    public InternalTable getInformationSchemaTable(Session session, String catalog, SchemaTableName table, Set<QualifiedTablePrefix> prefixes)
     {
         if (table.equals(TABLE_COLUMNS)) {
-            return buildColumns(session, catalog, filters);
+            return buildColumns(session, prefixes);
         }
         if (table.equals(TABLE_TABLES)) {
-            return buildTables(session, catalog, filters);
+            return buildTables(session, prefixes);
         }
         if (table.equals(TABLE_VIEWS)) {
-            return buildViews(session, catalog, filters);
+            return buildViews(session, prefixes);
         }
         if (table.equals(TABLE_SCHEMATA)) {
             return buildSchemata(session, catalog);
         }
         if (table.equals(TABLE_TABLE_PRIVILEGES)) {
-            return buildTablePrivileges(session, catalog, filters);
+            return buildTablePrivileges(session, prefixes);
         }
 
         throw new IllegalArgumentException(format("table does not exist: %s", table));
     }
 
-    private InternalTable buildColumns(Session session, String catalogName, Map<String, NullableValue> filters)
+    private InternalTable buildColumns(Session session, Set<QualifiedTablePrefix> prefixes)
     {
         InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_COLUMNS));
-        QualifiedTablePrefix prefix = extractQualifiedTablePrefix(catalogName, filters);
-        for (Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
-            SchemaTableName tableName = entry.getKey();
-            int ordinalPosition = 1;
-            for (ColumnMetadata column : entry.getValue()) {
-                if (column.isHidden()) {
-                    continue;
+        for (QualifiedTablePrefix prefix : prefixes) {
+            for (Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
+                SchemaTableName tableName = entry.getKey();
+                int ordinalPosition = 1;
+                for (ColumnMetadata column : entry.getValue()) {
+                    if (column.isHidden()) {
+                        continue;
+                    }
+                    table.add(
+                            prefix.getCatalogName(),
+                            tableName.getSchemaName(),
+                            tableName.getTableName(),
+                            column.getName(),
+                            ordinalPosition,
+                            null,
+                            "YES",
+                            column.getType().getDisplayName(),
+                            column.getComment(),
+                            column.getExtraInfo());
+                    ordinalPosition++;
                 }
-                table.add(
-                        catalogName,
-                        tableName.getSchemaName(),
-                        tableName.getTableName(),
-                        column.getName(),
-                        ordinalPosition,
-                        null,
-                        "YES",
-                        column.getType().getDisplayName(),
-                        column.getComment(),
-                        column.getExtraInfo());
-                ordinalPosition++;
             }
         }
         return table.build();
     }
 
-    private InternalTable buildTables(Session session, String catalogName, Map<String, NullableValue> filters)
+    private InternalTable buildTables(Session session, Set<QualifiedTablePrefix> prefixes)
     {
-        QualifiedTablePrefix prefix = extractQualifiedTablePrefix(catalogName, filters);
-        Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
-        Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
-
         InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_TABLES));
-        for (SchemaTableName name : union(tables, views)) {
-            // if table and view names overlap, the view wins
-            String type = views.contains(name) ? "VIEW" : "BASE TABLE";
-            table.add(
-                    catalogName,
-                    name.getSchemaName(),
-                    name.getTableName(),
-                    type);
-        }
-        return table.build();
-    }
+        for (QualifiedTablePrefix prefix : prefixes) {
+            Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
+            Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
 
-    private InternalTable buildTablePrivileges(Session session, String catalogName, Map<String, NullableValue> filters)
-    {
-        QualifiedTablePrefix prefix = extractQualifiedTablePrefix(catalogName, filters);
-        List<GrantInfo> grants = ImmutableList.copyOf(listTablePrivileges(session, metadata, accessControl, prefix));
-        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_TABLE_PRIVILEGES));
-        for (GrantInfo grant : grants) {
-            for (PrivilegeInfo privilegeInfo : grant.getPrivilegeInfo()) {
+            for (SchemaTableName name : union(tables, views)) {
+                // if table and view names overlap, the view wins
+                String type = views.contains(name) ? "VIEW" : "BASE TABLE";
                 table.add(
-                        grant.getGrantor().orElse(null),
-                        grant.getIdentity().getUser(),
-                        catalogName,
-                        grant.getSchemaTableName().getSchemaName(),
-                        grant.getSchemaTableName().getTableName(),
-                        privilegeInfo.getPrivilege().name(),
-                        privilegeInfo.isGrantOption(),
-                        grant.getWithHierarchy().orElse(null));
+                        prefix.getCatalogName(),
+                        name.getSchemaName(),
+                        name.getTableName(),
+                        type);
             }
         }
         return table.build();
     }
 
-    private InternalTable buildViews(Session session, String catalogName, Map<String, NullableValue> filters)
+    private InternalTable buildTablePrivileges(Session session, Set<QualifiedTablePrefix> prefixes)
+    {
+        InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_TABLE_PRIVILEGES));
+        for (QualifiedTablePrefix prefix : prefixes) {
+            List<GrantInfo> grants = ImmutableList.copyOf(listTablePrivileges(session, metadata, accessControl, prefix));
+            for (GrantInfo grant : grants) {
+                for (PrivilegeInfo privilegeInfo : grant.getPrivilegeInfo()) {
+                    table.add(
+                            grant.getGrantor().orElse(null),
+                            grant.getIdentity().getUser(),
+                            prefix.getCatalogName(),
+                            grant.getSchemaTableName().getSchemaName(),
+                            grant.getSchemaTableName().getTableName(),
+                            privilegeInfo.getPrivilege().name(),
+                            privilegeInfo.isGrantOption(),
+                            grant.getWithHierarchy().orElse(null));
+                }
+            }
+        }
+        return table.build();
+    }
+
+    private InternalTable buildViews(Session session, Set<QualifiedTablePrefix> prefixes)
     {
         InternalTable.Builder table = InternalTable.builder(informationSchemaTableColumns(TABLE_VIEWS));
-        for (Entry<QualifiedObjectName, ViewDefinition> entry : getViews(session, catalogName, filters).entrySet()) {
-            table.add(
-                    entry.getKey().getCatalogName(),
-                    entry.getKey().getSchemaName(),
-                    entry.getKey().getObjectName(),
-                    entry.getValue().getOriginalSql());
+        for (QualifiedTablePrefix prefix : prefixes) {
+            for (Entry<QualifiedObjectName, ViewDefinition> entry : getViews(session, prefix).entrySet()) {
+                table.add(
+                        entry.getKey().getCatalogName(),
+                        entry.getKey().getSchemaName(),
+                        entry.getKey().getObjectName(),
+                        entry.getValue().getOriginalSql());
+            }
         }
         return table.build();
     }
 
-    private Map<QualifiedObjectName, ViewDefinition> getViews(Session session, String catalogName, Map<String, NullableValue> filters)
+    private Map<QualifiedObjectName, ViewDefinition> getViews(Session session, QualifiedTablePrefix prefix)
     {
-        return metadata.getViews(session, extractQualifiedTablePrefix(catalogName, filters));
+        return metadata.getViews(session, prefix);
     }
 
     private InternalTable buildSchemata(Session session, String catalogName)
@@ -224,27 +224,5 @@ public class InformationSchemaPageSourceProvider
             table.add(catalogName, schema);
         }
         return table.build();
-    }
-
-    private static QualifiedTablePrefix extractQualifiedTablePrefix(String catalogName, Map<String, NullableValue> filters)
-    {
-        Optional<String> schemaName = getFilterColumn(filters, "table_schema");
-        Optional<String> tableName = getFilterColumn(filters, "table_name");
-        if (!schemaName.isPresent()) {
-            return new QualifiedTablePrefix(catalogName, Optional.empty(), Optional.empty());
-        }
-        return new QualifiedTablePrefix(catalogName, schemaName, tableName);
-    }
-
-    private static Optional<String> getFilterColumn(Map<String, NullableValue> filters, String columnName)
-    {
-        NullableValue value = filters.get(columnName);
-        if (value == null || value.getValue() == null) {
-            return Optional.empty();
-        }
-        if (isVarcharType(value.getType())) {
-            return Optional.of(((Slice) value.getValue()).toStringUtf8().toLowerCase(ENGLISH));
-        }
-        return Optional.empty();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplit.java
@@ -13,15 +13,16 @@
  */
 package com.facebook.presto.connector.informationSchema;
 
+import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
-import com.facebook.presto.spi.predicate.NullableValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -31,17 +32,17 @@ public class InformationSchemaSplit
         implements ConnectorSplit
 {
     private final InformationSchemaTableHandle tableHandle;
-    private final Map<String, NullableValue> filters;
+    private final Set<QualifiedTablePrefix> prefixes;
     private final List<HostAddress> addresses;
 
     @JsonCreator
     public InformationSchemaSplit(
             @JsonProperty("tableHandle") InformationSchemaTableHandle tableHandle,
-            @JsonProperty("filters") Map<String, NullableValue> filters,
+            @JsonProperty("prefixes") Set<QualifiedTablePrefix> prefixes,
             @JsonProperty("addresses") List<HostAddress> addresses)
     {
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
-        this.filters = requireNonNull(filters, "filters is null");
+        this.prefixes = ImmutableSet.copyOf(requireNonNull(prefixes, "prefixes is null"));
 
         requireNonNull(addresses, "hosts is null");
         checkArgument(!addresses.isEmpty(), "hosts is empty");
@@ -68,9 +69,9 @@ public class InformationSchemaSplit
     }
 
     @JsonProperty
-    public Map<String, NullableValue> getFilters()
+    public Set<QualifiedTablePrefix> getPrefixes()
     {
-        return filters;
+        return prefixes;
     }
 
     @Override
@@ -84,7 +85,7 @@ public class InformationSchemaSplit
     {
         return toStringHelper(this)
                 .add("tableHandle", tableHandle)
-                .add("filters", filters)
+                .add("prefixes", prefixes)
                 .add("addresses", addresses)
                 .toString();
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplitManager.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.connector.informationSchema;
 
 import com.facebook.presto.metadata.InternalNodeManager;
-import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
@@ -23,17 +22,11 @@ import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.predicate.NullableValue;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
-import static com.facebook.presto.spi.predicate.TupleDomain.extractFixedValues;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toMap;
 
 public class InformationSchemaSplitManager
         implements ConnectorSplitManager
@@ -49,15 +42,10 @@ public class InformationSchemaSplitManager
     public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
     {
         InformationSchemaTableLayoutHandle handle = (InformationSchemaTableLayoutHandle) layout;
-        Map<ColumnHandle, NullableValue> bindings = extractFixedValues(handle.getConstraint()).orElse(ImmutableMap.of());
 
         List<HostAddress> localAddress = ImmutableList.of(nodeManager.getCurrentNode().getHostAndPort());
 
-        Map<String, NullableValue> filters = bindings.entrySet().stream().collect(toMap(
-                entry -> ((InformationSchemaColumnHandle) entry.getKey()).getColumnName(),
-                Entry::getValue));
-
-        ConnectorSplit split = new InformationSchemaSplit(handle.getTable(), filters, localAddress);
+        ConnectorSplit split = new InformationSchemaSplit(handle.getTable(), handle.getPrefixes(), localAddress);
 
         return new FixedSplitSource(ImmutableList.of(split));
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaTableLayoutHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaTableLayoutHandle.java
@@ -13,11 +13,13 @@
  */
 package com.facebook.presto.connector.informationSchema;
 
-import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -25,15 +27,15 @@ public class InformationSchemaTableLayoutHandle
         implements ConnectorTableLayoutHandle
 {
     private final InformationSchemaTableHandle table;
-    private final TupleDomain<ColumnHandle> constraint;
+    private final Set<QualifiedTablePrefix> prefixes;
 
     @JsonCreator
     public InformationSchemaTableLayoutHandle(
             @JsonProperty("table") InformationSchemaTableHandle table,
-            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
+            @JsonProperty("prefixes") Set<QualifiedTablePrefix> prefixes)
     {
         this.table = requireNonNull(table, "table is null");
-        this.constraint = requireNonNull(constraint, "constraint is null");
+        this.prefixes = ImmutableSet.copyOf(requireNonNull(prefixes, "prefixes is null"));
     }
 
     @JsonProperty
@@ -43,9 +45,9 @@ public class InformationSchemaTableLayoutHandle
     }
 
     @JsonProperty
-    public TupleDomain<ColumnHandle> getConstraint()
+    public Set<QualifiedTablePrefix> getPrefixes()
     {
-        return constraint;
+        return prefixes;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -428,6 +428,7 @@ public class MetadataManager
                 ConnectorSession connectorSession = session.toConnectorSession(connectorId);
                 metadata.listTables(connectorSession, schemaNameOrNull).stream()
                         .map(convertFromSchemaTableName(prefix.getCatalogName()))
+                        .filter(prefix::matches)
                         .forEach(tables::add);
             }
         }
@@ -758,6 +759,7 @@ public class MetadataManager
                 ConnectorSession connectorSession = session.toConnectorSession(connectorId);
                 metadata.listViews(connectorSession, schemaNameOrNull).stream()
                         .map(convertFromSchemaTableName(prefix.getCatalogName()))
+                        .filter(prefix::matches)
                         .forEach(views::add);
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -428,7 +428,7 @@ public class MetadataManager
                 ConnectorMetadata metadata = catalogMetadata.getMetadataFor(connectorId);
                 ConnectorSession connectorSession = session.toConnectorSession(connectorId);
                 metadata.listTables(connectorSession, schemaNameOrNull).stream()
-                        .map(convertFromSchemaTableName(prefix.getCatalogName())::apply)
+                        .map(convertFromSchemaTableName(prefix.getCatalogName()))
                         .forEach(tables::add);
             }
         }
@@ -762,7 +762,7 @@ public class MetadataManager
                 ConnectorMetadata metadata = catalogMetadata.getMetadataFor(connectorId);
                 ConnectorSession connectorSession = session.toConnectorSession(connectorId);
                 metadata.listViews(connectorSession, schemaNameOrNull).stream()
-                        .map(convertFromSchemaTableName(prefix.getCatalogName())::apply)
+                        .map(convertFromSchemaTableName(prefix.getCatalogName()))
                         .forEach(views::add);
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnIdentity;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
-import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorResolvedIndex;
 import com.facebook.presto.spi.ConnectorSession;
@@ -594,12 +593,8 @@ public class MetadataManager
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, connectorId);
         ConnectorMetadata metadata = catalogMetadata.getMetadata();
 
-        Optional<ConnectorNewTableLayout> insertLayout = metadata.getInsertLayout(session.toConnectorSession(connectorId), table.getConnectorHandle());
-        if (!insertLayout.isPresent()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(new NewTableLayout(connectorId, catalogMetadata.getTransactionHandleFor(connectorId), insertLayout.get()));
+        return metadata.getInsertLayout(session.toConnectorSession(connectorId), table.getConnectorHandle())
+                .map(layout -> new NewTableLayout(connectorId, catalogMetadata.getTransactionHandleFor(connectorId), layout));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedObjectName.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedObjectName.java
@@ -80,6 +80,11 @@ public class QualifiedObjectName
         return new CatalogSchemaTableName(catalogName, schemaName, objectName);
     }
 
+    public QualifiedTablePrefix asQualifiedTablePrefix()
+    {
+        return new QualifiedTablePrefix(catalogName, schemaName, objectName);
+    }
+
     @Override
     public boolean equals(Object obj)
     {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedTablePrefix.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedTablePrefix.java
@@ -98,6 +98,13 @@ public class QualifiedTablePrefix
         }
     }
 
+    public boolean matches(QualifiedObjectName objectName)
+    {
+        return Objects.equals(catalogName, objectName.getCatalogName())
+                && schemaName.map(schema -> Objects.equals(schema, objectName.getSchemaName())).orElse(true)
+                && tableName.map(table -> Objects.equals(table, objectName.getObjectName())).orElse(true);
+    }
+
     @Override
     public boolean equals(Object obj)
     {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedTablePrefix.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedTablePrefix.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.SchemaTablePrefix;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -52,7 +53,10 @@ public class QualifiedTablePrefix
         this.tableName = Optional.of(checkTableName(tableName));
     }
 
-    public QualifiedTablePrefix(String catalogName, Optional<String> schemaName, Optional<String> tableName)
+    public QualifiedTablePrefix(
+            @JsonProperty("catalogName") String catalogName,
+            @JsonProperty("schemaName") Optional<String> schemaName,
+            @JsonProperty("tableName") Optional<String> tableName)
     {
         checkTableName(catalogName, schemaName, tableName);
         this.catalogName = catalogName;
@@ -60,16 +64,19 @@ public class QualifiedTablePrefix
         this.tableName = tableName;
     }
 
+    @JsonProperty
     public String getCatalogName()
     {
         return catalogName;
     }
 
+    @JsonProperty
     public Optional<String> getSchemaName()
     {
         return schemaName;
     }
 
+    @JsonProperty
     public Optional<String> getTableName()
     {
         return tableName;

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -189,6 +189,20 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
+        <!-- for benchmarks -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/presto-tests/src/test/java/com/facebook/presto/connector/informationschema/BenchmarkInformationSchema.java
+++ b/presto-tests/src/test/java/com/facebook/presto/connector/informationschema/BenchmarkInformationSchema.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.informationschema;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchHandleResolver;
+import com.facebook.presto.tpch.TpchRecordSetProvider;
+import com.facebook.presto.tpch.TpchSplitManager;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 4)
+@Fork(1)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkInformationSchema
+{
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Benchmark)
+    public static class BenchmarkData
+    {
+        private final Map<String, String> queries = ImmutableMap.of(
+                "FULL_SCAN", "SELECT count(*) FROM information_schema.columns",
+                "LIKE_PREDICATE", "SELECT count(*) FROM information_schema.columns WHERE table_name LIKE 'table_0' AND table_schema LIKE 'schema_0'",
+                "MIXED_PREDICATE", "SELECT count(*) FROM information_schema.columns WHERE table_name LIKE 'table_0' AND table_schema = 'schema_0'");
+
+        @Param({"FULL_SCAN", "LIKE_PREDICATE", "MIXED_PREDICATE"})
+        private String queryId = "LIKE_PREDICATE";
+        @Param({"200"})
+        private String schemasCount = "200";
+        @Param({"200"})
+        private String tablesCount = "200";
+        @Param({"100"})
+        private String columnsCount = "100";
+
+        private QueryRunner queryRunner;
+
+        private Session session = testSessionBuilder()
+                    .setCatalog("test_catalog")
+                    .setSchema("test_schema")
+                    .build();
+
+        private String query;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            queryRunner = DistributedQueryRunner.builder(session).build();
+            queryRunner.installPlugin(new Plugin() {
+                @Override
+                public Iterable<ConnectorFactory> getConnectorFactories()
+                {
+                    return ImmutableList.of(new TestingInformationSchemaConnectorFactory(schemasCount, tablesCount, columnsCount));
+                }
+            });
+            queryRunner.createCatalog("test_catalog", "testing_information_schema", ImmutableMap.of());
+
+            query = queries.get(queryId);
+        }
+
+        @TearDown
+        public void tearDown()
+        {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+
+    @Benchmark
+    public MaterializedResult queryInformationSchema(BenchmarkData benchmarkData)
+    {
+        return benchmarkData.queryRunner.execute(benchmarkData.query);
+    }
+
+    private static class TestingInformationSchemaConnectorFactory
+            implements ConnectorFactory
+    {
+        private final int schemasCount;
+        private final int tablesCount;
+        private final int columnsCount;
+
+        public TestingInformationSchemaConnectorFactory(String schemasCount, String tablesCount, String columnsCount)
+        {
+            this.schemasCount = Integer.parseInt(schemasCount);
+            this.tablesCount = Integer.parseInt(tablesCount);
+            this.columnsCount = Integer.parseInt(columnsCount);
+        }
+
+        @Override
+        public String getName()
+        {
+            return "testing_information_schema";
+        }
+
+        @Override
+        public ConnectorHandleResolver getHandleResolver()
+        {
+            return new TpchHandleResolver();
+        }
+
+        @Override
+        public Connector create(String connectorId, Map<String, String> config, ConnectorContext context)
+        {
+            return new Connector()
+            {
+                @Override
+                public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+                {
+                    return new ConnectorTransactionHandle() {};
+                }
+
+                @Override
+                public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
+                {
+                    return new ConnectorMetadata()
+                    {
+                        @Override
+                        public List<String> listSchemaNames(ConnectorSession session)
+                        {
+                            return IntStream.range(0, schemasCount)
+                                    .boxed()
+                                    .map(i -> "stream_" + i)
+                                    .collect(toImmutableList());
+                        }
+
+                        @Override
+                        public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+                        {
+                            return new ConnectorTableHandle() {};
+                        }
+
+                        @Override
+                        public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+                        {
+                            return null;
+                        }
+
+                        @Override
+                        public List<SchemaTableName> listTables(ConnectorSession session, String schemaNameOrNull)
+                        {
+                            List<String> tables = IntStream.range(0, tablesCount)
+                                    .boxed()
+                                    .map(i -> "table_" + i)
+                                    .collect(toImmutableList());
+                            List<String> schemas;
+                            if (schemaNameOrNull == null) {
+                                schemas = listSchemaNames(session);
+                            }
+                            else {
+                                schemas = ImmutableList.of(schemaNameOrNull);
+                            }
+                            return schemas.stream()
+                                    .flatMap(schema -> tables.stream().map(table -> new SchemaTableName(schema, table)))
+                                    .collect(toImmutableList());
+                        }
+
+                        @Override
+                        public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+                        {
+                            return IntStream.range(0, columnsCount)
+                                    .boxed()
+                                    .map(i -> "column_" + i)
+                                    .collect(toImmutableMap(column -> column, column -> new TpchColumnHandle(column, createUnboundedVarcharType()) {}));
+                        }
+
+                        @Override
+                        public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+                        {
+                            TpchColumnHandle tpchColumnHandle = (TpchColumnHandle) columnHandle;
+                            return new ColumnMetadata(tpchColumnHandle.getColumnName(), tpchColumnHandle.getType());
+                        }
+
+                        @Override
+                        public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+                        {
+                            return listTables(session, prefix.getSchemaName()).stream()
+                                    .collect(toImmutableMap(table -> table, table -> IntStream.range(0, 100)
+                                            .boxed()
+                                            .map(i -> new ColumnMetadata("column_" + i, createUnboundedVarcharType()))
+                                            .collect(toImmutableList())));
+                        }
+
+                        @Override
+                        public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+                        {
+                            return ImmutableList.of();
+                        }
+
+                        @Override
+                        public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
+                        {
+                            throw new UnsupportedOperationException();
+                        }
+                    };
+                }
+
+                @Override
+                public ConnectorSplitManager getSplitManager()
+                {
+                    return new TpchSplitManager(context.getNodeManager(), 1);
+                }
+
+                @Override
+                public ConnectorRecordSetProvider getRecordSetProvider()
+                {
+                    return new TpchRecordSetProvider();
+                }
+            };
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        try {
+            new BenchmarkInformationSchema().queryInformationSchema(data);
+        }
+        finally {
+            data.tearDown();
+        }
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkInformationSchema.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
Improve queries on information_schema.columns with filter on table_schema

In case of catalogs with high number of schemas and tables in them,
simple queries like:
```
SELECT * FROM information_schema WHERE table_schema LIKE 'pattern'
```
takes a really long time to complete.

Above queries are typical from BI tools, which commonly do not to escape
wildcards in LIKE pattern, even if the pattern goal is to match
single schema or single table.
