### PR TITLE
Support correlated no aggregation scalar subqueries (v2)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/FailureFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/FailureFunction.java
@@ -31,12 +31,35 @@ public final class FailureFunction
 
     // We shouldn't be using UNKNOWN as an explicit type. This will be fixed when we fix type inference
     @Description("Decodes json to an exception and throws it")
-    @ScalarFunction(hidden = true)
+    @ScalarFunction(value = "fail", hidden = true)
     @SqlType("unknown")
-    public static void fail(@SqlType(StandardTypes.JSON) Slice failureInfoSlice)
+    public static void failWithException(@SqlType(StandardTypes.JSON) Slice failureInfoSlice)
     {
         FailureInfo failureInfo = JSON_CODEC.fromJson(failureInfoSlice.getBytes());
         // wrap the failure in a new exception to append the current stack trace
         throw new PrestoException(StandardErrorCode.GENERIC_USER_ERROR, failureInfo.toException());
+    }
+
+    @Description("Throws an exception with a given message")
+    @ScalarFunction(value = "fail", hidden = true)
+    @SqlType("unknown")
+    public static void fail(@SqlType(StandardTypes.VARCHAR) Slice message)
+    {
+        throw new PrestoException(StandardErrorCode.GENERIC_USER_ERROR, message.toStringUtf8());
+    }
+
+    @Description("Throws an exception with a given error code and message")
+    @ScalarFunction(value = "fail", hidden = true)
+    @SqlType("unknown")
+    public static void fail(
+            @SqlType(StandardTypes.INTEGER) long errorCode,
+            @SqlType(StandardTypes.VARCHAR) Slice message)
+    {
+        for (StandardErrorCode standardErrorCode : StandardErrorCode.values()) {
+            if (standardErrorCode.toErrorCode().getCode() == errorCode) {
+                throw new PrestoException(standardErrorCode, message.toStringUtf8());
+            }
+        }
+        throw new PrestoException(StandardErrorCode.GENERIC_INTERNAL_ERROR, "Unable to find error for code: " + errorCode);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
 import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
@@ -177,6 +178,12 @@ public class EffectivePredicateExtractor
 
         @Override
         public Expression visitLimit(LimitNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Expression visitAssignUniqueId(AssignUniqueId node, Void context)
         {
             return node.getSource().accept(this, context);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -85,6 +85,7 @@ import com.facebook.presto.sql.planner.iterative.rule.SingleDistinctAggregationT
 import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedInPredicateToJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedLateralJoinToJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedScalarAggregationToJoin;
+import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedScalarSubquery;
 import com.facebook.presto.sql.planner.iterative.rule.TransformExistsApplyToLateralNode;
 import com.facebook.presto.sql.planner.iterative.rule.TransformSpatialPredicates;
 import com.facebook.presto.sql.planner.iterative.rule.TransformUncorrelatedInPredicateSubqueryToSemiJoin;
@@ -309,6 +310,8 @@ public class PlanOptimizers
                         ImmutableSet.of(
                                 new RemoveUnreferencedScalarApplyNodes(),
                                 new TransformCorrelatedInPredicateToJoin(), // must be run after PruneUnreferencedOutputs
+                                new TransformCorrelatedScalarSubquery(), // must be run after TransformCorrelatedScalarAggregationToJoin
+                                new TransformCorrelatedLateralJoinToJoin(),
                                 new ImplementFilteredAggregations())),
                 new TransformCorrelatedSingleRowSubqueryToProject(),
                 new CheckSubqueryNodesAreRewritten(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -34,6 +34,7 @@ import com.facebook.presto.sql.planner.plan.ExceptNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.IntersectNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
@@ -521,7 +522,7 @@ class RelationPlanner
         PlanBuilder leftPlanBuilder = initializePlanBuilder(leftPlan);
         PlanBuilder rightPlanBuilder = initializePlanBuilder(rightPlan);
 
-        PlanBuilder planBuilder = subqueryPlanner.appendLateralJoin(leftPlanBuilder, rightPlanBuilder, lateral.getQuery(), true);
+        PlanBuilder planBuilder = subqueryPlanner.appendLateralJoin(leftPlanBuilder, rightPlanBuilder, lateral.getQuery(), true, LateralJoinNode.Type.INNER);
 
         List<Symbol> outputSymbols = ImmutableList.<Symbol>builder()
                 .addAll(leftPlan.getRoot().getOutputSymbols())

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -231,10 +231,10 @@ class SubqueryPlanner
             subPlan.getTranslations().put(coercion, coercionSymbol);
         }
 
-        return appendLateralJoin(subPlan, subqueryPlan, scalarSubquery.getQuery(), correlationAllowed);
+        return appendLateralJoin(subPlan, subqueryPlan, scalarSubquery.getQuery(), correlationAllowed, LateralJoinNode.Type.LEFT);
     }
 
-    public PlanBuilder appendLateralJoin(PlanBuilder subPlan, PlanBuilder subqueryPlan, Query query, boolean correlationAllowed)
+    public PlanBuilder appendLateralJoin(PlanBuilder subPlan, PlanBuilder subqueryPlan, Query query, boolean correlationAllowed, LateralJoinNode.Type type)
     {
         PlanNode subqueryNode = subqueryPlan.getRoot();
         Map<Expression, Expression> correlation = extractCorrelation(subPlan, subqueryNode);
@@ -250,7 +250,7 @@ class SubqueryPlanner
                         subPlan.getRoot(),
                         subqueryNode,
                         ImmutableList.copyOf(SymbolsExtractor.extractUnique(correlation.values())),
-                        LateralJoinNode.Type.INNER,
+                        type,
                         query),
                 analysis.getParameters());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.LateralJoinNode;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.SimpleCaseExpression;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.sql.tree.WhenClause;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.matching.Pattern.nonEmpty;
