### PR TITLE
Remove TypeManager parameter from BlockEncodingFactory.readEncoding

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.block.BlockSerdeUtil;
 import com.facebook.presto.hive.metastore.StorageFormat;
 import com.facebook.presto.spi.ConnectorPageSource;
@@ -22,6 +23,7 @@ import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DateType;
@@ -37,6 +39,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.tests.StructuralTestUtil;
+import com.facebook.presto.type.TypeRegistry;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -460,6 +463,8 @@ public abstract class AbstractTestHiveFileFormats
             .add(new TestColumn("t_array_string_all_nulls", getStandardListObjectInspector(javaStringObjectInspector), Arrays.asList(null, null, null), arrayBlockOf(createUnboundedVarcharType(), null, null, null)))
             .build();
 
+    private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager(new TypeRegistry());
+
     private static <K, V> Map<K, V> asMap(K[] keys, V[] values)
     {
         checkArgument(keys.length == values.length, "array lengths don't match");
@@ -783,16 +788,16 @@ public abstract class AbstractTestHiveFileFormats
         }
     }
 
-    private static void assertBlockEquals(Block actual, Block expected, String message)
+    private void assertBlockEquals(Block actual, Block expected, String message)
     {
         assertEquals(blockToSlice(actual), blockToSlice(expected), message);
     }
 
