### PR TITLE
Properly propagate SQLException and VerifierException in Verifier

### DIFF
--- a/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/AbstractSvmModel.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.ml;
 
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.TimeLimiter;
 import libsvm.svm;
@@ -29,9 +28,11 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -90,8 +91,16 @@ public abstract class AbstractSvmModel
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
+        catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause != null) {
+                throwIfUnchecked(cause);
+                throw new RuntimeException(cause);
+            }
+        }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally {
             service.shutdownNow();


### PR DESCRIPTION
getResultSetConverter() method can throw SQLException and
VerifierException. However, those exceptions will be wrapped in
an ExecutionException by the TimeLimiter. That may cause the verifier
run to fail completely instead of failing a single query (e.g., when
the query result set has more than maxRowCount rows).


```
00:58:11 2018-04-13T00:58:11.227-0700	ERROR	main	Bootstrap	Uncaught exception in thread main
00:58:11 java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.RuntimeException: java.util.concurrent.ExecutionException: com.facebook.presto.verifier.VerifierException: More than '10000' rows, failing query
00:58:11 	at com.facebook.presto.verifier.Verifier.takeUnchecked(Verifier.java:247)
00:58:11 	at com.facebook.presto.verifier.Verifier.run(Verifier.java:133)
00:58:11 	at com.facebook.presto.verifier.VerifyCommand.run(VerifyCommand.java:150)
00:58:11 	at com.facebook.presto.verifier.PrestoFacebookVerifier.main(PrestoFacebookVerifier.java:22)
00:58:11 Caused by: java.util.concurrent.ExecutionException: java.lang.RuntimeException: java.util.concurrent.ExecutionException: com.facebook.presto.verifier.VerifierException: More than '10000' rows, failing query
00:58:11 	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
00:58:11 	at java.util.concurrent.FutureTask.get(FutureTask.java:192)
00:58:11 	at com.facebook.presto.verifier.Verifier.takeUnchecked(Verifier.java:244)
00:58:11 	... 3 more
00:58:11 Caused by: java.lang.RuntimeException: java.util.concurrent.ExecutionException: com.facebook.presto.verifier.VerifierException: More than '10000' rows, failing query
00:58:11 	at com.google.common.base.Throwables.propagate(Throwables.java:241)
00:58:11 	at com.facebook.presto.verifier.Validator.executeQuery(Validator.java:467)
00:58:11 	at com.facebook.presto.verifier.Validator.executeQueryControl(Validator.java:346)
00:58:11 	at com.facebook.presto.verifier.Validator.validate(Validator.java:207)
00:58:11 	at com.facebook.presto.verifier.Validator.valid(Validator.java:192)
00:58:11 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
00:58:11 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
00:58:11 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
00:58:11 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
00:58:11 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
00:58:11 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
00:58:11 	at java.lang.Thread.run(Thread.java:748)
00:58:11 Caused by: java.util.concurrent.ExecutionException: com.facebook.presto.verifier.VerifierException: More than '10000' rows, failing query
00:58:11 	at com.google.common.util.concurrent.SimpleTimeLimiter.wrapAndThrowExecutionExceptionOrError(SimpleTimeLimiter.java:274)
00:58:11 	at com.google.common.util.concurrent.SimpleTimeLimiter.callWithTimeout(SimpleTimeLimiter.java:161)
00:58:11 	at com.facebook.presto.verifier.Validator.executeQuery(Validator.java:433)
00:58:11 	... 10 more
00:58:11 Caused by: com.facebook.presto.verifier.VerifierException: More than '10000' rows, failing query
00:58:11 	at com.facebook.presto.verifier.Validator.convertJdbcResultSet(Validator.java:554)
00:58:11 	at com.facebook.presto.verifier.Validator.lambda$getResultSetConverter$4(Validator.java:505)
00:58:11 	... 4 more
```