### PR TITLE
Cleanup exception handling

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloConnectorFactory.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloConnectorFactory.java
@@ -17,13 +17,13 @@ import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 
 import java.util.Map;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class AccumuloConnectorFactory
@@ -56,7 +56,8 @@ public class AccumuloConnectorFactory
             return injector.getInstance(AccumuloConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-atop/src/main/java/com/facebook/presto/atop/AtopConnectorFactory.java
+++ b/presto-atop/src/main/java/com/facebook/presto/atop/AtopConnectorFactory.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
@@ -29,6 +28,7 @@ import java.util.Map;
 
 import static com.facebook.presto.atop.AtopConnectorConfig.SECURITY_FILE;
 import static com.facebook.presto.atop.AtopConnectorConfig.SECURITY_NONE;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.airlift.configuration.ConditionalModule.installModuleIf;
 import static java.util.Objects.requireNonNull;
 
@@ -90,7 +90,8 @@ public class AtopConnectorFactory
             return injector.getInstance(AtopConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-atop/src/test/java/com/facebook/presto/atop/TestingAtopFactory.java
+++ b/presto-atop/src/test/java/com/facebook/presto/atop/TestingAtopFactory.java
@@ -15,12 +15,12 @@ package com.facebook.presto.atop;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,7 +100,7 @@ public class TestingAtopFactory
                 reader.close();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         }
     }

--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/RegexTemplate.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/RegexTemplate.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.benchmark.driver;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +37,7 @@ public class RegexTemplate
             NAMED_GROUPS_METHOD.setAccessible(true);
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            throw new AssertionError(e);
         }
     }
 
@@ -61,8 +60,8 @@ public class RegexTemplate
         try {
             namedGroups = (Map<String, Integer>) NAMED_GROUPS_METHOD.invoke(pattern);
         }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
         }
         ImmutableSortedMap<Integer, String> sortedGroups = ImmutableSortedMap.copyOf(ImmutableBiMap.copyOf(namedGroups).inverse());
         this.fieldNames = ImmutableList.copyOf(sortedGroups.values());

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraConnectorFactory.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraConnectorFactory.java
@@ -17,7 +17,6 @@ import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -32,6 +31,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class CassandraConnectorFactory
@@ -84,7 +84,8 @@ public class CassandraConnectorFactory
             return injector.getInstance(CassandraConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleConnectorFactory.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleConnectorFactory.java
@@ -17,13 +17,13 @@ import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 
 import java.util.Map;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class ExampleConnectorFactory
@@ -60,7 +60,8 @@ public class ExampleConnectorFactory
             return injector.getInstance(ExampleConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -33,7 +33,6 @@ import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPag
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorSplitManager;
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeNodePartitioningProvider;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
@@ -50,6 +49,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class HiveConnectorFactory
@@ -137,7 +137,8 @@ public class HiveConnectorFactory
                     classLoader);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -41,7 +41,6 @@ import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
@@ -106,6 +105,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_DATABASE_LOCATION_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_SERDE_NOT_FOUND;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 import static com.facebook.presto.hive.HiveUtil.checkCondition;
 import static com.facebook.presto.hive.HiveUtil.isArrayType;
@@ -228,8 +228,11 @@ public final class HiveWriteUtils
             result.initialize(conf, properties);
             return result;
         }
+        catch (ClassNotFoundException e) {
+            throw new PrestoException(HIVE_SERDE_NOT_FOUND, "Serializer does not exist: " + serializerName);
+        }
         catch (SerDeException | ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            throw new PrestoException(HIVE_WRITER_DATA_ERROR, e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosAuthentication.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.hive.authentication;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -65,7 +64,7 @@ public class KerberosAuthentication
             return loginContext.getSubject();
         }
         catch (LoginException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -70,6 +69,7 @@ import static com.facebook.presto.hive.metastore.thrift.ThriftMetastoreUtil.toGr
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.String.format;
@@ -127,7 +127,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -151,7 +151,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -191,7 +191,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -219,7 +219,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -248,7 +248,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -277,7 +277,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -302,7 +302,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -327,7 +327,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -352,7 +352,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -377,7 +377,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -405,7 +405,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -430,7 +430,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -459,7 +459,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -483,7 +483,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -507,7 +507,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -542,7 +542,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -567,7 +567,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -592,7 +592,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -617,7 +617,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -645,7 +645,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -671,7 +671,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -746,7 +746,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -782,10 +782,7 @@ public class ThriftHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
         catch (Exception e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            throw Throwables.propagate(e);
+            throw propagate(e);
         }
     }
 
@@ -899,6 +896,7 @@ public class ThriftHiveMetastore
         if (throwable instanceof InterruptedException) {
             Thread.currentThread().interrupt();
         }
-        throw Throwables.propagate(throwable);
+        throwIfUnchecked(throwable);
+        throw new RuntimeException(throwable);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -57,7 +57,6 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.testing.TestingNodeManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -72,6 +71,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -517,8 +518,8 @@ public abstract class AbstractTestHiveClientS3
                     }
                 }
             }
