### PR TITLE
Fix infinite loop due to MultipleDistinctAggregationToMarkDistinct rule

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestDistinctAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestDistinctAggregations.java
@@ -222,4 +222,22 @@ public class TestDistinctAggregations
                         "   (3, 30, 300)) t(x, y, z)",
                 "VALUES (BIGINT '6', BIGINT '60', BIGINT '900')");
     }
+
+    @Test
+    public void testMixedDistinctWithFilter()
+    {
+        assertions.assertQuery(
+                "SELECT " +
+                        "     count(DISTINCT x) FILTER (WHERE x > 0), " +
+                        "     sum(x) " +
+                        "FROM (VALUES 0, 1, 1, 2) t(x)",
+                "VALUES (BIGINT '2', BIGINT '4')");
+
+        assertions.assertQuery(
+                "SELECT " +
+                        "     count(DISTINCT x), " +
+                        "     sum(x) FILTER (WHERE x > 0) " +
+                        "FROM (VALUES 0, 1, 1, 2) t(x)",
+                "VALUES (BIGINT '3', BIGINT '4')");
+    }
 }


### PR DESCRIPTION
The rule pattern accepted aggregations with DISTINCT and FILTER/mask, but the
body of the rule can't handle that scenario.

This changes adjusts the pattern to reject any aggregation node that contains
a DISTINCT aggregate with a mask of FILTER clause.
