### PR TITLE
Add Kudu connector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,12 @@ env:
     - TEST_SPECIFIC_MODULES=presto-cassandra
     - TEST_SPECIFIC_MODULES=presto-hive
     - TEST_SPECIFIC_MODULES=presto-main
-    - TEST_OTHER_MODULES=!presto-tests,!presto-raptor,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-docs,!presto-server,!presto-server-rpm,!presto-main
+    - TEST_OTHER_MODULES=!presto-tests,!presto-raptor,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm,!presto-main
     - PRODUCT_TESTS_BASIC_ENVIRONMENT=true
     - PRODUCT_TESTS_SPECIFIC_ENVIRONMENT=true
     - PRODUCT_TESTS_SPECIFIC_ENVIRONMENT_2=true
     - HIVE_TESTS=true
+    - KUDU_TESTS=true
 
 sudo: required
 dist: trusty
@@ -50,6 +51,10 @@ install:
   - |
     if [[ -v HIVE_TESTS ]]; then
       ./mvnw install $MAVEN_FAST_INSTALL -pl presto-hive-hadoop2 -am
+    fi
+  - |
+    if [[ -v KUDU_TESTS ]]; then
+      ./mvnw install $MAVEN_FAST_INSTALL -pl presto-kudu -am
     fi
 
 before_script:
@@ -151,7 +156,7 @@ script:
   - |
     if [[ -v PRODUCT_TESTS_SPECIFIC_ENVIRONMENT_2 ]]; then
       presto-product-tests/bin/run_on_docker.sh \
-        singlenode-kafka -g kafka 
+        singlenode-kafka -g kafka
     fi
   - |
     if [[ -v HIVE_TESTS ]]; then
@@ -170,6 +175,12 @@ script:
       env AWS_ACCESS_KEY_ID=$HIVE_TESTS_AWS_ACCESS_KEY_ID \
         AWS_SECRET_ACCESS_KEY=$HIVE_TESTS_AWS_SECRET_ACCESS_KEY \
         ./mvnw -pl presto-hive test -B -P test-hive-glue
+    fi
+  - |
+    if [[ -v KUDU_TESTS ]]; then
+      presto-kudu/bin/run_kudu_tests.sh 3 null
+      presto-kudu/bin/run_kudu_tests.sh 1 ""
+      presto-kudu/bin/run_kudu_tests.sh 1 presto::
     fi
 
 before_cache:

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <module>presto-matching</module>
         <module>presto-memory-context</module>
         <module>presto-proxy</module>
+        <module>presto-kudu</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-docs/src/main/sphinx/connector.rst
+++ b/presto-docs/src/main/sphinx/connector.rst
@@ -16,6 +16,7 @@ from different data sources.
     connector/jmx
     connector/kafka
     connector/kafka-tutorial
+    connector/kudu
     connector/localfile
     connector/memory
     connector/mongodb

--- a/presto-docs/src/main/sphinx/connector/kudu.rst
+++ b/presto-docs/src/main/sphinx/connector/kudu.rst
@@ -1,0 +1,620 @@
+==============
+Kudu Connector
+==============
+
+The Kudu connector allows querying, inserting and deleting data in `Apache Kudu`_
+
+.. _Apache Kudu: https://kudu.apache.org/
+
+
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+
+Compatibility
+-------------
+
+Connector is compatible with all Apache Kudu versions starting from 1.0.
+
+If the connector uses features that are not available on the target server, an error will be returned.
+Apache Kudu 1.7.0 is currently used for testing.
+
+
+Configuration
+-------------
+
+To configure the Kudu connector, create a catalog properties file
+``etc/catalog/kudu.properties`` with the following contents,
+replacing the properties as appropriate:
+
+  .. code-block:: none
+
+       connector.name=kudu
+
+       ## List of Kudu master addresses, at least one is needed (comma separated)
+       ## Supported formats: example.com, example.com:7051, 192.0.2.1, 192.0.2.1:7051,
+       ##                    [2001:db8::1], [2001:db8::1]:7051, 2001:db8::1
+       kudu.client.master-addresses=localhost
+
+       ## Kudu does not support schemas, but the connector can emulate them optionally.
+       ## By default, this feature is disabled, and all tables belong to the default schema.
+       ## For more details see connector documentation.
+       #kudu.schema-emulation.enabled=false
+
+       ## Prefix to use for schema emulation (only relevant if `kudu.schema-emulation.enabled=true`)
+       ## The standard prefix is `presto::`. Empty prefix is also supported.
+       ## For more details see connector documentation.
+       #kudu.schema-emulation.prefix=
+
+       #######################
+       ### Advanced Kudu Java client configuration
+       #######################
+
+       ## Default timeout used for administrative operations (e.g. createTable, deleteTable, etc.)
+       #kudu.client.defaultAdminOperationTimeout = 30s
+
+       ## Default timeout used for user operations
+       #kudu.client.defaultOperationTimeout = 30s
+
+       ## Default timeout to use when waiting on data from a socket
+       #kudu.client.defaultSocketReadTimeout = 10s
+
+       ## Disable Kudu client's collection of statistics.
+       #kudu.client.disableStatistics = false
+
+
+Querying Data
+-------------
+
+Apache Kudu does not support schemas, i.e. namespaces for tables.
+The connector can optionally emulate schemas by table naming conventions.
+
+Default behaviour (without schema emulation)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The emulation of schemas is disabled by default.
+In this case all Kudu tables are part of the ``default`` schema.
+
+For example, a Kudu table named ``orders`` can be queried in Presto
+with ``SELECT * FROM kudu.default.orders`` or simple with ``SELECT * FROM orders``
+if catalog and schema are set to ``kudu`` and ``default`` respectively.
+
+Table names can contain any characters in Kudu. In this case, use double quotes.
+E.g. To query a Kudu table named ``special.table!`` use ``SELECT * FROM kudu.default."special.table!"``.
+
+
+Example
+^^^^^^^
+
+-  Create a users table in the default schema with
+
+  .. code:: sql
+
+    CREATE TABLE kudu.default.users (
+      user_id int WITH (primary_key = true),
+      first_name varchar,
+      last_name varchar
+    ) WITH (
+      partition_by_hash_columns = ARRAY['user_id'],
+      partition_by_hash_buckets = 2
+    );
+
+On creating a Kudu table you must/can specify addition information about
+the primary key, encoding, and compression of columns and hash or range
+partitioning, and the number of replicas. Details see in section
+`Create Table`_.
+
+-  The table can be described using
+
+  .. code:: sql
+
+    DESCRIBE kudu.default.users;
+
+You should get something like
+
+::
+
+       Column   |  Type   |                      Extra                      | Comment
+    ------------+---------+-------------------------------------------------+---------
+     user_id    | integer | primary_key, encoding=auto, compression=default |
+     first_name | varchar | nullable, encoding=auto, compression=default    |
+     last_name  | varchar | nullable, encoding=auto, compression=default    |
+    (3 rows)
+
+
+-  Insert some data with
+
+  .. code:: sql
+
+    INSERT INTO kudu.default.users VALUES (1, 'Donald', 'Duck'), (2, 'Mickey', 'Mouse');
+
+-  Select the inserted data
+
+  .. code:: sql
+
+    SELECT * FROM kudu.default.users;
+
+
+Behaviour With Schema Emulation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If schema emulation has been enabled in the connector properties, i.e. ``etc/catalog/kudu.properties``,
+tables are mapped to schemas depending on some conventions.
+
+- With ``kudu.schema-emulation.enabled=true`` and ``kudu.schema-emulation.prefix=``,
+  the mapping works like:
+
+  +----------------------------+---------------------------------+
+  | Kudu Table Name            | Presto Qualified Name           |
+  +============================+=================================+
+  | ``orders``                 | ``kudu.default.orders``         |
+  +----------------------------+---------------------------------+
+  | ``part1.part2``            | ``kudu.part1.part2``            |
+  +----------------------------+---------------------------------+
+  | ``x.y.z``                  | ``kudu.x."y.z"``                |
+  +----------------------------+---------------------------------+
+
+  As schemas are not directly supported by Kudu, a special table named
+  ``$schemas`` is created for managing the schemas.
+
+
+- With ``kudu.schema-emulation.enabled=true`` and ``kudu.schema-emulation.prefix=presto::``,
+  the mapping works like:
+
+  +----------------------------+---------------------------------+
+  | Kudu Table Name            | Presto Qualified Name           |
+  +============================+=================================+
+  | ``orders``                 | ``kudu.default.orders``         |
+  +----------------------------+---------------------------------+
+  | ``part1.part2``            | ``kudu.default."part1.part2"``  |
+  +----------------------------+---------------------------------+
+  | ``x.y.z``                  | ``kudu.default."x.y.z"``        |
+  +----------------------------+---------------------------------+
+  | ``presto::part1.part2``    | ``kudu.part1.part2``            |
+  +----------------------------+---------------------------------+
+  | ``presto:x.y.z``           | ``kudu.x."y.z"``                |
+  +----------------------------+---------------------------------+
+
+  As schemas are not directly supported by Kudu, a special table named
+  ``presto::$schemas`` is created for managing the schemas.
+
+Data Type Mapping
+-----------------
+
+The data types of Presto and Kudu are mapped as far as possible:
+
++-----------------------+-----------------------+-----------------------+
+| Presto Data Type      | Kudu Data Type        | Comment               |
++=======================+=======================+=======================+
+| ``BOOLEAN``           | ``BOOL``              |                       |
++-----------------------+-----------------------+-----------------------+
+| ``TINYINT``           | ``INT8``              |                       |
++-----------------------+-----------------------+-----------------------+
+| ``SMALLINT``          | ``INT16``             |                       |
++-----------------------+-----------------------+-----------------------+
+| ``INTEGER``           | ``INT32``             |                       |
++-----------------------+-----------------------+-----------------------+
+| ``BIGINT``            | ``INT64``             |                       |
++-----------------------+-----------------------+-----------------------+
+| ``REAL``              | ``FLOAT``             |                       |
++-----------------------+-----------------------+-----------------------+
+| ``DOUBLE``            | ``DOUBLE``            |                       |
++-----------------------+-----------------------+-----------------------+
+| ``VARCHAR``           | ``STRING``            | see [1]_              |
++-----------------------+-----------------------+-----------------------+
+| ``VARBINARY``         | ``BINARY``            | see [1]_              |
++-----------------------+-----------------------+-----------------------+
+| ``TIMESTAMP``         | ``UNIXTIME_MICROS``   | µs resolution in Kudu |
+|                       |                       | column is reduced to  |
+|                       |                       | ms resolution         |
++-----------------------+-----------------------+-----------------------+
+| ``DECIMAL``           | ``DECIMAL``           | only supported for    |
+|                       |                       | Kudu server >= 1.7.0  |
++-----------------------+-----------------------+-----------------------+
+| ``CHAR``              | -                     | not supported         |
++-----------------------+-----------------------+-----------------------+
+| ``DATE``              | -                     | not supported [2]_    |
++-----------------------+-----------------------+-----------------------+
+| ``TIME``              | -                     | not supported         |
++-----------------------+-----------------------+-----------------------+
+| ``JSON``              | -                     | not supported         |
++-----------------------+-----------------------+-----------------------+
+| ``TIME WITH           | -                     | not supported         |
+| TIMEZONE``            |                       |                       |
++-----------------------+-----------------------+-----------------------+
+| ``TIMESTAMP WITH TIME | -                     | not supported         |
+| ZONE``                |                       |                       |
++-----------------------+-----------------------+-----------------------+
+| ``INTERVAL YEAR TO MO | -                     | not supported         |
+| NTH``                 |                       |                       |
++-----------------------+-----------------------+-----------------------+
+| ``INTERVAL DAY TO SEC | -                     | not supported         |
+| OND``                 |                       |                       |
++-----------------------+-----------------------+-----------------------+
+| ``ARRAY``             | -                     | not supported         |
++-----------------------+-----------------------+-----------------------+
+| ``MAP``               | -                     | not supported         |
++-----------------------+-----------------------+-----------------------+
+| ``IPADDRESS``         | -                     | not supported         |
++-----------------------+-----------------------+-----------------------+
+
+
+.. [1] On performing ``CREATE TABLE ... AS ...`` from a Presto table to Kudu,
+   the optional maximum length is lost
+
+.. [2] On performing ``CREATE TABLE ... AS ...`` from a Presto table to Kudu,
+   a ``DATE`` column is converted to ``STRING``
+
+
+Supported Presto SQL statements
+-------------------------------
+
++------------------------------------------+-------------------------------+
+| Presto SQL statement                     | Comment                       |
++==========================================+===============================+
+| ``SELECT``                               |                               |
++------------------------------------------+-------------------------------+
+| ``INSERT INTO ... VALUES``               | Behaves like ``upsert``       |
++------------------------------------------+-------------------------------+
+| ``INSERT INTO ... SELECT ...``           | Behaves like ``upsert``       |
++------------------------------------------+-------------------------------+
+| ``DELETE``                               |                               |
++------------------------------------------+-------------------------------+
+| ``CREATE SCHEMA``                        | Only allowed, if schema       |
+|                                          | emulation is enabled          |
++------------------------------------------+-------------------------------+
+| ``DROP SCHEMA``                          | Only allowed, if schema       |
+|                                          | emulation is enabled          |
++------------------------------------------+-------------------------------+
+| ``CREATE TABLE``                         | See `Create Table`_           |
++------------------------------------------+-------------------------------+
+| ``CREATE TABLE ... AS``                  |                               |
++------------------------------------------+-------------------------------+
+| ``DROP TABLE``                           |                               |
++------------------------------------------+-------------------------------+
+| ``ALTER TABLE ... RENAME TO ...``        |                               |
++------------------------------------------+-------------------------------+
+| ``ALTER TABLE ... RENAME COLUMN ...``    | Only allowed, if not part of  |
+|                                          | primary key                   |
++------------------------------------------+-------------------------------+
+| ``ALTER TABLE ... ADD COLUMN ...``       | See `Add Column`_             |
++------------------------------------------+-------------------------------+
+| ``ALTER TABLE ... DROP COLUMN ...``      | Only allowed, if not part of  |
+|                                          | primary key                   |
++------------------------------------------+-------------------------------+
+| ``SHOW SCHEMAS``                         |                               |
++------------------------------------------+-------------------------------+
+| ``SHOW TABLES``                          |                               |
++------------------------------------------+-------------------------------+
+| ``SHOW CREATE TABLE``                    |                               |
++------------------------------------------+-------------------------------+
+| ``SHOW COLUMNS FROM``                    |                               |
++------------------------------------------+-------------------------------+
+| ``DESCRIBE``                             | Same as ``SHOW COLUMNS FROM`` |
++------------------------------------------+-------------------------------+
+| ``CALL kudu.system.add_range_partition`` | Adds range partition to a     |
+|                                          | table. See `Managing range    |
+|                                          | partitions`_                  |
++------------------------------------------+-------------------------------+
+| ``CALL kudu.system.drop_range_partition``| Drops a range partition       |
+|                                          | from a table. See `Managing   |
+|                                          | range partitions`_            |
++------------------------------------------+-------------------------------+
+
+Not supported are ``SHOW PARTITIONS FROM ...``, ``ALTER SCHEMA ... RENAME``
+
+
+Create Table
+------------
+
+On creating a Kudu Table you need to provide the columns and their types, of
+course, but Kudu needs information about partitioning and optionally
+for column encoding and compression.
+
+Simple Example:
+
+  .. code:: sql
+
+    CREATE TABLE user_events (
+      user_id int WITH (primary_key = true),
+      event_name varchar WITH (primary_key = true),
+      message varchar,
+      details varchar WITH (nullable = true, encoding = 'plain')
+    ) WITH (
+      partition_by_hash_columns = ARRAY['user_id'],
+      partition_by_hash_buckets = 5
+    );
+
+Here the table is partitioned into five partitions by hash values of the column ``user_id``.
+Note that the primary key consists of ``user_id`` and ``event_name``.
+The primary key columns must always be the first columns of the column list.
+All columns used in partitions must be part of the primary key.
+Kudu supports two different kinds of partitioning: hash and range partitioning.
+Hash partitioning distributes rows by hash value into one of many buckets.
+Range partitions distributes rows using a totally-ordered range partition key.
+The concrete range partitions must be created explicitly.
+Kudu also supports multi-level partitioning. A table must have at least one
+partitioning (either hash or range). It can have at most one range partitioning,
+but multiple hash partitioning 'levels'.
+
+For more details see `Partitioning Design`_.
+
+
+Column Properties
+~~~~~~~~~~~~~~~~~
+
+Besides column name and type, you can specify some more properties of a column.
+
++----------------------+---------------+---------------------------------------------------------+
+| Column property name | Type          | Description                                             |
++======================+===============+=========================================================+
+| ``primary_key``      | ``BOOLEAN``   | If ``true``, the column belongs to primary key columns. |
+|                      |               | The Kudu primary key enforces a uniqueness constraint.  |
+|                      |               | Inserting a second row with the same primary key        |
+|                      |               | results in updating the existing row ('UPSERT').        |
+|                      |               | See also `Primary Key Design`_ in the Kudu              |
+|                      |               | documentation.                                          |
++----------------------+---------------+---------------------------------------------------------+
+| ``nullable``         | ``BOOLEAN``   | If ``true``, the value can be null. Primary key         |
+|                      |               | columns must not be nullable.                           |
++----------------------+---------------+---------------------------------------------------------+
+| ``encoding``         | ``VARCHAR``   | The column encoding can help to save storage space and  |
+|                      |               | to improve query performance. Kudu uses an auto         |
+|                      |               | encoding depending on the column type if not specified. |
+|                      |               | Valid values are:                                       |
+|                      |               | ``'auto'``, ``'plain'``, ``'bitshuffle'``,              |
+|                      |               | ``'runlength'``, ``'prefix'``, ``'dictionary'``,        |
+|                      |               | ``'group_varint'``.                                     |
+|                      |               | See also `Column encoding`_ in the Kudu documentation.  |
++----------------------+---------------+---------------------------------------------------------+
+| ``compression``      | ``VARCHAR``   | The encoded column values can be compressed. Kudu uses  |
+|                      |               | a default compression if not specified.                 |
+|                      |               | Valid values are:                                       |
+|                      |               | ``'default'``, ``'no'``, ``'lz4'``, ``'snappy'``,       |
+|                      |               | ``'zlib'``.                                             |
+|                      |               | See also `Column compression`_ in the Kudu              |
+|                      |               | documentation.                                          |
++----------------------+---------------+---------------------------------------------------------+
+
+.. _`Primary Key Design`: http://kudu.apache.org/docs/schema_design.html#primary-keys
+.. _`Column encoding`: https://kudu.apache.org/docs/schema_design.html#encoding
+.. _`Column compression`: https://kudu.apache.org/docs/schema_design.html#compression
+
+
+Example
+^^^^^^^
+
+  .. code:: sql
+
+    CREATE TABLE mytable (
+      name varchar WITH (primary_key = true, encoding = 'dictionary', compression = 'snappy'),
+      index bigint WITH (nullable = true, encoding = 'runlength', compression = 'lz4'),
+      comment varchar WITH (nullable = true, encoding = 'plain', compression = 'default'),
+       ...
+    ) WITH (...);
+
+
+
+Partitioning Design
+~~~~~~~~~~~~~~~~~~~
+
+A table must have at least one partitioning (either hash or range).
+It can have at most one range partitioning, but multiple hash partitioning 'levels'.
+For more details see Apache Kudu documentation: `Partitioning`_
+
+If you create a Kudu table in Presto, the partitioning design is given by
+several table properties.
+
+.. _Partitioning: https://kudu.apache.org/docs/schema_design.html#partitioning
+
+
+Hash partitioning
+^^^^^^^^^^^^^^^^^
+
+You can provide the first hash partition group with two table properties:
+
+The ``partition_by_hash_columns`` defines the column(s) belonging to the
+partition group and ``partition_by_hash_buckets`` the number of partitions to
+split the hash values range into. All partition columns must be part of the
+primary key.
+
+
+Example:
+
+  .. code:: sql
+
+    CREATE TABLE mytable (
+      col1 varchar WITH (primary_key=true),
+      col2 varchar WITH (primary_key=true),
+      ...
+    ) WITH (
+      partition_by_hash_columns = ARRAY['col1', 'col2'],
+      partition_by_hash_buckets = 4
+    )
+
+
+This defines a hash partitioning with the columns ``col1`` and ``col2``
+distributed over 4 partitions.
+
+To define two separate hash partition groups use also the second pair
+of table properties named ``partition_by_second_hash_columns`` and
+``partition_by_second_hash_buckets``.
+
+Example:
+
+  .. code:: sql
+
+    CREATE TABLE mytable (
+      col1 varchar WITH (primary_key=true),
+      col2 varchar WITH (primary_key=true),
+      ...
+    ) WITH (
+      partition_by_hash_columns = ARRAY['col1'],
+      partition_by_hash_buckets = 2,
+      partition_by_second_hash_columns = ARRAY['col2'],
+      partition_by_second_hash_buckets = 3
+    )
+
+This defines a two-level hash partitioning with the first hash partition group
+over the column ``col1`` distributed over 2 buckets and the second
+hash partition group over the column ``col2`` distributed over 3 buckets.
+As a result you have table with 2 x 3 = 6 partitions.
+
+
+Range partitioning
+^^^^^^^^^^^^^^^^^^
+
+You can provide at most one range partitioning in Apache Kudu. The columns
+are defined with the table property ``partition_by_range_columns``.
+The ranges themselves are given either in the
+table property ``range_partitions`` on creating the table.
+Or alternatively, the procedures ``kudu.system.add_range_partition`` and
+``kudu.system.drop_range_partition`` can be used to manage range
+partitions for existing tables. For both ways see below for more
+details.
+
+Example:
+
+  .. code:: sql
+
+    CREATE TABLE events (
+      rack varchar WITH (primary_key=true),
+      machine varchar WITH (primary_key=true),
+      event_time timestamp WITH (primary_key=true),
+      ...
+    ) WITH (
+      partition_by_hash_columns = ARRAY['rack'],
+      partition_by_hash_buckets = 2,
+      partition_by_second_hash_columns = ARRAY['machine'],
+      partition_by_second_hash_buckets = 3,
+      partition_by_range_columns = ARRAY['event_time'],
+      range_partitions = '[{"lower": null, "upper": "2018-01-01T00:00:00"}, {"lower": "2018-01-01T00:00:00", "upper": null}]'
+    )
+
+This defines a tree-level partitioning with two hash partition groups and
+one range partitioning on the ``event_time`` column.
+Two range partitions are created with a split at “2018-01-01T00:00:00”.
+
+
+Table property ``range_partitions``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With the ``range_partitions`` table property you specify the concrete
+range partitions to be created. The range partition definition itself
+must be given in the table property ``partition_design`` separately.
+
+Example:
+
+  .. code:: sql
+
+    CREATE TABLE events (
+      serialno varchar WITH (primary_key = true),
+      event_time timestamp WITH (primary_key = true),
+      message varchar
+    ) WITH (
+      partition_by_hash_columns = ARRAY['serialno'],
+      partition_by_hash_buckets = 4,
+      partition_by_range_columns = ARRAY['event_time'],
+      range_partitions = '[{"lower": null, "upper": "2017-01-01T00:00:00"},
+                           {"lower": "2017-01-01T00:00:00", "upper": "2017-07-01T00:00:00"},
+                           {"lower": "2017-07-01T00:00:00", "upper": "2018-01-01T00:00:00"}]'
+    );
+
+This creates a table with a hash partition on column ``serialno`` with 4
+buckets and range partitioning on column ``event_time``. Additionally
+three range partitions are created:
+
+    1. for all event_times before the year 2017 (lower bound = ``null`` means it is unbound)
+    2. for the first half of the year 2017
+    3. for the second half the year 2017
+
+This means any try to add rows with ``event_time`` of year 2018 or greater will fail, as no partition is defined.
+The next section shows how to define a new range partition for an existing table.
+
+Managing range partitions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For existing tables, there are procedures to add and drop a range
+partition.
+
+- adding a range partition
+
+  .. code:: sql
+
+    CALL kudu.system.add_range_partition(<schema>, <table>, <range_partition_as_json_string>),
+
+- dropping a range partition
+
+  .. code:: sql
+
+    CALL kudu.system.drop_range_partition(<schema>, <table>, <range_partition_as_json_string>)
+
+  - ``<schema>``: schema of the table
+
+  - ``<table>``: table names
+
+  - ``<range_partition_as_json_string>``: lower and upper bound of the
+    range partition as json string in the form
+    ``'{"lower": <value>, "upper": <value>}'``, or if the range partition
+    has multiple columns:
+    ``'{"lower": [<value_col1>,...], "upper": [<value_col1>,...]}'``. The
+    concrete literal for lower and upper bound values are depending on
+    the column types.
+
+    Examples:
+
+    +-------------------------------+----------------------------------------------+
+    | Presto Data Type              | JSON string example                          |
+    +===============================+==============================================+
+    | ``BIGINT``                    | ``‘{“lower”: 0, “upper”: 1000000}’``         |
+    +-------------------------------+----------------------------------------------+
+    | ``SMALLINT``                  | ``‘{“lower”: 10, “upper”: null}’``           |
+    +-------------------------------+----------------------------------------------+
+    | ``VARCHAR``                   | ``‘{“lower”: “A”, “upper”: “M”}’``           |
+    +-------------------------------+----------------------------------------------+
+    | ``TIMESTAMP``                 | ``‘{“lower”: “2018-02-01T00:00:00.000”,      |
+    |                               | “upper”: “2018-02-01T12:00:00.000”}’``       |
+    +-------------------------------+----------------------------------------------+
+    | ``BOOLEAN``                   | ``‘{“lower”: false, “upper”: true}’``        |
+    +-------------------------------+----------------------------------------------+
+    | ``VARBINARY``                 | values encoded as base64 strings             |
+    +-------------------------------+----------------------------------------------+
+
+    To specified an unbounded bound, use the value ``null``.
+
+Example:
+
+  .. code:: sql
+
+    CALL kudu.system.add_range_partition('myschema', 'events', '{"lower": "2018-01-01", "upper": "2018-06-01"}')
+
+This would add a range partition for a table ``events`` in the schema
+``myschema`` with the lower bound ``2018-01-01`` (more exactly
+``2018-01-01T00:00:00.000``) and the upper bound ``2018-07-01``.
+
+Use the sql statement ``SHOW CREATE TABLE`` to query the existing
+range partitions (they are shown in the table property
+``range_partitions``).
+
+Add Column
+----------
+
+Adding a column to an existing table uses the SQL statement ``ALTER TABLE ... ADD COLUMN ...``.
+You can specify the same column properties as on creating a table.
+
+Example:
+
+  .. code:: sql
+
+    ALTER TABLE mytable ADD COLUMN extraInfo varchar WITH (nullable = true, encoding = 'plain')
+
+See also `Column Properties`_.
+
+
+Known limitations
+-----------------
+
+-  Only lower case table and column names in Kudu are supported
+-  Using a secured Kudu cluster has not been tested.

