### PR TITLE
Fix partition offline check in HiveSplitManager

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -288,7 +288,7 @@ public class HiveSplitManager
                 String partName = makePartName(table.getPartitionColumns(), partition.getValues());
 
                 // verify partition is online
-                verifyOnline(tableName, Optional.of(partName), getProtectMode(partition), table.getParameters());
+                verifyOnline(tableName, Optional.of(partName), getProtectMode(partition), partition.getParameters());
 
                 // verify partition is not marked as non-readable
                 String partitionNotReadable = partition.getParameters().get(OBJECT_NOT_READABLE);


### PR DESCRIPTION
It is checking the table parameters rather than partition parameters.
The bug is introduced in f8824b16d5cd33cdeb95fad9f84ae074dc4c5531.