### PR TITLE
Do not derive all grouping sets when traversing tree

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.sql.tree;
 
-import java.util.Set;
-
 public abstract class DefaultTraversalVisitor<R, C>
         extends AstVisitor<R, C>
 {
@@ -484,13 +482,30 @@ public abstract class DefaultTraversalVisitor<R, C>
     }
 
     @Override
-    protected R visitGroupingElement(GroupingElement node, C context)
+    protected R visitCube(Cube node, C context)
     {
-        for (Set<Expression> expressions : node.enumerateGroupingSets()) {
-            for (Expression expression : expressions) {
-                process(expression, context);
-            }
+        return null;
+    }
+
+    @Override
+    protected R visitRollup(Rollup node, C context)
+    {
+        return null;
+    }
+
+    @Override
+    protected R visitSimpleGroupBy(SimpleGroupBy node, C context)
+    {
+        for (Expression expression : node.getColumnExpressions()) {
+            process(expression, context);
         }
+
+        return null;
+    }
+
+    @Override
+    protected R visitGroupingSets(GroupingSets node, C context)
+    {
         return null;
     }
 


### PR DESCRIPTION
The only node that has visitable expressions is SimpleGroupBy. There's
no point in synthesizing the grouping sets from nodes like Cube or Rollup
just for the purpose of visiting the resulting expressions.

One effect of doing so is that query creation can fail due to OOMs
when allocating too many objects.