### PR TITLE
Remove maxBlockSizeInBytes in BlockBuilderStatus

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/GroupArrayAggregationState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/GroupArrayAggregationState.java
@@ -71,7 +71,7 @@ public class GroupArrayAggregationState
         this.tailBlockIndex = new ShortBigArray(NULL);
         this.tailPosition = new IntBigArray(NULL);
 
-        this.pageBuilderStatus = new PageBuilderStatus(MAX_BLOCK_SIZE, MAX_BLOCK_SIZE);
+        this.pageBuilderStatus = new PageBuilderStatus(MAX_BLOCK_SIZE);
         this.currentBlockBuilder = type.createBlockBuilder(pageBuilderStatus.createBlockBuilderStatus(), 16);
         this.values = new ArrayList<>();
         this.sumPositions = new LongArrayList();
@@ -142,7 +142,7 @@ public class GroupArrayAggregationState
         if (pageBuilderStatus.isFull()) {
             valueBlocksRetainedSizeInBytes += currentBlockBuilder.getRetainedSizeInBytes();
             sumPositions.add(totalPositions);
-            pageBuilderStatus = new PageBuilderStatus(MAX_BLOCK_SIZE, MAX_BLOCK_SIZE);
+            pageBuilderStatus = new PageBuilderStatus(MAX_BLOCK_SIZE);
             currentBlockBuilder = currentBlockBuilder.newBlockBuilderLike(pageBuilderStatus.createBlockBuilderStatus());
             values.add(currentBlockBuilder);
 

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -112,7 +112,7 @@ public class TestMemoryPools
         // query will reserve all memory in the user pool and discard the output
         setUp(() -> {
             OutputFactory outputFactory = new PageConsumerOutputFactory(types -> (page -> {}));
-            return localQueryRunner.createDrivers("SELECT COUNT(*) FROM orders JOIN lineitem USING (orderkey)", outputFactory, taskContext);
+            return localQueryRunner.createDrivers("SELECT COUNT(*) FROM orders JOIN lineitem ON CAST(orders.orderkey AS VARCHAR) = CAST(lineitem.orderkey AS VARCHAR)", outputFactory, taskContext);
         });
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDistinctLimitOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDistinctLimitOperator.java
@@ -150,7 +150,7 @@ public class TestDistinctLimitOperator
     @Test(dataProvider = "dataType")
     public void testMemoryReservationYield(Type type)
     {
-        List<Page> input = createPagesWithDistinctHashKeys(type, 5_000, 500);
+        List<Page> input = createPagesWithDistinctHashKeys(type, 6_000, 600);
 
         OperatorFactory operatorFactory = new DistinctLimitOperator.DistinctLimitOperatorFactory(
                 0,
@@ -161,9 +161,9 @@ public class TestDistinctLimitOperator
                 Optional.of(1),
                 joinCompiler);
 
-        GroupByHashYieldAssertion.GroupByHashYieldResult result = finishOperatorWithYieldingGroupByHash(input, type, operatorFactory, operator -> ((DistinctLimitOperator) operator).getCapacity(), 170_000);
+        GroupByHashYieldAssertion.GroupByHashYieldResult result = finishOperatorWithYieldingGroupByHash(input, type, operatorFactory, operator -> ((DistinctLimitOperator) operator).getCapacity(), 1_400_000);
         assertGreaterThan(result.getYieldCount(), 5);
         assertGreaterThan(result.getMaxReservedBytes(), 20L << 20);
-        assertEquals(result.getOutput().stream().mapToInt(Page::getPositionCount).sum(), 5_000 * 500);
+        assertEquals(result.getOutput().stream().mapToInt(Page::getPositionCount).sum(), 6_000 * 600);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -454,7 +454,9 @@ public class TestHashAggregationOperator
     public void testMultiSliceAggregationOutput(boolean hashEnabled)
     {
         // estimate the number of entries required to create 1.5 pages of results
-        int fixedWidthSize = SIZE_OF_LONG + SIZE_OF_DOUBLE + SIZE_OF_DOUBLE;
+        // See InMemoryHashAggregationBuilder.buildTypes()
+        int fixedWidthSize = SIZE_OF_LONG + SIZE_OF_LONG +  // Used by BigintGroupByHash, see BigintGroupByHash.TYPES_WITH_RAW_HASH
+                SIZE_OF_LONG + SIZE_OF_DOUBLE;              // Used by COUNT and LONG_AVERAGE aggregators;
         int multiSlicePositionCount = (int) (1.5 * PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES / fixedWidthSize);
         multiSlicePositionCount = Math.min((int) (1.5 * DEFAULT_MAX_BLOCK_SIZE_IN_BYTES / SIZE_OF_DOUBLE), multiSlicePositionCount);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
@@ -164,9 +164,9 @@ public class TestHashSemiJoinOperator
                 type,
                 setBuilderOperatorFactory,
                 operator -> ((SetBuilderOperator) operator).getCapacity(),
-                170_000);
+                1_400_000);
 
-        assertGreaterThanOrEqual(result.getYieldCount(), 7);
+        assertGreaterThanOrEqual(result.getYieldCount(), 5);
         assertGreaterThan(result.getMaxReservedBytes(), 20L << 20);
         assertEquals(result.getOutput().stream().mapToInt(Page::getPositionCount).sum(), 0);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMarkDistinctOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMarkDistinctOperator.java
@@ -107,12 +107,12 @@ public class TestMarkDistinctOperator
     @Test(dataProvider = "dataType")
     public void testMemoryReservationYield(Type type)
     {
-        List<Page> input = createPagesWithDistinctHashKeys(type, 5_000, 500);
+        List<Page> input = createPagesWithDistinctHashKeys(type, 6_000, 600);
 
         OperatorFactory operatorFactory = new MarkDistinctOperatorFactory(0, new PlanNodeId("test"), ImmutableList.of(type), ImmutableList.of(0), Optional.of(1), joinCompiler);
 
         // get result with yield; pick a relatively small buffer for partitionRowCount's memory usage
-        GroupByHashYieldAssertion.GroupByHashYieldResult result = finishOperatorWithYieldingGroupByHash(input, type, operatorFactory, operator -> ((MarkDistinctOperator) operator).getCapacity(), 170_000);
+        GroupByHashYieldAssertion.GroupByHashYieldResult result = finishOperatorWithYieldingGroupByHash(input, type, operatorFactory, operator -> ((MarkDistinctOperator) operator).getCapacity(), 1_400_000);
         assertGreaterThan(result.getYieldCount(), 5);
         assertGreaterThan(result.getMaxReservedBytes(), 20L << 20);
 
@@ -124,6 +124,6 @@ public class TestMarkDistinctOperator
                 count++;
             }
         }
