### PR TITLE
[Not for Review, Test Only] Make SqlQueryManager a generic class

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -104,7 +104,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
 @ThreadSafe
-public class SqlQueryManager<C>
+public class SqlQueryManager
         implements QueryManager
 {
     private static final Logger log = Logger.get(SqlQueryManager.class);
@@ -113,7 +113,7 @@ public class SqlQueryManager<C>
 
     private final ExecutorService queryExecutor;
     private final ThreadPoolExecutorMBean queryExecutorMBean;
-    private final ResourceGroupManager<C> resourceGroupManager;
+    private final ResourceGroupManager<?> resourceGroupManager;
     private final ClusterMemoryManager memoryManager;
 
     private final boolean isIncludeCoordinator;
@@ -157,7 +157,7 @@ public class SqlQueryManager<C>
             NodeSchedulerConfig nodeSchedulerConfig,
             QueryManagerConfig queryManagerConfig,
             QueryMonitor queryMonitor,
-            ResourceGroupManager<C> resourceGroupManager,
+            ResourceGroupManager<?> resourceGroupManager,
             ClusterMemoryManager memoryManager,
             LocationFactory locationFactory,
             TransactionManager transactionManager,
@@ -366,7 +366,7 @@ public class SqlQueryManager<C>
         QueryId queryId = queryIdGenerator.createNextQueryId();
 
         Session session = null;
-        SelectionContext<C> selectionContext;
+        SelectionContext<?> selectionContext;
         QueryExecution queryExecution;
         Statement statement;
         try {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -104,7 +104,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
 @ThreadSafe
-public class SqlQueryManager
+public class SqlQueryManager<C>
         implements QueryManager
 {
     private static final Logger log = Logger.get(SqlQueryManager.class);
@@ -113,7 +113,7 @@ public class SqlQueryManager
 
     private final ExecutorService queryExecutor;
     private final ThreadPoolExecutorMBean queryExecutorMBean;
-    private final ResourceGroupManager resourceGroupManager;
+    private final ResourceGroupManager<C> resourceGroupManager;
     private final ClusterMemoryManager memoryManager;
 
     private final boolean isIncludeCoordinator;
@@ -157,7 +157,7 @@ public class SqlQueryManager
             NodeSchedulerConfig nodeSchedulerConfig,
             QueryManagerConfig queryManagerConfig,
             QueryMonitor queryMonitor,
-            ResourceGroupManager resourceGroupManager,
+            ResourceGroupManager<C> resourceGroupManager,
             ClusterMemoryManager memoryManager,
             LocationFactory locationFactory,
             TransactionManager transactionManager,
@@ -366,7 +366,7 @@ public class SqlQueryManager
         QueryId queryId = queryIdGenerator.createNextQueryId();
 
         Session session = null;
-        SelectionContext<?> selectionContext;
+        SelectionContext<C> selectionContext;
         QueryExecution queryExecution;
         Statement statement;
         try {


### PR DESCRIPTION
Commit c37ae66f54b452214f0429327572206d1d824f9c makes
ResourceGroupManager a generic class. This makes SqlQueryManager
use raw class in several places.

Make the context class as a type parameter to SqlQueryManager.