### PR TITLE
Modify TypeSignature for ROW types with quoted identifiers as fields

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -177,7 +177,10 @@ public class TypeSignature
             else if (c == ' ') {
                 if (bracketCount == 1 && inFieldName) {
                     checkArgument(parameterStart >= 0 && parameterStart < i, "Bad type signature: '%s'", signature);
-                    fieldName = signature.substring(parameterStart, i);
+                    // The field name identifier may have quotes at this stage but they are ignored
+                    // while creating the type signature. This ensures that signatures for quoted and
+                    // unquoted versions of the same field name will match.
+                    fieldName = signature.substring(parameterStart, i).replaceAll("^\"|\"$", "");
                     parameterStart = i + 1;
                     inFieldName = false;
                 }


### PR DESCRIPTION
The TypeSignature for ROW fields currently includes quotes if the
identifier was originally quoted. This is problematic if a single
query contains quoted and unquoted versions of the same field.
For example the query:
    select cast(row(11) as row(field1 bigint)) as col1
        union select cast(row(12) as row("field1" bigint));

Results in the output field 'field0'
        col1
    -------------
     {field0=12}
     {field0=11}

If any reserved words are used as field names then quoting them becomes necessary.
This change modifies TypeSignature construction to ignore any quotes
around a field.