-            catch (Exception e) {
-                throw Throwables.propagate(e);
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
             finally {
                 invalidateTable(databaseName, tableName);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -40,7 +40,6 @@ import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.testing.TestingSplit;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -596,7 +595,7 @@ public class TestOrcPageSourceMemoryTracking
             flushStripe.invoke(writer);
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -627,7 +626,7 @@ public class TestOrcPageSourceMemoryTracking
             return constructor;
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -48,7 +48,6 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordPageSource;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.OutputStreamSliceOutput;
 import org.apache.hadoop.conf.Configuration;
@@ -336,13 +335,8 @@ public enum FileFormat
     private static final JobConf conf;
 
     static {
-        try {
-            conf = new JobConf(new Configuration(false));
-            conf.set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
-        }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
-        }
+        conf = new JobConf(new Configuration(false));
+        conf.set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
     }
 
     public boolean supports(TestData testData)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.hive.metastore.thrift;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -206,7 +205,7 @@ public class MockHiveMetastoreClient
                 return new Partition(ImmutableList.copyOf(Warehouse.getPartValuesFromPartName(name)), TEST_DATABASE, TEST_TABLE, 0, 0, DEFAULT_STORAGE_DESCRIPTOR, ImmutableMap.of());
             }
             catch (MetaException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         });
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestingHiveCluster.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestingHiveCluster.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive.metastore.thrift;
 
 import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.authentication.NoHiveMetastoreAuthentication;
-import com.google.common.base.Throwables;
 import com.google.common.net.HostAndPort;
 import org.apache.thrift.transport.TTransportException;
 
@@ -42,7 +41,7 @@ public class TestingHiveCluster
             return new HiveMetastoreClientFactory(config, new NoHiveMetastoreAuthentication()).create(address);
         }
         catch (TTransportException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -18,7 +18,6 @@ import com.facebook.presto.hive.parquet.reader.ParquetReader;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Function;
-import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -47,6 +46,7 @@ import parquet.schema.MessageType;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -273,7 +273,7 @@ public class ParquetTester
                 file.delete();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -26,7 +26,6 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.EncryptionMaterials;
 import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
 import com.facebook.presto.hive.s3.PrestoS3FileSystem.UnrecoverableS3OperationException;
-import com.google.common.base.Throwables;
 import com.google.common.base.VerifyException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -485,7 +484,7 @@ public class TestPrestoS3FileSystem
             return (T) field.get(instance);
         }
         catch (ReflectiveOperationException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxConnectorFactory.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxConnectorFactory.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
@@ -28,6 +27,7 @@ import javax.management.MBeanServer;
 
 import java.util.Map;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.util.Objects.requireNonNull;
 
@@ -78,7 +78,8 @@ public class JmxConnectorFactory
             return injector.getInstance(JmxConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -79,6 +79,11 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorFactory.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorFactory.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
@@ -31,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -89,7 +89,8 @@ public class KafkaConnectorFactory
             return injector.getInstance(KafkaConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSimpleConsumerManager.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSimpleConsumerManager.java
@@ -15,7 +15,6 @@ package com.facebook.presto.kafka;
 
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.NodeManager;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -26,7 +25,6 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -79,12 +77,7 @@ public class KafkaSimpleConsumerManager
     public SimpleConsumer getConsumer(HostAddress host)
     {
         requireNonNull(host, "host is null");
-        try {
-            return consumerCache.get(host);
-        }
-        catch (ExecutionException e) {
-            throw Throwables.propagate(e.getCause());
-        }
+        return consumerCache.getUnchecked(host);
     }
 
     private SimpleConsumer createConsumer(HostAddress host)

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/JsonEncoder.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/JsonEncoder.java
@@ -13,12 +13,12 @@
  */
 package com.facebook.presto.kafka.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 import kafka.serializer.Encoder;
 import kafka.utils.VerifiableProperties;
 
-import java.io.IOException;
+import java.io.UncheckedIOException;
 
 public class JsonEncoder
         implements Encoder<Object>
@@ -37,8 +37,8 @@ public class JsonEncoder
         try {
             return objectMapper.writeValueAsBytes(o);
         }
-        catch (IOException e) {
-            throw Throwables.propagate(e);
+        catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileConnectorFactory.java
+++ b/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileConnectorFactory.java
@@ -18,12 +18,12 @@ import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 
 import java.util.Map;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class LocalFileConnectorFactory
@@ -60,7 +60,8 @@ public class LocalFileConnectorFactory
             return injector.getInstance(LocalFileConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -25,7 +25,6 @@ import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -43,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static java.util.Objects.requireNonNull;
 
 public class DataDefinitionExecution<T extends Statement>
@@ -138,9 +138,7 @@ public class DataDefinitionExecution<T extends Statement>
         }
         catch (Throwable e) {
             fail(e);
-            if (!(e instanceof RuntimeException)) {
-                throw Throwables.propagate(e);
-            }
+            throwIfInstanceOf(e, Error.class);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -40,7 +40,6 @@ import com.facebook.presto.sql.planner.PartitioningHandle;
 import com.facebook.presto.sql.planner.StageExecutionPlan;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -521,7 +520,7 @@ public class SqlQueryScheduler
         }
         catch (Throwable t) {
             queryStateMachine.transitionToFailed(t);
-            throw Throwables.propagate(t);
+            throw t;
         }
         finally {
             RuntimeException closeError = new RuntimeException();

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -173,7 +173,6 @@ import com.facebook.presto.type.setdigest.SetDigestFunctions;
 import com.facebook.presto.type.setdigest.SetDigestOperators;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -331,6 +330,7 @@ import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -883,7 +883,8 @@ public class FunctionRegistry
             return specializedWindowCache.getUnchecked(getSpecializedFunctionKey(signature));
         }
         catch (UncheckedExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
         }
     }
 
@@ -896,7 +897,8 @@ public class FunctionRegistry
             return specializedAggregationCache.getUnchecked(getSpecializedFunctionKey(signature));
         }
         catch (UncheckedExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
         }
     }
 
@@ -909,7 +911,8 @@ public class FunctionRegistry
             return specializedScalarCache.getUnchecked(getSpecializedFunctionKey(signature));
         }
         catch (UncheckedExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
         }
     }
 
