### PR TITLE
Publish exchange summary on query completion

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
@@ -90,10 +90,15 @@ public class ExchangeClientStatus
     }
 
     @JsonProperty
-
     public List<PageBufferClientStatus> getPageBufferClientStatuses()
     {
         return pageBufferClientStatuses;
+    }
+
+    @Override
+    public boolean isFinal()
+    {
+        return true;
     }
 
     @Override
@@ -101,7 +106,7 @@ public class ExchangeClientStatus
     {
         return toStringHelper(this)
                 .add("bufferBytes", bufferedBytes)
-                .add("maxBufferBytes", maxBufferedBytes)
+                .add("maxBufferedBytes", maxBufferedBytes)
                 .add("averageBytesPerRequest", averageBytesPerRequest)
                 .add("successfulRequestsCount", successfulRequestsCount)
                 .add("bufferedPages", bufferedPages)

--- a/presto-main/src/main/java/com/facebook/presto/util/Mergeable.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/Mergeable.java
@@ -17,6 +17,10 @@ import java.util.Optional;
 
 public interface Mergeable<T>
 {
+    /**
+     * Merges the current state with the state of the other instance, and returns the merged state.
+     * @throws NullPointerException if other is null
+     */
     T mergeWith(T other);
 
     static <T extends Mergeable<T>> Optional<T> merge(Optional<T> first, Optional<T> second)


### PR DESCRIPTION
For analyzing exchange memory usage we need to publish this information, which is already available in `ExchangeClientStatus`.