-    private static Slice blockToSlice(Block block)
+    private Slice blockToSlice(Block block)
     {
         // This function is strictly for testing use only
         SliceOutput sliceOutput = new DynamicSliceOutput(1000);
-        BlockSerdeUtil.writeBlock(sliceOutput, block);
+        BlockSerdeUtil.writeBlock(blockEncodingSerde, sliceOutput, block);
         return sliceOutput.slice();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/util/TestSerDeUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/util/TestSerDeUtils.java
@@ -13,11 +13,14 @@
  */
 package com.facebook.presto.hive.util;
 
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.block.BlockSerdeUtil;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
@@ -65,6 +68,8 @@ import static org.testng.Assert.assertEquals;
 @SuppressWarnings("PackageVisibleField")
 public class TestSerDeUtils
 {
+    private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager(new TypeRegistry());
+
     private static class ListHolder
     {
         List<InnerStruct> array;
@@ -292,16 +297,16 @@ public class TestSerDeUtils
         assertBlockEquals(actual, expected);
     }
 
-    private static void assertBlockEquals(Block actual, Block expected)
+    private void assertBlockEquals(Block actual, Block expected)
     {
         assertEquals(blockToSlice(actual), blockToSlice(expected));
     }
 
-    private static Slice blockToSlice(Block block)
+    private Slice blockToSlice(Block block)
     {
         // This function is strictly for testing use only
         SliceOutput sliceOutput = new DynamicSliceOutput(1000);
-        BlockSerdeUtil.writeBlock(sliceOutput, block);
+        BlockSerdeUtil.writeBlock(blockEncodingSerde, sliceOutput, block);
         return sliceOutput.slice();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/block/BlockEncodingManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/block/BlockEncodingManager.java
@@ -13,22 +13,22 @@
  */
 package com.facebook.presto.block;
 
-import com.facebook.presto.spi.block.ArrayBlockEncoding;
+import com.facebook.presto.spi.block.ArrayBlockEncoding.ArrayBlockEncodingFactory;
 import com.facebook.presto.spi.block.BlockEncoding;
 import com.facebook.presto.spi.block.BlockEncodingFactory;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
-import com.facebook.presto.spi.block.ByteArrayBlockEncoding;
-import com.facebook.presto.spi.block.DictionaryBlockEncoding;
-import com.facebook.presto.spi.block.FixedWidthBlockEncoding;
-import com.facebook.presto.spi.block.IntArrayBlockEncoding;
-import com.facebook.presto.spi.block.LongArrayBlockEncoding;
-import com.facebook.presto.spi.block.MapBlockEncoding;
-import com.facebook.presto.spi.block.RowBlockEncoding;
-import com.facebook.presto.spi.block.RunLengthBlockEncoding;
-import com.facebook.presto.spi.block.ShortArrayBlockEncoding;
-import com.facebook.presto.spi.block.SingleMapBlockEncoding;
-import com.facebook.presto.spi.block.SingleRowBlockEncoding;
-import com.facebook.presto.spi.block.VariableWidthBlockEncoding;
+import com.facebook.presto.spi.block.ByteArrayBlockEncoding.ByteArrayBlockEncodingFactory;
+import com.facebook.presto.spi.block.DictionaryBlockEncoding.DictionaryBlockEncodingFactory;
+import com.facebook.presto.spi.block.FixedWidthBlockEncoding.FixedWidthBlockEncodingFactory;
+import com.facebook.presto.spi.block.IntArrayBlockEncoding.IntArrayBlockEncodingFactory;
+import com.facebook.presto.spi.block.LongArrayBlockEncoding.LongArrayBlockEncodingFactory;
+import com.facebook.presto.spi.block.MapBlockEncoding.MapBlockEncodingFactory;
+import com.facebook.presto.spi.block.RowBlockEncoding.RowBlockEncodingFactory;
+import com.facebook.presto.spi.block.RunLengthBlockEncoding.RunLengthBlockEncodingFactory;
+import com.facebook.presto.spi.block.ShortArrayBlockEncoding.ShortArrayBlockEncodingFactory;
+import com.facebook.presto.spi.block.SingleMapBlockEncoding.SingleMapBlockEncodingFactory;
+import com.facebook.presto.spi.block.SingleRowBlockEncoding.SingleRowBlockEncodingFactory;
+import com.facebook.presto.spi.block.VariableWidthBlockEncoding.VariableWidthBlockEncodingFactory;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.SliceInput;
@@ -63,19 +63,19 @@ public final class BlockEncodingManager
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
 
         // always add the built-in BlockEncodingFactories
-        addBlockEncodingFactory(VariableWidthBlockEncoding.FACTORY);
-        addBlockEncodingFactory(FixedWidthBlockEncoding.FACTORY);
-        addBlockEncodingFactory(ByteArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(ShortArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(IntArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(LongArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(DictionaryBlockEncoding.FACTORY);
-        addBlockEncodingFactory(ArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(MapBlockEncoding.FACTORY);
-        addBlockEncodingFactory(SingleMapBlockEncoding.FACTORY);
-        addBlockEncodingFactory(RowBlockEncoding.FACTORY);
-        addBlockEncodingFactory(SingleRowBlockEncoding.FACTORY);
-        addBlockEncodingFactory(RunLengthBlockEncoding.FACTORY);
+        addBlockEncodingFactory(new VariableWidthBlockEncodingFactory());
+        addBlockEncodingFactory(new FixedWidthBlockEncodingFactory());
+        addBlockEncodingFactory(new ByteArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new ShortArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new IntArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new LongArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new DictionaryBlockEncodingFactory());
+        addBlockEncodingFactory(new ArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new MapBlockEncodingFactory());
+        addBlockEncodingFactory(new SingleMapBlockEncodingFactory());
+        addBlockEncodingFactory(new RowBlockEncodingFactory());
+        addBlockEncodingFactory(new SingleRowBlockEncodingFactory());
+        addBlockEncodingFactory(new RunLengthBlockEncodingFactory());
 
         for (BlockEncodingFactory<?> factory : requireNonNull(blockEncodingFactories, "blockEncodingFactories is null")) {
             addBlockEncodingFactory(factory);

--- a/presto-main/src/main/java/com/facebook/presto/block/BlockEncodingManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/block/BlockEncodingManager.java
@@ -106,48 +106,17 @@ public final class BlockEncodingManager
     @Override
     public void writeBlockEncoding(SliceOutput output, BlockEncoding encoding)
     {
-        writeBlockEncodingInternal(output, encoding);
-    }
+        // get the encoding name
+        String encodingName = encoding.getName();
 
-    /**
-     * This method enables internal implementations to serialize data without holding a BlockEncodingManager.
-     * For example, LiteralInterpreter.toExpression serializes data to produce literals.
-     */
-    public static void writeBlockEncodingInternal(SliceOutput output, BlockEncoding encoding)
-    {
-        WriteOnlyBlockEncodingManager.INSTANCE.writeBlockEncoding(output, encoding);
-    }
+        // look up the encoding factory
+        BlockEncodingFactory blockEncoding = blockEncodings.get(encodingName);
 
-    private static class WriteOnlyBlockEncodingManager
-            implements BlockEncodingSerde
-    {
-        static final WriteOnlyBlockEncodingManager INSTANCE = new WriteOnlyBlockEncodingManager();
+        // write the name to the output
+        writeLengthPrefixedString(output, encodingName);
 
-        private WriteOnlyBlockEncodingManager()
-        {
-        }
-
-        @Override
-        public BlockEncoding readBlockEncoding(SliceInput input)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void writeBlockEncoding(SliceOutput output, BlockEncoding encoding)
-        {
-            // get the encoding name
-            String encodingName = encoding.getName();
-
-            // look up the encoding factory
-            BlockEncodingFactory<BlockEncoding> blockEncoding = encoding.getFactory();
-
-            // write the name to the output
-            writeLengthPrefixedString(output, encodingName);
-
-            // write the encoding to the output
-            blockEncoding.writeEncoding(this, output, encoding);
-        }
+        // write the encoding to the output
+        blockEncoding.writeEncoding(this, output, encoding);
     }
 
     private static String readLengthPrefixedString(SliceInput input)

--- a/presto-main/src/main/java/com/facebook/presto/block/BlockEncodingManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/block/BlockEncodingManager.java
@@ -47,7 +47,6 @@ import static java.util.Objects.requireNonNull;
 public final class BlockEncodingManager
         implements BlockEncodingSerde
 {
-    private final TypeManager typeManager;
     private final ConcurrentMap<String, BlockEncodingFactory<?>> blockEncodings = new ConcurrentHashMap<>();
 
     public BlockEncodingManager(TypeManager typeManager, BlockEncodingFactory<?>... blockEncodingFactories)
@@ -60,8 +59,6 @@ public final class BlockEncodingManager
     {
         // This function should be called from Guice and tests only
 
-        this.typeManager = requireNonNull(typeManager, "typeManager is null");
-
         // always add the built-in BlockEncodingFactories
         addBlockEncodingFactory(new VariableWidthBlockEncodingFactory());
         addBlockEncodingFactory(new FixedWidthBlockEncodingFactory());
@@ -71,8 +68,8 @@ public final class BlockEncodingManager
         addBlockEncodingFactory(new LongArrayBlockEncodingFactory());
         addBlockEncodingFactory(new DictionaryBlockEncodingFactory());
         addBlockEncodingFactory(new ArrayBlockEncodingFactory());
-        addBlockEncodingFactory(new MapBlockEncodingFactory());
-        addBlockEncodingFactory(new SingleMapBlockEncodingFactory());
+        addBlockEncodingFactory(new MapBlockEncodingFactory(typeManager));
+        addBlockEncodingFactory(new SingleMapBlockEncodingFactory(typeManager));
         addBlockEncodingFactory(new RowBlockEncodingFactory());
         addBlockEncodingFactory(new SingleRowBlockEncodingFactory());
         addBlockEncodingFactory(new RunLengthBlockEncodingFactory());
@@ -100,7 +97,7 @@ public final class BlockEncodingManager
         checkArgument(blockEncoding != null, "Unknown block encoding %s", encodingName);
 
         // load read the encoding factory from the output stream
-        return blockEncoding.readEncoding(typeManager, this, input);
+        return blockEncoding.readEncoding(this, input);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/block/BlockSerdeUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/block/BlockSerdeUtil.java
@@ -62,24 +62,4 @@ public final class BlockSerdeUtil
         blockEncodingSerde.writeBlockEncoding(output, encoding);
         encoding.writeBlock(output, block);
     }
-
-    // This class is only used in LiteralInterpreter for magic literal. Most likely, you shouldn't use it from anywhere else.
-    public static void writeBlock(SliceOutput output, Block block)
-    {
-        while (true) {
-            // TODO: respect replacementBlockForWrite for Blocks nested in other Block
-            // A proposed simplified design for block encoding decoding will address this to-do item.
-
-            BlockEncoding encoding = block.getEncoding();
-            Optional<Block> replaceBlock = encoding.replacementBlockForWrite(block);
-            if (!replaceBlock.isPresent()) {
-                break;
-            }
-            block = replaceBlock.get();
-        }
-
-        BlockEncoding encoding = block.getEncoding();
-        BlockEncodingManager.writeBlockEncodingInternal(output, encoding);
-        encoding.writeBlock(output, block);
-    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -65,7 +65,6 @@ import static com.facebook.presto.sql.ExpressionUtils.and;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.combineDisjunctsWithDefault;
 import static com.facebook.presto.sql.ExpressionUtils.or;
-import static com.facebook.presto.sql.planner.LiteralEncoder.toExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
@@ -87,11 +86,14 @@ import static java.util.stream.Collectors.toList;
 
 public final class DomainTranslator
 {
-    private DomainTranslator()
+    private final LiteralEncoder literalEncoder;
+
+    public DomainTranslator(LiteralEncoder literalEncoder)
     {
+        this.literalEncoder = requireNonNull(literalEncoder, "literalEncoder is null");
     }
 
-    public static Expression toPredicate(TupleDomain<Symbol> tupleDomain)
+    public Expression toPredicate(TupleDomain<Symbol> tupleDomain)
     {
         if (tupleDomain.isNone()) {
             return FALSE_LITERAL;
@@ -104,7 +106,7 @@ public final class DomainTranslator
                 .collect(collectingAndThen(toImmutableList(), ExpressionUtils::combineConjuncts));
     }
 
-    private static Expression toPredicate(Domain domain, SymbolReference reference)
+    private Expression toPredicate(Domain domain, SymbolReference reference)
     {
         if (domain.getValues().isNone()) {
             return domain.isNullAllowed() ? new IsNullPredicate(reference) : FALSE_LITERAL;
@@ -131,7 +133,7 @@ public final class DomainTranslator
         return combineDisjunctsWithDefault(disjuncts, TRUE_LITERAL);
     }
 
-    private static Expression processRange(Type type, Range range, SymbolReference reference)
+    private Expression processRange(Type type, Range range, SymbolReference reference)
     {
         if (range.isAll()) {
             return TRUE_LITERAL;
@@ -139,17 +141,17 @@ public final class DomainTranslator
 
         if (isBetween(range)) {
             // specialize the range with BETWEEN expression if possible b/c it is currently more efficient
-            return new BetweenPredicate(reference, toExpression(range.getLow().getValue(), type), toExpression(range.getHigh().getValue(), type));
+            return new BetweenPredicate(reference, literalEncoder.toExpression(range.getLow().getValue(), type), literalEncoder.toExpression(range.getHigh().getValue(), type));
         }
 
         List<Expression> rangeConjuncts = new ArrayList<>();
         if (!range.getLow().isLowerUnbounded()) {
             switch (range.getLow().getBound()) {
                 case ABOVE:
-                    rangeConjuncts.add(new ComparisonExpression(GREATER_THAN, reference, toExpression(range.getLow().getValue(), type)));
+                    rangeConjuncts.add(new ComparisonExpression(GREATER_THAN, reference, literalEncoder.toExpression(range.getLow().getValue(), type)));
                     break;
                 case EXACTLY:
-                    rangeConjuncts.add(new ComparisonExpression(GREATER_THAN_OR_EQUAL, reference, toExpression(range.getLow().getValue(),
+                    rangeConjuncts.add(new ComparisonExpression(GREATER_THAN_OR_EQUAL, reference, literalEncoder.toExpression(range.getLow().getValue(),
                             type)));
                     break;
                 case BELOW:
@@ -163,10 +165,10 @@ public final class DomainTranslator
                 case ABOVE:
                     throw new IllegalStateException("High Marker should never use ABOVE bound: " + range);
                 case EXACTLY:
-                    rangeConjuncts.add(new ComparisonExpression(LESS_THAN_OR_EQUAL, reference, toExpression(range.getHigh().getValue(), type)));
+                    rangeConjuncts.add(new ComparisonExpression(LESS_THAN_OR_EQUAL, reference, literalEncoder.toExpression(range.getHigh().getValue(), type)));
                     break;
                 case BELOW:
-                    rangeConjuncts.add(new ComparisonExpression(LESS_THAN, reference, toExpression(range.getHigh().getValue(), type)));
+                    rangeConjuncts.add(new ComparisonExpression(LESS_THAN, reference, literalEncoder.toExpression(range.getHigh().getValue(), type)));
                     break;
                 default:
                     throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
@@ -177,7 +179,7 @@ public final class DomainTranslator
         return combineConjuncts(rangeConjuncts);
     }
 
-    private static Expression combineRangeWithExcludedPoints(Type type, SymbolReference reference, Range range, List<Expression> excludedPoints)
+    private Expression combineRangeWithExcludedPoints(Type type, SymbolReference reference, Range range, List<Expression> excludedPoints)
     {
         if (excludedPoints.isEmpty()) {
             return processRange(type, range, reference);
@@ -191,7 +193,7 @@ public final class DomainTranslator
         return combineConjuncts(processRange(type, range, reference), excludedPointsExpression);
     }
 
-    private static List<Expression> extractDisjuncts(Type type, Ranges ranges, SymbolReference reference)
+    private List<Expression> extractDisjuncts(Type type, Ranges ranges, SymbolReference reference)
     {
         List<Expression> disjuncts = new ArrayList<>();
         List<Expression> singleValues = new ArrayList<>();
@@ -206,14 +208,14 @@ public final class DomainTranslator
 
         for (Range range : originalUnionSingleValues) {
             if (range.isSingleValue()) {
-                singleValues.add(toExpression(range.getSingleValue(), type));
+                singleValues.add(literalEncoder.toExpression(range.getSingleValue(), type));
                 continue;
             }
 
             // attempt to optimize ranges that can be coalesced as long as single value points are excluded
             List<Expression> singleValuesInRange = new ArrayList<>();
             while (singleValueExclusions.hasNext() && range.contains(singleValueExclusions.peek())) {
-                singleValuesInRange.add(toExpression(singleValueExclusions.next().getSingleValue(), type));
+                singleValuesInRange.add(literalEncoder.toExpression(singleValueExclusions.next().getSingleValue(), type));
             }
 
             if (!singleValuesInRange.isEmpty()) {
@@ -234,10 +236,10 @@ public final class DomainTranslator
         return disjuncts;
     }
 
-    private static List<Expression> extractDisjuncts(Type type, DiscreteValues discreteValues, SymbolReference reference)
+    private List<Expression> extractDisjuncts(Type type, DiscreteValues discreteValues, SymbolReference reference)
     {
         List<Expression> values = discreteValues.getValues().stream()
-                .map(object -> toExpression(object, type))
+                .map(object -> literalEncoder.toExpression(object, type))
                 .collect(toList());
 
         // If values is empty, then the equatableValues was either ALL or NONE, both of which should already have been checked for
@@ -282,6 +284,7 @@ public final class DomainTranslator
             extends AstVisitor<ExtractionResult, Boolean>
     {
         private final Metadata metadata;
+        private final LiteralEncoder literalEncoder;
         private final Session session;
         private final Map<Symbol, Type> types;
         private final FunctionInvoker functionInvoker;
@@ -289,6 +292,7 @@ public final class DomainTranslator
         private Visitor(Metadata metadata, Session session, Map<Symbol, Type> types)
         {
             this.metadata = requireNonNull(metadata, "metadata is null");
+            this.literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
             this.session = requireNonNull(session, "session is null");
             this.types = ImmutableMap.copyOf(requireNonNull(types, "types is null"));
             this.functionInvoker = new FunctionInvoker(metadata.getFunctionRegistry());
@@ -607,7 +611,7 @@ public final class DomainTranslator
             boolean coercedValueIsEqualToOriginal = originalComparedToCoerced == 0;
             boolean coercedValueIsLessThanOriginal = originalComparedToCoerced > 0;
             boolean coercedValueIsGreaterThanOriginal = originalComparedToCoerced < 0;
-            Expression coercedLiteral = toExpression(coercedValue, symbolExpressionType);
+            Expression coercedLiteral = literalEncoder.toExpression(coercedValue, symbolExpressionType);
 
             switch (comparisonType) {
                 case GREATER_THAN_OR_EQUAL:

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -65,7 +65,7 @@ import static com.facebook.presto.sql.ExpressionUtils.and;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.combineDisjunctsWithDefault;
 import static com.facebook.presto.sql.ExpressionUtils.or;
-import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpression;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -63,11 +63,10 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
  * Note: non-deterministic predicates can not be pulled up (so they will be ignored)
  */
 public class EffectivePredicateExtractor
-        extends PlanVisitor<Expression, Void>
 {
     public static Expression extract(PlanNode node)
     {
-        return node.accept(new EffectivePredicateExtractor(), null);
+        return node.accept(new Visitor(), null);
     }
 
     private static final Predicate<Map.Entry<Symbol, ? extends Expression>> SYMBOL_MATCHES_EXPRESSION =
@@ -84,230 +83,234 @@ public class EffectivePredicateExtractor
 
     private EffectivePredicateExtractor() {}
 
-    @Override
-    protected Expression visitPlan(PlanNode node, Void context)
+    private static class Visitor
+            extends PlanVisitor<Expression, Void>
     {
-        return TRUE_LITERAL;
-    }
-
-    @Override
-    public Expression visitAggregation(AggregationNode node, Void context)
-    {
-        // GROUP BY () always produces a group, regardless of whether there's any
-        // input (unlike the case where there are group by keys, which produce
-        // no output if there's no input).
-        // Therefore, we can't say anything about the effective predicate of the
-        // output of such an aggregation.
-        if (node.getGroupingKeys().isEmpty()) {
+        @Override
+        protected Expression visitPlan(PlanNode node, Void context)
+        {
             return TRUE_LITERAL;
         }
 
-        Expression underlyingPredicate = node.getSource().accept(this, context);
-
-        return pullExpressionThroughSymbols(underlyingPredicate, node.getGroupingKeys());
-    }
-
-    @Override
-    public Expression visitFilter(FilterNode node, Void context)
-    {
-        Expression underlyingPredicate = node.getSource().accept(this, context);
-
-        Expression predicate = node.getPredicate();
-
-        // Remove non-deterministic conjuncts
-        predicate = filterDeterministicConjuncts(predicate);
-
-        return combineConjuncts(predicate, underlyingPredicate);
-    }
-
-    @Override
-    public Expression visitExchange(ExchangeNode node, Void context)
-    {
-        return deriveCommonPredicates(node, source -> {
-            Map<Symbol, SymbolReference> mappings = new HashMap<>();
-            for (int i = 0; i < node.getInputs().get(source).size(); i++) {
-                mappings.put(
-                        node.getOutputSymbols().get(i),
-                        node.getInputs().get(source).get(i).toSymbolReference());
+        @Override
+        public Expression visitAggregation(AggregationNode node, Void context)
+        {
+            // GROUP BY () always produces a group, regardless of whether there's any
+            // input (unlike the case where there are group by keys, which produce
+            // no output if there's no input).
+            // Therefore, we can't say anything about the effective predicate of the
+            // output of such an aggregation.
+            if (node.getGroupingKeys().isEmpty()) {
+                return TRUE_LITERAL;
             }
-            return mappings.entrySet();
-        });
-    }
 
-    @Override
-    public Expression visitProject(ProjectNode node, Void context)
-    {
-        // TODO: add simple algebraic solver for projection translation (right now only considers identity projections)
+            Expression underlyingPredicate = node.getSource().accept(this, context);
 
-        Expression underlyingPredicate = node.getSource().accept(this, context);
-
-        List<Expression> projectionEqualities = node.getAssignments().entrySet().stream()
-                .filter(SYMBOL_MATCHES_EXPRESSION.negate())
-                .map(ENTRY_TO_EQUALITY)
-                .collect(toImmutableList());
-
-        return pullExpressionThroughSymbols(combineConjuncts(
-                ImmutableList.<Expression>builder()
-                        .addAll(projectionEqualities)
-                        .add(underlyingPredicate)
-                        .build()),
-                node.getOutputSymbols());
-    }
-
-    @Override
-    public Expression visitTopN(TopNNode node, Void context)
-    {
-        return node.getSource().accept(this, context);
-    }
-
-    @Override
-    public Expression visitLimit(LimitNode node, Void context)
-    {
-        return node.getSource().accept(this, context);
-    }
-
-    @Override
-    public Expression visitDistinctLimit(DistinctLimitNode node, Void context)
-    {
-        return node.getSource().accept(this, context);
-    }
-
-    @Override
-    public Expression visitTableScan(TableScanNode node, Void context)
-    {
-        Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
-        return DomainTranslator.toPredicate(node.getCurrentConstraint().simplify().transform(assignments::get));
-    }
-
-    @Override
-    public Expression visitSort(SortNode node, Void context)
-    {
-        return node.getSource().accept(this, context);
-    }
-
-    @Override
-    public Expression visitWindow(WindowNode node, Void context)
-    {
-        return node.getSource().accept(this, context);
-    }
-
-    @Override
-    public Expression visitUnion(UnionNode node, Void context)
-    {
-        return deriveCommonPredicates(node, source -> node.outputSymbolMap(source).entries());
-    }
-
-    @Override
-    public Expression visitJoin(JoinNode node, Void context)
-    {
-        Expression leftPredicate = node.getLeft().accept(this, context);
-        Expression rightPredicate = node.getRight().accept(this, context);
-
-        List<Expression> joinConjuncts = node.getCriteria().stream()
-                .map(JoinNode.EquiJoinClause::toExpression)
-                .collect(toImmutableList());
-
-        switch (node.getType()) {
-            case INNER:
-                return combineConjuncts(ImmutableList.<Expression>builder()
-                        .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))
-                        .add(pullExpressionThroughSymbols(rightPredicate, node.getOutputSymbols()))
-                        .addAll(pullExpressionsThroughSymbols(joinConjuncts, node.getOutputSymbols()))
-                        .build());
-            case LEFT:
-                return combineConjuncts(ImmutableList.<Expression>builder()
-                        .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))
-                        .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(rightPredicate), node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
-                        .addAll(pullNullableConjunctsThroughOuterJoin(joinConjuncts, node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
-                        .build());
-            case RIGHT:
-                return combineConjuncts(ImmutableList.<Expression>builder()
-                        .add(pullExpressionThroughSymbols(rightPredicate, node.getOutputSymbols()))
-                        .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(leftPredicate), node.getOutputSymbols(), node.getLeft().getOutputSymbols()::contains))
-                        .addAll(pullNullableConjunctsThroughOuterJoin(joinConjuncts, node.getOutputSymbols(), node.getLeft().getOutputSymbols()::contains))
-                        .build());
-            case FULL:
-                return combineConjuncts(ImmutableList.<Expression>builder()
-                        .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(leftPredicate), node.getOutputSymbols(), node.getLeft().getOutputSymbols()::contains))
-                        .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(rightPredicate), node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
-                        .addAll(pullNullableConjunctsThroughOuterJoin(joinConjuncts, node.getOutputSymbols(), node.getLeft().getOutputSymbols()::contains, node.getRight().getOutputSymbols()::contains))
-                        .build());
-            default:
-                throw new UnsupportedOperationException("Unknown join type: " + node.getType());
+            return pullExpressionThroughSymbols(underlyingPredicate, node.getGroupingKeys());
         }
-    }
 
-    private static Iterable<Expression> pullNullableConjunctsThroughOuterJoin(List<Expression> conjuncts, Collection<Symbol> outputSymbols, Predicate<Symbol>... nullSymbolScopes)
-    {
-        // Conjuncts without any symbol dependencies cannot be applied to the effective predicate (e.g. FALSE literal)
-        return conjuncts.stream()
-                .map(expression -> pullExpressionThroughSymbols(expression, outputSymbols))
-                .map(expression -> SymbolsExtractor.extractAll(expression).isEmpty() ? TRUE_LITERAL : expression)
-                .map(expressionOrNullSymbols(nullSymbolScopes))
-                .collect(toImmutableList());
-    }
+        @Override
+        public Expression visitFilter(FilterNode node, Void context)
+        {
+            Expression underlyingPredicate = node.getSource().accept(this, context);
 
-    @Override
-    public Expression visitSemiJoin(SemiJoinNode node, Void context)
-    {
-        // Filtering source does not change the effective predicate over the output symbols
-        return node.getSource().accept(this, context);
-    }
+            Expression predicate = node.getPredicate();
 
-    private Expression deriveCommonPredicates(PlanNode node, Function<Integer, Collection<Map.Entry<Symbol, SymbolReference>>> mapping)
-    {
-        // Find the predicates that can be pulled up from each source
-        List<Set<Expression>> sourceOutputConjuncts = new ArrayList<>();
-        for (int i = 0; i < node.getSources().size(); i++) {
-            Expression underlyingPredicate = node.getSources().get(i).accept(this, null);
+            // Remove non-deterministic conjuncts
+            predicate = filterDeterministicConjuncts(predicate);
 
-            List<Expression> equalities = mapping.apply(i).stream()
+            return combineConjuncts(predicate, underlyingPredicate);
+        }
+
+        @Override
+        public Expression visitExchange(ExchangeNode node, Void context)
+        {
+            return deriveCommonPredicates(node, source -> {
+                Map<Symbol, SymbolReference> mappings = new HashMap<>();
+                for (int i = 0; i < node.getInputs().get(source).size(); i++) {
+                    mappings.put(
+                            node.getOutputSymbols().get(i),
+                            node.getInputs().get(source).get(i).toSymbolReference());
+                }
+                return mappings.entrySet();
+            });
+        }
+
+        @Override
+        public Expression visitProject(ProjectNode node, Void context)
+        {
+            // TODO: add simple algebraic solver for projection translation (right now only considers identity projections)
+
+            Expression underlyingPredicate = node.getSource().accept(this, context);
+
+            List<Expression> projectionEqualities = node.getAssignments().entrySet().stream()
                     .filter(SYMBOL_MATCHES_EXPRESSION.negate())
                     .map(ENTRY_TO_EQUALITY)
                     .collect(toImmutableList());
 
-            sourceOutputConjuncts.add(ImmutableSet.copyOf(extractConjuncts(pullExpressionThroughSymbols(combineConjuncts(
+            return pullExpressionThroughSymbols(combineConjuncts(
                     ImmutableList.<Expression>builder()
-                            .addAll(equalities)
+                            .addAll(projectionEqualities)
                             .add(underlyingPredicate)
                             .build()),
-                    node.getOutputSymbols()))));
+                    node.getOutputSymbols());
         }
 
-        // Find the intersection of predicates across all sources
-        // TODO: use a more precise way to determine overlapping conjuncts (e.g. commutative predicates)
-        Iterator<Set<Expression>> iterator = sourceOutputConjuncts.iterator();
-        Set<Expression> potentialOutputConjuncts = iterator.next();
-        while (iterator.hasNext()) {
-            potentialOutputConjuncts = Sets.intersection(potentialOutputConjuncts, iterator.next());
+        @Override
+        public Expression visitTopN(TopNNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
         }
 
-        return combineConjuncts(potentialOutputConjuncts);
-    }
+        @Override
+        public Expression visitLimit(LimitNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
 
-    private static List<Expression> pullExpressionsThroughSymbols(List<Expression> expressions, Collection<Symbol> symbols)
-    {
-        return expressions.stream()
-                .map(expression -> pullExpressionThroughSymbols(expression, symbols))
-                .collect(toImmutableList());
-    }
+        @Override
+        public Expression visitDistinctLimit(DistinctLimitNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
 
-    private static Expression pullExpressionThroughSymbols(Expression expression, Collection<Symbol> symbols)
-    {
-        EqualityInference equalityInference = createEqualityInference(expression);
+        @Override
+        public Expression visitTableScan(TableScanNode node, Void context)
+        {
+            Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
+            return DomainTranslator.toPredicate(node.getCurrentConstraint().simplify().transform(assignments::get));
+        }
 
-        ImmutableList.Builder<Expression> effectiveConjuncts = ImmutableList.builder();
-        for (Expression conjunct : EqualityInference.nonInferrableConjuncts(expression)) {
-            if (DeterminismEvaluator.isDeterministic(conjunct)) {
-                Expression rewritten = equalityInference.rewriteExpression(conjunct, in(symbols));
-                if (rewritten != null) {
-                    effectiveConjuncts.add(rewritten);
-                }
+        @Override
+        public Expression visitSort(SortNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Expression visitWindow(WindowNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Expression visitUnion(UnionNode node, Void context)
+        {
+            return deriveCommonPredicates(node, source -> node.outputSymbolMap(source).entries());
+        }
+
+        @Override
+        public Expression visitJoin(JoinNode node, Void context)
+        {
+            Expression leftPredicate = node.getLeft().accept(this, context);
+            Expression rightPredicate = node.getRight().accept(this, context);
+
+            List<Expression> joinConjuncts = node.getCriteria().stream()
+                    .map(JoinNode.EquiJoinClause::toExpression)
+                    .collect(toImmutableList());
+
+            switch (node.getType()) {
+                case INNER:
+                    return combineConjuncts(ImmutableList.<Expression>builder()
+                            .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))
+                            .add(pullExpressionThroughSymbols(rightPredicate, node.getOutputSymbols()))
+                            .addAll(pullExpressionsThroughSymbols(joinConjuncts, node.getOutputSymbols()))
+                            .build());
+                case LEFT:
+                    return combineConjuncts(ImmutableList.<Expression>builder()
+                            .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))
+                            .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(rightPredicate), node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
+                            .addAll(pullNullableConjunctsThroughOuterJoin(joinConjuncts, node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
+                            .build());
+                case RIGHT:
+                    return combineConjuncts(ImmutableList.<Expression>builder()
+                            .add(pullExpressionThroughSymbols(rightPredicate, node.getOutputSymbols()))
+                            .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(leftPredicate), node.getOutputSymbols(), node.getLeft().getOutputSymbols()::contains))
+                            .addAll(pullNullableConjunctsThroughOuterJoin(joinConjuncts, node.getOutputSymbols(), node.getLeft().getOutputSymbols()::contains))
+                            .build());
+                case FULL:
+                    return combineConjuncts(ImmutableList.<Expression>builder()
+                            .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(leftPredicate), node.getOutputSymbols(), node.getLeft().getOutputSymbols()::contains))
+                            .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(rightPredicate), node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
+                            .addAll(pullNullableConjunctsThroughOuterJoin(joinConjuncts, node.getOutputSymbols(), node.getLeft().getOutputSymbols()::contains, node.getRight().getOutputSymbols()::contains))
+                            .build());
+                default:
+                    throw new UnsupportedOperationException("Unknown join type: " + node.getType());
             }
         }
 
-        effectiveConjuncts.addAll(equalityInference.generateEqualitiesPartitionedBy(in(symbols)).getScopeEqualities());
+        private static Iterable<Expression> pullNullableConjunctsThroughOuterJoin(List<Expression> conjuncts, Collection<Symbol> outputSymbols, Predicate<Symbol>... nullSymbolScopes)
+        {
+            // Conjuncts without any symbol dependencies cannot be applied to the effective predicate (e.g. FALSE literal)
+            return conjuncts.stream()
+                    .map(expression -> pullExpressionThroughSymbols(expression, outputSymbols))
+                    .map(expression -> SymbolsExtractor.extractAll(expression).isEmpty() ? TRUE_LITERAL : expression)
+                    .map(expressionOrNullSymbols(nullSymbolScopes))
+                    .collect(toImmutableList());
+        }
 
-        return combineConjuncts(effectiveConjuncts.build());
+        @Override
+        public Expression visitSemiJoin(SemiJoinNode node, Void context)
+        {
+            // Filtering source does not change the effective predicate over the output symbols
+            return node.getSource().accept(this, context);
+        }
+
+        private Expression deriveCommonPredicates(PlanNode node, Function<Integer, Collection<Map.Entry<Symbol, SymbolReference>>> mapping)
+        {
+            // Find the predicates that can be pulled up from each source
+            List<Set<Expression>> sourceOutputConjuncts = new ArrayList<>();
+            for (int i = 0; i < node.getSources().size(); i++) {
+                Expression underlyingPredicate = node.getSources().get(i).accept(this, null);
+
+                List<Expression> equalities = mapping.apply(i).stream()
+                        .filter(SYMBOL_MATCHES_EXPRESSION.negate())
+                        .map(ENTRY_TO_EQUALITY)
+                        .collect(toImmutableList());
+
+                sourceOutputConjuncts.add(ImmutableSet.copyOf(extractConjuncts(pullExpressionThroughSymbols(combineConjuncts(
+                        ImmutableList.<Expression>builder()
+                                .addAll(equalities)
+                                .add(underlyingPredicate)
+                                .build()),
+                        node.getOutputSymbols()))));
+            }
+
+            // Find the intersection of predicates across all sources
+            // TODO: use a more precise way to determine overlapping conjuncts (e.g. commutative predicates)
+            Iterator<Set<Expression>> iterator = sourceOutputConjuncts.iterator();
+            Set<Expression> potentialOutputConjuncts = iterator.next();
+            while (iterator.hasNext()) {
+                potentialOutputConjuncts = Sets.intersection(potentialOutputConjuncts, iterator.next());
+            }
+
+            return combineConjuncts(potentialOutputConjuncts);
+        }
+
+        private static List<Expression> pullExpressionsThroughSymbols(List<Expression> expressions, Collection<Symbol> symbols)
+        {
+            return expressions.stream()
+                    .map(expression -> pullExpressionThroughSymbols(expression, symbols))
+                    .collect(toImmutableList());
+        }
+
+        private static Expression pullExpressionThroughSymbols(Expression expression, Collection<Symbol> symbols)
+        {
+            EqualityInference equalityInference = createEqualityInference(expression);
+
+            ImmutableList.Builder<Expression> effectiveConjuncts = ImmutableList.builder();
+            for (Expression conjunct : EqualityInference.nonInferrableConjuncts(expression)) {
+                if (DeterminismEvaluator.isDeterministic(conjunct)) {
+                    Expression rewritten = equalityInference.rewriteExpression(conjunct, in(symbols));
+                    if (rewritten != null) {
+                        effectiveConjuncts.add(rewritten);
+                    }
+                }
+            }
+
+            effectiveConjuncts.addAll(equalityInference.generateEqualitiesPartitionedBy(in(symbols)).getScopeEqualities());
+
+            return combineConjuncts(effectiveConjuncts.build());
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -117,8 +117,8 @@ import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.createConstant
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.EXPRESSION_NOT_CONSTANT;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.gen.VarArgsToMapAdapterGenerator.generateVarArgsToMapAdapter;
-import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpression;
-import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpressions;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toExpression;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toExpressions;
 import static com.facebook.presto.sql.planner.iterative.rule.CanonicalizeExpressionRewriter.canonicalizeExpression;
 import static com.facebook.presto.type.LikeFunctions.isLikePattern;
 import static com.facebook.presto.type.LikeFunctions.unescapeLiteralLikePattern;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralEncoder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralEncoder.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.scalar.VarbinaryFunctions;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
@@ -61,9 +62,14 @@ import static java.util.Objects.requireNonNull;
 
 public final class LiteralEncoder
 {
-    private LiteralEncoder() {}
+    private final BlockEncodingSerde blockEncodingSerde;
 
-    public static List<Expression> toExpressions(List<?> objects, List<? extends Type> types)
+    public LiteralEncoder(BlockEncodingSerde blockEncodingSerde)
+    {
+        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
+    }
+
+    public List<Expression> toExpressions(List<?> objects, List<? extends Type> types)
     {
         requireNonNull(objects, "objects is null");
         requireNonNull(types, "types is null");
@@ -78,7 +84,7 @@ public final class LiteralEncoder
         return expressions.build();
     }
 
-    public static Expression toExpression(Object object, Type type)
+    public Expression toExpression(Object object, Type type)
     {
         requireNonNull(type, "type is null");
 
@@ -176,7 +182,7 @@ public final class LiteralEncoder
 
         if (object instanceof Block) {
             SliceOutput output = new DynamicSliceOutput(toIntExact(((Block) object).getSizeInBytes()));
-            BlockSerdeUtil.writeBlock(output, (Block) object);
+            BlockSerdeUtil.writeBlock(blockEncodingSerde, output, (Block) object);
             object = output.slice();
             // This if condition will evaluate to true: object instanceof Slice && !type.equals(VARCHAR)
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralEncoder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralEncoder.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.block.BlockSerdeUtil;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.scalar.VarbinaryFunctions;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.CharType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.SqlDate;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
+import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
+import com.facebook.presto.sql.tree.BooleanLiteral;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.DecimalLiteral;
+import com.facebook.presto.sql.tree.DoubleLiteral;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GenericLiteral;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Primitives;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.SliceUtf8;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public final class LiteralEncoder
+{
+    private LiteralEncoder() {}
+
+    public static List<Expression> toExpressions(List<?> objects, List<? extends Type> types)
+    {
+        requireNonNull(objects, "objects is null");
+        requireNonNull(types, "types is null");
+        checkArgument(objects.size() == types.size(), "objects and types do not have the same size");
+
+        ImmutableList.Builder<Expression> expressions = ImmutableList.builder();
+        for (int i = 0; i < objects.size(); i++) {
+            Object object = objects.get(i);
+            Type type = types.get(i);
+            expressions.add(toExpression(object, type));
+        }
+        return expressions.build();
+    }
+
+    public static Expression toExpression(Object object, Type type)
+    {
+        requireNonNull(type, "type is null");
+
+        if (object instanceof Expression) {
+            return (Expression) object;
+        }
+
+        if (object == null) {
+            if (type.equals(UNKNOWN)) {
+                return new NullLiteral();
+            }
+            return new Cast(new NullLiteral(), type.getTypeSignature().toString(), false, true);
+        }
+
+        if (type.equals(INTEGER)) {
+            return new LongLiteral(object.toString());
+        }
+
+        if (type.equals(BIGINT)) {
+            LongLiteral expression = new LongLiteral(object.toString());
+            if (expression.getValue() >= Integer.MIN_VALUE && expression.getValue() <= Integer.MAX_VALUE) {
+                return new GenericLiteral("BIGINT", object.toString());
+            }
+            return new LongLiteral(object.toString());
+        }
+
+        checkArgument(Primitives.wrap(type.getJavaType()).isInstance(object), "object.getClass (%s) and type.getJavaType (%s) do not agree", object.getClass(), type.getJavaType());
+
+        if (type.equals(DOUBLE)) {
+            Double value = (Double) object;
+            // WARNING: the ORC predicate code depends on NaN and infinity not appearing in a tuple domain, so
+            // if you remove this, you will need to update the TupleDomainOrcPredicate
+            // When changing this, don't forget about similar code for REAL below
+            if (value.isNaN()) {
+                return new FunctionCall(QualifiedName.of("nan"), ImmutableList.of());
+            }
+            if (value.equals(Double.NEGATIVE_INFINITY)) {
+                return ArithmeticUnaryExpression.negative(new FunctionCall(QualifiedName.of("infinity"), ImmutableList.of()));
+            }
+            if (value.equals(Double.POSITIVE_INFINITY)) {
+                return new FunctionCall(QualifiedName.of("infinity"), ImmutableList.of());
+            }
+            return new DoubleLiteral(object.toString());
+        }
+
+        if (type.equals(REAL)) {
+            Float value = intBitsToFloat(((Long) object).intValue());
+            // WARNING for ORC predicate code as above (for double)
+            if (value.isNaN()) {
+                return new Cast(new FunctionCall(QualifiedName.of("nan"), ImmutableList.of()), StandardTypes.REAL);
+            }
+            if (value.equals(Float.NEGATIVE_INFINITY)) {
+                return ArithmeticUnaryExpression.negative(new Cast(new FunctionCall(QualifiedName.of("infinity"), ImmutableList.of()), StandardTypes.REAL));
+            }
+            if (value.equals(Float.POSITIVE_INFINITY)) {
+                return new Cast(new FunctionCall(QualifiedName.of("infinity"), ImmutableList.of()), StandardTypes.REAL);
+            }
+            return new GenericLiteral("REAL", value.toString());
+        }
+
+        if (type instanceof DecimalType) {
+            String string;
+            if (isShortDecimal(type)) {
+                string = Decimals.toString((long) object, ((DecimalType) type).getScale());
+            }
+            else {
+                string = Decimals.toString((Slice) object, ((DecimalType) type).getScale());
+            }
+            return new Cast(new DecimalLiteral(string), type.getDisplayName());
+        }
+
+        if (type instanceof VarcharType) {
+            VarcharType varcharType = (VarcharType) type;
+            Slice value = (Slice) object;
+            StringLiteral stringLiteral = new StringLiteral(value.toStringUtf8());
+
+            if (!varcharType.isUnbounded() && varcharType.getLengthSafe() == SliceUtf8.countCodePoints(value)) {
+                return stringLiteral;
+            }
+            return new Cast(stringLiteral, type.getDisplayName(), false, true);
+        }
+
+        if (type instanceof CharType) {
+            StringLiteral stringLiteral = new StringLiteral(((Slice) object).toStringUtf8());
+            return new Cast(stringLiteral, type.getDisplayName(), false, true);
+        }
+
+        if (type.equals(BOOLEAN)) {
+            return new BooleanLiteral(object.toString());
+        }
+
+        if (type.equals(DATE)) {
+            return new GenericLiteral("DATE", new SqlDate(toIntExact((Long) object)).toString());
+        }
+
+        if (object instanceof Block) {
+            SliceOutput output = new DynamicSliceOutput(toIntExact(((Block) object).getSizeInBytes()));
+            BlockSerdeUtil.writeBlock(output, (Block) object);
+            object = output.slice();
+            // This if condition will evaluate to true: object instanceof Slice && !type.equals(VARCHAR)
+        }
+
+        if (object instanceof Slice) {
+            // HACK: we need to serialize VARBINARY in a format that can be embedded in an expression to be
+            // able to encode it in the plan that gets sent to workers.
+            // We do this by transforming the in-memory varbinary into a call to from_base64(<base64-encoded value>)
+            FunctionCall fromBase64 = new FunctionCall(QualifiedName.of("from_base64"), ImmutableList.of(new StringLiteral(VarbinaryFunctions.toBase64((Slice) object).toStringUtf8())));
+            Signature signature = FunctionRegistry.getMagicLiteralFunctionSignature(type);
+            return new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.of(fromBase64));
+        }
+
+        Signature signature = FunctionRegistry.getMagicLiteralFunctionSignature(type);
+        Expression rawLiteral = toExpression(object, FunctionRegistry.typeForMagicLiteral(type));
+
+        return new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.of(rawLiteral));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -13,74 +13,43 @@
  */
 package com.facebook.presto.sql.planner;
 
-import com.facebook.presto.block.BlockSerdeUtil;
-import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.operator.scalar.VarbinaryFunctions;
 import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.type.CharType;
-import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
-import com.facebook.presto.spi.type.SqlDate;
-import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.FunctionInvoker;
 import com.facebook.presto.sql.analyzer.SemanticException;
-import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.BinaryLiteral;
 import com.facebook.presto.sql.tree.BooleanLiteral;
-import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CharLiteral;
 import com.facebook.presto.sql.tree.DecimalLiteral;
 import com.facebook.presto.sql.tree.DoubleLiteral;
 import com.facebook.presto.sql.tree.Expression;
-import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.IntervalLiteral;
 import com.facebook.presto.sql.tree.Literal;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NullLiteral;
-import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Primitives;
-import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
-import io.airlift.slice.SliceOutput;
-import io.airlift.slice.SliceUtf8;
-
-import java.util.List;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
-import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.spi.type.DateType.DATE;
-import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
-import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
-import static com.facebook.presto.spi.type.IntegerType.INTEGER;
-import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_LITERAL;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
 import static com.facebook.presto.type.JsonType.JSON;
-import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.util.DateTimeUtils.parseDayTimeInterval;
 import static com.facebook.presto.util.DateTimeUtils.parseTime;
 import static com.facebook.presto.util.DateTimeUtils.parseTimestampLiteral;
 import static com.facebook.presto.util.DateTimeUtils.parseYearMonthInterval;
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.utf8Slice;
-import static java.lang.Float.intBitsToFloat;
-import static java.lang.Math.toIntExact;
-import static java.util.Objects.requireNonNull;
 
 public final class LiteralInterpreter
 {
@@ -92,139 +61,6 @@ public final class LiteralInterpreter
             throw new IllegalArgumentException("node must be a Literal");
         }
         return new LiteralVisitor(metadata).process(node, session);
-    }
-
-    public static List<Expression> toExpressions(List<?> objects, List<? extends Type> types)
-    {
-        requireNonNull(objects, "objects is null");
-        requireNonNull(types, "types is null");
-        checkArgument(objects.size() == types.size(), "objects and types do not have the same size");
-
-        ImmutableList.Builder<Expression> expressions = ImmutableList.builder();
-        for (int i = 0; i < objects.size(); i++) {
-            Object object = objects.get(i);
-            Type type = types.get(i);
-            expressions.add(toExpression(object, type));
-        }
-        return expressions.build();
-    }
-
-    public static Expression toExpression(Object object, Type type)
-    {
-        requireNonNull(type, "type is null");
-
-        if (object instanceof Expression) {
-            return (Expression) object;
-        }
-
-        if (object == null) {
-            if (type.equals(UNKNOWN)) {
-                return new NullLiteral();
-            }
-            return new Cast(new NullLiteral(), type.getTypeSignature().toString(), false, true);
-        }
-
-        if (type.equals(INTEGER)) {
-            return new LongLiteral(object.toString());
-        }
-
-        if (type.equals(BIGINT)) {
-            LongLiteral expression = new LongLiteral(object.toString());
-            if (expression.getValue() >= Integer.MIN_VALUE && expression.getValue() <= Integer.MAX_VALUE) {
-                return new GenericLiteral("BIGINT", object.toString());
-            }
-            return new LongLiteral(object.toString());
-        }
-
-        checkArgument(Primitives.wrap(type.getJavaType()).isInstance(object), "object.getClass (%s) and type.getJavaType (%s) do not agree", object.getClass(), type.getJavaType());
-
-        if (type.equals(DOUBLE)) {
-            Double value = (Double) object;
-            // WARNING: the ORC predicate code depends on NaN and infinity not appearing in a tuple domain, so
-            // if you remove this, you will need to update the TupleDomainOrcPredicate
-            // When changing this, don't forget about similar code for REAL below
-            if (value.isNaN()) {
-                return new FunctionCall(QualifiedName.of("nan"), ImmutableList.of());
-            }
-            if (value.equals(Double.NEGATIVE_INFINITY)) {
-                return ArithmeticUnaryExpression.negative(new FunctionCall(QualifiedName.of("infinity"), ImmutableList.of()));
-            }
-            if (value.equals(Double.POSITIVE_INFINITY)) {
-                return new FunctionCall(QualifiedName.of("infinity"), ImmutableList.of());
-            }
-            return new DoubleLiteral(object.toString());
-        }
-
-        if (type.equals(REAL)) {
-            Float value = intBitsToFloat(((Long) object).intValue());
-            // WARNING for ORC predicate code as above (for double)
-            if (value.isNaN()) {
-                return new Cast(new FunctionCall(QualifiedName.of("nan"), ImmutableList.of()), StandardTypes.REAL);
-            }
-            if (value.equals(Float.NEGATIVE_INFINITY)) {
-                return ArithmeticUnaryExpression.negative(new Cast(new FunctionCall(QualifiedName.of("infinity"), ImmutableList.of()), StandardTypes.REAL));
-            }
-            if (value.equals(Float.POSITIVE_INFINITY)) {
-                return new Cast(new FunctionCall(QualifiedName.of("infinity"), ImmutableList.of()), StandardTypes.REAL);
-            }
-            return new GenericLiteral("REAL", value.toString());
-        }
-
-        if (type instanceof DecimalType) {
-            String string;
-            if (isShortDecimal(type)) {
-                string = Decimals.toString((long) object, ((DecimalType) type).getScale());
-            }
-            else {
-                string = Decimals.toString((Slice) object, ((DecimalType) type).getScale());
-            }
-            return new Cast(new DecimalLiteral(string), type.getDisplayName());
-        }
-
-        if (type instanceof VarcharType) {
-            VarcharType varcharType = (VarcharType) type;
-            Slice value = (Slice) object;
-            StringLiteral stringLiteral = new StringLiteral(value.toStringUtf8());
-
-            if (!varcharType.isUnbounded() && varcharType.getLengthSafe() == SliceUtf8.countCodePoints(value)) {
-                return stringLiteral;
-            }
-            return new Cast(stringLiteral, type.getDisplayName(), false, true);
-        }
-
-        if (type instanceof CharType) {
-            StringLiteral stringLiteral = new StringLiteral(((Slice) object).toStringUtf8());
-            return new Cast(stringLiteral, type.getDisplayName(), false, true);
-        }
-
-        if (type.equals(BOOLEAN)) {
-            return new BooleanLiteral(object.toString());
-        }
-
-        if (type.equals(DATE)) {
-            return new GenericLiteral("DATE", new SqlDate(toIntExact((Long) object)).toString());
-        }
-
-        if (object instanceof Block) {
-            SliceOutput output = new DynamicSliceOutput(toIntExact(((Block) object).getSizeInBytes()));
-            BlockSerdeUtil.writeBlock(output, (Block) object);
-            object = output.slice();
-            // This if condition will evaluate to true: object instanceof Slice && !type.equals(VARCHAR)
-        }
-
-        if (object instanceof Slice) {
-            // HACK: we need to serialize VARBINARY in a format that can be embedded in an expression to be
-            // able to encode it in the plan that gets sent to workers.
-            // We do this by transforming the in-memory varbinary into a call to from_base64(<base64-encoded value>)
-            FunctionCall fromBase64 = new FunctionCall(QualifiedName.of("from_base64"), ImmutableList.of(new StringLiteral(VarbinaryFunctions.toBase64((Slice) object).toStringUtf8())));
-            Signature signature = FunctionRegistry.getMagicLiteralFunctionSignature(type);
-            return new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.of(fromBase64));
-        }
-
-        Signature signature = FunctionRegistry.getMagicLiteralFunctionSignature(type);
-        Expression rawLiteral = toExpression(object, FunctionRegistry.typeForMagicLiteral(type));
-
-        return new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.of(rawLiteral));
     }
 
     private static class LiteralVisitor

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyExpressions.java
@@ -41,7 +41,7 @@ public class SimplifyExpressions
         extends ExpressionRewriteRuleSet
 {
     @VisibleForTesting
-    static Expression rewrite(Expression expression, Session session, SymbolAllocator symbolAllocator, Metadata metadata, SqlParser sqlParser)
+    static Expression rewrite(Expression expression, Session session, SymbolAllocator symbolAllocator, Metadata metadata, LiteralEncoder literalEncoder, SqlParser sqlParser)
     {
         requireNonNull(metadata, "metadata is null");
         requireNonNull(sqlParser, "sqlParser is null");
@@ -52,7 +52,7 @@ public class SimplifyExpressions
         expression = extractCommonPredicates(expression);
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, symbolAllocator.getTypes(), expression, emptyList() /* parameters already replaced */);
         ExpressionInterpreter interpreter = ExpressionInterpreter.expressionOptimizer(expression, metadata, session, expressionTypes);
-        return LiteralEncoder.toExpression(interpreter.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(NodeRef.of(expression)));
+        return literalEncoder.toExpression(interpreter.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(NodeRef.of(expression)));
     }
 
     public SimplifyExpressions(Metadata metadata, SqlParser sqlParser)
@@ -75,7 +75,8 @@ public class SimplifyExpressions
     {
         requireNonNull(metadata, "metadata is null");
         requireNonNull(sqlParser, "sqlParser is null");
+        LiteralEncoder literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
 
-        return (expression, context) -> rewrite(expression, context.getSession(), context.getSymbolAllocator(), metadata, sqlParser);
+        return (expression, context) -> rewrite(expression, context.getSession(), context.getSymbolAllocator(), metadata, literalEncoder, sqlParser);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyExpressions.java
@@ -18,7 +18,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
-import com.facebook.presto.sql.planner.LiteralInterpreter;
+import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.NoOpSymbolResolver;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.iterative.Rule;
@@ -52,7 +52,7 @@ public class SimplifyExpressions
         expression = extractCommonPredicates(expression);
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(session, metadata, sqlParser, symbolAllocator.getTypes(), expression, emptyList() /* parameters already replaced */);
         ExpressionInterpreter interpreter = ExpressionInterpreter.expressionOptimizer(expression, metadata, session, expressionTypes);
-        return LiteralInterpreter.toExpression(interpreter.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(NodeRef.of(expression)));
+        return LiteralEncoder.toExpression(interpreter.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(NodeRef.of(expression)));
     }
 
     public SimplifyExpressions(Metadata metadata, SqlParser sqlParser)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.Partitioning.ArgumentBinding;
 import com.facebook.presto.sql.planner.PartitioningScheme;
@@ -47,6 +48,7 @@ import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.SymbolReference;
@@ -70,7 +72,6 @@ import java.util.function.Function;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.sql.planner.LiteralEncoder.toExpression;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
@@ -859,7 +860,7 @@ public class HashGenerationOptimizer
 
         private Expression getHashExpression()
         {
-            Expression hashExpression = toExpression(INITIAL_HASH_VALUE, BIGINT);
+            Expression hashExpression = new GenericLiteral(StandardTypes.BIGINT, Integer.toString(INITIAL_HASH_VALUE));
             for (Symbol field : fields) {
                 hashExpression = getHashFunctionCall(hashExpression, field);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -70,7 +70,7 @@ import java.util.function.Function;
 
 import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpression;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toExpression;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.DomainTranslator;
+import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
@@ -225,11 +226,13 @@ public class IndexJoinOptimizer
         private final SymbolAllocator symbolAllocator;
         private final PlanNodeIdAllocator idAllocator;
         private final Metadata metadata;
+        private final DomainTranslator domainTranslator;
         private final Session session;
 
         private IndexSourceRewriter(SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Metadata metadata, Session session)
         {
             this.metadata = requireNonNull(metadata, "metadata is null");
+            this.domainTranslator = new DomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
             this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.session = requireNonNull(session, "session is null");
@@ -305,7 +308,7 @@ public class IndexJoinOptimizer
                     simplifiedConstraint);
 
             Expression resultingPredicate = combineConjuncts(
-                    DomainTranslator.toPredicate(resolvedIndex.getUnresolvedTupleDomain().transform(inverseAssignments::get)),
+                    domainTranslator.toPredicate(resolvedIndex.getUnresolvedTupleDomain().transform(inverseAssignments::get)),
                     decomposedPredicate.getRemainingExpression());
 
             if (!resultingPredicate.equals(TRUE_LITERAL)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -26,7 +26,7 @@ import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.DeterminismEvaluator;
-import com.facebook.presto.sql.planner.LiteralInterpreter;
+import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
@@ -168,7 +168,7 @@ public class MetadataQueryOptimizer
                             return context.defaultRewrite(node);
                         }
                         else {
-                            rowBuilder.add(LiteralInterpreter.toExpression(value.getValue(), type));
+                            rowBuilder.add(LiteralEncoder.toExpression(value.getValue(), type));
                         }
                     }
                     rowsBuilder.add(rowBuilder.build());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -21,7 +21,7 @@ import com.facebook.presto.sql.planner.DeterminismEvaluator;
 import com.facebook.presto.sql.planner.EffectivePredicateExtractor;
 import com.facebook.presto.sql.planner.EqualityInference;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
-import com.facebook.presto.sql.planner.LiteralInterpreter;
+import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.NoOpSymbolResolver;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
@@ -754,7 +754,7 @@ public class PredicatePushDown
                     expression,
                     emptyList() /* parameters have already been replaced */);
             ExpressionInterpreter optimizer = ExpressionInterpreter.expressionOptimizer(expression, metadata, session, expressionTypes);
-            return LiteralInterpreter.toExpression(optimizer.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(NodeRef.of(expression)));
+            return LiteralEncoder.toExpression(optimizer.optimize(NoOpSymbolResolver.INSTANCE), expressionTypes.get(NodeRef.of(expression)));
         }
 
         /**

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -23,6 +23,8 @@ import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.ExpressionUtils;
+import com.facebook.presto.sql.planner.DomainTranslator;
+import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
@@ -48,7 +50,6 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.planner.DomainTranslator.ExtractionResult;
 import static com.facebook.presto.sql.planner.DomainTranslator.fromPredicate;
-import static com.facebook.presto.sql.planner.DomainTranslator.toPredicate;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -63,10 +64,12 @@ public class WindowFilterPushDown
     private static final Signature ROW_NUMBER_SIGNATURE = new Signature("row_number", WINDOW, parseTypeSignature(StandardTypes.BIGINT), ImmutableList.of());
 
     private final Metadata metadata;
+    private final DomainTranslator domainTranslator;
 
     public WindowFilterPushDown(Metadata metadata)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
+        this.domainTranslator = new DomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
     }
 
     @Override
@@ -78,7 +81,7 @@ public class WindowFilterPushDown
         requireNonNull(symbolAllocator, "symbolAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        return SimplePlanRewriter.rewriteWith(new Rewriter(idAllocator, metadata, session, types), plan, null);
+        return SimplePlanRewriter.rewriteWith(new Rewriter(idAllocator, metadata, domainTranslator, session, types), plan, null);
     }
 
     private static class Rewriter
@@ -86,13 +89,15 @@ public class WindowFilterPushDown
     {
         private final PlanNodeIdAllocator idAllocator;
         private final Metadata metadata;
+        private final DomainTranslator domainTranslator;
         private final Session session;
         private final Map<Symbol, Type> types;
 
-        private Rewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, Session session, Map<Symbol, Type> types)
+        private Rewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, DomainTranslator domainTranslator, Session session, Map<Symbol, Type> types)
         {
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
+            this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
             this.session = requireNonNull(session, "session is null");
             this.types = ImmutableMap.copyOf(requireNonNull(types, "types is null"));
         }
@@ -191,7 +196,7 @@ public class WindowFilterPushDown
             TupleDomain<Symbol> newTupleDomain = TupleDomain.withColumnDomains(newDomains);
             Expression newPredicate = ExpressionUtils.combineConjuncts(
                     extractionResult.getRemainingExpression(),
-                    toPredicate(newTupleDomain));
+                    domainTranslator.toPredicate(newTupleDomain));
 
             if (newPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
                 return source;

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.ScheduledSplit;
 import com.facebook.presto.TaskSource;
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.cost.CoefficientBasedStatsCalculator;
@@ -38,7 +39,6 @@ import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.server.ServerMainModule;
-import com.facebook.presto.spi.block.TestingBlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.TestingTypeManager;
@@ -160,7 +160,7 @@ public final class TaskTestUtils
                 (types, partitionFunction, spillContext, memoryContext) -> {
                     throw new UnsupportedOperationException();
                 },
-                new TestingBlockEncodingSerde(new TestingTypeManager()),
+                new BlockEncodingManager(new TestingTypeManager()),
                 new PagesIndex.TestingFactory(false),
                 new JoinCompiler(),
                 new LookupJoinOperators());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.presto.OutputBuffers.OutputBufferId;
 import com.facebook.presto.ScheduledSplit;
 import com.facebook.presto.TaskSource;
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.BufferState;
@@ -44,7 +45,6 @@ import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.UpdatablePageSource;
-import com.facebook.presto.spi.block.TestingBlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.type.TestingTypeManager;
@@ -155,7 +155,7 @@ public class TestSqlTaskExecution
                     TABLE_SCAN_NODE_ID,
                     outputBuffer,
                     Function.identity(),
-                    new PagesSerdeFactory(new TestingBlockEncodingSerde(new TestingTypeManager()), false));
+                    new PagesSerdeFactory(new BlockEncodingManager(new TestingTypeManager()), false));
             LocalExecutionPlan localExecutionPlan = new LocalExecutionPlan(
                     ImmutableList.of(new DriverFactory(
                             0,
@@ -378,7 +378,7 @@ public class TestSqlTaskExecution
                     joinCNodeId,
                     outputBuffer,
                     Function.identity(),
-                    new PagesSerdeFactory(new TestingBlockEncodingSerde(new TestingTypeManager()), false));
+                    new PagesSerdeFactory(new BlockEncodingManager(new TestingTypeManager()), false));
             TestingCrossJoinOperatorFactory joinOperatorFactoryA = new TestingCrossJoinOperatorFactory(2, joinANodeId, buildStatesA);
             TestingCrossJoinOperatorFactory joinOperatorFactoryB = new TestingCrossJoinOperatorFactory(102, joinBNodeId, buildStatesB);
             TestingCrossJoinOperatorFactory joinOperatorFactoryC = new TestingCrossJoinOperatorFactory(3, joinCNodeId, buildStatesC);

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestingPagesSerdeFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestingPagesSerdeFactory.java
@@ -13,9 +13,9 @@
  */
 package com.facebook.presto.execution.buffer;
 
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
-import com.facebook.presto.spi.block.TestingBlockEncodingSerde;
 import com.facebook.presto.spi.type.TestingTypeManager;
 import io.airlift.compress.Compressor;
 import io.airlift.compress.Decompressor;
@@ -30,13 +30,13 @@ public class TestingPagesSerdeFactory
     public TestingPagesSerdeFactory()
     {
         // compression should be enabled in as many tests as possible
-        super(new TestingBlockEncodingSerde(new TestingTypeManager()), true);
+        super(new BlockEncodingManager(new TestingTypeManager()), true);
     }
 
     public static PagesSerde testingPagesSerde()
     {
         return new SynchronizedPagesSerde(
-                new TestingBlockEncodingSerde(new TestingTypeManager()),
+                new BlockEncodingManager(new TestingTypeManager()),
                 Optional.of(new Lz4Compressor()),
                 Optional.of(new Lz4Decompressor()));
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestSqlToRowExpressionTranslator.java
@@ -46,7 +46,7 @@ import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
-import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpression;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toExpression;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -74,7 +74,7 @@ import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.ExpressionUtils.and;
 import static com.facebook.presto.sql.ExpressionUtils.or;
-import static com.facebook.presto.sql.planner.LiteralInterpreter.toExpression;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpressionType.EQUAL;
@@ -1308,7 +1308,7 @@ public class TestDomainTranslator
     private static InPredicate in(Expression expression, Type expressisonType, List<?> values)
     {
         List<Type> types = nCopies(values.size(), expressisonType);
-        List<Expression> expressions = LiteralInterpreter.toExpressions(values, types);
+        List<Expression> expressions = LiteralEncoder.toExpressions(values, types);
         return new InPredicate(expression, new InListExpression(expressions));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -15,6 +15,8 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.metadata.TableLayoutHandle;
@@ -107,6 +109,9 @@ public class TestEffectivePredicateExtractor
     private static final Expression FE = F.toSymbolReference();
     private static final Expression GE = G.toSymbolReference();
 
+    private final Metadata metadata = MetadataManager.createTestMetadataManager();
+    private final EffectivePredicateExtractor effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde())));
+
     private Map<Symbol, ColumnHandle> scanAssignments;
     private TableScanNode baseTableScan;
     private ExpressionIdentityNormalizer expressionNormalizer;
@@ -157,7 +162,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // Rewrite in terms of group by symbols
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -180,7 +185,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         assertEquals(effectivePredicate, TRUE_LITERAL);
     }
@@ -193,7 +198,7 @@ public class TestEffectivePredicateExtractor
                         greaterThan(AE, new FunctionCall(QualifiedName.of("rand"), ImmutableList.of())),
                         lessThan(BE, bigintLiteral(10))));
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // Non-deterministic functions should be purged
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -211,7 +216,7 @@ public class TestEffectivePredicateExtractor
                                 lessThan(CE, bigintLiteral(10)))),
                 Assignments.of(D, AE, E, CE));
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // Rewrite in terms of project output symbols
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -231,7 +236,7 @@ public class TestEffectivePredicateExtractor
                                 lessThan(CE, bigintLiteral(10)))),
                 1, new OrderingScheme(ImmutableList.of(A), ImmutableMap.of(A, SortOrder.ASC_NULLS_LAST)), TopNNode.Step.PARTIAL);
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // Pass through
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -253,7 +258,7 @@ public class TestEffectivePredicateExtractor
                 1,
                 false);
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // Pass through
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -274,7 +279,7 @@ public class TestEffectivePredicateExtractor
                                 lessThan(CE, bigintLiteral(10)))),
                 new OrderingScheme(ImmutableList.of(A), ImmutableMap.of(A, SortOrder.ASC_NULLS_LAST)));
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // Pass through
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -303,7 +308,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableSet.of(),
                 0);
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // Pass through
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -326,7 +331,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 TupleDomain.all(),
                 null);
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(effectivePredicate, BooleanLiteral.TRUE_LITERAL);
 
         node = new TableScanNode(
@@ -337,7 +342,7 @@ public class TestEffectivePredicateExtractor
                 Optional.of(TESTING_TABLE_LAYOUT),
                 TupleDomain.none(),
                 null);
-        effectivePredicate = EffectivePredicateExtractor.extract(node);
+        effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(effectivePredicate, FALSE_LITERAL);
 
         node = new TableScanNode(
@@ -348,7 +353,7 @@ public class TestEffectivePredicateExtractor
                 Optional.of(TESTING_TABLE_LAYOUT),
                 TupleDomain.withColumnDomains(ImmutableMap.of(scanAssignments.get(A), Domain.singleValue(BIGINT, 1L))),
                 null);
-        effectivePredicate = EffectivePredicateExtractor.extract(node);
+        effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(1L), AE)));
 
         node = new TableScanNode(
@@ -361,7 +366,7 @@ public class TestEffectivePredicateExtractor
                         scanAssignments.get(A), Domain.singleValue(BIGINT, 1L),
                         scanAssignments.get(B), Domain.singleValue(BIGINT, 2L))),
                 null);
-        effectivePredicate = EffectivePredicateExtractor.extract(node);
+        effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(2L), BE), equals(bigintLiteral(1L), AE)));
 
         node = new TableScanNode(
@@ -372,7 +377,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 TupleDomain.all(),
                 null);
-        effectivePredicate = EffectivePredicateExtractor.extract(node);
+        effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(effectivePredicate, BooleanLiteral.TRUE_LITERAL);
     }
 
@@ -388,7 +393,7 @@ public class TestEffectivePredicateExtractor
                 symbolMapping,
                 ImmutableList.copyOf(symbolMapping.keySet()));
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // Only the common conjuncts can be inferred through a Union
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -447,7 +452,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // All predicates having output symbol should be carried through
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -510,7 +515,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // All right side symbols having output symbols should be checked against NULL
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -567,7 +572,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // False literal on the right side should be ignored
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -627,7 +632,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // All left side symbols should be checked against NULL
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -683,7 +688,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // False literal on the left side should be ignored
         assertEquals(normalizeConjuncts(effectivePredicate),
@@ -703,7 +708,7 @@ public class TestEffectivePredicateExtractor
                 Optional.empty(),
                 Optional.empty());
 
-        Expression effectivePredicate = EffectivePredicateExtractor.extract(node);
+        Expression effectivePredicate = effectivePredicateExtractor.extract(node);
 
         // Currently, only pull predicates through the source plan
         assertEquals(normalizeConjuncts(effectivePredicate),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.SymbolsExtractor;
@@ -42,6 +44,8 @@ import static org.testng.Assert.assertEquals;
 public class TestSimplifyExpressions
 {
     private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final MetadataManager METADATA = createTestMetadataManager();
+    private static final LiteralEncoder LITERAL_ENCODER = new LiteralEncoder(METADATA.getBlockEncodingSerde());
 
     @Test
     public void testPushesDownNegations()
@@ -114,7 +118,7 @@ public class TestSimplifyExpressions
     {
         Expression actualExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expression));
         Expression expectedExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expected));
-        Expression rewritten = rewrite(actualExpression, TEST_SESSION, new SymbolAllocator(booleanSymbolTypeMapFor(actualExpression)), createTestMetadataManager(), SQL_PARSER);
+        Expression rewritten = rewrite(actualExpression, TEST_SESSION, new SymbolAllocator(booleanSymbolTypeMapFor(actualExpression)), METADATA, LITERAL_ENCODER, SQL_PARSER);
         assertEquals(
                 normalize(rewritten),
                 normalize(expectedExpression));

--- a/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
@@ -52,6 +54,8 @@ import static org.testng.Assert.fail;
 
 public abstract class AbstractTestType
 {
+    private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager(new TypeRegistry());
+
     private final Class<?> objectValueType;
     private final Block testBlock;
     private final Type type;
@@ -290,9 +294,9 @@ public abstract class AbstractTestType
         }
         else {
             SliceOutput actualSliceOutput = new DynamicSliceOutput(100);
-            writeBlock(actualSliceOutput, (Block) type.getObject(block, position));
+            writeBlock(blockEncodingSerde, actualSliceOutput, (Block) type.getObject(block, position));
             SliceOutput expectedSliceOutput = new DynamicSliceOutput(actualSliceOutput.size());
-            writeBlock(expectedSliceOutput, (Block) expectedStackValue);
+            writeBlock(blockEncodingSerde, expectedSliceOutput, (Block) expectedStackValue);
             assertEquals(actualSliceOutput.slice(), expectedSliceOutput.slice());
             try {
                 type.getBoolean(block, position);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -114,7 +114,7 @@ public class TestArrayOperators
     {
         Block actualBlock = arrayBlockOf(new ArrayType(BIGINT), arrayBlockOf(BIGINT, 1L, 2L), arrayBlockOf(BIGINT, 3L));
         DynamicSliceOutput actualSliceOutput = new DynamicSliceOutput(100);
-        writeBlock(actualSliceOutput, actualBlock);
+        writeBlock(functionAssertions.getMetadata().getBlockEncodingSerde(), actualSliceOutput, actualBlock);
 
         Block expectedBlock = new ArrayType(BIGINT)
                 .createBlockBuilder(null, 3)
@@ -122,7 +122,7 @@ public class TestArrayOperators
                 .appendStructure(BIGINT.createBlockBuilder(null, 1).writeLong(3).closeEntry().build())
                 .build();
         DynamicSliceOutput expectedSliceOutput = new DynamicSliceOutput(100);
-        writeBlock(expectedSliceOutput, expectedBlock);
+        writeBlock(functionAssertions.getMetadata().getBlockEncodingSerde(), expectedSliceOutput, expectedBlock);
 
         assertEquals(actualSliceOutput.slice(), expectedSliceOutput.slice());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockEncoding.java
@@ -73,12 +73,6 @@ public class ArrayBlockEncoding
         return createArrayBlockInternal(0, positionCount, valueIsNull, offsets, values);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class ArrayBlockEncodingFactory
             implements BlockEncodingFactory<ArrayBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockEncoding.java
@@ -23,7 +23,6 @@ import static com.facebook.presto.spi.block.ArrayBlock.createArrayBlockInternal;
 public class ArrayBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<ArrayBlockEncoding> FACTORY = new ArrayBlockEncodingFactory();
     private static final String NAME = "ARRAY";
 
     private final BlockEncoding valueBlockEncoding;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockEncoding.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
@@ -82,7 +81,7 @@ public class ArrayBlockEncoding
         }
 
         @Override
-        public ArrayBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        public ArrayBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             BlockEncoding valueBlockEncoding = serde.readBlockEncoding(input);
             return new ArrayBlockEncoding(valueBlockEncoding);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockEncoding.java
@@ -16,6 +16,8 @@ package com.facebook.presto.spi.block;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
+import java.util.Optional;
+
 public interface BlockEncoding
 {
     /**
@@ -35,6 +37,14 @@ public interface BlockEncoding
     void writeBlock(SliceOutput sliceOutput, Block block);
 
     /**
+     * This method allows the implementor to specify a replacement object that will be serialized instead of the original one.
+     */
+    default Optional<Block> replacementBlockForWrite(Block block)
+    {
+        return Optional.empty();
+    }
+
+    /*
      * Return associated factory
      */
     BlockEncodingFactory getFactory();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockEncoding.java
@@ -43,9 +43,4 @@ public interface BlockEncoding
     {
         return Optional.empty();
     }
-
-    /*
-     * Return associated factory
-     */
-    BlockEncodingFactory getFactory();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockEncodingFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockEncodingFactory.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
@@ -27,7 +26,7 @@ public interface BlockEncodingFactory<T extends BlockEncoding>
     /**
      * Reads the encoding from the specified input.
      */
-    T readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input);
+    T readEncoding(BlockEncodingSerde serde, SliceInput input);
 
     /**
      * Writes this encoding to the output stream.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
@@ -73,7 +72,7 @@ public class ByteArrayBlockEncoding
         }
 
         @Override
-        public ByteArrayBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        public ByteArrayBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             return new ByteArrayBlockEncoding();
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
@@ -23,7 +23,6 @@ import static com.facebook.presto.spi.block.EncoderUtil.encodeNullsAsBits;
 public class ByteArrayBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<ByteArrayBlockEncoding> FACTORY = new ByteArrayBlockEncodingFactory();
     private static final String NAME = "BYTE_ARRAY";
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
@@ -64,12 +64,6 @@ public class ByteArrayBlockEncoding
         return new ByteArrayBlock(positionCount, valueIsNull, values);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class ByteArrayBlockEncodingFactory
             implements BlockEncodingFactory<ByteArrayBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
@@ -23,7 +23,6 @@ import static java.util.Objects.requireNonNull;
 public class DictionaryBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<DictionaryBlockEncoding> FACTORY = new DictionaryBlockEncodingFactory();
     private static final String NAME = "DICTIONARY";
     private final BlockEncoding dictionaryEncoding;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
@@ -101,7 +100,7 @@ public class DictionaryBlockEncoding
         }
 
         @Override
-        public DictionaryBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        public DictionaryBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             BlockEncoding dictionaryEncoding = serde.readBlockEncoding(input);
             return new DictionaryBlockEncoding(dictionaryEncoding);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlockEncoding.java
@@ -87,12 +87,6 @@ public class DictionaryBlockEncoding
         return new DictionaryBlock(positionCount, dictionaryBlock, ids, false, new DictionaryId(mostSignificantBits, leastSignificantBits, sequenceId));
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public BlockEncoding getDictionaryEncoding()
     {
         return dictionaryEncoding;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockEncoding.java
@@ -78,12 +78,6 @@ public class FixedWidthBlockEncoding
         return new FixedWidthBlock(fixedSize, positionCount, slice, Slices.wrappedBooleanArray(valueIsNull));
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class FixedWidthBlockEncodingFactory
             implements BlockEncodingFactory<FixedWidthBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockEncoding.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
@@ -87,7 +86,7 @@ public class FixedWidthBlockEncoding
         }
 
         @Override
-        public FixedWidthBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        public FixedWidthBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             int entrySize = input.readInt();
             return new FixedWidthBlockEncoding(entrySize);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockEncoding.java
@@ -25,7 +25,6 @@ import static com.facebook.presto.spi.block.EncoderUtil.encodeNullsAsBits;
 public class FixedWidthBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<FixedWidthBlockEncoding> FACTORY = new FixedWidthBlockEncodingFactory();
     private static final String NAME = "FIXED_WIDTH";
     private final int fixedSize;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
@@ -73,7 +72,7 @@ public class IntArrayBlockEncoding
         }
 
         @Override
-        public IntArrayBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        public IntArrayBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             return new IntArrayBlockEncoding();
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
@@ -23,7 +23,6 @@ import static com.facebook.presto.spi.block.EncoderUtil.encodeNullsAsBits;
 public class IntArrayBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<IntArrayBlockEncoding> FACTORY = new IntArrayBlockEncodingFactory();
     private static final String NAME = "INT_ARRAY";
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
@@ -64,12 +64,6 @@ public class IntArrayBlockEncoding
         return new IntArrayBlock(positionCount, valueIsNull, values);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class IntArrayBlockEncodingFactory
             implements BlockEncodingFactory<IntArrayBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -196,7 +196,7 @@ public class LazyBlock
     public BlockEncoding getEncoding()
     {
         assureLoaded();
-        return new LazyBlockEncoding(block.getEncoding());
+        return new LazyBlockEncoding();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlockEncoding.java
@@ -13,31 +13,29 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+
+import java.util.Optional;
 
 public class LazyBlockEncoding
         implements BlockEncoding
 {
-    private final BlockEncoding delegate;
+    private static final String NAME = "LAZY";
 
-    public LazyBlockEncoding(BlockEncoding delegate)
-    {
-        this.delegate = delegate;
-    }
+    public LazyBlockEncoding() {}
 
     @Override
     public String getName()
     {
-        return delegate.getName();
+        return NAME;
     }
 
     @Override
     public void writeBlock(SliceOutput sliceOutput, Block block)
     {
-        // The down casts here are safe because it is the block itself the provides this encoding implementation.
-        delegate.writeBlock(sliceOutput, ((LazyBlock) block).getBlock());
+        // We implemented replacementBlockForWrite, so we will never need to write a lazy block
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -48,37 +46,15 @@ public class LazyBlockEncoding
     }
 
     @Override
-    public BlockEncodingFactory getFactory()
+    public Optional<Block> replacementBlockForWrite(Block block)
     {
-        return new LazyBlockEncodingFactory(delegate.getFactory());
+        return Optional.of(((LazyBlock) block).getBlock());
     }
 
-    public static class LazyBlockEncodingFactory
-            implements BlockEncodingFactory<LazyBlockEncoding>
+    @Override
+    public BlockEncodingFactory getFactory()
     {
-        private final BlockEncodingFactory delegate;
-
-        public LazyBlockEncodingFactory(BlockEncodingFactory delegate)
-        {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public String getName()
-        {
-            return delegate.getName();
-        }
-
-        @Override
-        public LazyBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void writeEncoding(BlockEncodingSerde serde, SliceOutput output, LazyBlockEncoding blockEncoding)
-        {
-            delegate.writeEncoding(serde, output, blockEncoding.delegate);
-        }
+        // We implemented replacementBlockForWrite, so we will never need to write a lazy block
+        throw new UnsupportedOperationException();
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlockEncoding.java
@@ -50,11 +50,4 @@ public class LazyBlockEncoding
     {
         return Optional.of(((LazyBlock) block).getBlock());
     }
-
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        // We implemented replacementBlockForWrite, so we will never need to write a lazy block
-        throw new UnsupportedOperationException();
-    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
@@ -73,7 +72,7 @@ public class LongArrayBlockEncoding
         }
 
         @Override
-        public LongArrayBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        public LongArrayBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             return new LongArrayBlockEncoding();
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
@@ -64,12 +64,6 @@ public class LongArrayBlockEncoding
         return new LongArrayBlock(positionCount, valueIsNull, values);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class LongArrayBlockEncodingFactory
             implements BlockEncodingFactory<LongArrayBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
@@ -23,7 +23,6 @@ import static com.facebook.presto.spi.block.EncoderUtil.encodeNullsAsBits;
 public class LongArrayBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<LongArrayBlockEncoding> FACTORY = new LongArrayBlockEncodingFactory();
     private static final String NAME = "LONG_ARRAY";
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
@@ -111,6 +111,13 @@ public class MapBlockEncoding
     public static class MapBlockEncodingFactory
             implements BlockEncodingFactory<MapBlockEncoding>
     {
+        private final TypeManager typeManager;
+
+        public MapBlockEncodingFactory(TypeManager typeManager)
+        {
+            this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        }
+
         @Override
         public String getName()
         {
@@ -118,7 +125,7 @@ public class MapBlockEncoding
         }
 
         @Override
-        public MapBlockEncoding readEncoding(TypeManager typeManager, BlockEncodingSerde serde, SliceInput input)
+        public MapBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             Type keyType = TypeSerde.readType(typeManager, input);
             MethodHandle keyNativeEquals = typeManager.resolveOperator(OperatorType.EQUAL, asList(keyType, keyType));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
@@ -109,12 +109,6 @@ public class MapBlockEncoding
         return createMapBlockInternal(0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTable, keyType, keyBlockNativeEquals, keyNativeHashCode);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class MapBlockEncodingFactory
             implements BlockEncodingFactory<MapBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
@@ -36,7 +36,6 @@ import static java.util.Objects.requireNonNull;
 public class MapBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<MapBlockEncoding> FACTORY = new MapBlockEncodingFactory();
     private static final String NAME = "MAP";
 
     private final Type keyType;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
@@ -84,12 +84,6 @@ public class RowBlockEncoding
         return createRowBlockInternal(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class RowBlockEncodingFactory
             implements BlockEncodingFactory<RowBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
@@ -14,7 +14,6 @@
 
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
@@ -93,7 +92,7 @@ public class RowBlockEncoding
         }
 
         @Override
-        public RowBlockEncoding readEncoding(TypeManager typeManager, BlockEncodingSerde serde, SliceInput input)
+        public RowBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             int numFields = input.readInt();
             BlockEncoding[] fieldBlockEncodings = new BlockEncoding[numFields];

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockEncoding.java
@@ -25,7 +25,6 @@ import static java.util.Objects.requireNonNull;
 public class RowBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<RowBlockEncoding> FACTORY = new RowBlockEncodingFactory();
     private static final String NAME = "ROW";
 
     private final BlockEncoding[] fieldBlockEncodings;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthBlockEncoding.java
@@ -67,12 +67,6 @@ public class RunLengthBlockEncoding
         return new RunLengthEncodedBlock(value, positionCount);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     private static class RunLengthBlockEncodingFactory
             implements BlockEncodingFactory<RunLengthBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthBlockEncoding.java
@@ -22,7 +22,6 @@ import static java.util.Objects.requireNonNull;
 public class RunLengthBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<RunLengthBlockEncoding> FACTORY = new RunLengthBlockEncodingFactory();
     private static final String NAME = "RLE";
 
     private final BlockEncoding valueBlockEncoding;
@@ -67,7 +66,7 @@ public class RunLengthBlockEncoding
         return new RunLengthEncodedBlock(value, positionCount);
     }
 
-    private static class RunLengthBlockEncodingFactory
+    public static class RunLengthBlockEncodingFactory
             implements BlockEncodingFactory<RunLengthBlockEncoding>
     {
         @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthBlockEncoding.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
@@ -76,7 +75,7 @@ public class RunLengthBlockEncoding
         }
 
         @Override
-        public RunLengthBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        public RunLengthBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             BlockEncoding valueBlockEncoding = serde.readBlockEncoding(input);
             return new RunLengthBlockEncoding(valueBlockEncoding);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
@@ -23,7 +23,6 @@ import static com.facebook.presto.spi.block.EncoderUtil.encodeNullsAsBits;
 public class ShortArrayBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<ShortArrayBlockEncoding> FACTORY = new ShortArrayBlockEncodingFactory();
     private static final String NAME = "SHORT_ARRAY";
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
@@ -73,7 +72,7 @@ public class ShortArrayBlockEncoding
         }
 
         @Override
-        public ShortArrayBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        public ShortArrayBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             return new ShortArrayBlockEncoding();
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
@@ -64,12 +64,6 @@ public class ShortArrayBlockEncoding
         return new ShortArrayBlock(positionCount, valueIsNull, values);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class ShortArrayBlockEncodingFactory
             implements BlockEncodingFactory<ShortArrayBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
@@ -93,6 +93,13 @@ public class SingleMapBlockEncoding
     public static class SingleMapBlockEncodingFactory
             implements BlockEncodingFactory<SingleMapBlockEncoding>
     {
+        private final TypeManager typeManager;
+
+        public SingleMapBlockEncodingFactory(TypeManager typeManager)
+        {
+            this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        }
+
         @Override
         public String getName()
         {
@@ -100,7 +107,7 @@ public class SingleMapBlockEncoding
         }
 
         @Override
-        public SingleMapBlockEncoding readEncoding(TypeManager typeManager, BlockEncodingSerde serde, SliceInput input)
+        public SingleMapBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             Type keyType = TypeSerde.readType(typeManager, input);
             MethodHandle keyNativeHashCode = typeManager.resolveOperator(OperatorType.HASH_CODE, singletonList(keyType));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
@@ -35,7 +35,6 @@ import static java.util.Objects.requireNonNull;
 public class SingleMapBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<SingleMapBlockEncoding> FACTORY = new SingleMapBlockEncodingFactory();
     private static final String NAME = "MAP_ELEMENT";
 
     private final Type keyType;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
@@ -91,12 +91,6 @@ public class SingleMapBlockEncoding
         return new SingleMapBlock(0, keyBlock.getPositionCount() * 2, keyBlock, valueBlock, hashTable, keyType, keyNativeHashCode, keyBlockNativeEquals);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class SingleMapBlockEncodingFactory
             implements BlockEncodingFactory<SingleMapBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockEncoding.java
@@ -59,12 +59,6 @@ public class SingleRowBlockEncoding
         return new SingleRowBlock(0, fieldBlocks);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class SingleRowBlockEncodingFactory
             implements BlockEncodingFactory<SingleRowBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockEncoding.java
@@ -23,7 +23,6 @@ import static java.util.Objects.requireNonNull;
 public class SingleRowBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<SingleRowBlockEncoding> FACTORY = new SingleRowBlockEncodingFactory();
     private static final String NAME = "ROW_ELEMENT";
 
     private final BlockEncoding[] fieldBlockEncodings;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockEncoding.java
@@ -14,7 +14,6 @@
 
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
@@ -68,7 +67,7 @@ public class SingleRowBlockEncoding
         }
 
         @Override
-        public SingleRowBlockEncoding readEncoding(TypeManager typeManager, BlockEncodingSerde serde, SliceInput input)
+        public SingleRowBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             int numFields = input.readInt();
             BlockEncoding[] fieldBlockEncodings = new BlockEncoding[numFields];

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockEncoding.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spi.block;
 
-import com.facebook.presto.spi.type.TypeManager;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
@@ -84,7 +83,7 @@ public class VariableWidthBlockEncoding
         }
 
         @Override
-        public VariableWidthBlockEncoding readEncoding(TypeManager manager, BlockEncodingSerde serde, SliceInput input)
+        public VariableWidthBlockEncoding readEncoding(BlockEncodingSerde serde, SliceInput input)
         {
             return new VariableWidthBlockEncoding();
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockEncoding.java
@@ -75,12 +75,6 @@ public class VariableWidthBlockEncoding
         return new VariableWidthBlock(positionCount, slice, offsets, valueIsNull);
     }
 
-    @Override
-    public BlockEncodingFactory getFactory()
-    {
-        return FACTORY;
-    }
-
     public static class VariableWidthBlockEncodingFactory
             implements BlockEncodingFactory<VariableWidthBlockEncoding>
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockEncoding.java
@@ -26,7 +26,6 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 public class VariableWidthBlockEncoding
         implements BlockEncoding
 {
-    public static final BlockEncodingFactory<VariableWidthBlockEncoding> FACTORY = new VariableWidthBlockEncodingFactory();
     private static final String NAME = "VARIABLE_WIDTH";
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingBlockEncodingSerde.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingBlockEncodingSerde.java
@@ -93,7 +93,7 @@ public final class TestingBlockEncodingSerde
         String encodingName = encoding.getName();
 
         // look up the encoding factory
-        BlockEncodingFactory<BlockEncoding> blockEncoding = encoding.getFactory();
+        BlockEncodingFactory blockEncoding = blockEncodings.get(encodingName);
 
         // write the name to the output
         writeLengthPrefixedString(output, encodingName);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingBlockEncodingSerde.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingBlockEncodingSerde.java
@@ -13,6 +13,19 @@
  */
 package com.facebook.presto.spi.block;
 
+import com.facebook.presto.spi.block.ArrayBlockEncoding.ArrayBlockEncodingFactory;
+import com.facebook.presto.spi.block.ByteArrayBlockEncoding.ByteArrayBlockEncodingFactory;
+import com.facebook.presto.spi.block.DictionaryBlockEncoding.DictionaryBlockEncodingFactory;
+import com.facebook.presto.spi.block.FixedWidthBlockEncoding.FixedWidthBlockEncodingFactory;
+import com.facebook.presto.spi.block.IntArrayBlockEncoding.IntArrayBlockEncodingFactory;
+import com.facebook.presto.spi.block.LongArrayBlockEncoding.LongArrayBlockEncodingFactory;
+import com.facebook.presto.spi.block.MapBlockEncoding.MapBlockEncodingFactory;
+import com.facebook.presto.spi.block.RowBlockEncoding.RowBlockEncodingFactory;
+import com.facebook.presto.spi.block.RunLengthBlockEncoding.RunLengthBlockEncodingFactory;
+import com.facebook.presto.spi.block.ShortArrayBlockEncoding.ShortArrayBlockEncodingFactory;
+import com.facebook.presto.spi.block.SingleMapBlockEncoding.SingleMapBlockEncodingFactory;
+import com.facebook.presto.spi.block.SingleRowBlockEncoding.SingleRowBlockEncodingFactory;
+import com.facebook.presto.spi.block.VariableWidthBlockEncoding.VariableWidthBlockEncodingFactory;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.SliceInput;
@@ -46,19 +59,19 @@ public final class TestingBlockEncodingSerde
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
 
         // always add the built-in BlockEncodingFactories
-        addBlockEncodingFactory(VariableWidthBlockEncoding.FACTORY);
-        addBlockEncodingFactory(FixedWidthBlockEncoding.FACTORY);
-        addBlockEncodingFactory(ByteArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(ShortArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(IntArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(LongArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(DictionaryBlockEncoding.FACTORY);
-        addBlockEncodingFactory(ArrayBlockEncoding.FACTORY);
-        addBlockEncodingFactory(MapBlockEncoding.FACTORY);
-        addBlockEncodingFactory(SingleMapBlockEncoding.FACTORY);
-        addBlockEncodingFactory(RowBlockEncoding.FACTORY);
-        addBlockEncodingFactory(SingleRowBlockEncoding.FACTORY);
-        addBlockEncodingFactory(RunLengthBlockEncoding.FACTORY);
+        addBlockEncodingFactory(new VariableWidthBlockEncodingFactory());
+        addBlockEncodingFactory(new FixedWidthBlockEncodingFactory());
+        addBlockEncodingFactory(new ByteArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new ShortArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new IntArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new LongArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new DictionaryBlockEncodingFactory());
+        addBlockEncodingFactory(new ArrayBlockEncodingFactory());
+        addBlockEncodingFactory(new MapBlockEncodingFactory());
+        addBlockEncodingFactory(new SingleMapBlockEncodingFactory());
+        addBlockEncodingFactory(new RowBlockEncodingFactory());
+        addBlockEncodingFactory(new SingleRowBlockEncodingFactory());
+        addBlockEncodingFactory(new RunLengthBlockEncodingFactory());
 
         for (BlockEncodingFactory<?> factory : requireNonNull(blockEncodingFactories, "blockEncodingFactories is null")) {
             addBlockEncodingFactory(factory);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingBlockEncodingSerde.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingBlockEncodingSerde.java
@@ -26,6 +26,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
+// This class is exactly the same as BlockEncodingManager.
+// It is needed for tests for TupleDomain. They are in SPI and don't have access to BlockEncodingManager.
 public final class TestingBlockEncodingSerde
         implements BlockEncodingSerde
 {
@@ -54,6 +56,9 @@ public final class TestingBlockEncodingSerde
         addBlockEncodingFactory(ArrayBlockEncoding.FACTORY);
         addBlockEncodingFactory(MapBlockEncoding.FACTORY);
         addBlockEncodingFactory(SingleMapBlockEncoding.FACTORY);
+        addBlockEncodingFactory(RowBlockEncoding.FACTORY);
+        addBlockEncodingFactory(SingleRowBlockEncoding.FACTORY);
+        addBlockEncodingFactory(RunLengthBlockEncoding.FACTORY);
 
         for (BlockEncodingFactory<?> factory : requireNonNull(blockEncodingFactories, "blockEncodingFactories is null")) {
             addBlockEncodingFactory(factory);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingBlockEncodingSerde.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingBlockEncodingSerde.java
@@ -44,7 +44,6 @@ import static java.util.Objects.requireNonNull;
 public final class TestingBlockEncodingSerde
         implements BlockEncodingSerde
 {
-    private final TypeManager typeManager;
     private final ConcurrentMap<String, BlockEncodingFactory<?>> blockEncodings = new ConcurrentHashMap<>();
 
     public TestingBlockEncodingSerde(TypeManager typeManager, BlockEncodingFactory<?>... blockEncodingFactories)
@@ -56,7 +55,7 @@ public final class TestingBlockEncodingSerde
     {
         // This function should be called from Guice and tests only
 
-        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        requireNonNull(typeManager, "typeManager is null");
 
         // always add the built-in BlockEncodingFactories
         addBlockEncodingFactory(new VariableWidthBlockEncodingFactory());
@@ -67,8 +66,8 @@ public final class TestingBlockEncodingSerde
         addBlockEncodingFactory(new LongArrayBlockEncodingFactory());
         addBlockEncodingFactory(new DictionaryBlockEncodingFactory());
         addBlockEncodingFactory(new ArrayBlockEncodingFactory());
-        addBlockEncodingFactory(new MapBlockEncodingFactory());
-        addBlockEncodingFactory(new SingleMapBlockEncodingFactory());
+        addBlockEncodingFactory(new MapBlockEncodingFactory(typeManager));
+        addBlockEncodingFactory(new SingleMapBlockEncodingFactory(typeManager));
         addBlockEncodingFactory(new RowBlockEncodingFactory());
         addBlockEncodingFactory(new SingleRowBlockEncodingFactory());
         addBlockEncodingFactory(new RunLengthBlockEncodingFactory());
@@ -96,7 +95,7 @@ public final class TestingBlockEncodingSerde
         checkArgument(blockEncoding != null, "Unknown block encoding %s", encodingName);
 
         // load read the encoding factory from the output stream
-        return blockEncoding.readEncoding(typeManager, this, input);
+        return blockEncoding.readEncoding(this, input);
     }
 
     @Override


### PR DESCRIPTION
The bulk of this PR is in "Remove hack to serialize a Block without using BlockEncodingSerde".

This makes option 2 in #10386 feasible.