### PR TITLE
Ignore BLOOM_FILTER_UTF8 ORC streams

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -58,6 +58,7 @@ import static com.facebook.presto.orc.checkpoint.Checkpoints.getStreamCheckpoint
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY_V2;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.BLOOM_FILTER;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.BLOOM_FILTER_UTF8;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_COUNT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
@@ -369,7 +370,7 @@ public class StripeReader
 
     static boolean isIndexStream(Stream stream)
     {
-        return stream.getStreamKind() == ROW_INDEX || stream.getStreamKind() == DICTIONARY_COUNT || stream.getStreamKind() == BLOOM_FILTER;
+        return stream.getStreamKind() == ROW_INDEX || stream.getStreamKind() == DICTIONARY_COUNT || stream.getStreamKind() == BLOOM_FILTER || stream.getStreamKind() == BLOOM_FILTER_UTF8;
     }
 
     private Map<Integer, List<HiveBloomFilter>> readBloomFilterIndexes(Map<StreamId, Stream> streams, Map<StreamId, OrcInputStream> streamsData)
@@ -382,6 +383,7 @@ public class StripeReader
                 OrcInputStream inputStream = streamsData.get(entry.getKey());
                 bloomFilters.put(stream.getColumn(), metadataReader.readBloomFilterIndexes(inputStream));
             }
+            // TODO: add support for BLOOM_FILTER_UTF8
         }
         return bloomFilters.build();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -567,6 +567,8 @@ public class OrcMetadataReader
                 return StreamKind.ROW_INDEX;
             case BLOOM_FILTER:
                 return StreamKind.BLOOM_FILTER;
+            case BLOOM_FILTER_UTF8:
+                return StreamKind.BLOOM_FILTER_UTF8;
             default:
                 throw new IllegalStateException(streamKind + " stream type not implemented yet");
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Stream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Stream.java
@@ -28,6 +28,7 @@ public class Stream
         SECONDARY,
         ROW_INDEX,
         BLOOM_FILTER,
+        BLOOM_FILTER_UTF8,
         IN_DICTIONARY,
         ROW_GROUP_DICTIONARY,
         ROW_GROUP_DICTIONARY_LENGTH,


### PR DESCRIPTION
For now I just added a code that ignores `bloom filters utf_8` stream. However, I wonder maybe we can just add code:
```
            if (stream.getStreamKind() == BLOOM_FILTER_UTF8) {
                OrcInputStream inputStream = streamsData.get(entry.getKey());
                bloomFilters.put(stream.getColumn(), metadataReader.readBloomFilterIndexes(inputStream));
            }
```
to
```
StripeReader#readBloomFilterIndexes
```