@@ -919,7 +922,8 @@ public class FunctionRegistry
             return specializedFunctionKeyCache.getUnchecked(signature);
         }
         catch (UncheckedExecutionException e) {
-            throw Throwables.propagate(e.getCause());
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator;
 import com.facebook.presto.execution.buffer.SerializedPage;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.operator.HttpPageBufferClient.ClientCallback;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -46,6 +45,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.execution.buffer.PageCompression.UNCOMPRESSED;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static java.util.Objects.requireNonNull;
@@ -376,7 +376,8 @@ public class ExchangeClient
     {
         Throwable t = failure.get();
         if (t != null) {
-            throw Throwables.propagate(t);
+            throwIfUnchecked(t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.DynamicClassLoader;
 
@@ -42,6 +41,7 @@ import static com.facebook.presto.operator.aggregation.AggregationUtils.generate
 import static com.facebook.presto.operator.aggregation.state.StateCompiler.generateStateSerializer;
 import static com.facebook.presto.spi.StandardErrorCode.AMBIGUOUS_FUNCTION_CALL;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_MISSING;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 
@@ -159,8 +159,9 @@ public class ParametricAggregation
                 MethodHandle factoryHandle = bindDependencies(stateSerializerFactory.get(), implementation.getStateSerializerFactoryDependencies(), variables, typeManager, functionRegistry);
                 stateSerializer = (AccumulatorStateSerializer<?>) factoryHandle.invoke();
             }
-            catch (Throwable e) {
-                throw Throwables.propagate(e);
+            catch (Throwable t) {
+                throwIfUnchecked(t);
+                throw new RuntimeException(t);
             }
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/FieldSetFilteringRecordSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/FieldSetFilteringRecordSet.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
@@ -31,6 +30,7 @@ import java.util.Set;
 
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -187,8 +187,9 @@ public class FieldSetFilteringRecordSet
                     return (boolean) field1.getEqualsMethodHandle().invoke(cursor.getObject(field1.getField()), cursor.getObject(field2.getField()));
                 }
             }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
+            catch (Throwable t) {
+                throwIfUnchecked(t);
+                throw new RuntimeException(t);
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -29,7 +29,6 @@ import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -193,7 +192,7 @@ public class IndexLoader
                     for (UpdateRequest request : requests) {
                         request.failed(t);
                     }
-                    Throwables.propagate(t);
+                    throw t;
                 }
 
                 // Try loading just my request

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ApplyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ApplyFunction.java
@@ -21,7 +21,6 @@ import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.gen.lambda.UnaryFunctionInterface;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
@@ -93,11 +92,6 @@ public final class ApplyFunction
 
     public static Object apply(Object input, UnaryFunctionInterface function)
     {
-        try {
-            return function.apply(input);
-        }
-        catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
-        }
+        return function.apply(input);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.function.TypeParameterSpecialization;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.lambda.LambdaFunctionInterface;
-import com.google.common.base.Throwables;
 import io.airlift.slice.Slice;
 
 import static java.lang.Boolean.TRUE;
@@ -49,13 +48,7 @@ public final class ArrayFilterFunction
                 input = elementType.getLong(arrayBlock, position);
             }
 
-            Boolean keep;
-            try {
-                keep = function.apply(input);
-            }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
-            }
+            Boolean keep = function.apply(input);
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
             }
@@ -79,13 +72,7 @@ public final class ArrayFilterFunction
                 input = elementType.getDouble(arrayBlock, position);
             }
 
-            Boolean keep;
-            try {
-                keep = function.apply(input);
-            }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
-            }
+            Boolean keep = function.apply(input);
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
             }
@@ -109,13 +96,7 @@ public final class ArrayFilterFunction
                 input = elementType.getBoolean(arrayBlock, position);
             }
 
-            Boolean keep;
-            try {
-                keep = function.apply(input);
-            }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
-            }
+            Boolean keep = function.apply(input);
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
             }
@@ -139,13 +120,7 @@ public final class ArrayFilterFunction
                 input = elementType.getSlice(arrayBlock, position);
             }
 
-            Boolean keep;
-            try {
-                keep = function.apply(input);
-            }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
-            }
+            Boolean keep = function.apply(input);
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
             }
@@ -169,13 +144,7 @@ public final class ArrayFilterFunction
                 input = (Block) elementType.getObject(arrayBlock, position);
             }
 
-            Boolean keep;
-            try {
-                keep = function.apply(input);
-            }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
-            }
+            Boolean keep = function.apply(input);
             if (TRUE.equals(keep)) {
                 elementType.appendTo(arrayBlock, position, resultBuilder);
             }