--- a/presto-kudu/bin/run_kudu_tests.sh
+++ b/presto-kudu/bin/run_kudu_tests.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Runs all tests with Kudu server in docker containers.
+#
+# ./run_kudu_tests.sh <nodes> <inferSchemaPrefix>
+#
+# <nodes>                Number of tablet servers (1 oder 3). Also used for number of replicas.
+# <inferSchemaPrefix>    InferSchema setup: "null" = disabled,
+#                                           ""     = enabled, using empty prefix,
+#                                           "presto::" = enabled, using standard prefix
+#
+# If arguments are missing, defaults are 1 tablet server and disabled inferSchema.
+
+set -euo pipefail -x
+
+export KUDU_MASTER_RPC_PORT=17051
+export DOCKER_HOST_IP=$(docker network inspect bridge --format='{{index .IPAM.Config 0 "Gateway"}}')
+
+PROJECT_ROOT="${BASH_SOURCE%/*}/../.."
+
+# single or three tablet nodes?
+if [ $# -eq 0 ]
+then
+  DOCKER_COMPOSE_LOCATION="${BASH_SOURCE%/*}/../conf/docker-compose-single-node.yaml"
+elif [ $1 -eq 1 ]
+then
+  DOCKER_COMPOSE_LOCATION="${BASH_SOURCE%/*}/../conf/docker-compose-single-node.yaml"
+elif [ $1 -eq 3 ]
+then
+  DOCKER_COMPOSE_LOCATION="${BASH_SOURCE%/*}/../conf/docker-compose-three-nodes.yaml"
+else
+  echo unknown node configuration
+  exit 1
+fi
+
+# emulate schemas ?
+if [ $# -lt 2 ]
+then
+  TEST_SCHEMA_EMULATION_PREFIX=null
+else
+  TEST_SCHEMA_EMULATION_PREFIX=$2
+fi
+
+function start_docker_container() {
+  # stop already running containers
+  docker-compose -f "${DOCKER_COMPOSE_LOCATION}" down || true
+
+  # start containers
+  docker-compose -f "${DOCKER_COMPOSE_LOCATION}" up -d
+}
+
+function cleanup_docker_container() {
+  docker-compose -f "${DOCKER_COMPOSE_LOCATION}" down
+}
+
+
+start_docker_container
+
+# run product tests
+pushd ${PROJECT_ROOT}
+set +e
+./mvnw -pl presto-kudu test -P integration \
+  -Dkudu.client.master-addresses=${DOCKER_HOST_IP}:${KUDU_MASTER_RPC_PORT} \
+  -Dkudu.schema-emulation.prefix=${TEST_SCHEMA_EMULATION_PREFIX}
+EXIT_CODE=$?
+set -e
+popd
+
+cleanup_docker_container
+
+exit ${EXIT_CODE}

--- a/presto-kudu/conf/docker-compose-single-node.yaml
+++ b/presto-kudu/conf/docker-compose-single-node.yaml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  kudu:
+    hostname: kudu
+    image: 'usuresearch/kudu-docker-slim:release-v1.7.0-2'
+    ports:
+      - '18050:8050'
+      - '18051:8051'
+      - '17050:7050'
+      - "${KUDU_MASTER_RPC_PORT}:7051"
+    environment:
+      - "KUDU_MASTER_EXTRA_OPTS=--default_num_replicas 1 --webserver_advertised_addresses ${DOCKER_HOST_IP}:18051 --rpc_advertised_addresses ${DOCKER_HOST_IP}:${KUDU_MASTER_RPC_PORT}"
+      - "KUDU_TSERVER_EXTRA_OPTS=--webserver_advertised_addresses ${DOCKER_HOST_IP}:18050 --rpc_advertised_addresses ${DOCKER_HOST_IP}:17050"

--- a/presto-kudu/conf/docker-compose-three-nodes.yaml
+++ b/presto-kudu/conf/docker-compose-three-nodes.yaml
@@ -1,0 +1,33 @@
+version: '2'
+services:
+  kudu1:
+    hostname: kudu1
+    image: 'usuresearch/kudu-docker-slim:release-v1.7.0-2'
+    ports:
+      - '18050:8050'
+      - '18051:8051'
+      - '17050:7050'
+      - "${KUDU_MASTER_RPC_PORT}:7051"
+    environment:
+      - "KUDU_MASTER_EXTRA_OPTS=--webserver_advertised_addresses ${DOCKER_HOST_IP}:18051 --rpc_advertised_addresses ${DOCKER_HOST_IP}:${KUDU_MASTER_RPC_PORT}"
+      - "KUDU_TSERVER_EXTRA_OPTS=--webserver_advertised_addresses ${DOCKER_HOST_IP}:18050 --rpc_advertised_addresses ${DOCKER_HOST_IP}:17050"
+
+  kudu2:
+    hostname: kudu2
+    image: 'usuresearch/kudu-docker-slim'
+    ports:
+      - '28050:8050'
+      - '27050:7050'
+    environment:
+      - "KUDU_MASTER=${DOCKER_HOST_IP}:${KUDU_MASTER_RPC_PORT}"
+      - "KUDU_TSERVER_EXTRA_OPTS=--webserver_advertised_addresses ${DOCKER_HOST_IP}:28050 --rpc_advertised_addresses ${DOCKER_HOST_IP}:27050"
+
+  kudu3:
+    hostname: kudu3
+    image: 'usuresearch/kudu-docker-slim'
+    ports:
+      - '38050:8050'
+      - '37050:7050'
+    environment:
+      - "KUDU_MASTER=${DOCKER_HOST_IP}:${KUDU_MASTER_RPC_PORT}"
+      - "KUDU_TSERVER_EXTRA_OPTS=--webserver_advertised_addresses ${DOCKER_HOST_IP}:38050 --rpc_advertised_addresses ${DOCKER_HOST_IP}:37050"

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.209-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-kudu</artifactId>
+    <description>Presto - Kudu Connector</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <kudu.version>1.7.0</kudu.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kudu</groupId>
+            <artifactId>kudu-client</artifactId>
+            <version>${kudu.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/TestKuduIntegration*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>integration</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduClientConfig.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduClientConfig.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MaxDuration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration read from etc/catalog/kudu.properties
+ */
+public class KuduClientConfig
+{
+    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+
+    private List<String> masterAddresses;
+    private Duration defaultAdminOperationTimeout = new Duration(30, TimeUnit.SECONDS);
+    private Duration defaultOperationTimeout = new Duration(30, TimeUnit.SECONDS);
+    private Duration defaultSocketReadTimeout = new Duration(10, TimeUnit.SECONDS);
+    private boolean disableStatistics;
+    private boolean schemaEmulationEnabled;
+    private String schemaEmulationPrefix = "presto::";
+
+    @NotNull
+    @Size(min = 1)
+    public List<String> getMasterAddresses()
+    {
+        return masterAddresses;
+    }
+
+    @Config("kudu.client.master-addresses")
+    public KuduClientConfig setMasterAddresses(String commaSeparatedList)
+    {
+        this.masterAddresses = SPLITTER.splitToList(commaSeparatedList);
+        return this;
+    }
+
+    public KuduClientConfig setMasterAddresses(String... contactPoints)
+    {
+        this.masterAddresses = ImmutableList.copyOf(contactPoints);
+        return this;
+    }
+
+    @Config("kudu.client.default-admin-operation-timeout")
+    public KuduClientConfig setDefaultAdminOperationTimeout(Duration timeout)
+    {
+        this.defaultAdminOperationTimeout = timeout;
+        return this;
+    }
+
+    @MinDuration("1s")
+    @MaxDuration("1h")
+    public Duration getDefaultAdminOperationTimeout()
+    {
+        return defaultAdminOperationTimeout;
+    }
+
+    @Config("kudu.client.default-operation-timeout")
+    public KuduClientConfig setDefaultOperationTimeout(Duration timeout)
+    {
+        this.defaultOperationTimeout = timeout;
+        return this;
+    }
+
+    @MinDuration("1s")
+    @MaxDuration("1h")
+    public Duration getDefaultOperationTimeout()
+    {
+        return defaultOperationTimeout;
+    }
+
+    @Config("kudu.client.default-socket-read-timeout")
+    public KuduClientConfig setDefaultSocketReadTimeout(Duration timeout)
+    {
+        this.defaultSocketReadTimeout = timeout;
+        return this;
+    }
+
+    @MinDuration("1s")
+    @MaxDuration("1h")
+    public Duration getDefaultSocketReadTimeout()
+    {
+        return defaultSocketReadTimeout;
+    }
+
+    public boolean isDisableStatistics()
+    {
+        return this.disableStatistics;
+    }
+
+    @Config("kudu.client.disable-statistics")
+    public KuduClientConfig setDisableStatistics(boolean disableStatistics)
+    {
+        this.disableStatistics = disableStatistics;
+        return this;
+    }
+
+    public String getSchemaEmulationPrefix()
+    {
+        return schemaEmulationPrefix;
+    }
+
+    @Config("kudu.schema-emulation.prefix")
+    public KuduClientConfig setSchemaEmulationPrefix(String prefix)
+    {
+        this.schemaEmulationPrefix = prefix;
+        return this;
+    }
+
+    public boolean isSchemaEmulationEnabled()
+    {
+        return schemaEmulationEnabled;
+    }
+
+    @Config("kudu.schema-emulation.enabled")
+    public KuduClientConfig setSchemaEmulationEnabled(boolean enabled)
+    {
+        this.schemaEmulationEnabled = enabled;
+        return this;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduClientSession.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduClientSession.java
@@ -1,0 +1,581 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.kudu.properties.ColumnDesign;
+import com.facebook.presto.kudu.properties.HashPartitionDefinition;
+import com.facebook.presto.kudu.properties.KuduTableProperties;
+import com.facebook.presto.kudu.properties.PartitionDesign;
+import com.facebook.presto.kudu.properties.RangePartition;
+import com.facebook.presto.kudu.properties.RangePartitionDefinition;
+import com.facebook.presto.kudu.schema.SchemaEmulation;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaNotFoundException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.predicate.DiscreteValues;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.EquatableValueSet;
+import com.facebook.presto.spi.predicate.Marker;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.Ranges;
+import com.facebook.presto.spi.predicate.SortedRangeSet;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.type.DecimalType;
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.ColumnTypeAttributes;
+import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
+import org.apache.kudu.client.AlterTableOptions;
+import org.apache.kudu.client.CreateTableOptions;
+import org.apache.kudu.client.KuduClient;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.KuduPredicate;
+import org.apache.kudu.client.KuduScanToken;
+import org.apache.kudu.client.KuduScanner;
+import org.apache.kudu.client.KuduSession;
+import org.apache.kudu.client.KuduTable;
+import org.apache.kudu.client.PartialRow;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class KuduClientSession
+{
+    public static final String DEFAULT_SCHEMA = "default";
+    private final Logger log = Logger.get(getClass());
+    private final KuduConnectorId connectorId;
+    private final KuduClient client;
+    private final SchemaEmulation schemaEmulation;
+
+    public KuduClientSession(KuduConnectorId connectorId, KuduClient client, SchemaEmulation schemaEmulation)
+    {
+        this.connectorId = connectorId;
+        this.client = client;
+        this.schemaEmulation = schemaEmulation;
+    }
+
+    public List<String> listSchemaNames()
+    {
+        return schemaEmulation.listSchemaNames(client);
+    }
+
+    private List<String> internalListTables(String prefix)
+    {
+        try {
+            if (prefix.isEmpty()) {
+                return client.getTablesList().getTablesList();
+            }
+            else {
+                return client.getTablesList(prefix).getTablesList();
+            }
+        }
+        catch (KuduException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    public List<SchemaTableName> listTables(Optional<String> optSchemaName)
+    {
+        if (optSchemaName.isPresent()) {
+            return listTablesSingleSchema(optSchemaName.get());
+        }
+
+        List<SchemaTableName> all = new ArrayList<>();
+        for (String schemaName : listSchemaNames()) {
+            List<SchemaTableName> single = listTablesSingleSchema(schemaName);
+            all.addAll(single);
+        }
+        return all;
+    }
+
+    private List<SchemaTableName> listTablesSingleSchema(String schemaName)
+    {
+        final String prefix = schemaEmulation.getPrefixForTablesOfSchema(schemaName);
+
+        List<String> tables = internalListTables(prefix);
+        return tables.stream()
+                .map(schemaEmulation::fromRawName)
+                .filter(Objects::nonNull)
+                .collect(toImmutableList());
+    }
+
+    public Schema getTableSchema(KuduTableHandle tableHandle)
+    {
+        KuduTable table = tableHandle.getTable(this);
+        return table.getSchema();
+    }
+
+    public Map<String, Object> getTableProperties(KuduTableHandle tableHandle)
+    {
+        KuduTable table = tableHandle.getTable(this);
+        return KuduTableProperties.toMap(table);
+    }
+
+    public List<KuduSplit> buildKuduSplits(KuduTableLayoutHandle layoutHandle)
+    {
+        KuduTableHandle tableHandle = layoutHandle.getTableHandle();
+        KuduTable table = tableHandle.getTable(this);
+        final int primaryKeyColumnCount = table.getSchema().getPrimaryKeyColumnCount();
+        KuduScanToken.KuduScanTokenBuilder builder = client.newScanTokenBuilder(table);
+
+        TupleDomain<ColumnHandle> constraintSummary = layoutHandle.getConstraintSummary();
+        if (!addConstraintPredicates(table, builder, constraintSummary)) {
+            return ImmutableList.of();
+        }
+
+        Optional<Set<ColumnHandle>> desiredColumns = layoutHandle.getDesiredColumns();
+        if (desiredColumns.isPresent()) {
+            if (desiredColumns.get().contains(KuduColumnHandle.ROW_ID_HANDLE)) {
+                List<Integer> columnIndexes = IntStream
+                        .range(0, primaryKeyColumnCount)
+                        .boxed().collect(Collectors.toList());
+                for (ColumnHandle columnHandle : desiredColumns.get()) {
+                    if (columnHandle instanceof KuduColumnHandle) {
+                        KuduColumnHandle k = (KuduColumnHandle) columnHandle;
+                        int index = k.getOrdinalPosition();
+                        if (index >= primaryKeyColumnCount) {
+                            columnIndexes.add(index);
+                        }
+                    }
+                }
+                builder.setProjectedColumnIndexes(columnIndexes);
+            }
+            else {
+                List<Integer> columnIndexes = desiredColumns.get().stream()
+                        .map(handle -> ((KuduColumnHandle) handle).getOrdinalPosition())
+                        .collect(toImmutableList());
+                builder.setProjectedColumnIndexes(columnIndexes);
+            }
+        }
+
+        List<KuduScanToken> tokens = builder.build();
+        return tokens.stream()
+                .map(token -> toKuduSplit(tableHandle, token, primaryKeyColumnCount))
+                .collect(toImmutableList());
+    }
+
+    public KuduScanner createScanner(KuduSplit kuduSplit)
+    {
+        try {
+            return KuduScanToken.deserializeIntoScanner(kuduSplit.getSerializedScanToken(), client);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public KuduTable openTable(SchemaTableName schemaTableName)
+    {
+        String rawName = schemaEmulation.toRawName(schemaTableName);
+        try {
+            return client.openTable(rawName);
+        }
+        catch (KuduException e) {
+            log.debug("Error on doOpenTable: " + e, e);
+            if (!listSchemaNames().contains(schemaTableName.getSchemaName())) {
+                throw new SchemaNotFoundException(schemaTableName.getSchemaName());
+            }
+            throw new TableNotFoundException(schemaTableName);
+        }
+    }
+
+    public KuduSession newSession()
+    {
+        return client.newSession();
+    }
+
+    public void createSchema(String schemaName)
+    {
+        schemaEmulation.createSchema(client, schemaName);
+    }
+
+    public void dropSchema(String schemaName)
+    {
+        schemaEmulation.dropSchema(client, schemaName);
+    }
+
+    public void dropTable(SchemaTableName schemaTableName)
+    {
+        try {
+            String rawName = schemaEmulation.toRawName(schemaTableName);
+            client.deleteTable(rawName);
+        }
+        catch (KuduException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    public void renameTable(SchemaTableName schemaTableName, SchemaTableName newSchemaTableName)
+    {
+        try {
+            String rawName = schemaEmulation.toRawName(schemaTableName);
+            String newRawName = schemaEmulation.toRawName(newSchemaTableName);
+            AlterTableOptions alterOptions = new AlterTableOptions();
+            alterOptions.renameTable(newRawName);
+            client.alterTable(rawName, alterOptions);
+        }
+        catch (KuduException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    public KuduTable createTable(ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        try {
+            String rawName = schemaEmulation.toRawName(tableMetadata.getTable());
+            if (ignoreExisting) {
+                if (client.tableExists(rawName)) {
+                    return null;
+                }
+            }
+
+            if (!schemaEmulation.existsSchema(client, tableMetadata.getTable().getSchemaName())) {
+                throw new SchemaNotFoundException(tableMetadata.getTable().getSchemaName());
+            }
+
+            List<ColumnMetadata> columns = tableMetadata.getColumns();
+            Map<String, Object> properties = tableMetadata.getProperties();
+
+            Schema schema = buildSchema(columns, properties);
+            CreateTableOptions options = buildCreateTableOptions(schema, properties);
+            return client.createTable(rawName, schema, options);
+        }
+        catch (KuduException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    public void addColumn(SchemaTableName schemaTableName, ColumnMetadata column)
+    {
+        try {
+            String rawName = schemaEmulation.toRawName(schemaTableName);
+            AlterTableOptions alterOptions = new AlterTableOptions();
+            Type type = TypeHelper.toKuduClientType(column.getType());
+            alterOptions.addNullableColumn(column.getName(), type);
+            client.alterTable(rawName, alterOptions);
+        }
+        catch (KuduException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    public void dropColumn(SchemaTableName schemaTableName, String name)
+    {
+        try {
+            String rawName = schemaEmulation.toRawName(schemaTableName);
+            AlterTableOptions alterOptions = new AlterTableOptions();
+            alterOptions.dropColumn(name);
+            client.alterTable(rawName, alterOptions);
+        }
+        catch (KuduException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    public void renameColumn(SchemaTableName schemaTableName, String oldName, String newName)
+    {
+        try {
+            String rawName = schemaEmulation.toRawName(schemaTableName);
+            AlterTableOptions alterOptions = new AlterTableOptions();
+            alterOptions.renameColumn(oldName, newName);
+            client.alterTable(rawName, alterOptions);
+        }
+        catch (KuduException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    public void addRangePartition(SchemaTableName schemaTableName, RangePartition rangePartition)
+    {
+        changeRangePartition(schemaTableName, rangePartition, RangePartitionChange.ADD);
+    }
+
+    public void dropRangePartition(SchemaTableName schemaTableName, RangePartition rangePartition)
+    {
+        changeRangePartition(schemaTableName, rangePartition, RangePartitionChange.DROP);
+    }
+
+    private void changeRangePartition(SchemaTableName schemaTableName, RangePartition rangePartition,
+            RangePartitionChange change)
+    {
+        try {
+            String rawName = schemaEmulation.toRawName(schemaTableName);
+            KuduTable table = client.openTable(rawName);
+            Schema schema = table.getSchema();
+            PartitionDesign design = KuduTableProperties.getPartitionDesign(table);
+            RangePartitionDefinition definition = design.getRange();
+            if (definition == null) {
+                throw new PrestoException(QUERY_REJECTED, "Table " + schemaTableName + " has no range partition");
+            }
+            PartialRow lowerBound = KuduTableProperties.toRangeBoundToPartialRow(schema, definition, rangePartition.getLower());
+            PartialRow upperBound = KuduTableProperties.toRangeBoundToPartialRow(schema, definition, rangePartition.getUpper());
+            AlterTableOptions alterOptions = new AlterTableOptions();
+            switch (change) {
+                case ADD:
+                    alterOptions.addRangePartition(lowerBound, upperBound);
+                    break;
+                case DROP:
+                    alterOptions.dropRangePartition(lowerBound, upperBound);
+                    break;
+            }
+            client.alterTable(rawName, alterOptions);
+        }
+        catch (PrestoException e) {
+            throw e;
+        }
+        catch (KuduException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    private Schema buildSchema(List<ColumnMetadata> columns, Map<String, Object> tableProperties)
+    {
+        List<ColumnSchema> kuduColumns = columns.stream()
+                .map(this::toColumnSchema)
+                .collect(ImmutableList.toImmutableList());
+        return new Schema(kuduColumns);
+    }
+
+    private ColumnSchema toColumnSchema(ColumnMetadata columnMetadata)
+    {
+        String name = columnMetadata.getName();
+        ColumnDesign design = KuduTableProperties.getColumnDesign(columnMetadata.getProperties());
+        Type ktype = TypeHelper.toKuduClientType(columnMetadata.getType());
+        ColumnSchema.ColumnSchemaBuilder builder = new ColumnSchema.ColumnSchemaBuilder(name, ktype);
+        builder.key(design.isPrimaryKey()).nullable(design.isNullable());
+        setEncoding(name, builder, design);
+        setCompression(name, builder, design);
+        setTypeAttributes(columnMetadata, builder);
+        return builder.build();
+    }
+
+    private void setTypeAttributes(ColumnMetadata columnMetadata, ColumnSchema.ColumnSchemaBuilder builder)
+    {
+        if (columnMetadata.getType() instanceof DecimalType) {
+            DecimalType type = (DecimalType) columnMetadata.getType();
+            ColumnTypeAttributes attributes = new ColumnTypeAttributes.ColumnTypeAttributesBuilder()
+                    .precision(type.getPrecision())
+                    .scale(type.getScale()).build();
+            builder.typeAttributes(attributes);
+        }
+    }
+
+    private void setCompression(String name, ColumnSchema.ColumnSchemaBuilder builder, ColumnDesign design)
+    {
+        if (design.getCompression() != null) {
+            try {
+                ColumnSchema.CompressionAlgorithm algorithm = KuduTableProperties.lookupCompression(design.getCompression());
+                builder.compressionAlgorithm(algorithm);
+            }
+            catch (IllegalArgumentException e) {
+                throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unknown compression algorithm " + design.getCompression() + " for column " + name);
+            }
+        }
+    }
+
+    private void setEncoding(String name, ColumnSchema.ColumnSchemaBuilder builder, ColumnDesign design)
+    {
+        if (design.getEncoding() != null) {
+            try {
+                ColumnSchema.Encoding encoding = KuduTableProperties.lookupEncoding(design.getEncoding());
+                builder.encoding(encoding);
+            }
+            catch (IllegalArgumentException e) {
+                throw new PrestoException(GENERIC_INTERNAL_ERROR, "Unknown encoding " + design.getEncoding() + " for column " + name);
+            }
+        }
+    }
+
+    private CreateTableOptions buildCreateTableOptions(Schema schema, Map<String, Object> properties)
+    {
+        CreateTableOptions options = new CreateTableOptions();
+
+        RangePartitionDefinition rangePartitionDefinition = null;
+        PartitionDesign partitionDesign = KuduTableProperties.getPartitionDesign(properties);
+        if (partitionDesign.getHash() != null) {
+            for (HashPartitionDefinition partition : partitionDesign.getHash()) {
+                options.addHashPartitions(partition.getColumns(), partition.getBuckets());
+            }
+        }
+        if (partitionDesign.getRange() != null) {
+            rangePartitionDefinition = partitionDesign.getRange();
+            options.setRangePartitionColumns(rangePartitionDefinition.getColumns());
+        }
+
+        List<RangePartition> rangePartitions = KuduTableProperties.getRangePartitions(properties);
+        if (rangePartitionDefinition != null && !rangePartitions.isEmpty()) {
+            for (RangePartition rangePartition : rangePartitions) {
+                PartialRow lower = KuduTableProperties.toRangeBoundToPartialRow(schema, rangePartitionDefinition, rangePartition.getLower());
+                PartialRow upper = KuduTableProperties.toRangeBoundToPartialRow(schema, rangePartitionDefinition, rangePartition.getUpper());
+                options.addRangePartition(lower, upper);
+            }
+        }
+
+        Optional<Integer> numReplicas = KuduTableProperties.getNumReplicas(properties);
+        numReplicas.ifPresent(options::setNumReplicas);
+
+        return options;
+    }
+
+    /**
+     * translates TupleDomain to KuduPredicates.
+     *
+     * @return false if TupleDomain or one of its domains is none
+     */
+    private boolean addConstraintPredicates(KuduTable table, KuduScanToken.KuduScanTokenBuilder builder,
+            TupleDomain<ColumnHandle> constraintSummary)
+    {
+        if (constraintSummary.isNone()) {
+            return false;
+        }
+        else if (!constraintSummary.isAll()) {
+            Schema schema = table.getSchema();
+            for (TupleDomain.ColumnDomain<ColumnHandle> columnDomain : constraintSummary.getColumnDomains().get()) {
+                int position = ((KuduColumnHandle) columnDomain.getColumn()).getOrdinalPosition();
+                ColumnSchema columnSchema = schema.getColumnByIndex(position);
+                Domain domain = columnDomain.getDomain();
+                if (domain.isNone()) {
+                    return false;
+                }
+                else if (domain.isAll()) {
+                    // no restriction
+                }
+                else if (domain.isOnlyNull()) {
+                    builder.addPredicate(KuduPredicate.newIsNullPredicate(columnSchema));
+                }
+                else if (domain.getValues().isAll() && domain.isNullAllowed()) {
+                    builder.addPredicate(KuduPredicate.newIsNotNullPredicate(columnSchema));
+                }
+                else if (domain.isSingleValue()) {
+                    KuduPredicate predicate = createEqualsPredicate(columnSchema, domain.getSingleValue());
+                    builder.addPredicate(predicate);
+                }
+                else {
+                    ValueSet valueSet = domain.getValues();
+                    if (valueSet instanceof EquatableValueSet) {
+                        DiscreteValues discreteValues = valueSet.getDiscreteValues();
+                        KuduPredicate predicate = createInListPredicate(columnSchema, discreteValues);
+                        builder.addPredicate(predicate);
+                    }
+                    else if (valueSet instanceof SortedRangeSet) {
+                        Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
+                        Range span = ranges.getSpan();
+                        Marker low = span.getLow();
+                        if (!low.isLowerUnbounded()) {
+                            KuduPredicate.ComparisonOp op = (low.getBound() == Marker.Bound.ABOVE)
+                                    ? KuduPredicate.ComparisonOp.GREATER : KuduPredicate.ComparisonOp.GREATER_EQUAL;
+                            KuduPredicate predicate = createComparisonPredicate(columnSchema, op, low.getValue());
+                            builder.addPredicate(predicate);
+                        }
+                        Marker high = span.getHigh();
+                        if (!high.isUpperUnbounded()) {
+                            KuduPredicate.ComparisonOp op = (low.getBound() == Marker.Bound.BELOW)
+                                    ? KuduPredicate.ComparisonOp.LESS : KuduPredicate.ComparisonOp.LESS_EQUAL;
+                            KuduPredicate predicate = createComparisonPredicate(columnSchema, op, high.getValue());
+                            builder.addPredicate(predicate);
+                        }
+                    }
+                    else {
+                        throw new IllegalStateException("Unexpected domain: " + domain);
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    private KuduPredicate createInListPredicate(ColumnSchema columnSchema, DiscreteValues discreteValues)
+    {
+        com.facebook.presto.spi.type.Type type = TypeHelper.fromKuduColumn(columnSchema);
+        List<Object> javaValues = discreteValues.getValues().stream().map(value -> TypeHelper.getJavaValue(type, value)).collect(toImmutableList());
+        return KuduPredicate.newInListPredicate(columnSchema, javaValues);
+    }
+
+    private KuduPredicate createEqualsPredicate(ColumnSchema columnSchema, Object value)
+    {
+        return createComparisonPredicate(columnSchema, KuduPredicate.ComparisonOp.EQUAL, value);
+    }
+
+    private KuduPredicate createComparisonPredicate(ColumnSchema columnSchema,
+            KuduPredicate.ComparisonOp op,
+            Object value)
+    {
+        com.facebook.presto.spi.type.Type type = TypeHelper.fromKuduColumn(columnSchema);
+        Object javaValue = TypeHelper.getJavaValue(type, value);
+        if (javaValue instanceof Long) {
+            return KuduPredicate.newComparisonPredicate(columnSchema, op, (Long) javaValue);
+        }
+        else if (javaValue instanceof Integer) {
+            return KuduPredicate.newComparisonPredicate(columnSchema, op, (Integer) javaValue);
+        }
+        else if (javaValue instanceof Short) {
+            return KuduPredicate.newComparisonPredicate(columnSchema, op, (Short) javaValue);
+        }
+        else if (javaValue instanceof Byte) {
+            return KuduPredicate.newComparisonPredicate(columnSchema, op, (Byte) javaValue);
+        }
+        else if (javaValue instanceof String) {
+            return KuduPredicate.newComparisonPredicate(columnSchema, op, (String) javaValue);
+        }
+        else if (javaValue instanceof Double) {
+            return KuduPredicate.newComparisonPredicate(columnSchema, op, (Double) javaValue);
+        }
+        else if (javaValue instanceof Float) {
+            return KuduPredicate.newComparisonPredicate(columnSchema, op, (Float) javaValue);
+        }
+        else if (javaValue instanceof Boolean) {
+            return KuduPredicate.newComparisonPredicate(columnSchema, op, (Boolean) javaValue);
+        }
+        else if (javaValue instanceof byte[]) {
+            return KuduPredicate.newComparisonPredicate(columnSchema, op, (byte[]) javaValue);
+        }
+        else if (javaValue == null) {
+            throw new IllegalStateException("Unexpected null java value for column " + columnSchema.getName());
+        }
+        else {
+            throw new IllegalStateException("Unexpected java value for column "
+                    + columnSchema.getName() + ": " + javaValue + "(" + javaValue.getClass() + ")");
+        }
+    }
+
+    private KuduSplit toKuduSplit(KuduTableHandle tableHandle, KuduScanToken token,
+            int primaryKeyColumnCount)
+    {
+        try {
+            byte[] serializedScanToken = token.serialize();
+            return new KuduSplit(tableHandle, primaryKeyColumnCount, serializedScanToken);
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduColumnHandle.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduColumnHandle.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class KuduColumnHandle
+        implements ColumnHandle
+{
+    public static final String ROW_ID = "row_uuid";
+
+    public static final KuduColumnHandle ROW_ID_HANDLE = new KuduColumnHandle(ROW_ID, -1, VarbinaryType.VARBINARY);
+
+    private final String name;
+    private final int ordinalPosition;
+    private final Type type;
+
+    @JsonCreator
+    public KuduColumnHandle(
+            @JsonProperty("name") String name,
+            @JsonProperty("ordinalPosition") int ordinalPosition,
+            @JsonProperty("type") Type type)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.ordinalPosition = ordinalPosition;
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public int getOrdinalPosition()
+    {
+        return ordinalPosition;
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    public ColumnMetadata getColumnMetadata()
+    {
+        return new ColumnMetadata(name, type);
+    }
+
+    public boolean isVirtualRowId()
+    {
+        return name.equals(ROW_ID);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(
+                name,
+                ordinalPosition,
+                type);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        KuduColumnHandle other = (KuduColumnHandle) obj;
+        return Objects.equals(this.name, other.name) &&
+                Objects.equals(this.ordinalPosition, other.ordinalPosition) &&
+                Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("ordinalPosition", ordinalPosition)
+                .add("type", type)
+                .toString();
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduConnector.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduConnector.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.kudu.properties.KuduTableProperties;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.log.Logger;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.spi.transaction.IsolationLevel.READ_COMMITTED;
+import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static java.util.Objects.requireNonNull;
+
+public class KuduConnector
+        implements Connector
+{
+    private static final Logger log = Logger.get(KuduConnector.class);
+
+    private final LifeCycleManager lifeCycleManager;
+    private final KuduMetadata metadata;
+    private final ConnectorSplitManager splitManager;
+    private final ConnectorRecordSetProvider recordSetProvider;
+    private final ConnectorPageSourceProvider pageSourceProvider;
+    private final KuduTableProperties tableProperties;
+    private final ConnectorPageSinkProvider pageSinkProvider;
+    private final Set<Procedure> procedures;
+
+    @Inject
+    public KuduConnector(
+            LifeCycleManager lifeCycleManager,
+            KuduMetadata metadata,
+            ConnectorSplitManager splitManager,
+            ConnectorRecordSetProvider recordSetProvider,
+            KuduTableProperties tableProperties,
+            ConnectorPageSourceProvider pageSourceProvider,
+            ConnectorPageSinkProvider pageSinkProvider,
+            Set<Procedure> procedures)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+        this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
+        this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel,
+            boolean readOnly)
+    {
+        checkConnectorSupports(READ_COMMITTED, isolationLevel);
+        return KuduTransactionHandle.INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorRecordSetProvider getRecordSetProvider()
+    {
+        return recordSetProvider;
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider()
+    {
+        return pageSourceProvider;
+    }
+
+    @Override
+    public ConnectorPageSinkProvider getPageSinkProvider()
+    {
+        return pageSinkProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties.getTableProperties();
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getColumnProperties()
+    {
+        return tableProperties.getColumnProperties();
+    }
+
+    @Override
+    public Set<Procedure> getProcedures()
+    {
+        return procedures;
+    }
+
+    @Override
+    public final void shutdown()
+    {
+        try {
+            lifeCycleManager.stop();
+        }
+        catch (Exception e) {
+            log.error(e, "Error shutting down connector");
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduConnectorFactory.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduConnectorFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class KuduConnectorFactory
+        implements ConnectorFactory
+{
+    public KuduConnectorFactory()
+    {
+    }
+
+    @Override
+    public String getName()
+    {
+        return "kudu";
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new KuduHandleResolver();
+    }
+
+    @Override
+    public Connector create(String connectorId, Map<String, String> config, ConnectorContext context)
+    {
+        requireNonNull(config, "config is null");
+
+        try {
+            Bootstrap app = new Bootstrap(new JsonModule(),
+                    new KuduModule(connectorId, context.getTypeManager()));
+
+            Injector injector =
+                    app.strictConfig().doNotInitializeLogging().setRequiredConfigurationProperties(config)
+                            .initialize();
+
+            return injector.getInstance(KuduConnector.class);
+        }
+        catch (RuntimeException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduConnectorId.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduConnectorId.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.google.inject.Inject;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class KuduConnectorId
+{
+    private final String id;
+
+    @Inject
+    public KuduConnectorId(String id)
+    {
+        this.id = requireNonNull(id, "id is null");
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        return Objects.equals(this.id, ((KuduConnectorId) obj).id);
+    }
+
+    @Override
+    public String toString()
+    {
+        return id;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduHandleResolver.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduHandleResolver.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public class KuduHandleResolver
+        implements ConnectorHandleResolver
+{
+    @Override
+    public Class<? extends ConnectorTableHandle> getTableHandleClass()
+    {
+        return KuduTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTableLayoutHandle> getTableLayoutHandleClass()
+    {
+        return KuduTableLayoutHandle.class;
+    }
+
+    @Override
+    public Class<? extends ColumnHandle> getColumnHandleClass()
+    {
+        return KuduColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorSplit> getSplitClass()
+    {
+        return KuduSplit.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass()
+    {
+        return KuduTransactionHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
+    {
+        return KuduInsertTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorOutputTableHandle> getOutputTableHandleClass()
+    {
+        return KuduOutputTableHandle.class;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduInsertTableHandle.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduInsertTableHandle.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import org.apache.kudu.client.KuduTable;
+
+import java.util.List;
+
+public class KuduInsertTableHandle
+        extends KuduTableHandle
+        implements ConnectorInsertTableHandle, KuduTableMapping
+{
+    private final List<Type> columnTypes;
+
+    @JsonCreator
+    public KuduInsertTableHandle(
+            @JsonProperty("connectorId") String connectorId,
+            @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
+            @JsonProperty("columnTypes") List<Type> columnTypes)
+    {
+        this(connectorId, schemaTableName, columnTypes, null);
+    }
+
+    public KuduInsertTableHandle(
+            String connectorId,
+            SchemaTableName schemaTableName,
+            List<Type> columnTypes,
+            KuduTable table)
+    {
+        super(connectorId, schemaTableName, table);
+        this.columnTypes = ImmutableList.copyOf(columnTypes);
+    }
+
+    @JsonProperty
+    public List<Type> getColumnTypes()
+    {
+        return columnTypes;
+    }
+
+    public List<Type> getOriginalColumnTypes()
+    {
+        return columnTypes;
+    }
+
+    public boolean isGenerateUUID()
+    {
+        return false;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
@@ -1,0 +1,375 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.kudu.properties.KuduTableProperties;
+import com.facebook.presto.kudu.properties.PartitionDesign;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorNewTableLayout;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.NotFoundException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.client.KuduTable;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class KuduMetadata
+        implements ConnectorMetadata
+{
+    private final String connectorId;
+    private final KuduClientSession clientSession;
+
+    @Inject
+    public KuduMetadata(KuduConnectorId connectorId, KuduClientSession clientSession)
+    {
+        this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
+        this.clientSession = requireNonNull(clientSession, "clientSession is null");
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return clientSession.listSchemaNames();
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        return clientSession.listTables(schemaName);
+    }
+
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        requireNonNull(prefix, "SchemaTablePrefix is null");
+
+        List<SchemaTableName> tables;
+        if (prefix.getTableName() == null) {
+            tables = listTables(session, prefix.getSchemaName());
+        }
+        else {
+            tables = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        }
+
+        ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
+        for (SchemaTableName tableName : tables) {
+            KuduTableHandle tableHandle = getTableHandle(session, tableName);
+            if (tableHandle != null) {
+                ConnectorTableMetadata tableMetadata = getTableMetadata(tableHandle);
+                columns.put(tableName, tableMetadata.getColumns());
+            }
+        }
+        return columns.build();
+    }
+
+    private ColumnMetadata getColumnMetadata(ColumnSchema column)
+    {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        StringBuilder extra = new StringBuilder();
+        if (column.isKey()) {
+            properties.put(KuduTableProperties.PRIMARY_KEY, true);
+            extra.append("primary_key, ");
+        }
+
+        if (column.isNullable()) {
+            properties.put(KuduTableProperties.NULLABLE, true);
+            extra.append("nullable, ");
+        }
+
+        String encoding = KuduTableProperties.lookupEncodingString(column.getEncoding());
+        if (!column.getEncoding().equals(ColumnSchema.Encoding.AUTO_ENCODING)) {
+            properties.put(KuduTableProperties.ENCODING, encoding);
+        }
+        extra.append("encoding=").append(encoding).append(", ");
+
+        String compression = KuduTableProperties.lookupCompressionString(column.getCompressionAlgorithm());
+        if (!column.getCompressionAlgorithm().equals(ColumnSchema.CompressionAlgorithm.DEFAULT_COMPRESSION)) {
+            properties.put(KuduTableProperties.COMPRESSION, compression);
+        }
+        extra.append("compression=").append(compression);
+
+        Type prestoType = TypeHelper.fromKuduColumn(column);
+        return new ColumnMetadata(column.getName(), prestoType, null, extra.toString(), false, properties);
+    }
+
+    private ConnectorTableMetadata getTableMetadata(KuduTableHandle tableHandle)
+    {
+        KuduTable table = tableHandle.getTable(clientSession);
+        Schema schema = table.getSchema();
+
+        List<ColumnMetadata> columnsMetaList = schema.getColumns().stream()
+                .filter(column -> !column.isKey() || !column.getName().equals(KuduColumnHandle.ROW_ID))
+                .map(this::getColumnMetadata)
+                .collect(toImmutableList());
+
+        Map<String, Object> properties = clientSession.getTableProperties(tableHandle);
+        return new ConnectorTableMetadata(tableHandle.getSchemaTableName(), columnsMetaList, properties);
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle connectorTableHandle)
+    {
+        KuduTableHandle tableHandle = (KuduTableHandle) connectorTableHandle;
+        Schema schema = clientSession.getTableSchema(tableHandle);
+
+        ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
+        for (int ordinal = 0; ordinal < schema.getColumnCount(); ordinal++) {
+            ColumnSchema col = schema.getColumnByIndex(ordinal);
+            String name = col.getName();
+            Type type = TypeHelper.fromKuduColumn(col);
+            KuduColumnHandle columnHandle = new KuduColumnHandle(name, ordinal, type);
+            columnHandles.put(name, columnHandle);
+        }
+
+        return columnHandles.build();
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        KuduColumnHandle kuduColumnHandle = (KuduColumnHandle) columnHandle;
+        if (kuduColumnHandle.isVirtualRowId()) {
+            return new ColumnMetadata(KuduColumnHandle.ROW_ID, VarbinaryType.VARBINARY, null, true);
+        }
+        else {
+            return kuduColumnHandle.getColumnMetadata();
+        }
+    }
+
+    @Override
+    public KuduTableHandle getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        try {
+            KuduTable table = clientSession.openTable(schemaTableName);
+            return new KuduTableHandle(connectorId, schemaTableName, table);
+        }
+        catch (NotFoundException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            Constraint<ColumnHandle> constraint,
+            Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        KuduTableHandle handle = (KuduTableHandle) tableHandle;
+        ConnectorTableLayout layout = new ConnectorTableLayout(
+                new KuduTableLayoutHandle(handle, constraint.getSummary(), desiredColumns));
+        return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
+    }
+
+    @Override
+    public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
+    {
+        return new ConnectorTableLayout(handle);
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        KuduTableHandle kuduTableHandle = (KuduTableHandle) tableHandle;
+        return getTableMetadata(kuduTableHandle);
+    }
+
+    @Override
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
+    {
+        clientSession.createSchema(schemaName);
+    }
+
+    @Override
+    public void dropSchema(ConnectorSession session, String schemaName)
+    {
+        clientSession.dropSchema(schemaName);
+    }
+
+    @Override
+    public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        clientSession.createTable(tableMetadata, ignoreExisting);
+    }
+
+    @Override
+    public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        KuduTableHandle kuduTableHandle = (KuduTableHandle) tableHandle;
+        clientSession.dropTable(kuduTableHandle.getSchemaTableName());
+    }
+
+    @Override
+    public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
+    {
+        KuduTableHandle kuduTableHandle = (KuduTableHandle) tableHandle;
+        clientSession.renameTable(kuduTableHandle.getSchemaTableName(), newTableName);
+    }
+
+    @Override
+    public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
+    {
+        KuduTableHandle kuduTableHandle = (KuduTableHandle) tableHandle;
+        clientSession.addColumn(kuduTableHandle.getSchemaTableName(), column);
+    }
+
+    @Override
+    public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
+    {
+        KuduTableHandle kuduTableHandle = (KuduTableHandle) tableHandle;
+        KuduColumnHandle kuduColumnHandle = (KuduColumnHandle) column;
+        clientSession.dropColumn(kuduTableHandle.getSchemaTableName(), kuduColumnHandle.getName());
+    }
+
+    @Override
+    public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
+    {
+        KuduTableHandle kuduTableHandle = (KuduTableHandle) tableHandle;
+        KuduColumnHandle kuduColumnHandle = (KuduColumnHandle) source;
+        clientSession.renameColumn(kuduTableHandle.getSchemaTableName(), kuduColumnHandle.getName(), target);
+    }
+
+    @Override
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle connectorTableHandle)
+    {
+        KuduTableHandle tableHandle = (KuduTableHandle) connectorTableHandle;
+
+        KuduTable table = tableHandle.getTable(clientSession);
+        Schema schema = table.getSchema();
+
+        List<ColumnSchema> columns = schema.getColumns();
+        List<Type> columnTypes = columns.stream()
+                .map(TypeHelper::fromKuduColumn).collect(toImmutableList());
+
+        return new KuduInsertTableHandle(
+                connectorId,
+                tableHandle.getSchemaTableName(),
+                columnTypes,
+                table);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session,
+            ConnectorInsertTableHandle insertHandle,
+            Collection<Slice> fragments,
+            Collection<ComputedStatistics> computedStatistics)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session,
+            ConnectorTableMetadata tableMetadata,
+            Optional<ConnectorNewTableLayout> layout)
+    {
+        PartitionDesign design = KuduTableProperties.getPartitionDesign(tableMetadata.getProperties());
+        boolean generateUUID = !design.hasPartitions();
+        ConnectorTableMetadata finalTableMetadata = tableMetadata;
+        if (generateUUID) {
+            String rowId = KuduColumnHandle.ROW_ID;
+            List<ColumnMetadata> copy = new ArrayList<>(tableMetadata.getColumns());
+            Map<String, Object> columnProperties = new HashMap<>();
+            columnProperties.put(KuduTableProperties.PRIMARY_KEY, true);
+            copy.add(0, new ColumnMetadata(rowId, VarcharType.VARCHAR, "key=true", null, true, columnProperties));
+            List<ColumnMetadata> finalColumns = ImmutableList.copyOf(copy);
+            Map<String, Object> propsCopy = new HashMap<>(tableMetadata.getProperties());
+            propsCopy.put(KuduTableProperties.PARTITION_BY_HASH_COLUMNS, ImmutableList.of(rowId));
+            propsCopy.put(KuduTableProperties.PARTITION_BY_HASH_BUCKETS, 2);
+            Map<String, Object> finalProperties = ImmutableMap.copyOf(propsCopy);
+            finalTableMetadata = new ConnectorTableMetadata(tableMetadata.getTable(),
+                    finalColumns, finalProperties, tableMetadata.getComment());
+        }
+        KuduTable table = clientSession.createTable(finalTableMetadata, false);
+
+        Schema schema = table.getSchema();
+
+        List<ColumnSchema> columns = schema.getColumns();
+        List<Type> columnTypes = columns.stream()
+                .map(TypeHelper::fromKuduColumn).collect(toImmutableList());
+        List<Type> columnOriginalTypes = finalTableMetadata.getColumns().stream()
+                .map(ColumnMetadata::getType).collect(toImmutableList());
+
+        return new KuduOutputTableHandle(
+                connectorId,
+                finalTableMetadata.getTable(),
+                columnOriginalTypes,
+                columnTypes,
+                generateUUID,
+                table);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session,
+            ConnectorOutputTableHandle tableHandle,
+            Collection<Slice> fragments,
+            Collection<ComputedStatistics> computedStatistics)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        return KuduColumnHandle.ROW_ID_HANDLE;
+    }
+
+    @Override
+    public ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        return tableHandle;
+    }
+
+    @Override
+    public void finishDelete(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
+    {
+    }
+
+    @Override
+    public boolean supportsMetadataDelete(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorTableLayoutHandle tableLayoutHandle)
+    {
+        return false;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduModule.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduModule.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.kudu.procedures.RangePartitionProcedures;
+import com.facebook.presto.kudu.properties.KuduTableProperties;
+import com.facebook.presto.kudu.schema.NoSchemaEmulation;
+import com.facebook.presto.kudu.schema.SchemaEmulation;
+import com.facebook.presto.kudu.schema.SchemaEmulationByTableNameConvention;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.MultibindingsScanner;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import org.apache.kudu.client.KuduClient;
+
+import javax.inject.Singleton;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+public class KuduModule
+        extends AbstractModule
+{
+    private final String connectorId;
+    private final TypeManager typeManager;
+
+    public KuduModule(String connectorId, TypeManager typeManager)
+    {
+        this.connectorId = requireNonNull(connectorId, "connector id is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    protected void configure()
+    {
+        install(MultibindingsScanner.asModule());
+
+        bind(TypeManager.class).toInstance(typeManager);
+
+        bind(KuduConnector.class).in(Scopes.SINGLETON);
+        bind(KuduConnectorId.class).toInstance(new KuduConnectorId(connectorId));
+        bind(KuduMetadata.class).in(Scopes.SINGLETON);
+        bind(KuduTableProperties.class).in(Scopes.SINGLETON);
+        bind(ConnectorSplitManager.class).to(KuduSplitManager.class).in(Scopes.SINGLETON);
+        bind(ConnectorRecordSetProvider.class).to(KuduRecordSetProvider.class)
+                .in(Scopes.SINGLETON);
+        bind(ConnectorPageSourceProvider.class).to(KuduPageSourceProvider.class)
+                .in(Scopes.SINGLETON);
+        bind(ConnectorPageSinkProvider.class).to(KuduPageSinkProvider.class).in(Scopes.SINGLETON);
+        bind(KuduHandleResolver.class).in(Scopes.SINGLETON);
+        bind(KuduRecordSetProvider.class).in(Scopes.SINGLETON);
+        configBinder(binder()).bindConfig(KuduClientConfig.class);
+
+        bind(RangePartitionProcedures.class).in(Scopes.SINGLETON);
+        Multibinder.newSetBinder(binder(), Procedure.class);
+    }
+
+    @ProvidesIntoSet
+    Procedure getAddRangePartitionProcedure(RangePartitionProcedures procedures)
+    {
+        return procedures.getAddPartitionProcedure();
+    }
+
+    @ProvidesIntoSet
+    Procedure getDropRangePartitionProcedure(RangePartitionProcedures procedures)
+    {
+        return procedures.getDropPartitionProcedure();
+    }
+
+    @Singleton
+    @Provides
+    KuduClientSession createKuduClientSession(
+            KuduConnectorId connectorId,
+            KuduClientConfig config)
+    {
+        requireNonNull(config, "config is null");
+
+        KuduClient.KuduClientBuilder builder = new KuduClient.KuduClientBuilder(config.getMasterAddresses());
+        builder.defaultAdminOperationTimeoutMs(config.getDefaultAdminOperationTimeout().toMillis());
+        builder.defaultOperationTimeoutMs(config.getDefaultOperationTimeout().toMillis());
+        builder.defaultSocketReadTimeoutMs(config.getDefaultSocketReadTimeout().toMillis());
+        if (config.isDisableStatistics()) {
+            builder.disableStatistics();
+        }
+        KuduClient client = builder.build();
+
+        SchemaEmulation strategy;
+        if (config.isSchemaEmulationEnabled()) {
+            strategy = new SchemaEmulationByTableNameConvention(config.getSchemaEmulationPrefix());
+        }
+        else {
+            strategy = new NoSchemaEmulation();
+        }
+        return new KuduClientSession(connectorId, client, strategy);
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduOutputTableHandle.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduOutputTableHandle.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import org.apache.kudu.client.KuduTable;
+
+import java.util.List;
+
+public class KuduOutputTableHandle
+        extends KuduTableHandle
+        implements ConnectorOutputTableHandle, KuduTableMapping
+{
+    private final boolean generateUUID;
+    private final List<Type> columnTypes;
+    private final List<Type> originalColumnTypes;
+
+    @JsonCreator
+    public KuduOutputTableHandle(
+            @JsonProperty("connectorId") String connectorId,
+            @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
+            @JsonProperty("originalColumnTypes") List<Type> originalColumnTypes,
+            @JsonProperty("columnTypes") List<Type> columnTypes,
+            @JsonProperty("generateUUID") boolean generateUUID)
+    {
+        this(connectorId, schemaTableName, originalColumnTypes, columnTypes, generateUUID, null);
+    }
+
+    public KuduOutputTableHandle(
+            String connectorId,
+            SchemaTableName schemaTableName,
+            List<Type> originalColumnTypes,
+            List<Type> columnTypes,
+            boolean generateUUID,
+            KuduTable table)
+    {
+        super(connectorId, schemaTableName, table);
+        this.columnTypes = ImmutableList.copyOf(columnTypes);
+        this.originalColumnTypes = ImmutableList.copyOf(originalColumnTypes);
+        this.generateUUID = generateUUID;
+    }
+
+    @JsonProperty
+    public boolean isGenerateUUID()
+    {
+        return generateUUID;
+    }
+
+    @JsonProperty
+    public List<Type> getColumnTypes()
+    {
+        return columnTypes;
+    }
+
+    @JsonProperty
+    public List<Type> getOriginalColumnTypes()
+    {
+        return originalColumnTypes;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduPageSink.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduPageSink.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.SqlDate;
+import com.facebook.presto.spi.type.SqlDecimal;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.KuduSession;
+import org.apache.kudu.client.KuduTable;
+import org.apache.kudu.client.PartialRow;
+import org.apache.kudu.client.SessionConfiguration;
+import org.apache.kudu.client.Upsert;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
+import static java.lang.Float.intBitsToFloat;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class KuduPageSink
+        implements ConnectorPageSink
+{
+    private final ConnectorSession connectorSession;
+    private final KuduSession session;
+    private final KuduTable table;
+    private final List<Type> columnTypes;
+    private final List<Type> originalColumnTypes;
+    private final boolean generateUUID;
+
+    private final String uuid;
+    private int nextSubId;
+
+    public KuduPageSink(
+            ConnectorSession connectorSession,
+            KuduClientSession clientSession,
+            KuduInsertTableHandle tableHandle)
+    {
+        this(connectorSession, clientSession, tableHandle, tableHandle);
+    }
+
+    public KuduPageSink(
+            ConnectorSession connectorSession,
+            KuduClientSession clientSession,
+            KuduOutputTableHandle tableHandle)
+    {
+        this(connectorSession, clientSession, tableHandle, tableHandle);
+    }
+
+    private KuduPageSink(
+            ConnectorSession connectorSession,
+            KuduClientSession clientSession,
+            KuduTableHandle tableHandle,
+            KuduTableMapping mapping)
+    {
+        requireNonNull(clientSession, "clientSession is null");
+        this.connectorSession = connectorSession;
+        this.columnTypes = mapping.getColumnTypes();
+        this.originalColumnTypes = mapping.getOriginalColumnTypes();
+        this.generateUUID = mapping.isGenerateUUID();
+
+        this.table = tableHandle.getTable(clientSession);
+        this.session = clientSession.newSession();
+        this.session.setFlushMode(SessionConfiguration.FlushMode.AUTO_FLUSH_BACKGROUND);
+        uuid = UUID.randomUUID().toString();
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            Upsert upsert = table.newUpsert();
+            PartialRow row = upsert.getRow();
+            int start = 0;
+            if (generateUUID) {
+                String id = String.format("%s-%08x", uuid, nextSubId++);
+                row.addString(0, id);
+                start = 1;
+            }
+
+            for (int channel = 0; channel < page.getChannelCount(); channel++) {
+                appendColumn(row, page, position, channel, channel + start);
+            }
+
+            try {
+                session.apply(upsert);
+            }
+            catch (KuduException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return NOT_BLOCKED;
+    }
+
+    private void appendColumn(PartialRow row, Page page, int position, int channel, int destChannel)
+    {
+        Block block = page.getBlock(channel);
+        Type type = columnTypes.get(destChannel);
+        if (block.isNull(position)) {
+            row.setNull(destChannel);
+        }
+        else if (TIMESTAMP.equals(type)) {
+            row.addLong(destChannel, type.getLong(block, position) * 1000);
+        }
+        else if (REAL.equals(type)) {
+            row.addFloat(destChannel, intBitsToFloat((int) type.getLong(block, position)));
+        }
+        else if (BIGINT.equals(type)) {
+            row.addLong(destChannel, type.getLong(block, position));
+        }
+        else if (INTEGER.equals(type)) {
+            row.addInt(destChannel, (int) type.getLong(block, position));
+        }
+        else if (SMALLINT.equals(type)) {
+            row.addShort(destChannel, (short) type.getLong(block, position));
+        }
+        else if (TINYINT.equals(type)) {
+            row.addByte(destChannel, (byte) type.getLong(block, position));
+        }
+        else if (BOOLEAN.equals(type)) {
+            row.addBoolean(destChannel, type.getBoolean(block, position));
+        }
+        else if (DOUBLE.equals(type)) {
+            row.addDouble(destChannel, type.getDouble(block, position));
+        }
+        else if (isVarcharType(type)) {
+            Type originalType = originalColumnTypes.get(destChannel);
+            if (DATE.equals(originalType)) {
+                SqlDate date = (SqlDate) originalType.getObjectValue(connectorSession, block, position);
+                LocalDateTime ldt = LocalDateTime.ofEpochSecond(TimeUnit.DAYS.toSeconds(date.getDays()), 0, ZoneOffset.UTC);
+                byte[] bytes = ldt.format(DateTimeFormatter.ISO_LOCAL_DATE).getBytes(StandardCharsets.UTF_8);
+                row.addStringUtf8(destChannel, bytes);
+            }
+            else {
+                row.addString(destChannel, type.getSlice(block, position).toStringUtf8());
+            }
+        }
+        else if (VARBINARY.equals(type)) {
+            row.addBinary(destChannel, type.getSlice(block, position).toByteBuffer());
+        }
+        else if (type instanceof DecimalType) {
+            SqlDecimal sqlDecimal = (SqlDecimal) type.getObjectValue(connectorSession, block, position);
+            row.addDecimal(destChannel, sqlDecimal.toBigDecimal());
+        }
+        else {
+            throw new UnsupportedOperationException("Type is not supported: " + type);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        closeSession();
+        return completedFuture(ImmutableList.of());
+    }
+
+    @Override
+    public void abort()
+    {
+        closeSession();
+    }
+
+    private void closeSession()
+    {
+        try {
+            session.close();
+        }
+        catch (KuduException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduPageSinkProvider.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduPageSinkProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import javax.inject.Inject;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class KuduPageSinkProvider
+        implements ConnectorPageSinkProvider
+{
+    private final KuduClientSession clientSession;
+
+    @Inject
+    public KuduPageSinkProvider(KuduClientSession clientSession)
+    {
+        this.clientSession = requireNonNull(clientSession, "clientSession is null");
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle)
+    {
+        requireNonNull(outputTableHandle, "outputTableHandle is null");
+        checkArgument(outputTableHandle instanceof KuduOutputTableHandle, "outputTableHandle is not an instance of KuduOutputTableHandle");
+        KuduOutputTableHandle handle = (KuduOutputTableHandle) outputTableHandle;
+
+        return new KuduPageSink(session, clientSession, handle);
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle)
+    {
+        requireNonNull(insertTableHandle, "insertTableHandle is null");
+        checkArgument(insertTableHandle instanceof KuduInsertTableHandle, "insertTableHandle is not an instance of KuduInsertTableHandle");
+        KuduInsertTableHandle handle = (KuduInsertTableHandle) insertTableHandle;
+
+        return new KuduPageSink(session, clientSession, handle);
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduPageSourceProvider.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduPageSourceProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.RecordPageSource;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class KuduPageSourceProvider
+        implements ConnectorPageSourceProvider
+{
+    private KuduRecordSetProvider recordSetProvider;
+
+    @Inject
+    public KuduPageSourceProvider(KuduRecordSetProvider recordSetProvider)
+    {
+        this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+    }
+
+    @Override
+    public ConnectorPageSource createPageSource(ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session, ConnectorSplit split, List<ColumnHandle> columns)
+    {
+        KuduRecordSet recordSet = (KuduRecordSet) recordSetProvider.getRecordSet(transactionHandle, session, split, columns);
+        if (columns.contains(KuduColumnHandle.ROW_ID_HANDLE)) {
+            return new KuduUpdatablePageSource(recordSet);
+        }
+        else {
+            return new RecordPageSource(recordSet);
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduPlugin.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.collect.ImmutableList;
+
+public class KuduPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new KuduConnectorFactory());
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduRecordCursor.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduRecordCursor.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.KuduScanner;
+import org.apache.kudu.client.RowResult;
+import org.apache.kudu.client.RowResultIterator;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+public class KuduRecordCursor
+        implements RecordCursor
+{
+    private static final Logger log = Logger.get(KuduRecordCursor.class);
+
+    private final KuduScanner scanner;
+    private final List<Type> columnTypes;
+    private final Field rowDataField;
+    private RowResultIterator nextRows;
+    protected RowResult currentRow;
+
+    private long totalBytes;
+    private long nanoStart;
+    private long nanoEnd;
+    private boolean started;
+
+    public KuduRecordCursor(KuduScanner scanner, List<Type> columnTypes)
+    {
+        this.scanner = scanner;
+        this.columnTypes = columnTypes;
+        Field field = null;
+        try {
+            field = RowResult.class.getDeclaredField("rawData");
+            field.setAccessible(true);
+        }
+        catch (NoSuchFieldException e) {
+            // ignore
+        }
+        this.rowDataField = field;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return totalBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return nanoStart > 0L ? (nanoEnd == 0 ? System.nanoTime() : nanoEnd) - nanoStart : 0L;
+    }
+
+    @Override
+    public Type getType(int field)
+    {
+        return columnTypes.get(field);
+    }
+
+    protected int mapping(int field)
+    {
+        return field;
+    }
+
+    /**
+     * get next Row/Page
+     */
+    @Override
+    public boolean advanceNextPosition()
+    {
+        boolean needNextRows = !started || !nextRows.hasNext();
+
+        if (!started) {
+            started = true;
+            nanoStart = System.nanoTime();
+        }
+
+        if (needNextRows) {
+            currentRow = null;
+            try {
+                do {
+                    if (!scanner.hasMoreRows()) {
+                        return false;
+                    }
+
+                    nextRows = scanner.nextRows();
+                } while (!nextRows.hasNext());
+                log.debug("Fetched " + nextRows.getNumRows() + " rows");
+            }
+            catch (KuduException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        currentRow = nextRows.next();
+        totalBytes += getRowLength();
+        return true;
+    }
+
+    private org.apache.kudu.util.Slice getCurrentRowRawData()
+    {
+        if (rowDataField != null && currentRow != null) {
+            try {
+                return ((org.apache.kudu.util.Slice) rowDataField.get(currentRow));
+            }
+            catch (IllegalAccessException e) {
+                return null;
+            }
+        }
+        else {
+            return null;
+        }
+    }
+
+    private int getRowLength()
+    {
+        org.apache.kudu.util.Slice rawData = getCurrentRowRawData();
+        if (rawData != null) {
+            return rawData.length();
+        }
+        else {
+            return columnTypes.size();
+        }
+    }
+
+    @Override
+    public boolean getBoolean(int field)
+    {
+        int index = mapping(field);
+        return TypeHelper.getBoolean(columnTypes.get(field), currentRow, index);
+    }
+
+    @Override
+    public long getLong(int field)
+    {
+        int index = mapping(field);
+        return TypeHelper.getLong(columnTypes.get(field), currentRow, index);
+    }
+
+    @Override
+    public double getDouble(int field)
+    {
+        int index = mapping(field);
+        return TypeHelper.getDouble(columnTypes.get(field), currentRow, index);
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        int index = mapping(field);
+        return TypeHelper.getSlice(columnTypes.get(field), currentRow, index);
+    }
+
+    @Override
+    public Object getObject(int field)
+    {
+        int index = mapping(field);
+        return TypeHelper.getObject(columnTypes.get(field), currentRow, index);
+    }
+
+    @Override
+    public boolean isNull(int field)
+    {
+        int mappedField = mapping(field);
+        return mappedField >= 0 && currentRow.isNull(mappedField);
+    }
+
+    @Override
+    public void close()
+    {
+        nanoEnd = System.nanoTime();
+        currentRow = null;
+        nextRows = null;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduRecordCursorWithVirtualRowId.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduRecordCursorWithVirtualRowId.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.kudu.Schema;
+import org.apache.kudu.client.KeyEncoderAccessor;
+import org.apache.kudu.client.KuduScanner;
+import org.apache.kudu.client.KuduTable;
+import org.apache.kudu.client.PartialRow;
+
+import java.util.List;
+import java.util.Map;
+
+public class KuduRecordCursorWithVirtualRowId
+        extends KuduRecordCursor
+{
+    private final KuduTable table;
+    private final Map<Integer, Integer> fieldMapping;
+
+    public KuduRecordCursorWithVirtualRowId(KuduScanner scanner, KuduTable table,
+            List<Type> columnTypes,
+            Map<Integer, Integer> fieldMapping)
+    {
+        super(scanner, columnTypes);
+        this.table = table;
+        this.fieldMapping = fieldMapping;
+    }
+
+    @Override
+    protected int mapping(int field)
+    {
+        return fieldMapping.get(field);
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        if (fieldMapping.get(field) == -1) {
+            PartialRow partialRow = buildPrimaryKey();
+            return Slices.wrappedBuffer(KeyEncoderAccessor.encodePrimaryKey(partialRow));
+        }
+        else {
+            return super.getSlice(field);
+        }
+    }
+
+    private PartialRow buildPrimaryKey()
+    {
+        Schema schema = table.getSchema();
+        PartialRow row = new PartialRow(schema);
+        RowHelper.copyPrimaryKey(schema, currentRow, row);
+        return row;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduRecordSet.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduRecordSet.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.RecordSet;
+import com.facebook.presto.spi.type.Type;
+import org.apache.kudu.client.KuduScanner;
+import org.apache.kudu.client.KuduTable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class KuduRecordSet
+        implements RecordSet
+{
+    private final KuduClientSession clientSession;
+    private final KuduSplit kuduSplit;
+    private final List<? extends ColumnHandle> columns;
+    private final boolean containsVirtualRowId;
+
+    public KuduRecordSet(KuduClientSession clientSession, KuduSplit kuduSplit, List<? extends ColumnHandle> columns)
+    {
+        this.clientSession = clientSession;
+        this.kuduSplit = kuduSplit;
+        this.columns = columns;
+        this.containsVirtualRowId = columns.contains(KuduColumnHandle.ROW_ID_HANDLE);
+    }
+
+    @Override
+    public List<Type> getColumnTypes()
+    {
+        return columns.stream()
+                .map(column -> ((KuduColumnHandle) column).getType())
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public RecordCursor cursor()
+    {
+        KuduScanner scanner = clientSession.createScanner(kuduSplit);
+        if (!containsVirtualRowId) {
+            return new KuduRecordCursor(scanner, getColumnTypes());
+        }
+        else {
+            final int primaryKeyColumnCount = kuduSplit.getPrimaryKeyColumnCount();
+
+            Map<Integer, Integer> fieldMapping = new HashMap<>();
+            int index = primaryKeyColumnCount;
+            for (int i = 0; i < columns.size(); i++) {
+                KuduColumnHandle handle = (KuduColumnHandle) columns.get(i);
+                if (!handle.isVirtualRowId()) {
+                    if (handle.getOrdinalPosition() < primaryKeyColumnCount) {
+                        fieldMapping.put(i, handle.getOrdinalPosition());
+                    }
+                    else {
+                        fieldMapping.put(i, index);
+                        index++;
+                    }
+                }
+                else {
+                    fieldMapping.put(i, -1);
+                }
+            }
+
+            KuduTable table = getTable();
+            return new KuduRecordCursorWithVirtualRowId(scanner, table, getColumnTypes(), fieldMapping);
+        }
+    }
+
+    KuduTable getTable()
+    {
+        return kuduSplit.getTableHandle().getTable(clientSession);
+    }
+
+    KuduClientSession getClientSession()
+    {
+        return clientSession;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduRecordSetProvider.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduRecordSetProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.RecordSet;
+import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class KuduRecordSetProvider
+        implements ConnectorRecordSetProvider
+{
+    private final String connectorId;
+    private final KuduClientSession clientSession;
+
+    @Inject
+    public KuduRecordSetProvider(KuduConnectorId connectorId, KuduClientSession clientSession)
+    {
+        this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
+        this.clientSession = clientSession;
+    }
+
+    @Override
+    public RecordSet getRecordSet(ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session, ConnectorSplit split, List<? extends ColumnHandle> columns)
+    {
+        requireNonNull(split, "split is null");
+        requireNonNull(columns, "columns is null");
+
+        KuduSplit kuduSplit = (KuduSplit) split;
+
+        return new KuduRecordSet(clientSession, kuduSplit, columns);
+    }
+
+    public KuduClientSession getClientSession()
+    {
+        return clientSession;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplit.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplit.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.HostAddress;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class KuduSplit
+        implements ConnectorSplit
+{
+    private final KuduTableHandle tableHandle;
+    private final int primaryKeyColumnCount;
+    private final byte[] serializedScanToken;
+
+    @JsonCreator
+    public KuduSplit(@JsonProperty("tableHandle") KuduTableHandle tableHandle,
+            @JsonProperty("primaryKeyColumnCount") int primaryKeyColumnCount,
+            @JsonProperty("serializedScanToken") byte[] serializedScanToken)
+    {
+        this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+        this.primaryKeyColumnCount = primaryKeyColumnCount;
+        this.serializedScanToken = requireNonNull(serializedScanToken, "serializedScanToken is null");
+    }
+
+    @JsonProperty
+    public KuduTableHandle getTableHandle()
+    {
+        return tableHandle;
+    }
+
+    @JsonProperty
+    public byte[] getSerializedScanToken()
+    {
+        return serializedScanToken;
+    }
+
+    @JsonProperty
+    public int getPrimaryKeyColumnCount()
+    {
+        return primaryKeyColumnCount;
+    }
+
+    @Override
+    public boolean isRemotelyAccessible()
+    {
+        return true;
+    }
+
+    @Override
+    public List<HostAddress> getAddresses()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return this;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplitManager.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplitManager.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.FixedSplitSource;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class KuduSplitManager
+        implements ConnectorSplitManager
+{
+    private final String connectorId;
+    private final KuduClientSession clientSession;
+
+    @Inject
+    public KuduSplitManager(KuduConnectorId connectorId, KuduClientSession clientSession)
+    {
+        this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
+        this.clientSession = requireNonNull(clientSession, "clientSession is null");
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session, ConnectorTableLayoutHandle layout,
+            SplitSchedulingStrategy splitSchedulingStrategy)
+    {
+        KuduTableLayoutHandle layoutHandle = (KuduTableLayoutHandle) layout;
+
+        List<KuduSplit> splits = clientSession.buildKuduSplits(layoutHandle);
+
+        return new FixedSplitSource(splits);
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTableHandle.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTableHandle.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.kudu.client.KuduTable;
+
+import java.util.Objects;
+
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public class KuduTableHandle
+        implements ConnectorTableHandle
+{
+    private final String connectorId;
+    private final SchemaTableName schemaTableName;
+    private transient KuduTable table;
+
+    @JsonCreator
+    public KuduTableHandle(
+            @JsonProperty("connectorId") String connectorId,
+            @JsonProperty("schemaTableName") SchemaTableName schemaTableName)
+    {
+        this(connectorId, schemaTableName, null);
+    }
+
+    public KuduTableHandle(
+            String connectorId,
+            SchemaTableName schemaTableName,
+            KuduTable table)
+    {
+        this.connectorId = requireNonNull(connectorId.toLowerCase(ENGLISH), "connectorId is null");
+        this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+        this.table = table;
+    }
+
+    public KuduTable getTable(KuduClientSession session)
+    {
+        if (table == null) {
+            table = session.openTable(schemaTableName);
+        }
+        return table;
+    }
+
+    @JsonProperty
+    public String getConnectorId()
+    {
+        return connectorId;
+    }
+
+    @JsonProperty
+    public SchemaTableName getSchemaTableName()
+    {
+        return schemaTableName;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(connectorId, schemaTableName);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        KuduTableHandle other = (KuduTableHandle) obj;
+        return Objects.equals(this.connectorId, other.connectorId) && this.schemaTableName
+                .equals(other.getSchemaTableName());
+    }
+
+    @Override
+    public String toString()
+    {
+        return connectorId + ":" + schemaTableName;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTableLayoutHandle.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTableLayoutHandle.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class KuduTableLayoutHandle
+        implements ConnectorTableLayoutHandle
+{
+    private final KuduTableHandle tableHandle;
+    private final TupleDomain<ColumnHandle> constraintSummary;
+    private final Optional<Set<ColumnHandle>> desiredColumns;
+
+    @JsonCreator
+    public KuduTableLayoutHandle(@JsonProperty("tableHandle") KuduTableHandle tableHandle,
+            @JsonProperty("constraintSummary") TupleDomain<ColumnHandle> constraintSummary,
+            @JsonProperty("desiredColumns") Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        this.tableHandle = requireNonNull(tableHandle, "table is null");
+        this.constraintSummary = constraintSummary;
+        this.desiredColumns = desiredColumns;
+    }
+
+    @JsonProperty
+    public KuduTableHandle getTableHandle()
+    {
+        return tableHandle;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraintSummary()
+    {
+        return constraintSummary;
+    }
+
+    @JsonProperty
+    public Optional<Set<ColumnHandle>> getDesiredColumns()
+    {
+        return desiredColumns;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        KuduTableLayoutHandle other = (KuduTableLayoutHandle) obj;
+        return Objects.equals(tableHandle, other.tableHandle)
+                && Objects.equals(constraintSummary, other.constraintSummary)
+                && Objects.equals(desiredColumns, other.desiredColumns);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(tableHandle,
+                constraintSummary,
+                desiredColumns);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("tableHandle", tableHandle)
+                .add("constraintSummary", constraintSummary)
+                .add("desiredColumns", desiredColumns)
+                .toString();
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTableMapping.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTableMapping.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.type.Type;
+
+import java.util.List;
+
+interface KuduTableMapping
+{
+    boolean isGenerateUUID();
+
+    List<Type> getColumnTypes();
+
+    List<Type> getOriginalColumnTypes();
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTransactionHandle.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduTransactionHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public enum KuduTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    INSTANCE
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduUpdatablePageSource.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduUpdatablePageSource.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.RecordPageSource;
+import com.facebook.presto.spi.UpdatablePageSource;
+import com.facebook.presto.spi.block.Block;
+import io.airlift.slice.Slice;
+import org.apache.kudu.Schema;
+import org.apache.kudu.client.Delete;
+import org.apache.kudu.client.KeyEncoderAccessor;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.KuduSession;
+import org.apache.kudu.client.KuduTable;
+import org.apache.kudu.client.PartialRow;
+import org.apache.kudu.client.SessionConfiguration.FlushMode;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+public class KuduUpdatablePageSource
+        implements UpdatablePageSource
+{
+    private final KuduClientSession clientSession;
+    private final KuduTable table;
+    private final RecordPageSource inner;
+
+    public KuduUpdatablePageSource(KuduRecordSet recordSet)
+    {
+        this.clientSession = recordSet.getClientSession();
+        this.table = recordSet.getTable();
+        this.inner = new RecordPageSource(recordSet);
+    }
+
+    @Override
+    public void deleteRows(Block rowIds)
+    {
+        Schema schema = table.getSchema();
+        KuduSession session = clientSession.newSession();
+        session.setFlushMode(FlushMode.AUTO_FLUSH_BACKGROUND);
+        try {
+            try {
+                for (int i = 0; i < rowIds.getPositionCount(); i++) {
+                    int len = rowIds.getSliceLength(i);
+                    Slice slice = rowIds.getSlice(i, 0, len);
+                    PartialRow row = KeyEncoderAccessor.decodePrimaryKey(schema, slice.getBytes());
+                    Delete delete = table.newDelete();
+                    RowHelper.copyPrimaryKey(schema, row, delete.getRow());
+                    session.apply(delete);
+                }
+            }
+            finally {
+                session.close();
+            }
+        }
+        catch (KuduException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        CompletableFuture<Collection<Slice>> cf = new CompletableFuture<>();
+        cf.complete(Collections.emptyList());
+        return cf;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return inner.getCompletedBytes();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return inner.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return inner.isFinished();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        return inner.getNextPage();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return inner.getSystemMemoryUsage();
+    }
+
+    @Override
+    public void close()
+    {
+        inner.close();
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/RangePartitionChange.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/RangePartitionChange.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+enum RangePartitionChange
+{
+    ADD, DROP
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/RowHelper.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/RowHelper.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import org.apache.kudu.Schema;
+import org.apache.kudu.client.PartialRow;
+import org.apache.kudu.client.RowResult;
+
+import java.nio.charset.StandardCharsets;
+
+public class RowHelper
+{
+    private RowHelper()
+    {
+    }
+
+    public static void copyPrimaryKey(Schema schema, RowResult from, PartialRow to)
+    {
+        for (int i = 0; i < schema.getPrimaryKeyColumnCount(); i++) {
+            switch (schema.getColumnByIndex(i).getType()) {
+                case STRING:
+                    to.addStringUtf8(i, from.getString(i).getBytes(StandardCharsets.UTF_8));
+                    break;
+                case INT64:
+                case UNIXTIME_MICROS:
+                    to.addLong(i, from.getLong(i));
+                    break;
+                case INT32:
+                    to.addInt(i, from.getInt(i));
+                    break;
+                case INT16:
+                    to.addShort(i, from.getShort(i));
+                    break;
+                case INT8:
+                    to.addByte(i, from.getByte(i));
+                    break;
+                case DOUBLE:
+                    to.addDouble(i, from.getDouble(i));
+                    break;
+                case FLOAT:
+                    to.addFloat(i, from.getFloat(i));
+                    break;
+                case BOOL:
+                    to.addBoolean(i, from.getBoolean(i));
+                    break;
+                case BINARY:
+                    to.addBinary(i, from.getBinary(i));
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown type " + schema.getColumnByIndex(i).getType()
+                            + " for column " + schema.getColumnByIndex(i).getName());
+            }
+        }
+    }
+
+    public static void copyPrimaryKey(Schema schema, PartialRow from, PartialRow to)
+    {
+        for (int i = 0; i < schema.getPrimaryKeyColumnCount(); i++) {
+            switch (schema.getColumnByIndex(i).getType()) {
+                case STRING:
+                    to.addStringUtf8(i, from.getString(i).getBytes(StandardCharsets.UTF_8));
+                    break;
+                case INT64:
+                case UNIXTIME_MICROS:
+                    to.addLong(i, from.getLong(i));
+                    break;
+                case INT32:
+                    to.addInt(i, from.getInt(i));
+                    break;
+                case INT16:
+                    to.addShort(i, from.getShort(i));
+                    break;
+                case INT8:
+                    to.addByte(i, from.getByte(i));
+                    break;
+                case DOUBLE:
+                    to.addDouble(i, from.getDouble(i));
+                    break;
+                case FLOAT:
+                    to.addFloat(i, from.getFloat(i));
+                    break;
+                case BOOL:
+                    to.addBoolean(i, from.getBoolean(i));
+                    break;
+                case BINARY:
+                    to.addBinary(i, from.getBinary(i));
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown type " + schema.getColumnByIndex(i).getType()
+                            + " for column " + schema.getColumnByIndex(i).getName());
+            }
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/TypeHelper.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/TypeHelper.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.CharType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.SmallintType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TinyintType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.facebook.presto.spi.type.VarcharType;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.ColumnTypeAttributes;
+import org.apache.kudu.client.RowResult;
+
+import java.math.BigDecimal;
+
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+public class TypeHelper
+{
+    private TypeHelper()
+    {
+    }
+
+    public static org.apache.kudu.Type toKuduClientType(Type type)
+    {
+        if (type instanceof VarcharType) {
+            return org.apache.kudu.Type.STRING;
+        }
+        else if (type == TimestampType.TIMESTAMP) {
+            return org.apache.kudu.Type.UNIXTIME_MICROS;
+        }
+        else if (type == BigintType.BIGINT) {
+            return org.apache.kudu.Type.INT64;
+        }
+        else if (type == IntegerType.INTEGER) {
+            return org.apache.kudu.Type.INT32;
+        }
+        else if (type == SmallintType.SMALLINT) {
+            return org.apache.kudu.Type.INT16;
+        }
+        else if (type == TinyintType.TINYINT) {
+            return org.apache.kudu.Type.INT8;
+        }
+        else if (type == RealType.REAL) {
+            return org.apache.kudu.Type.FLOAT;
+        }
+        else if (type == DoubleType.DOUBLE) {
+            return org.apache.kudu.Type.DOUBLE;
+        }
+        else if (type == BooleanType.BOOLEAN) {
+            return org.apache.kudu.Type.BOOL;
+        }
+        else if (type instanceof VarbinaryType) {
+            return org.apache.kudu.Type.BINARY;
+        }
+        else if (type instanceof DecimalType) {
+            return org.apache.kudu.Type.DECIMAL;
+        }
+        else if (type == DateType.DATE) {
+            return org.apache.kudu.Type.STRING;
+        }
+        else if (type instanceof CharType) {
+            return org.apache.kudu.Type.STRING;
+        }
+        else {
+            throw new IllegalStateException("Type mapping implemented for Presto type: " + type);
+        }
+    }
+
+    public static Type fromKuduColumn(ColumnSchema column)
+    {
+        return fromKuduClientType(column.getType(), column.getTypeAttributes());
+    }
+
+    private static Type fromKuduClientType(org.apache.kudu.Type ktype, ColumnTypeAttributes attributes)
+    {
+        switch (ktype) {
+            case STRING:
+                return VarcharType.VARCHAR;
+            case UNIXTIME_MICROS:
+                return TimestampType.TIMESTAMP;
+            case INT64:
+                return BigintType.BIGINT;
+            case INT32:
+                return IntegerType.INTEGER;
+            case INT16:
+                return SmallintType.SMALLINT;
+            case INT8:
+                return TinyintType.TINYINT;
+            case FLOAT:
+                return RealType.REAL;
+            case DOUBLE:
+                return DoubleType.DOUBLE;
+            case BOOL:
+                return BooleanType.BOOLEAN;
+            case BINARY:
+                return VarbinaryType.VARBINARY;
+            case DECIMAL:
+                return DecimalType.createDecimalType(attributes.getPrecision(), attributes.getScale());
+            default:
+                throw new IllegalStateException("Kudu type not implemented for " + ktype);
+        }
+    }
+
+    public static Object getJavaValue(Type type, Object nativeValue)
+    {
+        if (type instanceof VarcharType) {
+            return ((Slice) nativeValue).toStringUtf8();
+        }
+        else if (type == TimestampType.TIMESTAMP) {
+            return ((Long) nativeValue) * 1000;
+        }
+        else if (type == BigintType.BIGINT) {
+            return nativeValue;
+        }
+        else if (type == IntegerType.INTEGER) {
+            return ((Long) nativeValue).intValue();
+        }
+        else if (type == SmallintType.SMALLINT) {
+            return ((Long) nativeValue).shortValue();
+        }
+        else if (type == TinyintType.TINYINT) {
+            return ((Long) nativeValue).byteValue();
+        }
+        else if (type == DoubleType.DOUBLE) {
+            return nativeValue;
+        }
+        else if (type == RealType.REAL) {
+            // conversion can result in precision lost
+            return intBitsToFloat(((Long) nativeValue).intValue());
+        }
+        else if (type == BooleanType.BOOLEAN) {
+            return nativeValue;
+        }
+        else if (type instanceof VarbinaryType) {
+            return ((Slice) nativeValue).toByteBuffer();
+        }
+        else if (type instanceof DecimalType) {
+            return nativeValue;
+        }
+        else {
+            throw new IllegalStateException("Back conversion not implemented for " + type);
+        }
+    }
+
+    public static Object getObject(Type type, RowResult row, int field)
+    {
+        if (row.isNull(field)) {
+            return null;
+        }
+        else {
+            if (type instanceof VarcharType) {
+                return row.getString(field);
+            }
+            else if (type == TimestampType.TIMESTAMP) {
+                return row.getLong(field) / 1000;
+            }
+            else if (type == BigintType.BIGINT) {
+                return row.getLong(field);
+            }
+            else if (type == IntegerType.INTEGER) {
+                return row.getInt(field);
+            }
+            else if (type == SmallintType.SMALLINT) {
+                return row.getShort(field);
+            }
+            else if (type == TinyintType.TINYINT) {
+                return row.getByte(field);
+            }
+            else if (type == DoubleType.DOUBLE) {
+                return row.getDouble(field);
+            }
+            else if (type == RealType.REAL) {
+                return row.getFloat(field);
+            }
+            else if (type == BooleanType.BOOLEAN) {
+                return row.getBoolean(field);
+            }
+            else if (type instanceof VarbinaryType) {
+                return Slices.wrappedBuffer(row.getBinary(field));
+            }
+            else if (type instanceof DecimalType) {
+                return row.getDecimal(field);
+            }
+            else {
+                throw new IllegalStateException("getObject not implemented for " + type);
+            }
+        }
+    }
+
+    public static long getLong(Type type, RowResult row, int field)
+    {
+        if (type == TimestampType.TIMESTAMP) {
+            return row.getLong(field) / 1000;
+        }
+        else if (type == BigintType.BIGINT) {
+            return row.getLong(field);
+        }
+        else if (type == IntegerType.INTEGER) {
+            return row.getInt(field);
+        }
+        else if (type == SmallintType.SMALLINT) {
+            return row.getShort(field);
+        }
+        else if (type == TinyintType.TINYINT) {
+            return row.getByte(field);
+        }
+        else if (type == RealType.REAL) {
+            return floatToRawIntBits(row.getFloat(field));
+        }
+        else if (type instanceof DecimalType) {
+            DecimalType dtype = (DecimalType) type;
+            if (dtype.isShort()) {
+                return row.getDecimal(field).unscaledValue().longValue();
+            }
+            else {
+                throw new IllegalStateException("getLong not supported for long decimal: " + type);
+            }
+        }
+        else {
+            throw new IllegalStateException("getLong not implemented for " + type);
+        }
+    }
+
+    public static boolean getBoolean(Type type, RowResult row, int field)
+    {
+        if (type == BooleanType.BOOLEAN) {
+            return row.getBoolean(field);
+        }
+        else {
+            throw new IllegalStateException("getBoolean not implemented for " + type);
+        }
+    }
+
+    public static double getDouble(Type type, RowResult row, int field)
+    {
+        if (type == DoubleType.DOUBLE) {
+            return row.getDouble(field);
+        }
+        else {
+            throw new IllegalStateException("getDouble not implemented for " + type);
+        }
+    }
+
+    public static Slice getSlice(Type type, RowResult row, int field)
+    {
+        if (type instanceof VarcharType) {
+            return Slices.utf8Slice(row.getString(field));
+        }
+        else if (type instanceof VarbinaryType) {
+            return Slices.wrappedBuffer(row.getBinary(field));
+        }
+        else if (type instanceof DecimalType) {
+            BigDecimal dec = row.getDecimal(field);
+            return Decimals.encodeScaledValue(dec);
+        }
+        else {
+            throw new IllegalStateException("getSlice not implemented for " + type);
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/procedures/RangePartitionProcedures.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/procedures/RangePartitionProcedures.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.procedures;
+
+import com.facebook.presto.kudu.KuduClientSession;
+import com.facebook.presto.kudu.properties.KuduTableProperties;
+import com.facebook.presto.kudu.properties.RangePartition;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.facebook.presto.spi.procedure.Procedure.Argument;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.spi.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class RangePartitionProcedures
+{
+    private static final MethodHandle ADD = methodHandle(RangePartitionProcedures.class, "addRangePartition",
+            String.class, String.class, String.class);
+    private static final MethodHandle DROP = methodHandle(RangePartitionProcedures.class, "dropRangePartition",
+            String.class, String.class, String.class);
+
+    private final KuduClientSession clientSession;
+
+    @Inject
+    public RangePartitionProcedures(KuduClientSession clientSession)
+    {
+        this.clientSession = requireNonNull(clientSession);
+    }
+
+    public Procedure getAddPartitionProcedure()
+    {
+        return new Procedure(
+                "system",
+                "add_range_partition",
+                ImmutableList.of(new Argument("schema", VARCHAR), new Argument("table", VARCHAR),
+                        new Argument("range_bounds", VARCHAR)),
+                ADD.bindTo(this));
+    }
+
+    public Procedure getDropPartitionProcedure()
+    {
+        return new Procedure(
+                "system",
+                "drop_range_partition",
+                ImmutableList.of(new Argument("schema", VARCHAR), new Argument("table", VARCHAR),
+                        new Argument("range_bounds", VARCHAR)),
+                DROP.bindTo(this));
+    }
+
+    public void addRangePartition(String schema, String table, String rangeBounds)
+    {
+        SchemaTableName schemaTableName = new SchemaTableName(schema, table);
+        RangePartition rangePartition = KuduTableProperties.parseRangePartition(rangeBounds);
+        clientSession.addRangePartition(schemaTableName, rangePartition);
+    }
+
+    public void dropRangePartition(String schema, String table, String rangeBounds)
+    {
+        SchemaTableName schemaTableName = new SchemaTableName(schema, table);
+        RangePartition rangePartition = KuduTableProperties.parseRangePartition(rangeBounds);
+        clientSession.dropRangePartition(schemaTableName, rangePartition);
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/ColumnDesign.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/ColumnDesign.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+public class ColumnDesign
+{
+    public static final ColumnDesign DEFAULT;
+
+    static {
+        ColumnDesign design = new ColumnDesign();
+        design.setNullable(true);
+        DEFAULT = design;
+    }
+
+    private boolean primaryKey;
+    private boolean nullable;
+    private String encoding;
+    private String compression;
+
+    public boolean isPrimaryKey()
+    {
+        return primaryKey;
+    }
+
+    public void setPrimaryKey(boolean primaryKey)
+    {
+        this.primaryKey = primaryKey;
+    }
+
+    public String getEncoding()
+    {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding)
+    {
+        this.encoding = encoding;
+    }
+
+    public String getCompression()
+    {
+        return compression;
+    }
+
+    public void setCompression(String compression)
+    {
+        this.compression = compression;
+    }
+
+    public boolean isNullable()
+    {
+        return nullable;
+    }
+
+    public void setNullable(boolean nullable)
+    {
+        this.nullable = nullable;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/HashPartitionDefinition.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/HashPartitionDefinition.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+import java.util.List;
+
+public class HashPartitionDefinition
+{
+    private List<String> columns;
+    private int buckets;
+
+    public List<String> getColumns()
+    {
+        return columns;
+    }
+
+    public void setColumns(List<String> columns)
+    {
+        this.columns = columns;
+    }
+
+    public int getBuckets()
+    {
+        return buckets;
+    }
+
+    public void setBuckets(int buckets)
+    {
+        this.buckets = buckets;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/KuduTableProperties.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/KuduTableProperties.java
@@ -1,0 +1,691 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.spi.type.TypeManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
+import org.apache.kudu.client.KeyEncoderAccessor;
+import org.apache.kudu.client.KuduTable;
+import org.apache.kudu.client.LocatedTablet;
+import org.apache.kudu.client.PartialRow;
+import org.apache.kudu.client.Partition;
+import org.apache.kudu.client.PartitionSchema;
+import org.apache.kudu.shaded.com.google.common.base.Predicates;
+import org.apache.kudu.shaded.com.google.common.collect.Iterators;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public final class KuduTableProperties
+{
+    public static final String PARTITION_BY_HASH_COLUMNS = "partition_by_hash_columns";
+    public static final String PARTITION_BY_HASH_BUCKETS = "partition_by_hash_buckets";
+    public static final String PARTITION_BY_HASH_COLUMNS_2 = "partition_by_second_hash_columns";
+    public static final String PARTITION_BY_HASH_BUCKETS_2 = "partition_by_second_hash_buckets";
+    public static final String PARTITION_BY_RANGE_COLUMNS = "partition_by_range_columns";
+    public static final String RANGE_PARTITIONS = "range_partitions";
+    public static final String NUM_REPLICAS = "num_replicas";
+    public static final String PRIMARY_KEY = "primary_key";
+    public static final String NULLABLE = "nullable";
+    public static final String ENCODING = "encoding";
+    public static final String COMPRESSION = "compression";
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final long DEFAULT_DEADLINE = 20000; // deadline for retrieving range partitions in milliseconds
+
+    private final List<PropertyMetadata<?>> tableProperties;
+
+    private final List<PropertyMetadata<?>> columnProperties;
+
+    @Inject
+    public KuduTableProperties(TypeManager typeManager)
+    {
+        tableProperties = ImmutableList.of(
+                new PropertyMetadata<>(
+                        PARTITION_BY_HASH_COLUMNS,
+                        "Columns for optional first hash partition level",
+                        typeManager.getType(parseTypeSignature("array(varchar)")),
+                        List.class,
+                        ImmutableList.of(),
+                        false,
+                        value -> ImmutableList.copyOf(((Collection<?>) value).stream()
+                                .map(name -> ((String) name).toLowerCase(ENGLISH))
+                                .collect(Collectors.toList())),
+                        value -> value),
+                integerProperty(
+                        PARTITION_BY_HASH_BUCKETS,
+                        "Number of buckets for optional first hash partition level.",
+                        null,
+                        false),
+                new PropertyMetadata<>(
+                        PARTITION_BY_HASH_COLUMNS_2,
+                        "Columns for optional second hash partition level",
+                        typeManager.getType(parseTypeSignature("array(varchar)")),
+                        List.class,
+                        ImmutableList.of(),
+                        false,
+                        value -> ImmutableList.copyOf(((Collection<?>) value).stream()
+                                .map(name -> ((String) name).toLowerCase(ENGLISH))
+                                .collect(Collectors.toList())),
+                        value -> value),
+                integerProperty(
+                        PARTITION_BY_HASH_BUCKETS_2,
+                        "Number of buckets for optional second hash partition level.",
+                        null,
+                        false),
+                new PropertyMetadata<>(
+                        PARTITION_BY_RANGE_COLUMNS,
+                        "Columns for optional range partition level",
+                        typeManager.getType(parseTypeSignature("array(varchar)")),
+                        List.class,
+                        ImmutableList.of(),
+                        false,
+                        value -> ImmutableList.copyOf(((Collection<?>) value).stream()
+                                .map(name -> ((String) name).toLowerCase(ENGLISH))
+                                .collect(Collectors.toList())),
+                        value -> value),
+                integerProperty(
+                        NUM_REPLICAS,
+                        "Number of tablet replicas. Uses default value from Kudu master if not specified.",
+                        null,
+                        false),
+                stringProperty(
+                        RANGE_PARTITIONS,
+                        "Initial range partitions as JSON",
+                        null,
+                        false));
+
+        columnProperties = ImmutableList.of(
+                booleanProperty(
+                        PRIMARY_KEY,
+                        "If column belongs to primary key",
+                        false,
+                        false),
+                booleanProperty(
+                        NULLABLE,
+                        "If column can be set to null",
+                        false,
+                        false),
+                stringProperty(
+                        ENCODING,
+                        "Optional specification of the column encoding. Otherwise default encoding is applied.",
+                        null,
+                        false),
+                stringProperty(
+                        COMPRESSION,
+                        "Optional specification of the column compression. Otherwise default compression is applied.",
+                        null,
+                        false));
+    }
+
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    public List<PropertyMetadata<?>> getColumnProperties()
+    {
+        return columnProperties;
+    }
+
+    public static PartitionDesign getPartitionDesign(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        List<String> hashColumns = (List) tableProperties.get(PARTITION_BY_HASH_COLUMNS);
+        List<String> hashColumns2 = (List) tableProperties.get(PARTITION_BY_HASH_COLUMNS_2);
+
+        PartitionDesign design = new PartitionDesign();
+        if (!hashColumns.isEmpty()) {
+            List<HashPartitionDefinition> hashPartitions = new ArrayList<>();
+            HashPartitionDefinition hash1 = getHashPartitionDefinition(tableProperties, hashColumns, PARTITION_BY_HASH_BUCKETS);
+            hashPartitions.add(hash1);
+            if (!hashColumns2.isEmpty()) {
+                HashPartitionDefinition hash2 = getHashPartitionDefinition(tableProperties, hashColumns2, PARTITION_BY_HASH_BUCKETS_2);
+                hashPartitions.add(hash2);
+            }
+            design.setHash(hashPartitions);
+        }
+        else if (!hashColumns2.isEmpty()) {
+            throw new PrestoException(GENERIC_USER_ERROR, "Table property " + PARTITION_BY_HASH_COLUMNS_2 + " is only allowed if there is also " + PARTITION_BY_HASH_COLUMNS);
+        }
+
+        List<String> rangeColumns = (List) tableProperties.get(PARTITION_BY_RANGE_COLUMNS);
+        if (!rangeColumns.isEmpty()) {
+            RangePartitionDefinition range = new RangePartitionDefinition();
+            range.setColumns(rangeColumns);
+            design.setRange(range);
+        }
+
+        return design;
+    }
+
+    public static ColumnDesign getColumnDesign(Map<String, Object> columnProperties)
+    {
+        requireNonNull(columnProperties);
+        if (columnProperties.isEmpty()) {
+            return ColumnDesign.DEFAULT;
+        }
+
+        ColumnDesign design = new ColumnDesign();
+        Boolean key = (Boolean) columnProperties.get(PRIMARY_KEY);
+        if (key != null) {
+            design.setPrimaryKey(key);
+        }
+
+        Boolean nullable = (Boolean) columnProperties.get(NULLABLE);
+        if (nullable != null) {
+            design.setNullable(nullable);
+        }
+
+        String encoding = (String) columnProperties.get(ENCODING);
+        if (encoding != null) {
+            design.setEncoding(encoding);
+        }
+
+        String compression = (String) columnProperties.get(COMPRESSION);
+        if (compression != null) {
+            design.setCompression(compression);
+        }
+        return design;
+    }
+
+    private static HashPartitionDefinition getHashPartitionDefinition(Map<String, Object> tableProperties, List<String> columns, String bucketPropertyName)
+    {
+        Integer hashBuckets = (Integer) tableProperties.get(bucketPropertyName);
+        if (hashBuckets == null) {
+            throw new PrestoException(GENERIC_USER_ERROR, "Missing table property " + bucketPropertyName);
+        }
+        HashPartitionDefinition definition = new HashPartitionDefinition();
+        definition.setColumns(columns);
+        definition.setBuckets(hashBuckets);
+        return definition;
+    }
+
+    public static List<RangePartition> getRangePartitions(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        @SuppressWarnings("unchecked")
+        String json = (String) tableProperties.get(RANGE_PARTITIONS);
+        if (json != null) {
+            try {
+                RangePartition[] partitions = mapper.readValue(json, RangePartition[].class);
+                if (partitions == null) {
+                    return ImmutableList.of();
+                }
+                return ImmutableList.copyOf(partitions);
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        else {
+            return ImmutableList.of();
+        }
+    }
+
+    public static RangePartition parseRangePartition(String json)
+    {
+        if (json == null) {
+            return null;
+        }
+        else {
+            try {
+                return mapper.readValue(json, RangePartition.class);
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static Optional<Integer> getNumReplicas(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        @SuppressWarnings("unchecked")
+        Integer numReplicas = (Integer) tableProperties.get(NUM_REPLICAS);
+        return Optional.ofNullable(numReplicas);
+    }
+
+    public static Map<String, Object> toMap(KuduTable table)
+    {
+        Map<String, Object> properties = new HashMap<>();
+
+        LinkedHashMap<String, ColumnDesign> columns = getColumns(table);
+
+        PartitionDesign partitionDesign = getPartitionDesign(table);
+
+        List<RangePartition> rangePartitionList = getRangePartitionList(table, DEFAULT_DEADLINE);
+
+        try {
+            if (partitionDesign.getHash() != null) {
+                List<HashPartitionDefinition> list = partitionDesign.getHash();
+                if (!list.isEmpty()) {
+                    properties.put(PARTITION_BY_HASH_COLUMNS, list.get(0).getColumns());
+                    properties.put(PARTITION_BY_HASH_BUCKETS, list.get(0).getBuckets());
+                }
+                if (list.size() >= 2) {
+                    properties.put(PARTITION_BY_HASH_COLUMNS_2, list.get(1).getColumns());
+                    properties.put(PARTITION_BY_HASH_BUCKETS_2, list.get(1).getBuckets());
+                }
+            }
+
+            if (partitionDesign.getRange() != null) {
+                properties.put(PARTITION_BY_RANGE_COLUMNS, partitionDesign.getRange().getColumns());
+            }
+
+            String partitionRangesValue = mapper.writeValueAsString(rangePartitionList);
+            properties.put(RANGE_PARTITIONS, partitionRangesValue);
+
+            // currently no access to numReplicas?
+
+            return properties;
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static List<RangePartition> getRangePartitionList(KuduTable table, long deadline)
+    {
+        List<RangePartition> rangePartitions = new ArrayList<>();
+        if (!table.getPartitionSchema().getRangeSchema().getColumns().isEmpty()) {
+            try {
+                Iterator var4 = table.getTabletsLocations(deadline).iterator();
+
+                while (var4.hasNext()) {
+                    LocatedTablet tablet = (LocatedTablet) var4.next();
+                    Partition partition = tablet.getPartition();
+                    if (Iterators.all(partition.getHashBuckets().iterator(), Predicates.equalTo(0))) {
+                        RangePartition rangePartition = buildRangePartition(table, partition);
+                        rangePartitions.add(rangePartition);
+                    }
+                }
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return rangePartitions;
+    }
+
+    private static RangePartition buildRangePartition(KuduTable table, Partition partition)
+    {
+        RangeBoundValue lower = buildRangePartitionBound(table, partition.getRangeKeyStart());
+        RangeBoundValue upper = buildRangePartitionBound(table, partition.getRangeKeyEnd());
+
+        return new RangePartition(lower, upper);
+    }
+
+    private static RangeBoundValue buildRangePartitionBound(KuduTable table, byte[] rangeKey)
+    {
+        if (rangeKey.length == 0) {
+            return null;
+        }
+        else {
+            Schema schema = table.getSchema();
+            PartitionSchema partitionSchema = table.getPartitionSchema();
+            PartitionSchema.RangeSchema rangeSchema = partitionSchema.getRangeSchema();
+            List<Integer> rangeColumns = rangeSchema.getColumns();
+
+            final int numColumns = rangeColumns.size();
+
+            PartialRow bound = KeyEncoderAccessor.decodeRangePartitionKey(schema, partitionSchema, rangeKey);
+
+            ArrayList<Object> list = new ArrayList<>();
+            for (int i = 0; i < numColumns; i++) {
+                Object obj = toValue(schema, bound, rangeColumns.get(i));
+                list.add(obj);
+            }
+            return new RangeBoundValue(list);
+        }
+    }
+
+    private static Object toValue(Schema schema, PartialRow bound, Integer idx)
+    {
+        Type type = schema.getColumnByIndex(idx).getType();
+        switch (type) {
+            case UNIXTIME_MICROS:
+                long millis = bound.getLong(idx) / 1000;
+                return ISODateTimeFormat.dateTime().withZone(DateTimeZone.UTC).print(millis);
+            case STRING:
+                return bound.getString(idx);
+            case INT64:
+                return bound.getLong(idx);
+            case INT32:
+                return bound.getInt(idx);
+            case INT16:
+                return bound.getShort(idx);
+            case INT8:
+                return (short) bound.getByte(idx);
+            case BOOL:
+                return bound.getBoolean(idx);
+            case BINARY:
+                return bound.getBinaryCopy(idx);
+            default:
+                throw new IllegalStateException("Unhandled type " + type + " for range partition");
+        }
+    }
+
+    private static LinkedHashMap<String, ColumnDesign> getColumns(KuduTable table)
+    {
+        Schema schema = table.getSchema();
+        LinkedHashMap<String, ColumnDesign> columns = new LinkedHashMap<>();
+        for (ColumnSchema columnSchema : schema.getColumns()) {
+            ColumnDesign design = new ColumnDesign();
+            design.setNullable(columnSchema.isNullable());
+            design.setPrimaryKey(columnSchema.isKey());
+            design.setCompression(lookupCompressionString(columnSchema.getCompressionAlgorithm()));
+            design.setEncoding(lookupEncodingString(columnSchema.getEncoding()));
+            columns.put(columnSchema.getName(), design);
+        }
+        return columns;
+    }
+
+    public static PartitionDesign getPartitionDesign(KuduTable table)
+    {
+        Schema schema = table.getSchema();
+        PartitionDesign partitionDesign = new PartitionDesign();
+        PartitionSchema partitionSchema = table.getPartitionSchema();
+
+        List<HashPartitionDefinition> hashPartitions = partitionSchema.getHashBucketSchemas().stream()
+                .map(hashBucketSchema -> {
+                    HashPartitionDefinition hash = new HashPartitionDefinition();
+                    List<String> cols = hashBucketSchema.getColumnIds().stream()
+                            .map(idx -> schema.getColumnByIndex(idx).getName()).collect(toImmutableList());
+                    hash.setColumns(cols);
+                    hash.setBuckets(hashBucketSchema.getNumBuckets());
+                    return hash;
+                }).collect(toImmutableList());
+        partitionDesign.setHash(hashPartitions);
+
+        List<Integer> rangeColumns = partitionSchema.getRangeSchema().getColumns();
+        if (!rangeColumns.isEmpty()) {
+            RangePartitionDefinition definition = new RangePartitionDefinition();
+            definition.setColumns(rangeColumns.stream()
+                    .map(i -> schema.getColumns().get(i).getName())
+                    .collect(ImmutableList.toImmutableList()));
+            partitionDesign.setRange(definition);
+        }
+
+        return partitionDesign;
+    }
+
+    public static PartialRow toRangeBoundToPartialRow(Schema schema, RangePartitionDefinition definition,
+            RangeBoundValue boundValue)
+    {
+        PartialRow partialRow = new PartialRow(schema);
+        if (boundValue != null) {
+            List<Integer> rangeColumns = definition.getColumns().stream()
+                    .map(schema::getColumnIndex).collect(toImmutableList());
+
+            if (rangeColumns.size() != boundValue.getValues().size()) {
+                throw new IllegalStateException("Expected " + rangeColumns.size()
+                        + " range columns, but got " + boundValue.getValues().size());
+            }
+            for (int i = 0; i < rangeColumns.size(); i++) {
+                Object obj = boundValue.getValues().get(i);
+                int idx = rangeColumns.get(i);
+                ColumnSchema columnSchema = schema.getColumnByIndex(idx);
+                setColumnValue(partialRow, idx, obj, columnSchema.getType(), columnSchema.getName());
+            }
+        }
+        return partialRow;
+    }
+
+    private static void setColumnValue(PartialRow partialRow, int idx, Object obj, Type type, String name)
+    {
+        Number n;
+
+        switch (type) {
+            case STRING:
+                if (obj instanceof String) {
+                    partialRow.addString(idx, (String) obj);
+                }
+                else {
+                    handleInvalidValue(name, type, obj);
+                }
+                break;
+            case INT64:
+                n = toNumber(obj, type, name);
+                partialRow.addLong(idx, n.longValue());
+                break;
+            case INT32:
+                n = toNumber(obj, type, name);
+                partialRow.addInt(idx, n.intValue());
+                break;
+            case INT16:
+                n = toNumber(obj, type, name);
+                partialRow.addShort(idx, n.shortValue());
+                break;
+            case INT8:
+                n = toNumber(obj, type, name);
+                partialRow.addByte(idx, n.byteValue());
+                break;
+            case DOUBLE:
+                n = toNumber(obj, type, name);
+                partialRow.addDouble(idx, n.doubleValue());
+                break;
+            case FLOAT:
+                n = toNumber(obj, type, name);
+                partialRow.addFloat(idx, n.floatValue());
+                break;
+            case UNIXTIME_MICROS:
+                long l = toUnixTimeMicros(obj, type, name);
+                partialRow.addLong(idx, l);
+                break;
+            case BOOL:
+                boolean b = toBoolean(obj, type, name);
+                partialRow.addBoolean(idx, b);
+                break;
+            case BINARY:
+                byte[] bytes = toByteArray(obj, type, name);
+                partialRow.addBinary(idx, bytes);
+                break;
+            default:
+                handleInvalidValue(name, type, obj);
+                break;
+        }
+    }
+
+    private static byte[] toByteArray(Object obj, Type type, String name)
+    {
+        if (obj instanceof byte[]) {
+            return (byte[]) obj;
+        }
+        else if (obj instanceof String) {
+            return Base64.getDecoder().decode((String) obj);
+        }
+        else {
+            handleInvalidValue(name, type, obj);
+            return null;
+        }
+    }
+
+    private static boolean toBoolean(Object obj, Type type, String name)
+    {
+        if (obj instanceof Boolean) {
+            return (Boolean) obj;
+        }
+        else if (obj instanceof String) {
+            return Boolean.valueOf((String) obj);
+        }
+        else {
+            handleInvalidValue(name, type, obj);
+            return false;
+        }
+    }
+
+    private static long toUnixTimeMicros(Object obj, Type type, String name)
+    {
+        if (Number.class.isAssignableFrom(obj.getClass())) {
+            return ((Number) obj).longValue();
+        }
+        else if (obj instanceof String) {
+            String s = (String) obj;
+            s = s.trim().replace(' ', 'T');
+            long millis = ISODateTimeFormat.dateOptionalTimeParser().withZone(DateTimeZone.UTC).parseMillis(s);
+            return millis * 1000;
+        }
+        else {
+            handleInvalidValue(name, type, obj);
+            return 0;
+        }
+    }
+
+    private static Number toNumber(Object obj, Type type, String name)
+    {
+        if (Number.class.isAssignableFrom(obj.getClass())) {
+            return (Number) obj;
+        }
+        else if (obj instanceof String) {
+            String s = (String) obj;
+            BigDecimal d = new BigDecimal((String) obj);
+            return d;
+        }
+        else {
+            handleInvalidValue(name, type, obj);
+            return 0;
+        }
+    }
+
+    private static void handleInvalidValue(String name, Type type, Object obj)
+    {
+        throw new IllegalStateException("Invalid value " + obj + " for column " + name + " of type " + type);
+    }
+
+    public static ColumnSchema.CompressionAlgorithm lookupCompression(String compression)
+    {
+        switch (compression.toLowerCase(Locale.ENGLISH)) {
+            case "default":
+            case "default_compression":
+                return ColumnSchema.CompressionAlgorithm.DEFAULT_COMPRESSION;
+            case "no":
+            case "no_compression":
+                return ColumnSchema.CompressionAlgorithm.NO_COMPRESSION;
+            case "lz4":
+                return ColumnSchema.CompressionAlgorithm.LZ4;
+            case "snappy":
+                return ColumnSchema.CompressionAlgorithm.SNAPPY;
+            case "zlib":
+                return ColumnSchema.CompressionAlgorithm.ZLIB;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    public static String lookupCompressionString(ColumnSchema.CompressionAlgorithm algorithm)
+    {
+        switch (algorithm) {
+            case DEFAULT_COMPRESSION:
+                return "default";
+            case NO_COMPRESSION:
+                return "no";
+            case LZ4:
+                return "lz4";
+            case SNAPPY:
+                return "snappy";
+            case ZLIB:
+                return "zlib";
+            default:
+                return "unknown";
+        }
+    }
+
+    public static ColumnSchema.Encoding lookupEncoding(String encoding)
+    {
+        switch (encoding.toLowerCase(Locale.ENGLISH)) {
+            case "auto":
+            case "auto_encoding":
+                return ColumnSchema.Encoding.AUTO_ENCODING;
+            case "bitshuffle":
+            case "bit_shuffle":
+                return ColumnSchema.Encoding.BIT_SHUFFLE;
+            case "dictionary":
+            case "dict_encoding":
+                return ColumnSchema.Encoding.DICT_ENCODING;
+            case "plain":
+            case "plain_encoding":
+                return ColumnSchema.Encoding.PLAIN_ENCODING;
+            case "prefix":
+            case "prefix_encoding":
+                return ColumnSchema.Encoding.PREFIX_ENCODING;
+            case "runlength":
+            case "run_length":
+            case "run length":
+            case "rle":
+                return ColumnSchema.Encoding.RLE;
+            case "group_varint":
+                return ColumnSchema.Encoding.GROUP_VARINT;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    public static String lookupEncodingString(ColumnSchema.Encoding encoding)
+    {
+        switch (encoding) {
+            case AUTO_ENCODING:
+                return "auto";
+            case BIT_SHUFFLE:
+                return "bitshuffle";
+            case DICT_ENCODING:
+                return "dictionary";
+            case PLAIN_ENCODING:
+                return "plain";
+            case PREFIX_ENCODING:
+                return "prefix";
+            case RLE:
+                return "runlength";
+            case GROUP_VARINT:
+                return "group_varint";
+            default:
+                return "unknown";
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/PartitionDesign.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/PartitionDesign.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+import java.util.List;
+
+public class PartitionDesign
+{
+    private List<HashPartitionDefinition> hash;
+    private RangePartitionDefinition range;
+
+    public List<HashPartitionDefinition> getHash()
+    {
+        return hash;
+    }
+
+    public void setHash(List<HashPartitionDefinition> hash)
+    {
+        this.hash = hash;
+    }
+
+    public RangePartitionDefinition getRange()
+    {
+        return range;
+    }
+
+    public void setRange(RangePartitionDefinition range)
+    {
+        this.range = range;
+    }
+
+    public boolean hasPartitions()
+    {
+        return hash != null && !hash.isEmpty() && !hash.get(0).getColumns().isEmpty()
+                || range != null && !range.getColumns().isEmpty();
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangeBoundValue.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangeBoundValue.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+@JsonDeserialize(using = RangeBoundValueDeserializer.class)
+@JsonSerialize(using = RangeBoundValueSerializer.class)
+public class RangeBoundValue
+{
+    private final List<Object> values;
+
+    public RangeBoundValue(List<Object> values)
+    {
+        this.values = ImmutableList.copyOf(values);
+    }
+
+    public List<Object> getValues()
+    {
+        return values;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangeBoundValueDeserializer.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangeBoundValueDeserializer.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class RangeBoundValueDeserializer
+        extends JsonDeserializer
+{
+    @Override
+    public RangeBoundValue deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException
+    {
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        if (node.isNull()) {
+            return null;
+        }
+        else {
+            List<Object> list;
+            if (node.isArray()) {
+                list = new ArrayList<>();
+                Iterator<JsonNode> iter = node.elements();
+                while (iter.hasNext()) {
+                    Object v = toValue(iter.next());
+                    list.add(v);
+                }
+            }
+            else {
+                Object v = toValue(node);
+                list = ImmutableList.of(v);
+            }
+            return new RangeBoundValue(list);
+        }
+    }
+
+    private Object toValue(JsonNode node)
+            throws IOException
+    {
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        else if (node.isNumber()) {
+            return node.numberValue();
+        }
+        else if (node.isBoolean()) {
+            return node.asBoolean();
+        }
+        else if (node.isBinary()) {
+            return node.binaryValue();
+        }
+        else {
+            throw new IllegalStateException("Unexpected range bound value: " + node);
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangeBoundValueSerializer.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangeBoundValueSerializer.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class RangeBoundValueSerializer
+        extends JsonSerializer
+{
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException
+    {
+        if (value == null) {
+            gen.writeNull();
+        }
+        else {
+            RangeBoundValue rbv = (RangeBoundValue) value;
+            if (rbv.getValues().size() == 1) {
+                writeValue(rbv.getValues().get(0), gen);
+            }
+            else {
+                gen.writeStartArray(rbv.getValues().size());
+                for (Object obj : rbv.getValues()) {
+                    writeValue(obj, gen);
+                }
+                gen.writeEndArray();
+            }
+        }
+    }
+
+    private void writeValue(Object obj, JsonGenerator gen)
+            throws IOException
+    {
+        if (obj == null) {
+            throw new IllegalStateException("Unexpected null value");
+        }
+        else if (obj instanceof String) {
+            gen.writeString((String) obj);
+        }
+        else if (Number.class.isAssignableFrom(obj.getClass())) {
+            if (obj instanceof Long) {
+                gen.writeNumber((Long) obj);
+            }
+            else if (obj instanceof Integer) {
+                gen.writeNumber((Integer) obj);
+            }
+            else if (obj instanceof Short) {
+                gen.writeNumber((Short) obj);
+            }
+            else if (obj instanceof Double) {
+                gen.writeNumber((Double) obj);
+            }
+            else if (obj instanceof Float) {
+                gen.writeNumber((Float) obj);
+            }
+            else if (obj instanceof BigInteger) {
+                gen.writeNumber((BigInteger) obj);
+            }
+            else if (obj instanceof BigDecimal) {
+                gen.writeNumber((BigDecimal) obj);
+            }
+            else {
+                throw new IllegalStateException("Unknown number value: " + obj);
+            }
+        }
+        else if (obj instanceof Boolean) {
+            gen.writeBoolean((Boolean) obj);
+        }
+        else if (obj instanceof byte[]) {
+            gen.writeBinary((byte[]) obj);
+        }
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangePartition.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangePartition.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RangePartition
+{
+    private final RangeBoundValue lower;
+    private final RangeBoundValue upper;
+
+    @JsonCreator
+    public RangePartition(
+            @JsonProperty("lower") RangeBoundValue lower,
+            @JsonProperty("upper") RangeBoundValue upper)
+    {
+        this.lower = lower;
+        this.upper = upper;
+    }
+
+    public RangeBoundValue getLower()
+    {
+        return lower;
+    }
+
+    public RangeBoundValue getUpper()
+    {
+        return upper;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangePartitionDefinition.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangePartitionDefinition.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+import java.util.List;
+
+public class RangePartitionDefinition
+{
+    private List<String> columns;
+
+    public List<String> getColumns()
+    {
+        return columns;
+    }
+
+    public void setColumns(List<String> columns)
+    {
+        this.columns = columns;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/schema/NoSchemaEmulation.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/schema/NoSchemaEmulation.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.schema;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaNotFoundException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.collect.ImmutableList;
+import org.apache.kudu.client.KuduClient;
+
+import java.util.List;
+
+import static com.facebook.presto.kudu.KuduClientSession.DEFAULT_SCHEMA;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
+
+public class NoSchemaEmulation
+        implements SchemaEmulation
+{
+    @Override
+    public void createSchema(KuduClient client, String schemaName)
+    {
+        if (DEFAULT_SCHEMA.equals(schemaName)) {
+            throw new SchemaAlreadyExistsException(schemaName);
+        }
+        else {
+            throw new PrestoException(GENERIC_USER_ERROR, "Creating schema in Kudu connector not allowed if schema emulation is disabled.");
+        }
+    }
+
+    @Override
+    public void dropSchema(KuduClient client, String schemaName)
+    {
+        if (DEFAULT_SCHEMA.equals(schemaName)) {
+            throw new PrestoException(GENERIC_USER_ERROR, "Deleting default schema not allowed.");
+        }
+        else {
+            throw new SchemaNotFoundException(schemaName);
+        }
+    }
+
+    @Override
+    public boolean existsSchema(KuduClient client, String schemaName)
+    {
+        return DEFAULT_SCHEMA.equals(schemaName);
+    }
+
+    @Override
+    public List<String> listSchemaNames(KuduClient client)
+    {
+        return ImmutableList.of("default");
+    }
+
+    @Override
+    public String toRawName(SchemaTableName schemaTableName)
+    {
+        if (DEFAULT_SCHEMA.equals(schemaTableName.getSchemaName())) {
+            return schemaTableName.getTableName();
+        }
+        else {
+            throw new SchemaNotFoundException(schemaTableName.getSchemaName());
+        }
+    }
+
+    @Override
+    public SchemaTableName fromRawName(String rawName)
+    {
+        return new SchemaTableName(DEFAULT_SCHEMA, rawName);
+    }
+
+    @Override
+    public String getPrefixForTablesOfSchema(String schemaName)
+    {
+        return "";
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/schema/SchemaAlreadyExistsException.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/schema/SchemaAlreadyExistsException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.schema;
+
+import com.facebook.presto.spi.PrestoException;
+
+import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
+import static java.lang.String.format;
+
+public class SchemaAlreadyExistsException
+        extends PrestoException
+{
+    private final String schemaName;
+
+    public SchemaAlreadyExistsException(String schemaName)
+    {
+        this(schemaName, format("Schema already exists: '%s'", schemaName));
+    }
+
+    public SchemaAlreadyExistsException(String schemaName, String message)
+    {
+        super(ALREADY_EXISTS, message);
+        this.schemaName = schemaName;
+    }
+
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/schema/SchemaEmulation.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/schema/SchemaEmulation.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.schema;
+
+import com.facebook.presto.spi.SchemaTableName;
+import org.apache.kudu.client.KuduClient;
+
+import java.util.List;
+
+public interface SchemaEmulation
+{
+    void createSchema(KuduClient client, String schemaName);
+
+    void dropSchema(KuduClient client, String schemaName);
+
+    boolean existsSchema(KuduClient client, String schemaName);
+
+    List<String> listSchemaNames(KuduClient client);
+
+    String toRawName(SchemaTableName schemaTableName);
+
+    SchemaTableName fromRawName(String rawName);
+
+    String getPrefixForTablesOfSchema(String schemaName);
+}

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/schema/SchemaEmulationByTableNameConvention.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/schema/SchemaEmulationByTableNameConvention.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.schema;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaNotFoundException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.collect.ImmutableList;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
+import org.apache.kudu.client.CreateTableOptions;
+import org.apache.kudu.client.Delete;
+import org.apache.kudu.client.Insert;
+import org.apache.kudu.client.KuduClient;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.KuduScanner;
+import org.apache.kudu.client.KuduSession;
+import org.apache.kudu.client.KuduTable;
+import org.apache.kudu.client.RowResult;
+import org.apache.kudu.client.RowResultIterator;
+import org.apache.kudu.client.SessionConfiguration;
+import org.apache.kudu.client.Upsert;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static com.facebook.presto.kudu.KuduClientSession.DEFAULT_SCHEMA;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
+
+public class SchemaEmulationByTableNameConvention
+        implements SchemaEmulation
+{
+    private final String commonPrefix;
+    private final String rawSchemasTableName;
+    private KuduTable rawSchemasTable;
+
+    public SchemaEmulationByTableNameConvention(String commonPrefix)
+    {
+        this.commonPrefix = commonPrefix;
+        this.rawSchemasTableName = commonPrefix + "$schemas";
+    }
+
+    @Override
+    public void createSchema(KuduClient client, String schemaName)
+    {
+        if (DEFAULT_SCHEMA.equals(schemaName)) {
+            throw new SchemaAlreadyExistsException(schemaName);
+        }
+        else {
+            try {
+                KuduTable schemasTable = getSchemasTable(client);
+                KuduSession session = client.newSession();
+                try {
+                    Upsert upsert = schemasTable.newUpsert();
+                    upsert.getRow().addString(0, schemaName);
+                    session.apply(upsert);
+                }
+                finally {
+                    session.close();
+                }
+            }
+            catch (KuduException e) {
+                throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+            }
+        }
+    }
+
+    @Override
+    public boolean existsSchema(KuduClient client, String schemaName)
+    {
+        if (DEFAULT_SCHEMA.equals(schemaName)) {
+            return true;
+        }
+        else {
+            List<String> schemas = listSchemaNames(client);
+            return schemas.contains(schemaName);
+        }
+    }
+
+    @Override
+    public void dropSchema(KuduClient client, String schemaName)
+    {
+        if (DEFAULT_SCHEMA.equals(schemaName)) {
+            throw new PrestoException(GENERIC_USER_ERROR, "Deleting default schema not allowed.");
+        }
+        else {
+            try {
+                String prefix = getPrefixForTablesOfSchema(schemaName);
+                for (String name : client.getTablesList(prefix).getTablesList()) {
+                    client.deleteTable(name);
+                }
+
+                KuduTable schemasTable = getSchemasTable(client);
+                KuduSession session = client.newSession();
+                try {
+                    Delete delete = schemasTable.newDelete();
+                    delete.getRow().addString(0, schemaName);
+                    session.apply(delete);
+                }
+                finally {
+                    session.close();
+                }
+            }
+            catch (KuduException e) {
+                throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+            }
+        }
+    }
+
+    @Override
+    public List<String> listSchemaNames(KuduClient client)
+    {
+        try {
+            if (rawSchemasTable == null) {
+                if (!client.tableExists(rawSchemasTableName)) {
+                    createAndFillSchemasTable(client);
+                }
+                rawSchemasTable = getSchemasTable(client);
+            }
+
+            KuduScanner scanner = client.newScannerBuilder(rawSchemasTable).build();
+            RowResultIterator iterator = scanner.nextRows();
+            ArrayList<String> result = new ArrayList<>();
+            while (iterator != null) {
+                for (RowResult row : iterator) {
+                    result.add(row.getString(0));
+                }
+                iterator = scanner.nextRows();
+            }
+            return result;
+        }
+        catch (KuduException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    private KuduTable getSchemasTable(KuduClient client)
+            throws KuduException
+    {
+        if (rawSchemasTable == null) {
+            rawSchemasTable = client.openTable(rawSchemasTableName);
+        }
+        return rawSchemasTable;
+    }
+
+    private void createAndFillSchemasTable(KuduClient client)
+            throws KuduException
+    {
+        List<String> existingSchemaNames = listSchemaNamesFromTablets(client);
+        ColumnSchema schemaColumnSchema = new ColumnSchema.ColumnSchemaBuilder("schema", Type.STRING)
+                .key(true).build();
+        Schema schema = new Schema(ImmutableList.of(schemaColumnSchema));
+        CreateTableOptions options = new CreateTableOptions();
+        options.addHashPartitions(ImmutableList.of(schemaColumnSchema.getName()), 2);
+        KuduTable schemasTable = client.createTable(rawSchemasTableName, schema, options);
+        KuduSession session = client.newSession();
+        try {
+            session.setFlushMode(SessionConfiguration.FlushMode.AUTO_FLUSH_BACKGROUND);
+            for (String schemaName : existingSchemaNames) {
+                Insert insert = schemasTable.newInsert();
+                insert.getRow().addString(0, schemaName);
+                session.apply(insert);
+            }
+        }
+        finally {
+            session.close();
+        }
+    }
+
+    private List<String> listSchemaNamesFromTablets(KuduClient client)
+            throws KuduException
+    {
+        List<String> tables = client.getTablesList().getTablesList();
+        LinkedHashSet<String> schemas = new LinkedHashSet<>();
+        schemas.add(DEFAULT_SCHEMA);
+        for (String table : tables) {
+            SchemaTableName schemaTableName = fromRawName(table);
+            if (schemaTableName != null) {
+                schemas.add(schemaTableName.getSchemaName());
+            }
+        }
+        return ImmutableList.copyOf(schemas);
+    }
+
+    @Override
+    public String toRawName(SchemaTableName schemaTableName)
+    {
+        if (DEFAULT_SCHEMA.equals(schemaTableName.getSchemaName())) {
+            if (commonPrefix.isEmpty()) {
+                if (schemaTableName.getTableName().indexOf('.') != -1) {
+                    // in default schema table name must not contain dots if common prefix is empty
+                    throw new PrestoException(GENERIC_USER_ERROR, "Table name conflicts with schema emulation settings. No '.' allowed for tables in schema 'default'.");
+                }
+            }
+            else {
+                if (schemaTableName.getTableName().startsWith(commonPrefix)) {
+                    // in default schema table name must not start with common prefix
+                    throw new PrestoException(GENERIC_USER_ERROR, "Table name conflicts with schema emulation settings. Table name must not start with '" + commonPrefix + "'.");
+                }
+            }
+        }
+        else if (schemaTableName.getSchemaName().indexOf('.') != -1) {
+            // schema names with dots are not possible
+            throw new SchemaNotFoundException(schemaTableName.getSchemaName());
+        }
+
+        if (DEFAULT_SCHEMA.equals(schemaTableName.getSchemaName())) {
+            return schemaTableName.getTableName();
+        }
+        else {
+            return commonPrefix + schemaTableName.getSchemaName() + "." + schemaTableName.getTableName();
+        }
+    }
+
+    @Override
+    public SchemaTableName fromRawName(String rawName)
+    {
+        if (commonPrefix.isEmpty()) {
+            int dotIndex = rawName.indexOf('.');
+            if (dotIndex == -1) {
+                return new SchemaTableName(DEFAULT_SCHEMA, rawName);
+            }
+            else if (dotIndex == 0 || dotIndex == rawName.length() - 1) {
+                return null; // illegal rawName ignored
+            }
+            return new SchemaTableName(rawName.substring(0, dotIndex), rawName.substring(dotIndex + 1));
+        }
+        else {
+            if (rawName.startsWith(commonPrefix)) {
+                int start = commonPrefix.length();
+                int dotIndex = rawName.indexOf('.', start);
+                if (dotIndex == -1 || dotIndex == start || dotIndex == rawName.length() - 1) {
+                    return null; // illegal rawName ignored
+                }
+                String schema = rawName.substring(start, dotIndex);
+                if (DEFAULT_SCHEMA.equalsIgnoreCase(schema)) {
+                    return null; // illegal rawName ignored
+                }
+                return new SchemaTableName(schema, rawName.substring(dotIndex + 1));
+            }
+            else {
+                return new SchemaTableName(DEFAULT_SCHEMA, rawName);
+            }
+        }
+    }
+
+    @Override
+    public String getPrefixForTablesOfSchema(String schemaName)
+    {
+        if (DEFAULT_SCHEMA.equals(schemaName)) {
+            return "";
+        }
+        else {
+            return commonPrefix + schemaName + ".";
+        }
+    }
+}

--- a/presto-kudu/src/main/java/org/apache/kudu/client/KeyEncoderAccessor.java
+++ b/presto-kudu/src/main/java/org/apache/kudu/client/KeyEncoderAccessor.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kudu.client;
+
+import org.apache.kudu.Schema;
+
+/**
+ * Little wrapper to access KeyEncoder in Kudu Java client.
+ */
+public class KeyEncoderAccessor
+{
+    private KeyEncoderAccessor()
+    {
+    }
+
+    public static byte[] encodePrimaryKey(PartialRow row)
+    {
+        return KeyEncoder.encodePrimaryKey(row);
+    }
+
+    public static PartialRow decodePrimaryKey(Schema schema, byte[] key)
+    {
+        return KeyEncoder.decodePrimaryKey(schema, key);
+    }
+
+    public static byte[] encodeRangePartitionKey(PartialRow row, PartitionSchema.RangeSchema rangeSchema)
+    {
+        return KeyEncoder.encodeRangePartitionKey(row, rangeSchema);
+    }
+
+    public static PartialRow decodeRangePartitionKey(Schema schema, PartitionSchema partitionSchema, byte[] key)
+    {
+        return KeyEncoder.decodeRangePartitionKey(schema, partitionSchema, key);
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/KuduQueryRunnerFactory.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/KuduQueryRunnerFactory.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
+
+import java.util.Map;
+
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static java.util.Locale.ENGLISH;
+
+public class KuduQueryRunnerFactory
+{
+    private KuduQueryRunnerFactory() {}
+
+    public static QueryRunner createKuduQueryRunner(String schema)
+            throws Exception
+    {
+        QueryRunner runner = null;
+        String kuduSchema = isSchemaEmulationEnabled() ? schema : "default";
+        try {
+            runner = DistributedQueryRunner.builder(createSession(kuduSchema)).setNodeCount(3).build();
+
+            installKuduConnector(runner, kuduSchema);
+
+            return runner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, runner);
+            throw e;
+        }
+    }
+
+    public static QueryRunner createKuduQueryRunnerTpch(TpchTable<?>... tables)
+            throws Exception
+    {
+        return createKuduQueryRunnerTpch(ImmutableList.copyOf(tables));
+    }
+
+    public static QueryRunner createKuduQueryRunnerTpch(Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        DistributedQueryRunner runner = null;
+        String kuduSchema = isSchemaEmulationEnabled() ? "tpch" : "default";
+        try {
+            runner = DistributedQueryRunner.builder(createSession(kuduSchema)).setNodeCount(3).build();
+
+            runner.installPlugin(new TpchPlugin());
+            runner.createCatalog("tpch", "tpch");
+
+            installKuduConnector(runner, kuduSchema);
+
+            copyTpchTables(runner, "tpch", TINY_SCHEMA_NAME, createSession(kuduSchema), tables);
+
+            return runner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, runner);
+            throw e;
+        }
+    }
+
+    private static boolean isSchemaEmulationEnabled()
+    {
+        return getSchemaEmulationPrefix() != null;
+    }
+
+    private static String getSchemaEmulationPrefix()
+    {
+        String prefix = System.getProperty("kudu.schema-emulation.prefix");
+        if (prefix == null || prefix.equals("null")) {
+            return null;
+        }
+        else if (prefix.isEmpty()) {
+            return "";
+        }
+        return prefix;
+    }
+
+    private static void installKuduConnector(QueryRunner runner, String schema)
+    {
+        String masterAddresses = System.getProperty("kudu.client.master-addresses", "localhost:7051");
+        Map<String, String> properties;
+        if (!isSchemaEmulationEnabled()) {
+            properties = ImmutableMap.of(
+                    "kudu.schema-emulation.enabled", "false",
+                    "kudu.client.master-addresses", masterAddresses);
+        }
+        else {
+            properties = ImmutableMap.of(
+                    "kudu.schema-emulation.enabled", "true",
+                    "kudu.schema-emulation.prefix", getSchemaEmulationPrefix(),
+                    "kudu.client.master-addresses", masterAddresses);
+        }
+
+        runner.installPlugin(new KuduPlugin());
+        runner.createCatalog("kudu", "kudu", properties);
+
+        if (isSchemaEmulationEnabled()) {
+            runner.execute("DROP SCHEMA IF EXISTS " + schema);
+            runner.execute("CREATE SCHEMA " + schema);
+        }
+    }
+
+    public static Session createSession(String schema)
+    {
+        return testSessionBuilder()
+                .setCatalog("kudu")
+                .setSchema(schema)
+                .setTimeZoneKey(UTC_KEY)
+                .setLocale(ENGLISH)
+                .build();
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationDecimalColumns.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationDecimalColumns.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestKuduIntegrationDecimalColumns
+        extends AbstractTestQueryFramework
+{
+    private QueryRunner queryRunner;
+
+    static final TestDec[] testDecList = {
+            new TestDec(10, 0),
+            new TestDec(15, 4),
+            new TestDec(18, 6),
+            new TestDec(18, 7),
+            new TestDec(19, 8),
+            new TestDec(24, 14),
+            new TestDec(38, 20),
+            new TestDec(38, 28),
+    };
+
+    public TestKuduIntegrationDecimalColumns()
+    {
+        super(() -> KuduQueryRunnerFactory.createKuduQueryRunner("decimal"));
+    }
+
+    @Test
+    public void testCreateTableWithDecimalColumn()
+    {
+        for (TestDec dec : testDecList) {
+            doTestCreateTableWithDecimalColumn(dec);
+        }
+    }
+
+    private void doTestCreateTableWithDecimalColumn(TestDec dec)
+    {
+        String tableName = dec.getTableName();
+        String dropTable = "DROP TABLE IF EXISTS " + tableName;
+        String createTable = "CREATE TABLE " + tableName + " (\n";
+        createTable += "  id INT WITH (primary_key=true),\n";
+        createTable += "  dec DECIMAL(" + dec.precision + "," + dec.scale + ")\n";
+        createTable += ") WITH (\n" +
+                " partition_by_hash_columns = ARRAY['id'],\n" +
+                " partition_by_hash_buckets = 2\n" +
+                ")";
+
+        queryRunner.execute(dropTable);
+        queryRunner.execute(createTable);
+
+        String fullPrecisionValue = "1234567890.1234567890123456789012345678";
+        int maxScale = dec.precision - 10;
+        int valuePrecision = dec.precision - maxScale + Math.min(maxScale, dec.scale);
+        String insertValue = fullPrecisionValue.substring(0, valuePrecision + 1);
+        queryRunner.execute("INSERT INTO " + tableName + " VALUES(1, DECIMAL '" + insertValue + "')");
+
+        MaterializedResult result = queryRunner.execute("SELECT id, CAST((dec - (DECIMAL '" + insertValue + "')) as DOUBLE) FROM " + tableName);
+        assertEquals(result.getRowCount(), 1);
+        Object obj = result.getMaterializedRows().get(0).getField(1);
+        assertTrue(obj instanceof Double);
+        Double actual = (Double) obj;
+        assertEquals(0, actual, 0.3 * Math.pow(0.1, dec.scale), "p=" + dec.precision + ",s=" + dec.scale + " => " + actual + ",insert = " + insertValue);
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = getQueryRunner();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+
+    static class TestDec
+    {
+        final int precision;
+        final int scale;
+
+        TestDec(int precision, int scale)
+        {
+            this.precision = precision;
+            this.scale = scale;
+        }
+
+        String getTableName()
+        {
+            return "test_dec_" + precision + "_" + scale;
+        }
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationHashPartitioning.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationHashPartitioning.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestKuduIntegrationHashPartitioning
+        extends AbstractTestQueryFramework
+{
+    private QueryRunner queryRunner;
+
+    public TestKuduIntegrationHashPartitioning()
+    {
+        super(() -> KuduQueryRunnerFactory.createKuduQueryRunner("hash"));
+    }
+
+    @Test
+    public void testCreateTableSingleHashPartitionLevel()
+    {
+        String dropTable = "DROP TABLE IF EXISTS hashtest1";
+        String createTable = "CREATE TABLE hashtest1 (\n";
+        createTable += "  id INT WITH (primary_key=true,encoding='auto',compression='default'),\n";
+        createTable += "  event_time TIMESTAMP WITH (primary_key=true, encoding='plain', compression='lz4'),\n";
+        createTable += "  value DOUBLE WITH (primary_key=false,nullable=false,compression='no')\n";
+        createTable += ") WITH (\n" +
+                " partition_by_hash_columns = ARRAY['id','event_time'],\n" +
+                " partition_by_hash_buckets = 3\n" +
+                ")";
+
+        doTestCreateTable("hashtest1", createTable);
+    }
+
+    @Test
+    public void testCreateTableDoubleHashPartitionLevel()
+    {
+        String createTable = "CREATE TABLE hashtest2 (\n";
+        createTable += "  id INT WITH (primary_key=true, encoding='bitshuffle',compression='zlib'),\n";
+        createTable += "  event_time TIMESTAMP WITH (primary_key=true, encoding='runlength', compression='snappy'),\n";
+        createTable += "  value DOUBLE WITH (nullable=true)\n";
+        createTable += ") WITH (\n" +
+                " partition_by_hash_columns = ARRAY['id'],\n" +
+                " partition_by_hash_buckets = 3\n," +
+                " partition_by_second_hash_columns = ARRAY['event_time'],\n" +
+                " partition_by_second_hash_buckets = 3\n" +
+                ")";
+
+        doTestCreateTable("hashtest2", createTable);
+    }
+
+    private void doTestCreateTable(String tableName, String createTable)
+    {
+        String dropTable = "DROP TABLE IF EXISTS " + tableName;
+
+        queryRunner.execute(dropTable);
+        queryRunner.execute(createTable);
+
+        String insert = "INSERT INTO " + tableName + " VALUES (1, TIMESTAMP '2001-08-22 03:04:05.321', 2.5)";
+
+        queryRunner.execute(insert);
+
+        MaterializedResult result = queryRunner.execute("SELECT id FROM " + tableName);
+        assertEquals(result.getRowCount(), 1);
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = getQueryRunner();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationIntegerColumns.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationIntegerColumns.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestKuduIntegrationIntegerColumns
+        extends AbstractTestQueryFramework
+{
+    private QueryRunner queryRunner;
+
+    static class TestInt
+    {
+        final String type;
+        final int bits;
+
+        TestInt(String type, int bits)
+        {
+            this.type = type;
+            this.bits = bits;
+        }
+    }
+
+    static final TestInt[] testList = {
+            new TestInt("TINYINT", 8),
+            new TestInt("SMALLINT", 16),
+            new TestInt("INTEGER", 32),
+            new TestInt("BIGINT", 64),
+    };
+
+    public TestKuduIntegrationIntegerColumns()
+    {
+        super(() -> KuduQueryRunnerFactory.createKuduQueryRunner("test_integer"));
+    }
+
+    @Test
+    public void testCreateTableWithIntegerColumn()
+    {
+        for (TestInt test : testList) {
+            doTestCreateTableWithIntegerColumn(test);
+        }
+    }
+
+    public void doTestCreateTableWithIntegerColumn(TestInt test)
+    {
+        String dropTable = "DROP TABLE IF EXISTS test_int";
+        String createTable = "CREATE TABLE test_int (\n";
+        createTable += "  id INT WITH (primary_key=true),\n";
+        createTable += "  intcol " + test.type + "\n";
+        createTable += ") WITH (\n" +
+                " partition_by_hash_columns = ARRAY['id'],\n" +
+                " partition_by_hash_buckets = 2\n" +
+                ")";
+
+        queryRunner.execute(dropTable);
+        queryRunner.execute(createTable);
+
+        long maxValue = Long.MAX_VALUE;
+        long casted = maxValue >> (64 - test.bits);
+        queryRunner.execute("INSERT INTO test_int VALUES(1, CAST(" + casted + " AS " + test.type + "))");
+
+        MaterializedResult result = queryRunner.execute("SELECT id, intcol FROM test_int");
+        assertEquals(result.getRowCount(), 1);
+        Object obj = result.getMaterializedRows().get(0).getField(1);
+        switch (test.bits) {
+            case 64:
+                assertTrue(obj instanceof Long);
+                assertEquals(((Long) obj).longValue(), casted);
+                break;
+            case 32:
+                assertTrue(obj instanceof Integer);
+                assertEquals(((Integer) obj).longValue(), casted);
+                break;
+            case 16:
+                assertTrue(obj instanceof Short);
+                assertEquals(((Short) obj).longValue(), casted);
+                break;
+            case 8:
+                assertTrue(obj instanceof Byte);
+                assertEquals(((Byte) obj).longValue(), casted);
+                break;
+            default:
+                fail("Unexpected bits: " + test.bits);
+                break;
+        }
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = getQueryRunner();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationRangePartitioning.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationRangePartitioning.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestKuduIntegrationRangePartitioning
+        extends AbstractTestQueryFramework
+{
+    private QueryRunner queryRunner;
+
+    static final TestRanges[] testRangesList = {
+            new TestRanges("varchar",
+                    "{\"lower\": null, \"upper\": \"D\"}",
+                    "{\"lower\": \"D\", \"upper\": \"M\"}",
+                    "{\"lower\": \"M\", \"upper\": \"S\"}",
+                    "{\"lower\": \"S\", \"upper\": null}"),
+            new TestRanges("timestamp",
+                    "{\"lower\": null, \"upper\": \"2017-01-01T02:03:04.567Z\"}",
+                    "{\"lower\": \"2017-01-01 03:03:04.567+01:00\", \"upper\": \"2017-02-01 12:34\"}",
+                    "{\"lower\": \"2017-02-01 12:34\", \"upper\": \"2017-03-01\"}",
+                    "{\"lower\": \"2017-03-01\", \"upper\": null}",
+                    "{\"lower\": null, \"upper\": \"2017-01-01T02:03:04.567Z\"}",
+                    "{\"lower\": \"2017-01-01T02:03:04.567Z\", \"upper\": \"2017-02-01T12:34:00.000Z\"}",
+                    "{\"lower\": \"2017-02-01T12:34:00.000Z\", \"upper\": \"2017-03-01T00:00:00.000Z\"}",
+                    "{\"lower\": \"2017-03-01T00:00:00.000Z\", \"upper\": null}"),
+            new TestRanges("tinyint",
+                    "{\"lower\": null, \"upper\": -10}",
+                    "{\"lower\": \"-10\", \"upper\": 0}",
+                    "{\"lower\": 0, \"upper\": 10}",
+                    "{\"lower\": 10, \"upper\": 20}",
+                    "{\"lower\": null, \"upper\": -10}",
+                    "{\"lower\": -10, \"upper\": 0}",
+                    "{\"lower\": 0, \"upper\": 10}",
+                    "{\"lower\": 10, \"upper\": 20}"),
+            new TestRanges("smallint",
+                    "{\"lower\": null, \"upper\": -1000}",
+                    "{\"lower\": -1000, \"upper\": 0}",
+                    "{\"lower\": 0, \"upper\": 1000}",
+                    "{\"lower\": 1000, \"upper\": 2000}"),
+            new TestRanges("integer",
+                    "{\"lower\": null, \"upper\": -1000000}",
+                    "{\"lower\": -1000000, \"upper\": 0}",
+                    "{\"lower\": 0, \"upper\": 10000}",
+                    "{\"lower\": 10000, \"upper\": 1000000}"),
+            new TestRanges("bigint",
+                    "{\"lower\": null, \"upper\": \"-123456789012345\"}",
+                    "{\"lower\": \"-123456789012345\", \"upper\": 0}",
+                    "{\"lower\": 0, \"upper\": 123400}",
+                    "{\"lower\": 123400, \"upper\": 123456789012345}",
+                    "{\"lower\": null, \"upper\": -123456789012345}",
+                    "{\"lower\": -123456789012345, \"upper\": 0}",
+                    "{\"lower\": 0, \"upper\": 123400}",
+                    "{\"lower\": 123400, \"upper\": 123456789012345}"),
+            new TestRanges("varbinary",
+                    "{\"lower\": null, \"upper\": \"YWI=\"}",
+                    "{\"lower\": \"YWI=\", \"upper\": \"ZA==\"}",
+                    "{\"lower\": \"ZA==\", \"upper\": \"bW1t\"}",
+                    "{\"lower\": \"bW1t\", \"upper\": \"eg==\"}"),
+            new TestRanges(new String[] {"smallint", "varchar"},
+                    "{\"lower\": null, \"upper\": [1, \"M\"]}",
+                    "{\"lower\": [1, \"M\"], \"upper\": [1, \"T\"]}",
+                    "{\"lower\": [1, \"T\"], \"upper\": [2, \"Z\"]}",
+                    "{\"lower\": [2, \"Z\"], \"upper\": null}"),
+    };
+
+    public TestKuduIntegrationRangePartitioning()
+    {
+        super(() -> KuduQueryRunnerFactory.createKuduQueryRunner("range_partitioning"));
+    }
+
+    @Test
+    public void testCreateAndChangeTableWithRangePartition()
+    {
+        for (TestRanges ranges : testRangesList) {
+            doTestCreateAndChangeTableWithRangePartition(ranges);
+        }
+    }
+
+    public void doTestCreateAndChangeTableWithRangePartition(TestRanges ranges)
+    {
+        String[] types = ranges.types;
+        String name = String.join("_", ranges.types);
+        String tableName = "range_partitioning_" + name;
+        String createTable = "CREATE TABLE " + tableName + " (\n";
+        String rangePartitionColumns = "ARRAY[";
+        for (int i = 0; i < types.length; i++) {
+            String type = types[i];
+            String columnName = "key" + i;
+            createTable += "  " + columnName + " " + type + " WITH (primary_key=true),\n";
+            if (i > 0) {
+                rangePartitionColumns += ",";
+            }
+            rangePartitionColumns += "'" + columnName + "'";
+        }
+        rangePartitionColumns += "]";
+
+        createTable +=
+                "  value varchar\n" +
+                        ") WITH (\n" +
+                        " partition_by_range_columns = " + rangePartitionColumns + ",\n" +
+                        " range_partitions = '[" + ranges.range1 + "," + ranges.range2 + "]'\n" +
+                        ")";
+        queryRunner.execute(createTable);
+
+        String schema = queryRunner.getDefaultSession().getSchema().get();
+
+        String addPartition3 = "CALL kudu.system.add_range_partition('" + schema + "','" + tableName + "','" + ranges.range3 + "')";
+        queryRunner.execute(addPartition3);
+        String addPartition4 = "CALL kudu.system.add_range_partition('" + schema + "','" + tableName + "','" + ranges.range4 + "')";
+        queryRunner.execute(addPartition4);
+
+        String dropPartition3 = addPartition3.replace(".add_range_partition(", ".drop_range_partition(");
+        queryRunner.execute(dropPartition3);
+
+        MaterializedResult result = queryRunner.execute("SHOW CREATE TABLE " + tableName);
+        assertEquals(result.getRowCount(), 1);
+        String createSQL = result.getMaterializedRows().get(0).getField(0).toString();
+        String rangesArray = "'[" + ranges.cmp1 + "," + ranges.cmp2 + "," + ranges.cmp4 + "]'";
+        rangesArray = rangesArray.replaceAll("\\s+", "");
+        String expectedRanges = "range_partitions = " + rangesArray;
+        assertTrue(createSQL.contains(expectedRanges), createSQL + "\ncontains\n" + expectedRanges);
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = getQueryRunner();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+
+    static class TestRanges
+    {
+        final String[] types;
+        final String range1;
+        final String range2;
+        final String range3;
+        final String range4;
+        final String cmp1;
+        final String cmp2;
+        final String cmp3;
+        final String cmp4;
+
+        TestRanges(String type, String range1, String range2, String range3, String range4)
+        {
+            this(new String[] {type}, range1, range2, range3, range4, range1, range2, range3, range4);
+        }
+
+        TestRanges(String type, String range1, String range2, String range3, String range4,
+                String cmp1, String cmp2, String cmp3, String cmp4)
+        {
+            this(new String[] {type}, range1, range2, range3, range4, cmp1, cmp2, cmp3, cmp4);
+        }
+
+        TestRanges(String[] types, String range1, String range2, String range3, String range4)
+        {
+            this(types, range1, range2, range3, range4, range1, range2, range3, range4);
+        }
+
+        TestRanges(String[] types, String range1, String range2, String range3, String range4,
+                String cmp1, String cmp2, String cmp3, String cmp4)
+        {
+            this.types = types;
+            this.range1 = range1;
+            this.range2 = range2;
+            this.range3 = range3;
+            this.range4 = range4;
+            this.cmp1 = cmp1;
+            this.cmp2 = cmp2;
+            this.cmp3 = cmp3;
+            this.cmp4 = cmp4;
+        }
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationSchemaNotExisting.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationSchemaNotExisting.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestKuduIntegrationSchemaNotExisting
+        extends AbstractTestQueryFramework
+{
+    private static String oldPrefix;
+    private QueryRunner queryRunner;
+
+    private static final String SCHEMA_NAME = "test_presto_schema";
+
+    private static final String CREATE_SCHEMA = "create schema kudu." + SCHEMA_NAME;
+
+    private static final String DROP_SCHEMA = "drop schema if exists kudu." + SCHEMA_NAME;
+
+    private static final String CREATE_TABLE = "create table if not exists kudu." + SCHEMA_NAME + ".test_presto_table (\n" +
+            "id INT WITH (primary_key=true),\n" +
+            "user_name VARCHAR\n" +
+            ") WITH (\n" +
+            " partition_by_hash_columns = ARRAY['id'],\n" +
+            " partition_by_hash_buckets = 2\n" +
+            ")";
+
+    private static final String DROP_TABLE = "drop table if exists kudu." + SCHEMA_NAME + ".test_presto_table";
+
+    public TestKuduIntegrationSchemaNotExisting()
+    {
+        super(() -> createKuduQueryRunner());
+    }
+
+    private static QueryRunner createKuduQueryRunner()
+            throws Exception
+    {
+        oldPrefix = System.getProperty("kudu.schema-emulation.prefix");
+        System.setProperty("kudu.schema-emulation.prefix", "");
+        try {
+            return KuduQueryRunnerFactory.createKuduQueryRunner("test_dummy");
+        }
+        catch (Throwable t) {
+            System.setProperty("kudu.schema-emulation.prefix", oldPrefix);
+            throw t;
+        }
+    }
+
+    @Test
+    public void testCreateTableWithoutSchema()
+    {
+        try {
+            queryRunner.execute(CREATE_TABLE);
+            fail();
+        }
+        catch (Exception e) {
+            assertEquals("Schema " + SCHEMA_NAME + " not found", e.getMessage());
+        }
+
+        queryRunner.execute(CREATE_SCHEMA);
+        queryRunner.execute(CREATE_TABLE);
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = getQueryRunner();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        System.setProperty("kudu.schema-emulation.prefix", oldPrefix);
+        if (queryRunner != null) {
+            queryRunner.execute(DROP_TABLE);
+            queryRunner.execute(DROP_SCHEMA);
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationSmoke.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationSmoke.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static io.airlift.tpch.TpchTable.ORDERS;
+
+public class TestKuduIntegrationSmoke
+        extends AbstractTestIntegrationSmokeTest
+{
+    public static final String SCHEMA = "tpch";
+
+    private QueryRunner queryRunner;
+
+    public TestKuduIntegrationSmoke()
+    {
+        super(() -> KuduQueryRunnerFactory.createKuduQueryRunnerTpch(ORDERS));
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = getQueryRunner();
+    }
+
+    /**
+     * Overrides original implementation because of usage of 'extra' column.
+     */
+    @Test
+    @Override
+    public void testDescribeTable()
+    {
+        MaterializedResult actualColumns = this.computeActual("DESC orders").toTestTypes();
+        MaterializedResult.Builder builder = MaterializedResult.resultBuilder(this.getQueryRunner().getDefaultSession(), VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR);
+        for (MaterializedRow row : actualColumns.getMaterializedRows()) {
+            builder.row(row.getField(0), row.getField(1), "", "");
+        }
+        MaterializedResult filteredActual = builder.build();
+        builder = MaterializedResult.resultBuilder(this.getQueryRunner().getDefaultSession(), VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR);
+        MaterializedResult expectedColumns = builder
+                .row("orderkey", "bigint", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "varchar", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("clerk", "varchar", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("comment", "varchar", "", "").build();
+        assertEquals(filteredActual, expectedColumns, String.format("%s != %s", filteredActual, expectedColumns));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        queryRunner.close();
+        queryRunner = null;
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduPlugin.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduPlugin.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.testing.TestingConnectorContext;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class TestKuduPlugin
+{
+    @Test
+    public void testCreateConnector()
+            throws Exception
+    {
+        Plugin plugin = new KuduPlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create("test", ImmutableMap.of("kudu.client.master-addresses", "localhost:7051"), new TestingConnectorContext());
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/properties/TestRangePartitionSerialization.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/properties/TestRangePartitionSerialization.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.properties;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestRangePartitionSerialization
+{
+    private String[] testInputs = new String[] {
+            "{\"lower\":1,\"upper\":null}",
+            "{\"lower\":12345678901234567890,\"upper\":1.234567890123457E-13}",
+            "{\"lower\":\"abc\",\"upper\":\"abf\"}",
+            "{\"lower\":false,\"upper\":true}",
+            "{\"lower\":\"ABCD\",\"upper\":\"ABCDEF\"}",
+            "{\"lower\":[\"ABCD\",1,0],\"upper\":[\"ABCD\",13,0]}",
+    };
+
+    @Test
+    public void testDeserializationSerialization()
+            throws IOException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+
+        for (String input : testInputs) {
+            RangePartition partition = mapper.readValue(input, RangePartition.class);
+
+            String serialized = mapper.writeValueAsString(partition);
+            assertEquals(serialized, input);
+        }
+    }
+}

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/schema/TestSchemaEmulation.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/schema/TestSchemaEmulation.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kudu.schema;
+
+import com.facebook.presto.spi.SchemaTableName;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestSchemaEmulation
+{
+    private static class Input
+    {
+        final String tableNamePrefix;
+        final String kuduTableName;
+        final boolean valid;
+        final String prestoSchema;
+        final String prestoTable;
+
+        Input(String tableNamePrefix, String kuduTableName, boolean valid, String prestoSchema, String prestoTable)
+        {
+            this.tableNamePrefix = tableNamePrefix;
+            this.kuduTableName = kuduTableName;
+            this.valid = valid;
+            this.prestoSchema = prestoSchema;
+            this.prestoTable = prestoTable;
+        }
+    }
+
+    private Input[] testInputs = new Input[] {
+            new Input(null, "table1", true, "default", "table1"),
+            new Input(null, "x.y", true, "default", "x.y"),
+            new Input(null, "presto::x.y.z", true, "default", "presto::x.y.z"),
+            new Input("", "table1", true, "default", "table1"),
+            new Input("", "x.y", true, "x", "y"),
+            new Input("", "x.y.z", true, "x", "y.z"),
+            new Input("", ".y", false, null, null),
+            new Input("", "y.", false, null, null),
+            new Input("presto::", "table1", true, "default", "table1"),
+            new Input("presto::", "x.y", true, "default", "x.y"),
+            new Input("presto::", "presto::x", false, null, null),
+            new Input("presto::", "presto::x.y", true, "x", "y"),
+            new Input("presto::", "presto::x.y.z", true, "x", "y.z"),
+            new Input("presto::", "presto::.y", false, null, null),
+            new Input("presto::", "presto::y.", false, null, null),
+            new Input("presto::", "presto::default.y", false, null, null),
+    };
+
+    @Test
+    public void testFromRawToRaw()
+    {
+        for (Input input : testInputs) {
+            SchemaEmulation emulation = input.tableNamePrefix != null
+                    ? new SchemaEmulationByTableNameConvention(input.tableNamePrefix) : new NoSchemaEmulation();
+            SchemaTableName schemaTableName = emulation.fromRawName(input.kuduTableName);
+            assertEquals(input.valid, schemaTableName != null);
+            if (input.valid) {
+                assertEquals(schemaTableName, new SchemaTableName(input.prestoSchema, input.prestoTable));
+                String raw = emulation.toRawName(schemaTableName);
+                assertEquals(raw, input.kuduTableName);
+            }
+        }
+    }
+}

--- a/presto-server/src/main/provisio/presto.xml
+++ b/presto-server/src/main/provisio/presto.xml
@@ -80,6 +80,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/kudu">
+        <artifact id="${project.groupId}:presto-kudu:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/atop">
         <artifact id="${project.groupId}:presto-atop:zip:${project.version}">
             <unpack />


### PR DESCRIPTION
Add connector to Apache Kudu.

It supports
- querying a Kudu table with full support of Kudu scanner predicates and Kudu partitionings/splits
- inserting, updating, deleting rows
- creating and dropping tables and schemas
- copying tables
- managing range partitions

Note: This pull request is based on the source code of [https://github.com/MartinWeindel/presto-kudu](https://github.com/MartinWeindel/presto-kudu) with adaptions for Presto build, package names, and coding styles.