### PR TITLE
Disable optimization to short circuit on empty tables

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -239,13 +239,6 @@ public class LookupJoinOperator
             }
             lookupSourceProvider = requireNonNull(getDone(lookupSourceProviderFuture));
             statisticsCounter.updateLookupSourcePositions(lookupSourceProvider.withLease(lookupSourceLease -> lookupSourceLease.getLookupSource().getJoinPositionCount()));
-
-            // check if we can finish the join earlier
-            if (!probeOnOuterSide &&
-                    lookupSourceProvider.withLease(lookupSourceLease ->
-                            lookupSourceLease.getLookupSource().isEmpty())) {
-                finishing = true;
-            }
         }
         return true;
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -97,7 +97,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -988,8 +987,6 @@ public class TestHashJoinOperator
         operator.addInput(pages.get(0));
         Page outputPage = operator.getOutput();
         assertNull(outputPage);
-
-        assertFalse(operator.needsInput());
     }
 
     @Test(dataProvider = "hashJoinTestValues")
@@ -1021,8 +1018,6 @@ public class TestHashJoinOperator
         operator.addInput(pages.get(0));
         Page outputPage = operator.getOutput();
         assertNull(outputPage);
-
-        assertFalse(operator.needsInput());
     }
 
     @Test(dataProvider = "hashJoinTestValues")


### PR DESCRIPTION
We found out a problem with this change when you have a large table joined with a small table (not an empty table) causing the query to hang.
cc: @findepi 