+import static com.facebook.presto.spi.StandardErrorCode.SUBQUERY_MULTIPLE_ROWS;
+import static com.facebook.presto.spi.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isAtMostScalar;
+import static com.facebook.presto.sql.planner.plan.Patterns.LateralJoin.correlation;
+import static com.facebook.presto.sql.planner.plan.Patterns.lateralJoin;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+
+/**
+ * Scalar filter scan query is something like:
+ * <pre>
+ *     SELECT a,b,c FROM rel WHERE a = correlated1 AND b = correlated2
+ * </pre>
+ * <p>
+ * This optimizer can rewrite to mark distinct and filter over a left outer join:
+ * <p>
+ * From:
+ * <pre>
+ * - LateralJoin (with correlation list: [C])
+ *   - (input) plan which produces symbols: [A, B, C]
+ *   - (scalar subquery) Project F
+ *     - Filter(D = C AND E > 5)
+ *       - plan which produces symbols: [D, E, F]
+ * </pre>
+ * to:
+ * <pre>
+ * - Filter(CASE isDistinct WHEN true THEN true ELSE fail('Scalar sub-query has returned multiple rows'))
+ *   - MarkDistinct(isDistinct)
+ *     - LateralJoin (with correlation list: [C])
+ *       - AssignUniqueId(adds symbol U)
+ *         - (input) plan which produces symbols: [A, B, C]
+ *       - non scalar subquery
+ * </pre>
+ * <p>
+ *
+ *  This must be run after {@link TransformCorrelatedScalarAggregationToJoin}
+ */
+public class TransformCorrelatedScalarSubquery
+        implements Rule<LateralJoinNode>
+{
+    private static final Pattern<LateralJoinNode> PATTERN = lateralJoin()
+            .with(nonEmpty(correlation()));
+
+    @Override
+    public Pattern getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(LateralJoinNode lateralJoinNode, Captures captures, Context context)
+    {
+        PlanNode subquery = context.getLookup().resolve(lateralJoinNode.getSubquery());
+
+        if (!searchFrom(subquery, context.getLookup())
+                .where(EnforceSingleRowNode.class::isInstance)
+                .recurseOnlyWhen(ProjectNode.class::isInstance)
+                .matches()) {
+            return Result.empty();
+        }
+
+        PlanNode rewrittenSubquery = searchFrom(subquery, context.getLookup())
+                .where(EnforceSingleRowNode.class::isInstance)
+                .recurseOnlyWhen(ProjectNode.class::isInstance)
+                .removeFirst();
+
+        if (isAtMostScalar(rewrittenSubquery, context.getLookup())) {
+            return Result.ofPlanNode(new LateralJoinNode(
+                    context.getIdAllocator().getNextId(),
+                    lateralJoinNode.getInput(),
+                    rewrittenSubquery,
+                    lateralJoinNode.getCorrelation(),
+                    lateralJoinNode.getType(),
+                    lateralJoinNode.getOriginSubquery()));
+        }
+
+        Symbol unique = context.getSymbolAllocator().newSymbol("unique", BigintType.BIGINT);
+
+        LateralJoinNode rewrittenLateralJoinNode = new LateralJoinNode(
+                context.getIdAllocator().getNextId(),
+                new AssignUniqueId(
+                        context.getIdAllocator().getNextId(),
+                        lateralJoinNode.getInput(),
+                        unique),
+                rewrittenSubquery,
+                lateralJoinNode.getCorrelation(),
+                lateralJoinNode.getType(),
+                lateralJoinNode.getOriginSubquery());
+
+        Symbol isDistinct = context.getSymbolAllocator().newSymbol("is_distinct", BooleanType.BOOLEAN);
+        MarkDistinctNode markDistinctNode = new MarkDistinctNode(
+                context.getIdAllocator().getNextId(),
+                rewrittenLateralJoinNode,
+                isDistinct,
+                ImmutableList.of(unique),
+                Optional.empty());
+
+        FilterNode filterNode = new FilterNode(
+                context.getIdAllocator().getNextId(),
+                markDistinctNode,
+                new SimpleCaseExpression(
+                        isDistinct.toSymbolReference(),
+                        ImmutableList.of(
+                                new WhenClause(TRUE_LITERAL, TRUE_LITERAL)),
+                        Optional.of(new Cast(
+                                new FunctionCall(
+                                        QualifiedName.of("fail"),
+                                        ImmutableList.of(
+                                                new LongLiteral(Integer.toString(SUBQUERY_MULTIPLE_ROWS.toErrorCode().getCode())),
+                                                new StringLiteral("Scalar sub-query has returned multiple rows"))),
+                                BOOLEAN))));
+
+        return Result.ofPlanNode(new ProjectNode(
+                context.getIdAllocator().getNextId(),
+                filterNode,
+                Assignments.identity(lateralJoinNode.getOutputSymbols())));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -56,7 +56,6 @@ import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import io.airlift.log.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -92,8 +91,6 @@ import static java.util.Objects.requireNonNull;
 public class PredicatePushDown
         implements PlanOptimizer
 {
-    private static final Logger log = Logger.get(PredicatePushDown.class);
-
     private final Metadata metadata;
     private final LiteralEncoder literalEncoder;
     private final EffectivePredicateExtractor effectivePredicateExtractor;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -184,6 +184,11 @@ public class Patterns
         {
             return property("correlation", LateralJoinNode::getCorrelation);
         }
+
+        public static Property<LateralJoinNode, PlanNode> subquery()
+        {
+            return property("subquery", LateralJoinNode::getSubquery);
+        }
     }
 
     public static class Limit

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.StandardErrorCode;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.SimpleCaseExpression;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.WhenClause;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.lateral;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.markDistinct;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+
+public class TestTransformCorrelatedScalarSubquery
+        extends BaseRuleTest
+{
+    private static final ImmutableList<List<Expression>> ONE_ROW = ImmutableList.of(ImmutableList.of());
+    private static final ImmutableList<List<Expression>> TWO_ROWS = ImmutableList.of(ImmutableList.of(), ImmutableList.of());
+
+    private Rule rule = new TransformCorrelatedScalarSubquery();
+
+    @Test
+    public void doesNotFireOnPlanWithoutLateralNode()
+    {
+        tester().assertThat(rule)
+                .on(p -> p.values(p.symbol("a")))
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireOnCorrelatedNonScalar()
+    {
+        tester().assertThat(rule)
+                .on(p -> p.lateral(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.values(p.symbol("a"))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void doesNotFireOnUncorrelated()
+    {
+        tester().assertThat(rule)
+                .on(p -> p.lateral(
+                        ImmutableList.<Symbol>of(),
+                        p.values(p.symbol("a")),
+                        p.values(ImmutableList.of(p.symbol("b")), ImmutableList.of(expressions("1")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void rewritesOnSubqueryWithoutProjection()
+    {
+        tester().assertThat(rule)
+                .on(p -> p.lateral(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.enforceSingleRow(
+                                p.filter(
+                                        p.expression("1 = a"), // TODO use correlated predicate, it requires support for correlated subqueries in plan matchers
+                                        p.values(ImmutableList.of(p.symbol("a")), TWO_ROWS)))))
+                .matches(
+                        project(
+                                filter(
+                                        ensureScalarSubquery(),
+                                        markDistinct(
+                                                "is_distinct",
+                                                ImmutableList.of("unique"),
+                                                lateral(
+                                                        ImmutableList.of("corr"),
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")),
+                                                        filter(
+                                                                "1 = a",
+                                                                values("a")))))));
+    }
+
+    @Test
+    public void rewritesOnSubqueryWithProjection()
+    {
+        tester().assertThat(rule)
+                .on(p -> p.lateral(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.enforceSingleRow(
+                                p.project(
+                                        Assignments.of(p.symbol("a2"), p.expression("a * 2")),
+                                        p.filter(
+                                                p.expression("1 = a"), // TODO use correlated predicate, it requires support for correlated subqueries in plan matchers
+                                                p.values(ImmutableList.of(p.symbol("a")), TWO_ROWS))))))
+                .matches(
+                        project(
+                                filter(
+                                        ensureScalarSubquery(),
+                                        markDistinct(
+                                                "is_distinct",
+                                                ImmutableList.of("unique"),
+                                                lateral(
+                                                        ImmutableList.of("corr"),
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")),
+                                                        project(ImmutableMap.of("a2", expression("a * 2")),
+                                                                filter("1 = a",
+                                                                        values("a"))))))));
+    }
+
+    @Test
+    public void rewritesOnSubqueryWithProjectionOnTopEnforceSingleNode()
+    {
+        tester().assertThat(rule)
+                .on(p -> p.lateral(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.project(
+                                Assignments.of(p.symbol("a3"), p.expression("a2 + 1")),
+                                p.enforceSingleRow(
+                                        p.project(
+                                                Assignments.of(p.symbol("a2"), p.expression("a * 2")),
+                                                p.filter(
+                                                        p.expression("1 = a"), // TODO use correlated predicate, it requires support for correlated subqueries in plan matchers
+                                                        p.values(ImmutableList.of(p.symbol("a")), TWO_ROWS)))))))
+                .matches(
+                        project(
+                                filter(
+                                        ensureScalarSubquery(),
+                                        markDistinct(
+                                                "is_distinct",
+                                                ImmutableList.of("unique"),
+                                                lateral(
+                                                        ImmutableList.of("corr"),
+                                                        assignUniqueId(
+                                                                "unique",
+                                                                values("corr")),
+                                                        project(
+                                                                ImmutableMap.of("a3", expression("a2 + 1")),
+                                                                project(
+                                                                        ImmutableMap.of("a2", expression("a * 2")),
+                                                                        filter(
+                                                                                "1 = a",
+                                                                                values("a")))))))));
+    }
+
+    @Test
+    public void rewritesScalarSubquery()
+    {
+        tester().assertThat(rule)
+                .on(p -> p.lateral(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.enforceSingleRow(
+                                p.filter(
+                                        p.expression("1 = a"), // TODO use correlated predicate, it requires support for correlated subqueries in plan matchers
+                                        p.values(ImmutableList.of(p.symbol("a")), ONE_ROW)))))
+                .matches(
+                        lateral(
+                                ImmutableList.of("corr"),
+                                values("corr"),
+                                filter(
+                                        "1 = a",
+                                        values("a"))));
+    }
+
+    private static Expression ensureScalarSubquery()
+    {
+        return new SimpleCaseExpression(
+                new SymbolReference("is_distinct"),
+                ImmutableList.of(new WhenClause(TRUE_LITERAL, TRUE_LITERAL)),
+                Optional.of(new Cast(new FunctionCall(
+                        QualifiedName.of("fail"),
+                        ImmutableList.of(
+                                new LongLiteral(Long.toString(StandardErrorCode.SUBQUERY_MULTIPLE_ROWS.ordinal())),
+                                new StringLiteral("Scalar sub-query has returned multiple rows"))),
+                        StandardTypes.BOOLEAN)));
+    }
+}


### PR DESCRIPTION
Support correlated no aggregation scalar subqueries

Adding support correlated non aggregation scalar subqueries like:
SELECT a FROM rel WHERE b = correlation
