### PR TITLE
Make s3 fs rename fail if it is already renamed

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -394,7 +394,7 @@ public class PrestoS3FileSystem
         }
 
         if (keysEqual(src, dst)) {
-            return true;
+            return false;
         }
 
         if (srcDirectory) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -307,7 +307,7 @@ public abstract class AbstractTestHiveClientS3
         assertTrue(fs.exists(path));
 
         // rename foo.txt to foo.txt
-        assertTrue(fs.rename(path, path));
+        assertTrue(!fs.rename(path, path));
         assertTrue(fs.exists(path));
 
         // delete foo.txt


### PR DESCRIPTION
Make s3 fs rename fail if it is already renamed

If file is already named foo.txt it cannot be renamed to foo.txt.
