### PR TITLE
Rethrow remote exception with wrapping in tests

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.client.StatementClientFactory.newStatementClient;
@@ -104,7 +105,8 @@ public abstract class AbstractTestingPrestoClient<T>
             }
 
             if (error.getFailureInfo() != null) {
-                throw error.getFailureInfo().toException();
+                RuntimeException remoteException = error.getFailureInfo().toException();
+                throw new RuntimeException(Optional.ofNullable(remoteException.getMessage()).orElseGet(remoteException::toString), remoteException);
             }
             throw new RuntimeException("Query failed: " + error.getMessage());
 


### PR DESCRIPTION
This is important for an IDE to be able to say in which line a test
failed.