@@ -194,13 +163,7 @@ public final class ArrayFilterFunction
         int positionCount = arrayBlock.getPositionCount();
         BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
         for (int position = 0; position < positionCount; position++) {
-            Boolean keep;
-            try {
-                keep = function.apply(null);
-            }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
-            }
+            Boolean keep = function.apply(null);
             if (TRUE.equals(keep)) {
                 resultBuilder.appendNull();
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReduceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReduceFunction.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.gen.lambda.BinaryFunctionInterface;
 import com.facebook.presto.sql.gen.lambda.UnaryFunctionInterface;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 
@@ -107,18 +106,8 @@ public final class ArrayReduceFunction
         Object intermediateValue = initialIntermediateValue;
         for (int position = 0; position < positionCount; position++) {
             Object input = readNativeValue(inputType, block, position);
-            try {
-                intermediateValue = inputFunction.apply(intermediateValue, input);
-            }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
-            }
+            intermediateValue = inputFunction.apply(intermediateValue, input);
         }
-        try {
-            return outputFunction.apply(intermediateValue);
-        }
-        catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
-        }
+        return outputFunction.apply(intermediateValue);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/InvokeFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/InvokeFunction.java
@@ -22,7 +22,6 @@ import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.gen.lambda.LambdaFunctionInterface;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
@@ -88,12 +87,7 @@ public final class InvokeFunction
 
     public static Object invoke(InvokeLambda function)
     {
-        try {
-            return function.apply();
-        }
-        catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
-        }
+        return function.apply();
     }
 
     @FunctionalInterface

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/ReflectionWindowFunctionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/ReflectionWindowFunctionSupplier.java
@@ -17,12 +17,10 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.WindowFunction;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import static com.facebook.presto.metadata.FunctionKind.WINDOW;
@@ -65,11 +63,8 @@ public class ReflectionWindowFunctionSupplier<T extends WindowFunction>
                 return constructor.newInstance(inputs);
             }
         }
-        catch (InvocationTargetException e) {
+        catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
-        }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -45,7 +45,6 @@ import com.facebook.presto.testing.TestingEventListenerManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
@@ -88,6 +87,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
@@ -297,7 +297,8 @@ public class TestingPrestoServer
             }
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally {
             if (isDirectory(baseDataDir)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/Bootstrap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/Bootstrap.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.sql.gen;
 
-import com.google.common.base.Throwables;
 import io.airlift.bytecode.DynamicClassLoader;
 
 import java.lang.invoke.CallSite;
@@ -34,7 +33,7 @@ public final class Bootstrap
             BOOTSTRAP_METHOD = Bootstrap.class.getMethod("bootstrap", MethodHandles.Lookup.class, String.class, MethodType.class, long.class);
         }
         catch (NoSuchMethodException e) {
-            throw Throwables.propagate(e);
+            throw new AssertionError(e);
         }
     }
 
@@ -44,21 +43,13 @@ public final class Bootstrap
 
     public static CallSite bootstrap(MethodHandles.Lookup callerLookup, String name, MethodType type, long bindingId)
     {
-        try {
-            ClassLoader classLoader = callerLookup.lookupClass().getClassLoader();
-            checkArgument(classLoader instanceof DynamicClassLoader, "Expected %s's classloader to be of type %s", callerLookup.lookupClass().getName(), DynamicClassLoader.class.getName());
+        ClassLoader classLoader = callerLookup.lookupClass().getClassLoader();
+        checkArgument(classLoader instanceof DynamicClassLoader, "Expected %s's classloader to be of type %s", callerLookup.lookupClass().getName(), DynamicClassLoader.class.getName());
 
-            DynamicClassLoader dynamicClassLoader = (DynamicClassLoader) classLoader;
-            MethodHandle target = dynamicClassLoader.getCallSiteBindings().get(bindingId);
-            checkArgument(target != null, "Binding %s for function %s%s not found", bindingId, name, type.parameterList());
+        DynamicClassLoader dynamicClassLoader = (DynamicClassLoader) classLoader;
+        MethodHandle target = dynamicClassLoader.getCallSiteBindings().get(bindingId);
+        checkArgument(target != null, "Binding %s for function %s%s not found", bindingId, name, type.parameterList());
 
-            return new ConstantCallSite(target);
-        }
-        catch (Throwable e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            throw Throwables.propagate(e);
-        }
+        return new ConstantCallSite(target);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
@@ -22,13 +22,10 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.ExecutionError;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.bytecode.BytecodeBlock;
 import io.airlift.bytecode.ClassDefinition;
 import io.airlift.bytecode.MethodDefinition;
@@ -45,7 +42,6 @@ import org.weakref.jmx.Nested;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
 
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.facebook.presto.util.CompilerUtils.defineClass;
@@ -82,12 +78,7 @@ public class OrderingCompiler
         requireNonNull(sortChannels, "sortChannels is null");
         requireNonNull(sortOrders, "sortOrders is null");
 
-        try {
-            return pagesIndexOrderings.get(new PagesIndexComparatorCacheKey(sortTypes, sortChannels, sortOrders));
-        }
-        catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
-        }
+        return pagesIndexOrderings.getUnchecked(new PagesIndexComparatorCacheKey(sortTypes, sortChannels, sortOrders));
     }
 
     @VisibleForTesting

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -35,7 +35,6 @@ import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.TimeLiteral;
 import com.facebook.presto.sql.tree.TimestampLiteral;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
