### PR TITLE
nextUri respects the X-Forwarded-Proto header

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -463,7 +463,13 @@ class Query
 
     private synchronized URI createNextResultsUri(String scheme, UriInfo uriInfo)
     {
-        return uriInfo.getBaseUriBuilder().replacePath("/v1/statement").path(queryId.toString()).path(String.valueOf(resultId.incrementAndGet())).replaceQuery("").scheme(scheme).build();
+        return uriInfo.getBaseUriBuilder()
+                .scheme(scheme)
+                .replacePath("/v1/statement")
+                .path(queryId.toString())
+                .path(String.valueOf(resultId.incrementAndGet()))
+                .replaceQuery("")
+                .build();
     }
 
     private static StatementStats toStatementStats(QueryInfo queryInfo)

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -378,6 +378,13 @@ class Query
             nextResultsUri = createNextResultsUri(scheme, uriInfo);
         }
 
+        URI queryHtmlUri = uriInfo
+                .getRequestUriBuilder()
+                .scheme(scheme)
+                .replaceQuery(queryId.toString())
+                .replacePath("query.html")
+                .build();
+
         // update catalog and schema
         setCatalog = queryInfo.getSetCatalog();
         setSchema = queryInfo.getSetSchema();
@@ -397,7 +404,7 @@ class Query
         // first time through, self is null
         QueryResults queryResults = new QueryResults(
                 queryId.toString(),
-                uriInfo.getRequestUriBuilder().replaceQuery(queryId.toString()).replacePath("query.html").build(),
+                queryHtmlUri,
                 findCancelableLeafStage(queryInfo),
                 nextResultsUri,
                 columns,

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
@@ -69,6 +69,7 @@ import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SESSION;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_STARTED_TRANSACTION_ID;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.http.server.AsyncResponseHandler.bindAsyncResponse;
 import static java.util.Objects.requireNonNull;
@@ -123,7 +124,7 @@ public class StatementResource
             String statement,
             @Context HttpServletRequest servletRequest,
             @Context UriInfo uriInfo,
-            @HeaderParam("x-forwarded-proto") String proto,
+            @HeaderParam(X_FORWARDED_PROTO) String proto,
             @Suspended AsyncResponse asyncResponse)
     {
         if (isNullOrEmpty(statement)) {
@@ -161,7 +162,7 @@ public class StatementResource
             @PathParam("queryId") QueryId queryId,
             @PathParam("token") long token,
             @QueryParam("maxWait") Duration maxWait,
-            @HeaderParam("x-forwarded-proto") String proto,
+            @HeaderParam(X_FORWARDED_PROTO) String proto,
             @Context UriInfo uriInfo,
             @Suspended AsyncResponse asyncResponse)
     {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
@@ -106,7 +106,8 @@ public class AuthenticationFilter
         response.sendError(SC_UNAUTHORIZED, Joiner.on(" | ").join(messages));
     }
 
-    private static boolean isSecureRequest(HttpServletRequest request) {
+    private static boolean isSecureRequest(HttpServletRequest request)
+    {
         String forwardedProto = request.getHeader(X_FORWARDED_PROTO);
         return request.isSecure() || (forwardedProto != null && forwardedProto.equals("https"));
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import static com.google.common.io.ByteStreams.copy;
 import static com.google.common.io.ByteStreams.nullOutputStream;
 import static com.google.common.net.HttpHeaders.WWW_AUTHENTICATE;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static java.util.Objects.requireNonNull;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
@@ -65,7 +66,7 @@ public class AuthenticationFilter
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
         // skip authentication if non-secure or not configured
-        if (!request.isSecure() || authenticators.isEmpty()) {
+        if (!isSecureRequest(request) || authenticators.isEmpty()) {
             nextFilter.doFilter(request, response);
             return;
         }
@@ -103,6 +104,11 @@ public class AuthenticationFilter
             messages.add("Unauthorized");
         }
         response.sendError(SC_UNAUTHORIZED, Joiner.on(" | ").join(messages));
+    }
+
+    private static boolean isSecureRequest(HttpServletRequest request) {
+        String forwardedProto = request.getHeader(X_FORWARDED_PROTO);
+        return request.isSecure() || (forwardedProto != null && forwardedProto.equals("https"));
     }
 
     private static ServletRequest withPrincipal(HttpServletRequest request, Principal principal)


### PR DESCRIPTION
Resolves #8232. As I noted on the issue, this is not ideal, but hopefully Jersey will add support for Forwarded headers in the future. In the meantime this is a pretty small changeset to support TLS termination in a proxy without clients needing to rewrite the nextUri when fetching result sets.