-        assertEquals(count, 5_000 * 500);
+        assertEquals(count, 6_000 * 600);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
@@ -151,7 +151,7 @@ public class TestRowNumberOperator
     @Test(dataProvider = "dataType")
     public void testMemoryReservationYield(Type type)
     {
-        List<Page> input = createPagesWithDistinctHashKeys(type, 5_000, 500);
+        List<Page> input = createPagesWithDistinctHashKeys(type, 6_000, 600);
 
         OperatorFactory operatorFactory = new RowNumberOperator.RowNumberOperatorFactory(
                 0,
@@ -166,7 +166,7 @@ public class TestRowNumberOperator
                 joinCompiler);
 
         // get result with yield; pick a relatively small buffer for partitionRowCount's memory usage
-        GroupByHashYieldAssertion.GroupByHashYieldResult result = finishOperatorWithYieldingGroupByHash(input, type, operatorFactory, operator -> ((RowNumberOperator) operator).getCapacity(), 170_000);
+        GroupByHashYieldAssertion.GroupByHashYieldResult result = finishOperatorWithYieldingGroupByHash(input, type, operatorFactory, operator -> ((RowNumberOperator) operator).getCapacity(), 1_400_000);
         assertGreaterThan(result.getYieldCount(), 5);
         assertGreaterThan(result.getMaxReservedBytes(), 20L << 20);
 
@@ -178,7 +178,7 @@ public class TestRowNumberOperator
                 count++;
             }
         }
-        assertEquals(count, 5_000 * 500);
+        assertEquals(count, 6_000 * 600);
     }
 
     @Test(dataProvider = "hashEnabledValues")

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryBuilder.java
@@ -19,7 +19,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import org.openjdk.jol.info.ClassLayout;
 
-import static com.facebook.presto.spi.block.BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+import static com.facebook.presto.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
@@ -51,7 +51,7 @@ public class DictionaryBuilder
         checkArgument(expectedSize >= 0, "expectedSize must not be negative");
 
         // todo we can do better