@@ -133,12 +132,7 @@ public final class LiteralInterpreter
 
             if (JSON.equals(type)) {
                 Signature operatorSignature = new Signature("json_parse", SCALAR, JSON.getTypeSignature(), VARCHAR.getTypeSignature());
-                try {
-                    return functionInvoker.invoke(operatorSignature, session, ImmutableList.of(utf8Slice(node.getValue())));
-                }
-                catch (Throwable throwable) {
-                    throw Throwables.propagate(throwable);
-                }
+                return functionInvoker.invoke(operatorSignature, session, ImmutableList.of(utf8Slice(node.getValue())));
             }
 
             try {
@@ -147,9 +141,6 @@ public final class LiteralInterpreter
             }
             catch (IllegalArgumentException e) {
                 throw new SemanticException(TYPE_MISMATCH, node, "No literal form for type %s", type);
-            }
-            catch (Throwable throwable) {
-                throw Throwables.propagate(throwable);
             }
         }
 
@@ -165,7 +156,7 @@ public final class LiteralInterpreter
             try {
                 return parseTimestampLiteral(session.getTimeZoneKey(), node.getValue());
             }
-            catch (Exception e) {
+            catch (RuntimeException e) {
                 throw new SemanticException(INVALID_LITERAL, node, "'%s' is not a valid timestamp literal", node.getValue());
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -99,7 +99,6 @@ import com.google.common.base.CaseFormat;
 import com.google.common.base.Functions;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -1438,9 +1437,6 @@ public class PlanPrinter
         }
         catch (OperatorNotFoundException e) {
             return "<UNREPRESENTABLE VALUE>";
-        }
-        catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -167,7 +167,6 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.transaction.TransactionManagerConfig;
 import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.util.FinalizerService;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -180,6 +179,7 @@ import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.testing.TestingMBeanServer;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -653,7 +653,7 @@ public class LocalQueryRunner
             return builder.get().build();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
         finally {
             lock.readLock().unlock();

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.type.FixedWidthType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
@@ -33,6 +32,7 @@ import java.util.List;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public final class TypeUtils
@@ -85,7 +85,8 @@ public final class TypeUtils
             }
         }
         catch (Throwable throwable) {
-            throw Throwables.propagate(throwable);
+            throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigest.java
@@ -14,7 +14,6 @@
 
 package com.facebook.presto.type.setdigest;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Shorts;
@@ -33,6 +32,7 @@ import it.unimi.dsi.fastutil.longs.LongSortedSet;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -120,7 +120,7 @@ public class SetDigest
             return output.slice();
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigestFunctions.java
@@ -23,11 +23,11 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 import io.airlift.json.ObjectMapperProvider;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
+import java.io.UncheckedIOException;
 import java.util.Map;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -111,7 +111,7 @@ public final class SetDigestFunctions
             return Slices.utf8Slice(OBJECT_MAPPER.writeValueAsString(digest.getHashCounts()));
         }
         catch (JsonProcessingException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/util/DateTimeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/DateTimeUtils.java
@@ -123,7 +123,7 @@ public final class DateTimeUtils
             DateTime dateTime = TIMESTAMP_WITH_TIME_ZONE_FORMATTER.parseDateTime(value);
             return packDateTimeWithZone(dateTime);
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             return TIMESTAMP_WITHOUT_TIME_ZONE_FORMATTER.withChronology(getChronology(timeZoneKey)).parseMillis(value);
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCommitTask.java
@@ -25,12 +25,10 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.base.Throwables;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_IN_TRANSACTION;
@@ -89,13 +87,8 @@ public class TestCommitTask
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "COMMIT", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor, metadata);
 
         try {
-            try {
-                getFutureValue(new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
-                fail();
-            }
-            catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
-            }
+            getFutureValue(new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
+            fail();
         }
         catch (PrestoException e) {
             assertEquals(e.getErrorCode(), NOT_IN_TRANSACTION.toErrorCode());
@@ -118,13 +111,8 @@ public class TestCommitTask
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "COMMIT", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor, metadata);
 
         try {
-            try {
-                getFutureValue(new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
-                fail();
-            }
-            catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
-            }
+            getFutureValue(new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
+            fail();
         }
         catch (PrestoException e) {
             assertEquals(e.getErrorCode(), UNKNOWN_TRANSACTION.toErrorCode());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestRollbackTask.java
@@ -25,12 +25,10 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.sql.tree.Rollback;
 import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.base.Throwables;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_IN_TRANSACTION;
@@ -88,13 +86,8 @@ public class TestRollbackTask
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "ROLLBACK", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor, metadata);
 
         try {
-            try {
-                getFutureValue(new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
-                fail();
-            }
-            catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
-            }
+            getFutureValue(new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
+            fail();
         }
         catch (PrestoException e) {
             assertEquals(e.getErrorCode(), NOT_IN_TRANSACTION.toErrorCode());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStartTransactionTask.java
@@ -31,14 +31,12 @@ import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionInfo;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.transaction.TransactionManagerConfig;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.Duration;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -82,13 +80,8 @@ public class TestStartTransactionTask
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
         try {
-            try {
-                getFutureValue(new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
-                fail();
-            }
-            catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
-            }
+            getFutureValue(new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
+            fail();
         }
         catch (PrestoException e) {
             assertEquals(e.getErrorCode(), INCOMPATIBLE_CLIENT.toErrorCode());
@@ -112,13 +105,8 @@ public class TestStartTransactionTask
         QueryStateMachine stateMachine = QueryStateMachine.begin(new QueryId("query"), "START TRANSACTION", session, URI.create("fake://uri"), true, transactionManager, accessControl, executor, metadata);
 
         try {
-            try {
-                getFutureValue(new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
-                fail();
-            }
-            catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
-            }
+            getFutureValue(new StartTransactionTask().execute(new StartTransaction(ImmutableList.of()), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList()));
+            fail();
         }
         catch (PrestoException e) {
             assertEquals(e.getErrorCode(), NOT_SUPPORTED.toErrorCode());
@@ -189,19 +177,14 @@ public class TestStartTransactionTask
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
         try {
-            try {
-                getFutureValue(new StartTransactionTask().execute(
-                        new StartTransaction(ImmutableList.of(new Isolation(Isolation.Level.READ_COMMITTED), new Isolation(Isolation.Level.READ_COMMITTED))),
-                        transactionManager,
-                        metadata,
-                        new AllowAllAccessControl(),
-                        stateMachine,
-                        emptyList()));
-                fail();
-            }
-            catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
-            }
+            getFutureValue(new StartTransactionTask().execute(
+                    new StartTransaction(ImmutableList.of(new Isolation(Isolation.Level.READ_COMMITTED), new Isolation(Isolation.Level.READ_COMMITTED))),
+                    transactionManager,
+                    metadata,
+                    new AllowAllAccessControl(),
+                    stateMachine,
+                    emptyList()));
+            fail();
         }
         catch (SemanticException e) {
             assertEquals(e.getCode(), INVALID_TRANSACTION_MODE);
@@ -224,19 +207,14 @@ public class TestStartTransactionTask
         assertFalse(stateMachine.getSession().getTransactionId().isPresent());
 
         try {
-            try {
-                getFutureValue(new StartTransactionTask().execute(
-                        new StartTransaction(ImmutableList.of(new TransactionAccessMode(true), new TransactionAccessMode(true))),
-                        transactionManager,
-                        metadata,
-                        new AllowAllAccessControl(),
-                        stateMachine,
-                        emptyList()));
-                fail();
-            }
-            catch (CompletionException e) {
-                throw Throwables.propagate(e.getCause());
-            }
+            getFutureValue(new StartTransactionTask().execute(
+                    new StartTransaction(ImmutableList.of(new TransactionAccessMode(true), new TransactionAccessMode(true))),
+                    transactionManager,
+                    metadata,
+                    new AllowAllAccessControl(),
+                    stateMachine,
+                    emptyList()));
+            fail();
         }
         catch (SemanticException e) {
             assertEquals(e.getCode(), INVALID_TRANSACTION_MODE);

--- a/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/OperatorAssertion.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.block.RowBlockBuilder;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.testing.MaterializedResult;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -39,6 +38,7 @@ import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.facebook.presto.util.StructuralTestUtil.appendToBlockBuilder;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
@@ -133,7 +133,8 @@ public final class OperatorAssertion
             return toPages(operator, input.iterator());
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
@@ -18,7 +18,6 @@ import com.facebook.presto.execution.buffer.SerializedPage;
 import com.facebook.presto.operator.HttpPageBufferClient.ClientCallback;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Page;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableListMultimap;
 import io.airlift.http.client.HttpStatus;
 import io.airlift.http.client.Request;
@@ -518,10 +517,10 @@ public class TestHttpPageBufferClient
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
             catch (BrokenBarrierException | TimeoutException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
@@ -34,7 +34,6 @@ import com.facebook.presto.sql.relational.CallExpression;
 import com.facebook.presto.sql.relational.LambdaDefinitionExpression;
 import com.facebook.presto.sql.relational.RowExpression;
 import com.facebook.presto.sql.relational.VariableReferenceExpression;
-import com.google.common.base.Throwables;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -73,6 +72,7 @@ import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.field;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.lang.Boolean.TRUE;
 
 @SuppressWarnings("MethodMayBeStatic")
@@ -241,8 +241,9 @@ public class BenchmarkArrayFilter
                 try {
                     keep = (Boolean) function.invokeExact(input);
                 }
-                catch (Throwable throwable) {
-                    throw Throwables.propagate(throwable);
+                catch (Throwable t) {
+                    throwIfUnchecked(t);
+                    throw new RuntimeException(t);
                 }
                 if (TRUE.equals(keep)) {
                     block.writePositionTo(position, resultBuilder);

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -32,7 +32,6 @@ import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.tree.Extract.Field;
 import com.facebook.presto.type.LikeFunctions;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ObjectArrays;
@@ -65,7 +64,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.stream.LongStream;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
@@ -154,7 +152,7 @@ public class TestExpressionCompiler
     private long start;
     private ListeningExecutorService executor;
     private FunctionAssertions functionAssertions;
-    private List<ListenableFuture<Void>> futures;
+    private List<ListenableFuture<?>> futures;
 
     @BeforeSuite
     public void setupClass()
@@ -1786,18 +1784,13 @@ public class TestExpressionCompiler
         addCallable(new AssertExecuteTask(functionAssertions, expression, expectedType, expected));
     }
 
-    private void addCallable(Callable<Void> callable)
+    private void addCallable(Runnable runnable)
     {
         if (PARALLEL) {
-            futures.add(executor.submit(callable));
+            futures.add(executor.submit(runnable));
         }
         else {
-            try {
-                callable.call();
-            }
-            catch (Exception e) {
-                throw Throwables.propagate(e);
-            }
+            runnable.run();
         }
     }
 
@@ -1829,7 +1822,7 @@ public class TestExpressionCompiler
     }
 
     private static class AssertExecuteTask
-            implements Callable<Void>
+            implements Runnable
     {
         private final FunctionAssertions functionAssertions;
         private final String expression;
@@ -1845,7 +1838,7 @@ public class TestExpressionCompiler
         }
 
         @Override
-        public Void call()
+        public void run()
         {
             try {
                 functionAssertions.assertFunction(expression, expectedType, expected);
@@ -1853,7 +1846,6 @@ public class TestExpressionCompiler
             catch (Throwable e) {
                 throw new RuntimeException("Error processing " + expression, e);
             }
-            return null;
         }
     }
 
@@ -1868,7 +1860,7 @@ public class TestExpressionCompiler
     }
 
     private static class AssertFilterTask
-            implements Callable<Void>
+            implements Runnable
     {
         private final FunctionAssertions functionAssertions;
         private final String filter;
@@ -1884,7 +1876,7 @@ public class TestExpressionCompiler
         }
 
         @Override
-        public Void call()
+        public void run()
         {
             try {
                 functionAssertions.assertFilter(filter, expected, withNoInputColumns);
@@ -1892,7 +1884,6 @@ public class TestExpressionCompiler
             catch (Throwable e) {
                 throw new RuntimeException("Error processing " + filter, e);
             }
-            return null;
         }
     }
 }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryConnectorFactory.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryConnectorFactory.java
@@ -17,13 +17,13 @@ import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 
 import java.util.Map;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class MemoryConnectorFactory
@@ -60,7 +60,8 @@ public class MemoryConnectorFactory
             return injector.getInstance(MemoryConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnectorFactory.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnectorFactory.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
@@ -27,6 +26,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class MongoConnectorFactory
@@ -70,7 +70,8 @@ public class MongoConnectorFactory
             return injector.getInstance(MongoConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -38,7 +38,6 @@ import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
-import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -88,6 +87,7 @@ import org.joda.time.DateTimeZone;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.sql.Date;
@@ -818,7 +818,7 @@ public class OrcTester
                 actualValue = ((OrcLazyObject) actualValue).materialize();
             }
             catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         }
         if (actualValue instanceof BooleanWritable) {
@@ -1115,8 +1115,8 @@ public class OrcTester
         try {
             writer.getClass().getMethod("enterLowMemoryMode").invoke(writer);
         }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -1127,8 +1127,8 @@ public class OrcTester
             writerField.setAccessible(true);
             return writerField.get(instance);
         }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -1139,8 +1139,8 @@ public class OrcTester
             writerField.setAccessible(true);
             writerField.set(instance, value);
         }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -38,6 +37,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
 import static java.util.Objects.requireNonNull;
 
@@ -98,7 +98,8 @@ public class RaptorConnectorFactory
             return injector.getInstance(RaptorConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.base.Ticker;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -32,7 +31,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
@@ -630,8 +628,9 @@ public class DatabaseShardManager
         try {
             return bucketAssignmentsCache.getUnchecked(distributionId);
         }
-        catch (UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
         }
     }
 
@@ -735,8 +734,9 @@ public class DatabaseShardManager
         try {
             return nodeIdCache.getUnchecked(nodeIdentifier);
         }
-        catch (UncheckedExecutionException | ExecutionError e) {
-            throw Throwables.propagate(e.getCause());
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
         }
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationJob.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationJob.java
@@ -19,10 +19,10 @@ import com.facebook.presto.raptor.metadata.ShardInfo;
 import com.facebook.presto.raptor.metadata.ShardManager;
 import com.facebook.presto.raptor.metadata.TableColumn;
 import com.facebook.presto.raptor.metadata.TableMetadata;
-import com.google.common.base.Throwables;
 import io.airlift.log.Logger;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -58,8 +58,8 @@ class OrganizationJob
         try {
             runJob(organizationSet.getTableId(), organizationSet.getBucketNumber(), organizationSet.getShards());
         }
-        catch (Throwable e) {
-            throw Throwables.propagate(e);
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizer.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizer.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.raptor.storage.organization;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
@@ -22,6 +21,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -57,14 +57,7 @@ public class TestShardOrganizer
         @Override
         public Runnable create(OrganizationSet organizationSet)
         {
-            return () -> {
-                try {
-                    MILLISECONDS.sleep(10);
-                }
-                catch (InterruptedException e) {
-                    throw Throwables.propagate(e);
-                }
-            };
+            return () -> sleepUninterruptibly(10, MILLISECONDS);
         }
     }
 

--- a/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
@@ -37,7 +37,6 @@ import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
-import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -102,6 +101,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -230,7 +230,7 @@ public class RcFileTester
                     return columnarSerDe;
                 }
                 catch (SerDeException e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
 
@@ -587,7 +587,7 @@ public class RcFileTester
             slice.setBytes(0, in, slice.length());
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new UncheckedIOException(e);
         }
 
         List<Long> syncPositionsBruteForce = new ArrayList<>();

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -77,6 +77,16 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -100,11 +110,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- for testing -->

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisConnectorFactory.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisConnectorFactory.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.type.TypeManager;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
@@ -31,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -91,7 +91,8 @@ public class RedisConnectorFactory
             return injector.getInstance(RedisConnector.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisJedisManager.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisJedisManager.java
@@ -15,7 +15,6 @@ package com.facebook.presto.redis;
 
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.NodeManager;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -27,7 +26,6 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -75,12 +73,7 @@ public class RedisJedisManager
     public JedisPool getJedisPool(HostAddress host)
     {
         requireNonNull(host, "host is null");
-        try {
-            return jedisPoolCache.get(host);
-        }
-        catch (ExecutionException e) {
-            throw Throwables.propagate(e.getCause());
-        }
+        return jedisPoolCache.getUnchecked(host);
     }
 
     private JedisPool createConsumer(HostAddress host)

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisRecordCursor.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisRecordCursor.java
@@ -19,7 +19,6 @@ import com.facebook.presto.decoder.FieldValueProvider;
 import com.facebook.presto.decoder.RowDecoder;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.base.Throwables;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -323,9 +322,6 @@ public class RedisRecordCursor
                     return false;
             }
         }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
-        }
         return true;
     }
 
@@ -358,9 +354,6 @@ public class RedisRecordCursor
                     log.debug("Redis type for key %s is unsupported", keyString);
                     return false;
             }
-        }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
         }
         return true;
     }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplitManager.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplitManager.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import redis.clients.jedis.Jedis;
 
