### PR TITLE
Fix unnecessary delay during scheduling of splits for a Partitioned table

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -266,7 +266,7 @@ public class SourcePartitionedScheduler
             // 1. It always returns a completed future when there are no tasks, regardless of whether all nodes are blocked.
             // 2. The returned future will only be completed when a node with an assigned task becomes unblocked. Other nodes don't trigger future completion.
             // As a result, to avoid busy loops caused by 1, we check pendingSplits.isEmpty() instead of placementFuture.isDone() here.
-            if (scheduleGroup.nextSplitBatchFuture == null && scheduleGroup.pendingSplits.isEmpty() && scheduleGroup.state != ScheduleGroupState.DONE) {
+            if (scheduleGroup.nextSplitBatchFuture == null && scheduleGroup.pendingSplits.isEmpty()) {
                 anyNotBlocked = true;
             }
         }


### PR DESCRIPTION
This PR fixes the unnecessary delay of 1s when splits are scheduled for a partitioned tables (Issue : #10409) . This delay is seen when we are scheduling the last batch of splits for a partitioned tables. 

 