-        int expectedEntries = min(expectedSize, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES / EXPECTED_BYTES_PER_ENTRY);
+        int expectedEntries = min(expectedSize, DEFAULT_MAX_PAGE_SIZE_IN_BYTES / EXPECTED_BYTES_PER_ENTRY);
         // it is guaranteed expectedEntries * EXPECTED_BYTES_PER_ENTRY will not overflow
         this.elementBlock = new VariableWidthBlockBuilder(
                 null,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
@@ -16,20 +16,20 @@ package com.facebook.presto.spi;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.PageBuilderStatus;
-import com.facebook.presto.spi.type.FixedWidthType;
 import com.facebook.presto.spi.type.Type;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.spi.block.BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
 import static com.facebook.presto.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 public class PageBuilder
 {
+    private static final int DEFAULT_INITIAL_EXPECTED_ENTRIES = 1024;
+
     private final BlockBuilder[] blockBuilders;
     private final List<Type> types;
     private PageBuilderStatus pageBuilderStatus;
@@ -37,7 +37,7 @@ public class PageBuilder
 
     public PageBuilder(List<? extends Type> types)
     {
-        this(Integer.MAX_VALUE, types);
+        this(DEFAULT_INITIAL_EXPECTED_ENTRIES, types);
     }
 
     public PageBuilder(int initialExpectedEntries, List<? extends Type> types)
@@ -47,22 +47,14 @@ public class PageBuilder
 
     public static PageBuilder withMaxPageSize(int maxPageBytes, List<? extends Type> types)
     {
-        return new PageBuilder(Integer.MAX_VALUE, maxPageBytes, types, Optional.empty());
+        return new PageBuilder(DEFAULT_INITIAL_EXPECTED_ENTRIES, maxPageBytes, types, Optional.empty());
     }
 
     private PageBuilder(int initialExpectedEntries, int maxPageBytes, List<? extends Type> types, Optional<BlockBuilder[]> templateBlockBuilders)
     {
         this.types = unmodifiableList(new ArrayList<>(requireNonNull(types, "types is null")));
 
-        int maxBlockSizeInBytes;
-        if (!types.isEmpty()) {
-            maxBlockSizeInBytes = (int) (1.0 * maxPageBytes / types.size());
-            maxBlockSizeInBytes = Math.min(DEFAULT_MAX_BLOCK_SIZE_IN_BYTES, maxBlockSizeInBytes);
-        }
-        else {
-            maxBlockSizeInBytes = 0;
-        }
-        pageBuilderStatus = new PageBuilderStatus(maxPageBytes, maxBlockSizeInBytes);
+        pageBuilderStatus = new PageBuilderStatus(maxPageBytes);
         blockBuilders = new BlockBuilder[types.size()];
 
         if (templateBlockBuilders.isPresent()) {
@@ -73,22 +65,8 @@ public class PageBuilder
             }
         }
         else {
-            int expectedEntries = Math.min(maxBlockSizeInBytes, initialExpectedEntries);
-            for (Type type : types) {
-                if (type instanceof FixedWidthType) {
-                    int fixedSize = Math.max(((FixedWidthType) type).getFixedSize(), 1);
-                    expectedEntries = Math.min(expectedEntries, maxBlockSizeInBytes / fixedSize);
-                }
-                else {
-                    // We really have no idea how big these are going to be, so just guess. In reset() we'll make a better guess
-                    expectedEntries = Math.min(expectedEntries, maxBlockSizeInBytes / 32);
-                }
-            }
             for (int i = 0; i < blockBuilders.length; i++) {
-                blockBuilders[i] = types.get(i).createBlockBuilder(
-                        pageBuilderStatus.createBlockBuilderStatus(),
-                        expectedEntries,
-                        pageBuilderStatus.getMaxBlockSizeInBytes() / expectedEntries);
+                blockBuilders[i] = types.get(i).createBlockBuilder(pageBuilderStatus.createBlockBuilderStatus(), initialExpectedEntries);
             }
         }
     }
@@ -98,7 +76,7 @@ public class PageBuilder
         if (isEmpty()) {
             return;
         }
-        pageBuilderStatus = new PageBuilderStatus(pageBuilderStatus.getMaxPageSizeInBytes(), pageBuilderStatus.getMaxBlockSizeInBytes());
+        pageBuilderStatus = new PageBuilderStatus(pageBuilderStatus.getMaxPageSizeInBytes());
 
         declaredPositions = 0;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilderStatus.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilderStatus.java
@@ -24,38 +24,31 @@ import static java.util.Objects.requireNonNull;
 public class BlockBuilderStatus
 {
     public static final int INSTANCE_SIZE = deepInstanceSize(BlockBuilderStatus.class);
-    public static final int DEFAULT_MAX_BLOCK_SIZE_IN_BYTES = 64 * 1024;
 
     private final PageBuilderStatus pageBuilderStatus;
-    private final int maxBlockSizeInBytes;
 
     private int currentSize;
 
-    BlockBuilderStatus(PageBuilderStatus pageBuilderStatus, int maxBlockSizeInBytes)
+    BlockBuilderStatus(PageBuilderStatus pageBuilderStatus)
     {
         this.pageBuilderStatus = requireNonNull(pageBuilderStatus, "pageBuilderStatus must not be null");
-        this.maxBlockSizeInBytes = maxBlockSizeInBytes;
     }
 
-    public int getMaxBlockSizeInBytes()
+    public int getMaxPageSizeInBytes()
     {
-        return maxBlockSizeInBytes;
+        return pageBuilderStatus.getMaxPageSizeInBytes();
     }
 
     public void addBytes(int bytes)
     {
         currentSize += bytes;
         pageBuilderStatus.addBytes(bytes);
-        if (currentSize >= maxBlockSizeInBytes) {
-            pageBuilderStatus.setFull();
-        }
     }
 
     @Override
     public String toString()
     {
         StringBuilder buffer = new StringBuilder("BlockBuilderStatus{");
-        buffer.append("maxSizeInBytes=").append(maxBlockSizeInBytes);
         buffer.append(", currentSize=").append(currentSize);
         buffer.append('}');
         return buffer.toString();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/PageBuilderStatus.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/PageBuilderStatus.java
@@ -13,37 +13,27 @@
  */
 package com.facebook.presto.spi.block;
 
-import static com.facebook.presto.spi.block.BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
-
 public class PageBuilderStatus
 {
     public static final int DEFAULT_MAX_PAGE_SIZE_IN_BYTES = 1024 * 1024;
 
     private final int maxPageSizeInBytes;
-    private final int maxBlockSizeInBytes;
 
-    private boolean full;
     private int currentSize;
 
     public PageBuilderStatus()
     {
-        this(DEFAULT_MAX_PAGE_SIZE_IN_BYTES, DEFAULT_MAX_BLOCK_SIZE_IN_BYTES);
+        this(DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
     }
 
-    public PageBuilderStatus(int maxPageSizeInBytes, int maxBlockSizeInBytes)
+    public PageBuilderStatus(int maxPageSizeInBytes)
     {
         this.maxPageSizeInBytes = maxPageSizeInBytes;
-        this.maxBlockSizeInBytes = maxBlockSizeInBytes;
     }
 
     public BlockBuilderStatus createBlockBuilderStatus()
     {
-        return new BlockBuilderStatus(this, maxBlockSizeInBytes);
-    }
-
-    public int getMaxBlockSizeInBytes()
-    {
-        return maxBlockSizeInBytes;
+        return new BlockBuilderStatus(this);
     }
 
     public int getMaxPageSizeInBytes()
@@ -58,12 +48,7 @@ public class PageBuilderStatus
 
     public boolean isFull()
     {
-        return full || currentSize >= maxPageSizeInBytes;
-    }
-
-    void setFull()
-    {
-        this.full = true;
+        return currentSize >= maxPageSizeInBytes;
     }
 
     void addBytes(int bytes)
@@ -81,7 +66,6 @@ public class PageBuilderStatus
     {
         StringBuilder buffer = new StringBuilder("BlockBuilderStatus{");
         buffer.append("maxSizeInBytes=").append(maxPageSizeInBytes);
-        buffer.append(", full=").append(full);
         buffer.append(", currentSize=").append(currentSize);
         buffer.append('}');
         return buffer.toString();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractFixedWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractFixedWidthType.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 import io.airlift.slice.Slice;
 
 public abstract class AbstractFixedWidthType
@@ -42,10 +43,10 @@ public abstract class AbstractFixedWidthType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
         return new FixedWidthBlockBuilder(
                 getFixedSize(),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.IntArrayBlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 import io.airlift.slice.Slice;
 
 import static java.lang.Long.rotateLeft;
@@ -106,10 +107,10 @@ public abstract class AbstractIntType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
         return new IntArrayBlockBuilder(
                 blockBuilderStatus,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LongArrayBlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 import io.airlift.slice.Slice;
 
 import static java.lang.Long.rotateLeft;
@@ -104,10 +105,10 @@ public abstract class AbstractLongType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
         return new LongArrayBlockBuilder(
                 blockBuilderStatus,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.type;
 
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 
 import static java.lang.Math.min;
@@ -35,10 +36,10 @@ public abstract class AbstractVariableWidthType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
 
         // it is guaranteed Math.min will not overflow; safe to cast

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.ByteArrayBlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 
@@ -43,10 +44,10 @@ public final class BooleanType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
         return new ByteArrayBlockBuilder(
                 blockBuilderStatus,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LongArrayBlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static java.lang.Double.doubleToLongBits;
@@ -114,10 +115,10 @@ public final class DoubleType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
         return new LongArrayBlockBuilder(
                 blockBuilderStatus,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.FixedWidthBlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.spi.type.Decimals.MAX_PRECISION;
@@ -46,10 +47,10 @@ final class LongDecimalType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
         return new FixedWidthBlockBuilder(
                 getFixedSize(),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LongArrayBlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 
 import java.math.BigInteger;
 
@@ -44,10 +45,10 @@ final class ShortDecimalType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
         return new LongArrayBlockBuilder(
                 blockBuilderStatus,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 import com.facebook.presto.spi.block.ShortArrayBlockBuilder;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -46,10 +47,10 @@ public final class SmallintType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
         return new ShortArrayBlockBuilder(
                 blockBuilderStatus,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.ByteArrayBlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -46,10 +47,10 @@ public final class TinyintType
     {
         int maxBlockSizeInBytes;
         if (blockBuilderStatus == null) {
-            maxBlockSizeInBytes = BlockBuilderStatus.DEFAULT_MAX_BLOCK_SIZE_IN_BYTES;
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
         }
         else {
-            maxBlockSizeInBytes = blockBuilderStatus.getMaxBlockSizeInBytes();
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
         }
         return new ByteArrayBlockBuilder(
                 blockBuilderStatus,

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestArrayBlockBuilder.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestArrayBlockBuilder.java
@@ -29,8 +29,7 @@ public class TestArrayBlockBuilder
     @Test
     public void testArrayBlockIsFull()
     {
-        testIsFull(new PageBuilderStatus(THREE_INTS_ENTRY_SIZE * EXPECTED_ENTRY_COUNT, 10240));
-        testIsFull(new PageBuilderStatus(10240, THREE_INTS_ENTRY_SIZE * EXPECTED_ENTRY_COUNT));
+        testIsFull(new PageBuilderStatus(THREE_INTS_ENTRY_SIZE * EXPECTED_ENTRY_COUNT));
     }
 
     private void testIsFull(PageBuilderStatus pageBuilderStatus)

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestFixedWidthBlockBuilder.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestFixedWidthBlockBuilder.java
@@ -27,8 +27,7 @@ public class TestFixedWidthBlockBuilder
     @Test
     public void testFixedBlockIsFull()
     {
-        testIsFull(new PageBuilderStatus(BOOLEAN_ENTRY_SIZE * EXPECTED_ENTRY_COUNT, 1024));
-        testIsFull(new PageBuilderStatus(1024, BOOLEAN_ENTRY_SIZE * EXPECTED_ENTRY_COUNT));
+        testIsFull(new PageBuilderStatus(BOOLEAN_ENTRY_SIZE * EXPECTED_ENTRY_COUNT));
     }
 
     private static void testIsFull(PageBuilderStatus pageBuilderStatus)

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockBuilder.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestVariableWidthBlockBuilder.java
@@ -37,8 +37,7 @@ public class TestVariableWidthBlockBuilder
     @Test
     public void testFixedBlockIsFull()
     {
-        testIsFull(new PageBuilderStatus(VARCHAR_ENTRY_SIZE * EXPECTED_ENTRY_COUNT, 1024));
-        testIsFull(new PageBuilderStatus(1024, VARCHAR_ENTRY_SIZE * EXPECTED_ENTRY_COUNT));
+        testIsFull(new PageBuilderStatus(VARCHAR_ENTRY_SIZE * EXPECTED_ENTRY_COUNT));
     }
 
     @Test


### PR DESCRIPTION
Historically, we limit the size of each individual BlockBuilder since
we cannot limit the size of PageBuilder.  This is no longer the case
since 2a59617c44305975b960f9d0c013f72b7a21f209 as we can limit the PageBuilder size.

The BlockBuilder size in PageBulder is limited in an average way, i.e.
maxPageBytes / numBlocks. This can be problematic when there are
most BlockBuilder in a PageBuilder store primitive types,
while one BlockBuilder in the PageBuilder stores structural types.
The PageBuilder will be considered as full prematurely.