### PR TITLE
Skip looking up predicates for complex types to avoid mismatch error in Parquet

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/predicate/ParquetPredicateUtils.java
@@ -56,6 +56,7 @@ import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Math.toIntExact;
 import static java.util.Map.Entry;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE;
 import static parquet.column.Encoding.BIT_PACKED;
 import static parquet.column.Encoding.PLAIN_DICTIONARY;
 import static parquet.column.Encoding.RLE;
@@ -83,7 +84,13 @@ public final class ParquetPredicateUtils
 
         ImmutableMap.Builder<ColumnDescriptor, Domain> predicate = ImmutableMap.builder();
         for (Entry<HiveColumnHandle, Domain> entry : effectivePredicate.getDomains().get().entrySet()) {
-            Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, ImmutableList.of(entry.getKey().getName()));
+            HiveColumnHandle columnHandle = entry.getKey();
+            // skip looking up predicates for complex types as Parquet only stores stats for primitives
+            if (!columnHandle.getHiveType().getCategory().equals(PRIMITIVE)) {
+                continue;
+            }
+
+            Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, ImmutableList.of(columnHandle.getName()));
             if (descriptor.isPresent()) {
                 predicate.put(descriptor.get(), entry.getValue());
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -13,20 +13,47 @@
  */
 package com.facebook.presto.hive.parquet.predicate;
 
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
+import parquet.column.ColumnDescriptor;
 import parquet.column.Encoding;
+import parquet.schema.GroupType;
+import parquet.schema.MessageType;
+import parquet.schema.PrimitiveType;
 
+import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.getParquetTupleDomain;
 import static com.facebook.presto.hive.parquet.predicate.ParquetPredicateUtils.isOnlyDictionaryEncodingPages;
+import static com.facebook.presto.spi.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.google.common.collect.Sets.union;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static parquet.column.Encoding.BIT_PACKED;
 import static parquet.column.Encoding.PLAIN;
 import static parquet.column.Encoding.PLAIN_DICTIONARY;
 import static parquet.column.Encoding.RLE;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static parquet.schema.Type.Repetition.OPTIONAL;
+import static parquet.schema.Type.Repetition.REPEATED;
+import static parquet.schema.Type.Repetition.REQUIRED;
 
 public class TestParquetPredicateUtils
 {
@@ -51,5 +78,102 @@ public class TestParquetPredicateUtils
         assertTrue(isOnlyDictionaryEncodingPages(union(required, dictionary)), "required dictionary");
         assertTrue(isOnlyDictionaryEncodingPages(union(optional, dictionary)), "optional dictionary");
         assertTrue(isOnlyDictionaryEncodingPages(union(repeated, dictionary)), "repeated dictionary");
+    }
+
+    @Test
+    public void testParquetTupleDomainPrimitiveArray()
+    {
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_array", HiveType.valueOf("array<int>"), parseTypeSignature(StandardTypes.ARRAY), 0, REGULAR, Optional.empty());
+        TupleDomain<HiveColumnHandle> domain = TupleDomain.withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(new ArrayType(INTEGER))));
+
+        MessageType fileSchema = new MessageType("hive_schema",
+                new GroupType(OPTIONAL, "my_array",
+                        new GroupType(REPEATED, "bag", new PrimitiveType(OPTIONAL, INT32, "array_element"))));
+
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+        assertTrue(tupleDomain.getDomains().get().isEmpty());
+    }
+
+    @Test
+    public void testParquetTupleDomainStructArray()
+    {
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_array_struct", HiveType.valueOf("array<struct<a:int>>"), parseTypeSignature(StandardTypes.ARRAY), 0, REGULAR, Optional.empty());
+        RowType.Field rowField = new RowType.Field(Optional.of("a"), INTEGER);
+        RowType rowType = RowType.from(ImmutableList.of(rowField));
+        TupleDomain<HiveColumnHandle> domain = TupleDomain.withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(new ArrayType(rowType))));
+
+        MessageType fileSchema = new MessageType("hive_schema",
+                new GroupType(OPTIONAL, "my_array_struct",
+                        new GroupType(REPEATED, "bag",
+                                new GroupType(OPTIONAL, "array_element", new PrimitiveType(OPTIONAL, INT32, "a")))));
+
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+        assertTrue(tupleDomain.getDomains().get().isEmpty());
+    }
+
+    @Test
+    public void testParquetTupleDomainPrimitive()
+    {
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_primitive", HiveType.valueOf("bigint"), parseTypeSignature(StandardTypes.BIGINT), 0, REGULAR, Optional.empty());
+        Domain singleValueDomain = Domain.singleValue(BIGINT, 123L);
+        TupleDomain<HiveColumnHandle> domain = TupleDomain.withColumnDomains(ImmutableMap.of(columnHandle, singleValueDomain));
+
+        MessageType fileSchema = new MessageType("hive_schema", new PrimitiveType(OPTIONAL, INT64, "my_primitive"));
+
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+
+        assertEquals(tupleDomain.getDomains().get().size(), 1);
+        ColumnDescriptor descriptor = tupleDomain.getDomains().get().keySet().iterator().next();
+        assertEquals(descriptor.getPath().length, 1);
+        assertEquals(descriptor.getPath()[0], "my_primitive");
+
+        Domain predicateDomain = tupleDomain.getDomains().get().values().iterator().next();
+        assertEquals(predicateDomain, singleValueDomain);
+    }
+
+    @Test
+    public void testParquetTupleDomainStruct()
+    {
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_struct", HiveType.valueOf("struct<a:int,b:int>"), parseTypeSignature(StandardTypes.ROW), 0, REGULAR, Optional.empty());
+        RowType.Field rowField = new RowType.Field(Optional.of("my_struct"), INTEGER);
+        RowType rowType = RowType.from(ImmutableList.of(rowField));
+        TupleDomain<HiveColumnHandle> domain = TupleDomain.withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(rowType)));
+
+        MessageType fileSchema = new MessageType("hive_schema",
+                new GroupType(OPTIONAL, "my_struct",
+                        new PrimitiveType(OPTIONAL, INT32, "a"),
+                        new PrimitiveType(OPTIONAL, INT32, "b")));
+
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+        assertTrue(tupleDomain.getDomains().get().isEmpty());
+    }
+
+    @Test
+    public void testParquetTupleDomainMap()
+    {
+        HiveColumnHandle columnHandle = new HiveColumnHandle("my_map", HiveType.valueOf("map<int,int>"), parseTypeSignature(StandardTypes.MAP), 0, REGULAR, Optional.empty());
+
+        MapType mapType = new MapType(
+                INTEGER,
+                INTEGER,
+                methodHandle(TestParquetPredicateUtils.class, "throwUnsupportedOperationException"),
+                methodHandle(TestParquetPredicateUtils.class, "throwUnsupportedOperationException"),
+                methodHandle(TestParquetPredicateUtils.class, "throwUnsupportedOperationException"));
+
+        TupleDomain<HiveColumnHandle> domain = TupleDomain.withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(mapType)));
+
+        MessageType fileSchema = new MessageType("hive_schema",
+                new GroupType(OPTIONAL, "my_map",
+                        new GroupType(REPEATED, "map",
+                            new PrimitiveType(REQUIRED, INT32, "key"),
+                            new PrimitiveType(OPTIONAL, INT32, "value"))));
+
+        TupleDomain<ColumnDescriptor> tupleDomain = getParquetTupleDomain(fileSchema, fileSchema, domain);
+        assertTrue(tupleDomain.getDomains().get().isEmpty());
+    }
+
+    public static void throwUnsupportedOperationException()
+    {
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
Based on this issue: https://github.com/prestodb/presto/issues/10415
Added some unit tests which fail without these changes (as they end up picking an incorrect primitive field in the complex type type. E.g. for the struct: a, b field `b` is picked up and there's a mismatch error as we're expecting a type of struct while we get b). 

Also tested these changes on a running Presto build and verified they work.