### PR TITLE
Use target path for table location

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -398,7 +398,7 @@ public abstract class AbstractTestHiveClientS3
             metastoreClient.updateTableLocation(
                     database,
                     tableName.getTableName(),
-                    locationService.writePathRoot(((HiveOutputTableHandle) outputHandle).getLocationHandle()).get().toString());
+                    locationService.targetPath(((HiveOutputTableHandle) outputHandle).getLocationHandle(), Optional.empty()).toString());
         }
 
         try (Transaction transaction = newTransaction()) {


### PR DESCRIPTION
Use target path for table location

locationService::writePathRoot returns a location where data was staged
during the insert. It is not guaranteed that this location will still
exists after the insert commit. Moreover this location contains data
from single insert.

Using locationService.targetPath returns a real table location where
data staged data is moved.
