### PR TITLE
Include full path to password auth config file when not found

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/PasswordAuthenticatorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/PasswordAuthenticatorManager.java
@@ -60,11 +60,12 @@ public class PasswordAuthenticatorManager
             return;
         }
 
-        Map<String, String> properties = new HashMap<>(loadProperties(CONFIG_FILE));
+        File configFileLocation = CONFIG_FILE.getAbsoluteFile();
+        Map<String, String> properties = new HashMap<>(loadProperties(configFileLocation));
 
         String name = properties.remove(NAME_PROPERTY);
         checkArgument(!isNullOrEmpty(name),
-                "Password authenticator configuration %s does not contain %s", CONFIG_FILE.getAbsoluteFile(), NAME_PROPERTY);
+                "Password authenticator configuration %s does not contain %s", configFileLocation, NAME_PROPERTY);
 
         log.info("-- Loading password authenticator --");
 


### PR DESCRIPTION
Previously, when `PasswordAuthenticatorManager`'s config file was not
found, the following would get logged, which doesn't tell where Presto
is looking for the config file:

```
2018-04-20T22:01:53.887+0200	ERROR	main	com.facebook.presto.server.PrestoServer	etc/password-authenticator.properties (No such file or directory)
java.io.FileNotFoundException: etc/password-authenticator.properties (No such file or directory)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at com.facebook.presto.util.PropertiesUtil.loadProperties(PropertiesUtil.java:33)
	at com.facebook.presto.server.security.PasswordAuthenticatorManager.loadPasswordAuthenticator(PasswordAuthenticatorManager.java:63)
```