### PR TITLE
Fix bing_tile_coordinates function to produce row block

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoPlugin.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoPlugin.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.geospatial;
 
+import com.facebook.presto.plugin.geospatial.BingTileFunctions.BingTileCoordinatesFunction;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -39,6 +40,7 @@ public class GeoPlugin
                 .add(GeoFunctions.class)
                 .add(BingTileOperators.class)
                 .add(BingTileFunctions.class)
+                .add(BingTileCoordinatesFunction.class)
                 .build();
     }
 }

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
@@ -119,6 +119,8 @@ public class TestBingTileFunctions
         assertFunction("bing_tile_coordinates(bing_tile('213')).y", INTEGER, 5);
         assertFunction("bing_tile_coordinates(bing_tile('123030123010121')).x", INTEGER, 21845);
         assertFunction("bing_tile_coordinates(bing_tile('123030123010121')).y", INTEGER, 13506);
+
+        assertCachedInstanceHasBoundedRetainedSize("bing_tile_coordinates(bing_tile('213'))");
     }
 
     @Test


### PR DESCRIPTION
Previously, bing_tile_coordinates produces a IntArrayBlock with length 2
to represent Row(INTEGER, INTEGER). This now longer works since
RowBlockBuilder.appendStructure now require row block in
630ec959c4e29d09c3b46cba2085e320d815f1ac.