@@ -76,9 +75,6 @@ public class RedisSplitManager
         if (redisTableHandle.getKeyDataFormat().equals("zset")) {
             try (Jedis jedis = jedisManager.getJedisPool(nodes.get(0)).getResource()) {
                 numberOfKeys = jedis.zcount(redisTableHandle.getKeyName(), "-inf", "+inf");
-            }
-            catch (Exception e) {
-                throw Throwables.propagate(e);
             }
         }
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestMinimalFunctionality.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestMinimalFunctionality.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.StandaloneQueryRunner;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -91,18 +90,11 @@ public class TestMinimalFunctionality
     private void populateData(int count)
     {
         JsonEncoder jsonEncoder = new JsonEncoder();
-        try {
-            for (long i = 0; i < count; i++) {
-                Object value = ImmutableMap.of("id", Long.toString(i), "value", UUID.randomUUID().toString());
-
-                try (Jedis jedis = embeddedRedis.getJedisPool().getResource()) {
-                    jedis.set(tableName + ":" + i,
-                            jsonEncoder.toString(value));
-                }
+        for (long i = 0; i < count; i++) {
+            Object value = ImmutableMap.of("id", Long.toString(i), "value", UUID.randomUUID().toString());
+            try (Jedis jedis = embeddedRedis.getJedisPool().getResource()) {
+                jedis.set(tableName + ":" + i, jsonEncoder.toString(value));
             }
-        }
-        catch (Exception e) {
-            throw Throwables.propagate(e);
         }
     }
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/util/JsonEncoder.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/util/JsonEncoder.java
@@ -13,10 +13,10 @@
  */
 package com.facebook.presto.redis.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 
-import java.io.IOException;
+import java.io.UncheckedIOException;
 
 public class JsonEncoder
 {
@@ -27,8 +27,8 @@ public class JsonEncoder
         try {
             return objectMapper.writeValueAsString(o);
         }
-        catch (IOException e) {
-            throw Throwables.propagate(e);
+        catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManagerFactory.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManagerFactory.java
@@ -18,13 +18,13 @@ import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManager;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerContext;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 
 import java.util.Map;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class FileResourceGroupConfigurationManagerFactory
@@ -60,7 +60,8 @@ public class FileResourceGroupConfigurationManagerFactory
             return injector.getInstance(FileResourceGroupConfigurationManager.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManagerFactory.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManagerFactory.java
@@ -19,13 +19,13 @@ import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManager;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerContext;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 
 import java.util.Map;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class DbResourceGroupConfigurationManagerFactory
@@ -62,7 +62,8 @@ public class DbResourceGroupConfigurationManagerFactory
             return injector.getInstance(DbResourceGroupConfigurationManager.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2ResourceGroupConfigurationManagerFactory.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2ResourceGroupConfigurationManagerFactory.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManager;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerContext;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
-import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
@@ -28,6 +27,7 @@ import io.airlift.node.NodeModule;
 
 import java.util.Map;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 public class H2ResourceGroupConfigurationManagerFactory
@@ -66,7 +66,8 @@ public class H2ResourceGroupConfigurationManagerFactory
             return injector.getInstance(DbResourceGroupConfigurationManager.class);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
This removes all usages of the deprecated `Throwables.propagate()` method.

Note that this is not a mechanical refactoring. I investigated every usage to determine the proper exception handling strategy. Many of the problems described in [this article](https://github.com/google/guava/wiki/Why-we-deprecated-Throwables.propagate) were present in our code base. Examples:

* Only catching a checked exception (rather than mixed checked/unchecked). These are directly wrapped with `RuntimeException` or specializations such as `UncheckedIOException`.
* Catching checked exceptions in places where they cannot be thrown. These are removed entirely.
* Overly broad catches. For example, catching `Exception` when the only checked exception is `IOException`.
* Re-wrapping exceptions that were already wrapped. For example, if the cause of `UncheckedExecutionException` is checked, the original can be re-thrown directly, rather than re-wrapping the cause.