### PR TITLE
Remove system pool

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -16,8 +16,8 @@ package com.facebook.presto.benchmark;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskStateMachine;
+import com.facebook.presto.memory.DefaultQueryContext;
 import com.facebook.presto.memory.MemoryPool;
-import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.operator.Driver;
 import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.TaskContext;
@@ -132,14 +132,13 @@ public abstract class AbstractOperatorBenchmark
                 .setSystemProperty("optimizer.optimize-hash-generation", "true")
                 .build();
         MemoryPool memoryPool = new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE));
-        MemoryPool systemMemoryPool = new MemoryPool(new MemoryPoolId("testSystem"), new DataSize(1, GIGABYTE));
         SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(new DataSize(1, GIGABYTE));
 
-        TaskContext taskContext = new QueryContext(
+        TaskContext taskContext = new DefaultQueryContext(
                 new QueryId("test"),
                 new DataSize(256, MEGABYTE),
+                new DataSize(512, MEGABYTE),
                 memoryPool,
-                systemMemoryPool,
                 new TestingGcMonitor(),
                 localQueryRunner.getExecutor(),
                 localQueryRunner.getScheduler(),

--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
@@ -16,8 +16,8 @@ package com.facebook.presto.benchmark;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskStateMachine;
+import com.facebook.presto.memory.DefaultQueryContext;
 import com.facebook.presto.memory.MemoryPool;
-import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.TableHandle;
@@ -73,14 +73,12 @@ public class MemoryLocalQueryRunner
     public List<Page> execute(@Language("SQL") String query)
     {
         MemoryPool memoryPool = new MemoryPool(new MemoryPoolId("test"), new DataSize(2, GIGABYTE));
-        MemoryPool systemMemoryPool = new MemoryPool(new MemoryPoolId("testSystem"), new DataSize(2, GIGABYTE));
-
         SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(new DataSize(1, GIGABYTE));
-        QueryContext queryContext = new QueryContext(
+        DefaultQueryContext queryContext = new DefaultQueryContext(
                 new QueryId("test"),
                 new DataSize(1, GIGABYTE),
+                new DataSize(2, GIGABYTE),
                 memoryPool,
-                systemMemoryPool,
                 new TestingGcMonitor(),
                 localQueryRunner.getExecutor(),
                 localQueryRunner.getScheduler(),

--- a/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
+++ b/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
@@ -29,9 +29,14 @@ public class ExceededMemoryLimitException
         return new ExceededMemoryLimitException(maxMemory, format("Query exceeded max memory size of %s", maxMemory));
     }
 
-    public static ExceededMemoryLimitException exceededLocalLimit(DataSize maxMemory)
+    public static ExceededMemoryLimitException exceededLocalUserMemoryLimit(DataSize maxMemory)
     {
-        return new ExceededMemoryLimitException(maxMemory, format("Query exceeded local memory limit of %s", maxMemory));
+        return new ExceededMemoryLimitException(maxMemory, format("Query exceeded local user memory limit of %s", maxMemory));
+    }
+
+    public static ExceededMemoryLimitException exceededLocalTotalMemoryLimit(DataSize maxMemory)
+    {
+        return new ExceededMemoryLimitException(maxMemory, format("Query exceeded local total memory limit of %s", maxMemory));
     }
 
     private ExceededMemoryLimitException(DataSize maxMemory, String message)

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -93,6 +93,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public long getTotalMemoryReservation()
+    {
+        return 0;
+    }
+
+    @Override
     public Duration getTotalCpuTime()
     {
         return new Duration(0, TimeUnit.SECONDS);

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -95,6 +95,12 @@ public class FailedQueryExecution
     }
 
     @Override
+    public long getTotalMemoryReservation()
+    {
+        return 0;
+    }
+
+    @Override
     public Duration getTotalCpuTime()
     {
         return new Duration(0, TimeUnit.SECONDS);

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -59,6 +59,11 @@ public interface QueryExecution
 
     long getUserMemoryReservation();
 
+    /**
+     * @return the user + system memory reservation
+     */
+    long getTotalMemoryReservation();
+
     Duration getTotalCpuTime();
 
     Session getSession();

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -339,6 +339,7 @@ public class QueryStateMachine
 
         long cumulativeUserMemory = 0;
         long userMemoryReservation = 0;
+        long totalMemoryReservation = 0;
 
         long totalScheduledTime = 0;
         long totalCpuTime = 0;
@@ -377,6 +378,7 @@ public class QueryStateMachine
 
             cumulativeUserMemory += stageStats.getCumulativeUserMemory();
             userMemoryReservation += stageStats.getUserMemoryReservation().toBytes();
+            totalMemoryReservation += stageStats.getTotalMemoryReservation().toBytes();
             totalScheduledTime += stageStats.getTotalScheduledTime().roundTo(MILLISECONDS);
             totalCpuTime += stageStats.getTotalCpuTime().roundTo(MILLISECONDS);
             totalUserTime += stageStats.getTotalUserTime().roundTo(MILLISECONDS);
@@ -436,6 +438,7 @@ public class QueryStateMachine
 
                 cumulativeUserMemory,
                 succinctBytes(userMemoryReservation),
+                succinctBytes(totalMemoryReservation),
                 succinctBytes(getPeakUserMemoryInBytes()),
                 succinctBytes(getPeakTotalMemoryInBytes()),
                 succinctBytes(getPeakTaskTotalMemory()),
@@ -881,6 +884,7 @@ public class QueryStateMachine
                 queryStats.getCompletedDrivers(),
                 queryStats.getCumulativeUserMemory(),
                 queryStats.getUserMemoryReservation(),
+                queryStats.getTotalMemoryReservation(),
                 queryStats.getPeakUserMemoryReservation(),
                 queryStats.getPeakTotalMemoryReservation(),
                 queryStats.getPeakTaskTotalMemory(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -64,6 +64,7 @@ public class QueryStats
 
     private final double cumulativeUserMemory;
     private final DataSize userMemoryReservation;
+    private final DataSize totalMemoryReservation;
     private final DataSize peakUserMemoryReservation;
     private final DataSize peakTotalMemoryReservation;
     private final DataSize peakTaskTotalMemory;
@@ -114,6 +115,7 @@ public class QueryStats
         this.completedDrivers = 0;
         this.cumulativeUserMemory = 0.0;
         this.userMemoryReservation = null;
+        this.totalMemoryReservation = null;
         this.peakUserMemoryReservation = null;
         this.peakTotalMemoryReservation = null;
         this.peakTaskTotalMemory = null;
@@ -161,6 +163,7 @@ public class QueryStats
 
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
+            @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
             @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
             @JsonProperty("peakTotalMemoryReservation") DataSize peakTotalMemoryReservation,
             @JsonProperty("peakTaskTotalMemory") DataSize peakTaskTotalMemory,
@@ -220,6 +223,7 @@ public class QueryStats
         checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
         this.cumulativeUserMemory = cumulativeUserMemory;
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
+        this.totalMemoryReservation = requireNonNull(totalMemoryReservation, "totalMemoryReservation is null");
         this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
         this.peakTotalMemoryReservation = requireNonNull(peakTotalMemoryReservation, "peakTotalMemoryReservation is null");
         this.peakTaskTotalMemory = requireNonNull(peakTaskTotalMemory, "peakTaskTotalMemory is null");
@@ -383,6 +387,12 @@ public class QueryStats
     public DataSize getUserMemoryReservation()
     {
         return userMemoryReservation;
+    }
+
+    @JsonProperty
+    public DataSize getTotalMemoryReservation()
+    {
+        return totalMemoryReservation;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -202,8 +202,8 @@ public final class SqlQueryExecution
     @Override
     public long getUserMemoryReservation()
     {
-        // acquire reference to outputStage before checking finalQueryInfo, because
-        // state change listener sets finalQueryInfo and then clears outputStage when
+        // acquire reference to scheduler before checking finalQueryInfo, because
+        // state change listener sets finalQueryInfo and then clears scheduler when
         // the query finishes.
         SqlQueryScheduler scheduler = queryScheduler.get();
         Optional<QueryInfo> finalQueryInfo = stateMachine.getFinalQueryInfo();
@@ -214,6 +214,23 @@ public final class SqlQueryExecution
             return 0;
         }
         return scheduler.getUserMemoryReservation();
+    }
+
+    @Override
+    public long getTotalMemoryReservation()
+    {
+        // acquire reference to scheduler before checking finalQueryInfo, because
+        // state change listener sets finalQueryInfo and then clears scheduler when
+        // the query finishes.
+        SqlQueryScheduler scheduler = queryScheduler.get();
+        Optional<QueryInfo> finalQueryInfo = stateMachine.getFinalQueryInfo();
+        if (finalQueryInfo.isPresent()) {
+            return finalQueryInfo.get().getQueryStats().getTotalMemoryReservation().toBytes();
+        }
+        if (scheduler == null) {
+            return 0;
+        }
+        return scheduler.getTotalMemoryReservation();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -214,6 +214,11 @@ public final class SqlStageExecution
         return stateMachine.getUserMemoryReservation();
     }
 
+    public long getTotalMemoryReservation()
+    {
+        return stateMachine.getTotalMemoryReservation();
+    }
+
     public synchronized Duration getTotalCpuTime()
     {
         long millis = getAllTasks().stream()
@@ -416,7 +421,8 @@ public final class SqlStageExecution
     private class StageTaskListener
             implements StateChangeListener<TaskStatus>
     {
-        private long previousMemory;
+        private long previousUserMemory;
+        private long previousSystemMemory;
         private final Set<Lifespan> completedDriverGroups = new HashSet<>();
 
         @Override
@@ -459,10 +465,13 @@ public final class SqlStageExecution
 
         private synchronized void updateMemoryUsage(TaskStatus taskStatus)
         {
-            long currentMemory = taskStatus.getMemoryReservation().toBytes();
-            long deltaMemoryInBytes = currentMemory - previousMemory;
-            previousMemory = currentMemory;
-            stateMachine.updateMemoryUsage(deltaMemoryInBytes);
+            long currentUserMemory = taskStatus.getMemoryReservation().toBytes();
+            long currentSystemMemory = taskStatus.getSystemMemoryReservation().toBytes();
+            long deltaUserMemoryInBytes = currentUserMemory - previousUserMemory;
+            long deltaTotalMemoryInBytes = (currentUserMemory + currentSystemMemory) - (previousUserMemory + previousSystemMemory);
+            previousUserMemory = currentUserMemory;
+            previousSystemMemory = currentSystemMemory;
+            stateMachine.updateMemoryUsage(deltaUserMemoryInBytes, deltaTotalMemoryInBytes);
         }
 
         private synchronized void updateCompletedDriverGroups(TaskStatus taskStatus)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -21,6 +21,8 @@ import com.facebook.presto.event.query.QueryMonitor;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.executor.TaskExecutor;
+import com.facebook.presto.memory.DefaultQueryContext;
+import com.facebook.presto.memory.LegacyQueryContext;
 import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.memory.MemoryPoolAssignment;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
@@ -32,6 +34,7 @@ import com.facebook.presto.spiller.LocalSpillManager;
 import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.PlanFragment;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -131,21 +134,12 @@ public class SqlTaskManager
         SqlTaskExecutionFactory sqlTaskExecutionFactory = new SqlTaskExecutionFactory(taskNotificationExecutor, taskExecutor, planner, queryMonitor, config);
 
         this.localMemoryManager = requireNonNull(localMemoryManager, "localMemoryManager is null");
-        DataSize maxQueryMemoryPerNode = nodeMemoryConfig.getMaxQueryMemoryPerNode();
-
+        DataSize maxQueryUserMemoryPerNode = nodeMemoryConfig.getMaxQueryMemoryPerNode();
+        DataSize maxQueryTotalMemoryPerNode = nodeMemoryConfig.getMaxQueryTotalMemoryPerNode();
         DataSize maxQuerySpillPerNode = nodeSpillConfig.getQueryMaxSpillPerNode();
 
         queryContexts = CacheBuilder.newBuilder().weakValues().build(CacheLoader.from(
-                queryId -> new QueryContext(
-                        queryId,
-                        maxQueryMemoryPerNode,
-                        localMemoryManager.getPool(LocalMemoryManager.GENERAL_POOL),
-                        localMemoryManager.getPool(LocalMemoryManager.SYSTEM_POOL),
-                        gcMonitor,
-                        taskNotificationExecutor,
-                        driverYieldExecutor,
-                        maxQuerySpillPerNode,
-                        localSpillManager.getSpillSpaceTracker())));
+                queryId -> createQueryContext(queryId, localMemoryManager, nodeMemoryConfig, localSpillManager, gcMonitor, maxQueryUserMemoryPerNode, maxQueryTotalMemoryPerNode, maxQuerySpillPerNode)));
 
         tasks = CacheBuilder.newBuilder().build(CacheLoader.from(
                 taskId -> new SqlTask(
@@ -160,6 +154,41 @@ public class SqlTaskManager
                             return null;
                         },
                         maxBufferSize)));
+    }
+
+    private QueryContext createQueryContext(
+            QueryId queryId,
+            LocalMemoryManager localMemoryManager,
+            NodeMemoryConfig nodeMemoryConfig,
+            LocalSpillManager localSpillManager,
+            GcMonitor gcMonitor,
+            DataSize maxQueryUserMemoryPerNode,
+            DataSize maxQueryTotalMemoryPerNode,
+            DataSize maxQuerySpillPerNode)
+    {
+        if (nodeMemoryConfig.isLegacySystemPoolEnabled()) {
+            return new LegacyQueryContext(
+                    queryId,
+                    maxQueryUserMemoryPerNode,
+                    localMemoryManager.getPool(LocalMemoryManager.GENERAL_POOL),
+                    localMemoryManager.getPool(LocalMemoryManager.SYSTEM_POOL),
+                    gcMonitor,
+                    taskNotificationExecutor,
+                    driverYieldExecutor,
+                    maxQuerySpillPerNode,
+                    localSpillManager.getSpillSpaceTracker());
+        }
+
+        return new DefaultQueryContext(
+                queryId,
+                maxQueryUserMemoryPerNode,
+                maxQueryTotalMemoryPerNode,
+                localMemoryManager.getPool(LocalMemoryManager.GENERAL_POOL),
+                gcMonitor,
+                taskNotificationExecutor,
+                driverYieldExecutor,
+                maxQuerySpillPerNode,
+                localSpillManager.getSpillSpaceTracker());
     }
 
     @Override
@@ -435,5 +464,12 @@ public class SqlTaskManager
     {
         requireNonNull(taskId, "taskId is null");
         tasks.getUnchecked(taskId).addStateChangeListener(stateChangeListener);
+    }
+
+    @VisibleForTesting
+    public QueryContext getQueryContext(QueryId queryId)
+
+    {
+        return queryContexts.getUnchecked(queryId);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -81,6 +81,7 @@ public class StageStateMachine
 
     private final AtomicLong peakUserMemory = new AtomicLong();
     private final AtomicLong currentUserMemory = new AtomicLong();
+    private final AtomicLong currentTotalMemory = new AtomicLong();
 
     public StageStateMachine(
             StageId stageId,
@@ -186,12 +187,16 @@ public class StageStateMachine
         return currentUserMemory.get();
     }
 
-    public void updateMemoryUsage(long deltaUserMemoryInBytes)
+    public long getTotalMemoryReservation()
     {
-        long currentMemoryValue = currentUserMemory.addAndGet(deltaUserMemoryInBytes);
-        if (currentMemoryValue > peakUserMemory.get()) {
-            peakUserMemory.updateAndGet(x -> currentMemoryValue > x ? currentMemoryValue : x);
-        }
+        return currentTotalMemory.get();
+    }
+
+    public void updateMemoryUsage(long deltaUserMemoryInBytes, long deltaTotalMemoryInBytes)
+    {
+        currentTotalMemory.addAndGet(deltaTotalMemoryInBytes);
+        currentUserMemory.addAndGet(deltaUserMemoryInBytes);
+        peakUserMemory.updateAndGet(currentPeakValue -> Math.max(currentUserMemory.get(), currentPeakValue));
     }
 
     public StageInfo getStageInfo(Supplier<Iterable<TaskInfo>> taskInfosSupplier, Supplier<Iterable<StageInfo>> subStageInfosSupplier)
@@ -217,6 +222,7 @@ public class StageStateMachine
 
         long cumulativeUserMemory = 0;
         long userMemoryReservation = 0;
+        long totalMemoryReservation = 0;
         long peakUserMemoryReservation = peakUserMemory.get();
 
         long totalScheduledTime = 0;
@@ -264,7 +270,11 @@ public class StageStateMachine
             completedDrivers += taskStats.getCompletedDrivers();
 
             cumulativeUserMemory += taskStats.getCumulativeUserMemory();
-            userMemoryReservation += taskStats.getUserMemoryReservation().toBytes();
+
+            long taskUserMemory = taskStats.getUserMemoryReservation().toBytes();
+            long taskSystemMemory = taskStats.getSystemMemoryReservation().toBytes();
+            userMemoryReservation += taskUserMemory;
+            totalMemoryReservation += taskUserMemory + taskSystemMemory;
 
             totalScheduledTime += taskStats.getTotalScheduledTime().roundTo(NANOSECONDS);
             totalCpuTime += taskStats.getTotalCpuTime().roundTo(NANOSECONDS);
@@ -321,6 +331,7 @@ public class StageStateMachine
 
                 cumulativeUserMemory,
                 succinctBytes(userMemoryReservation),
+                succinctBytes(totalMemoryReservation),
                 succinctBytes(peakUserMemoryReservation),
                 succinctDuration(totalScheduledTime, NANOSECONDS),
                 succinctDuration(totalCpuTime, NANOSECONDS),

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
@@ -54,6 +54,7 @@ public class StageStats
 
     private final double cumulativeUserMemory;
     private final DataSize userMemoryReservation;
+    private final DataSize totalMemoryReservation;
     private final DataSize peakUserMemoryReservation;
 
     private final Duration totalScheduledTime;
@@ -99,6 +100,7 @@ public class StageStats
 
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
+            @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
             @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
 
             @JsonProperty("totalScheduledTime") Duration totalScheduledTime,
@@ -149,6 +151,7 @@ public class StageStats
         checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
         this.cumulativeUserMemory = cumulativeUserMemory;
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
+        this.totalMemoryReservation = requireNonNull(totalMemoryReservation, "totalMemoryReservation is null");
         this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
 
         this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
@@ -260,6 +263,12 @@ public class StageStats
     public DataSize getUserMemoryReservation()
     {
         return userMemoryReservation;
+    }
+
+    @JsonProperty
+    public DataSize getTotalMemoryReservation()
+    {
+        return totalMemoryReservation;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
@@ -230,7 +230,7 @@ public class ArbitraryOutputBuffer
             clientBuffer.loadPagesIfNecessary(masterBuffer);
         }
 
-        return memoryManager.getNotFullFuture();
+        return memoryManager.getBufferBlockedFuture();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
@@ -18,6 +18,7 @@ import com.facebook.presto.OutputBuffers.OutputBufferId;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
@@ -227,7 +228,7 @@ public class BroadcastOutputBuffer
         // drop the initial reference
         serializedPageReferences.forEach(SerializedPageReference::dereferencePage);
 
-        return memoryManager.getNotFullFuture();
+        return memoryManager.getBufferBlockedFuture();
     }
 
     @Override
@@ -382,5 +383,11 @@ public class BroadcastOutputBuffer
         if (safeGetBuffersSnapshot().stream().allMatch(ClientBuffer::isDestroyed)) {
             destroy();
         }
+    }
+
+    @VisibleForTesting
+    OutputBufferMemoryManager getMemoryManager()
+    {
+        return memoryManager;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
@@ -193,7 +193,7 @@ public class PartitionedOutputBuffer
         // drop the initial reference
         serializedPageReferences.forEach(SerializedPageReference::dereferencePage);
 
-        return memoryManager.getNotFullFuture();
+        return memoryManager.getBufferBlockedFuture();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -426,6 +426,13 @@ public class SqlQueryScheduler
                 .sum();
     }
 
+    public long getTotalMemoryReservation()
+    {
+        return stages.values().stream()
+                .mapToLong(SqlStageExecution::getTotalMemoryReservation)
+                .sum();
+    }
+
     public Duration getTotalCpuTime()
     {
         long millis = stages.values().stream()

--- a/presto-main/src/main/java/com/facebook/presto/memory/DefaultQueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/DefaultQueryContext.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskStateMachine;
+import com.facebook.presto.memory.context.MemoryReservationHandler;
+import com.facebook.presto.memory.context.MemoryTrackingContext;
+import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spiller.SpillSpaceTracker;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.stats.GcMonitor;
+import io.airlift.units.DataSize;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.LongFunction;
+import java.util.function.LongPredicate;
+
+import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalTotalMemoryLimit;
+import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalUserMemoryLimit;
+import static com.facebook.presto.ExceededSpillLimitException.exceededPerQueryLocalLimit;
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newRootAggregatedMemoryContext;
+import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.airlift.units.DataSize.succinctBytes;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+@ThreadSafe
+public class DefaultQueryContext
+        implements QueryContext
+{
+    private static final long GUARANTEED_MEMORY = new DataSize(1, MEGABYTE).toBytes();
+
+    private final QueryId queryId;
+    private final GcMonitor gcMonitor;
+    private final Executor notificationExecutor;
+    private final ScheduledExecutorService yieldExecutor;
+    private final long maxSpill;
+    private final SpillSpaceTracker spillSpaceTracker;
+    private final Map<TaskId, TaskContext> taskContexts = new ConcurrentHashMap();
+
+    // TODO: This field should be final. However, due to the way QueryContext is constructed the memory limit is not known in advance
+    @GuardedBy("this")
+    private long maxUserMemory;
+    @GuardedBy("this")
+    private long maxTotalMemory;
+
+    private final MemoryTrackingContext queryMemoryContext;
+
+    @GuardedBy("this")
+    private MemoryPool memoryPool;
+
+    @GuardedBy("this")
+    private long spillUsed;
+
+    public DefaultQueryContext(
+            QueryId queryId,
+            DataSize maxUserMemory,
+            DataSize maxTotalMemory,
+            MemoryPool memoryPool,
+            GcMonitor gcMonitor,
+            Executor notificationExecutor,
+            ScheduledExecutorService yieldExecutor,
+            DataSize maxSpill,
+            SpillSpaceTracker spillSpaceTracker)
+    {
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.maxUserMemory = requireNonNull(maxUserMemory, "maxUserMemory is null").toBytes();
+        this.maxTotalMemory = requireNonNull(maxTotalMemory, "maxTotalMemory is null").toBytes();
+        this.memoryPool = requireNonNull(memoryPool, "memoryPool is null");
+        this.gcMonitor = requireNonNull(gcMonitor, "gcMonitor is null");
+        this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
+        this.yieldExecutor = requireNonNull(yieldExecutor, "yieldExecutor is null");
+        this.maxSpill = requireNonNull(maxSpill, "maxSpill is null").toBytes();
+        this.spillSpaceTracker = requireNonNull(spillSpaceTracker, "spillSpaceTracker is null");
+        this.queryMemoryContext = new MemoryTrackingContext(
+                newRootAggregatedMemoryContext(new QueryMemoryReservationHandler(this::updateUserMemory, this::tryUpdateUserMemory), GUARANTEED_MEMORY),
+                newRootAggregatedMemoryContext(new QueryMemoryReservationHandler(this::updateRevocableMemory, this::tryReserveMemoryNotSupported), 0L),
+                newRootAggregatedMemoryContext(new QueryMemoryReservationHandler(this::updateSystemMemory, this::tryReserveMemoryNotSupported), 0L));
+    }
+
+    // TODO: This method should be removed, and the correct limit set in the constructor. However, due to the way QueryContext is constructed the memory limit is not known in advance
+    @Override
+    public synchronized void setResourceOvercommit()
+    {
+        // Allow the query to use the entire pool. This way the worker will kill the query, if it uses the entire local general pool.
+        // The coordinator will kill the query if the cluster runs out of memory.
+        maxUserMemory = memoryPool.getMaxBytes();
+        maxTotalMemory = memoryPool.getMaxBytes();
+    }
+
+    @VisibleForTesting
+    MemoryTrackingContext getQueryMemoryContext()
+    {
+        return queryMemoryContext;
+    }
+
+    /**
+     * Deadlock is possible for concurrent user and system allocations when updateSystemMemory()/updateUserMemory
+     * calls queryMemoryContext.getUserMemory()/queryMemoryContext.getSystemMemory(), respectively.
+     * @see this##updateSystemMemory(long) for details.
+     */
+    private synchronized ListenableFuture<?> updateUserMemory(long delta)
+    {
+        if (delta >= 0) {
+            if (queryMemoryContext.getUserMemory() + delta > maxUserMemory) {
+                throw exceededLocalUserMemoryLimit(succinctBytes(maxUserMemory));
+            }
+            return memoryPool.reserve(queryId, delta);
+        }
+        memoryPool.free(queryId, -delta);
+        return NOT_BLOCKED;
+    }
+
+    private synchronized ListenableFuture<?> updateRevocableMemory(long delta)
+    {
+        if (delta >= 0) {
+            return memoryPool.reserveRevocable(queryId, delta);
+        }
+        memoryPool.freeRevocable(queryId, -delta);
+        return NOT_BLOCKED;
+    }
+
+    private synchronized ListenableFuture<?> updateSystemMemory(long delta)
+    {
+        // We call memoryPool.getQueryMemoryReservation(queryId) instead of calling queryMemoryContext.getUserMemory() to
+        // calculate the total memory size.
+        //
+        // Calling the latter can result in a deadlock:
+        // * A thread doing a user allocation will acquire locks in this order:
+        //   1. monitor of queryMemoryContext.userAggregateMemoryContext
+        //   2. monitor of this (QueryContext)
+        // * The current thread doing a system allocation will acquire locks in this order:
+        //   1. monitor of this (QueryContext)
+        //   2. monitor of queryMemoryContext.userAggregateMemoryContext
+
+        // Deadlock is possible for concurrent user and system allocations when updateSystemMemory()/updateUserMemory
+        // calls queryMemoryContext.getUserMemory()/queryMemoryContext.getSystemMemory(), respectively. For concurrent
+        // allocations of the same type (e.g., tryUpdateUserMemory/updateUserMemory) it is not possible as they share
+        // the same RootAggregatedMemoryContext instance, and one of the threads will be blocked on the monitor of that
+        // RootAggregatedMemoryContext instance even before calling the QueryContext methods (the monitors of
+        // RootAggregatedMemoryContext instance and this will be acquired in the same order).
+        long totalMemory = memoryPool.getQueryMemoryReservation(queryId);
+        if (delta >= 0) {
+            if (totalMemory + delta > maxTotalMemory) {
+                throw exceededLocalTotalMemoryLimit(succinctBytes(maxTotalMemory));
+            }
+            return memoryPool.reserve(queryId, delta);
+        }
+        memoryPool.free(queryId, -delta);
+        return NOT_BLOCKED;
+    }
+
+    //TODO move spill tracking to the new memory tracking framework
+    @Override
+    public synchronized ListenableFuture<?> reserveSpill(long bytes)
+    {
+        checkArgument(bytes >= 0, "bytes is negative");
+        if (spillUsed + bytes > maxSpill) {
+            throw exceededPerQueryLocalLimit(succinctBytes(maxSpill));
+        }
+        ListenableFuture<?> future = spillSpaceTracker.reserve(bytes);
+        spillUsed += bytes;
+        return future;
+    }
+
+    private synchronized boolean tryUpdateUserMemory(long delta)
+    {
+        if (delta <= 0) {
+            ListenableFuture<?> future = updateUserMemory(delta);
+            verify(future.isDone(), "future should be done");
+            return true;
+        }
+        if (queryMemoryContext.getUserMemory() + delta > maxUserMemory) {
+            return false;
+        }
+        return memoryPool.tryReserve(queryId, delta);
+    }
+
+    @Override
+    public synchronized void freeSpill(long bytes)
+    {
+        checkArgument(spillUsed - bytes >= 0, "tried to free more memory than is reserved");
+        spillUsed -= bytes;
+        spillSpaceTracker.free(bytes);
+    }
+
+    @Override
+    public synchronized void setMemoryPool(MemoryPool pool)
+    {
+        // This method first acquires the monitor of this instance.
+        // After that in this method if we acquire the monitors of the
+        // user/revocable memory contexts in the queryMemoryContext instance
+        // (say, by calling queryMemoryContext.getUserMemory()) it's possible
+        // to have a deadlock. Because, the driver threads running the operators
+        // will allocate memory concurrently through the child memory context -> ... ->
+        // root memory context -> this.updateUserMemory() calls, and will acquire
+        // the monitors of the user/revocable memory contexts in the queryMemoryContext instance
+        // first, and then the monitor of this, which may cause deadlocks.
+        // That's why instead of calling methods on queryMemoryContext to get the
+        // user/revocable memory reservations, we call the MemoryPool to get the same
+        // information.
+        requireNonNull(pool, "pool is null");
+        if (memoryPool == pool) {
+            // Don't unblock our tasks and thrash the pools, if this is a no-op
+            return;
+        }
+        MemoryPool originalPool = memoryPool;
+        long originalReserved = originalPool.getQueryMemoryReservation(queryId);
+        long originalRevocableReserved = originalPool.getQueryRevocableMemoryReservation(queryId);
+        memoryPool = pool;
+        ListenableFuture<?> future = pool.reserve(queryId, originalReserved);
+        originalPool.free(queryId, originalReserved);
+        pool.reserveRevocable(queryId, originalRevocableReserved);
+        originalPool.freeRevocable(queryId, originalRevocableReserved);
+        future.addListener(() -> {
+            // Unblock all the tasks, if they were waiting for memory, since we're in a new pool.
+            taskContexts.values().forEach(TaskContext::moreMemoryAvailable);
+        }, directExecutor());
+    }
+
+    @Override
+    public synchronized MemoryPool getMemoryPool()
+    {
+        return memoryPool;
+    }
+
+    @Override
+    public TaskContext addTaskContext(TaskStateMachine taskStateMachine, Session session, boolean verboseStats, boolean cpuTimerEnabled)
+    {
+        TaskContext taskContext = TaskContext.createTaskContext(
+                this,
+                taskStateMachine,
+                gcMonitor,
+                notificationExecutor,
+                yieldExecutor,
+                session,
+                queryMemoryContext.newMemoryTrackingContext(),
+                verboseStats,
+                cpuTimerEnabled);
+        taskContexts.put(taskStateMachine.getTaskId(), taskContext);
+        return taskContext;
+    }
+
+    @Override
+    public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)
+    {
+        return visitor.visitQueryContext(this, context);
+    }
+
+    @Override
+    public <C, R> List<R> acceptChildren(QueryContextVisitor<C, R> visitor, C context)
+    {
+        return taskContexts.values()
+                .stream()
+                .map(taskContext -> taskContext.accept(visitor, context))
+                .collect(toList());
+    }
+
+    @Override
+    public TaskContext getTaskContextByTaskId(TaskId taskId)
+    {
+        TaskContext taskContext = taskContexts.get(taskId);
+        verify(taskContext != null, "task does not exist");
+        return taskContext;
+    }
+
+    private static class QueryMemoryReservationHandler
+            implements MemoryReservationHandler
+    {
+        private final LongFunction<ListenableFuture<?>> reserveMemoryFunction;
+        private final LongPredicate tryReserveMemoryFunction;
+
+        public QueryMemoryReservationHandler(LongFunction<ListenableFuture<?>> reserveMemoryFunction, LongPredicate tryReserveMemoryFunction)
+        {
+            this.reserveMemoryFunction = requireNonNull(reserveMemoryFunction, "reserveMemoryFunction is null");
+            this.tryReserveMemoryFunction = requireNonNull(tryReserveMemoryFunction, "tryReserveMemoryFunction is null");
+        }
+
+        @Override
+        public ListenableFuture<?> reserveMemory(long delta)
+        {
+            return reserveMemoryFunction.apply(delta);
+        }
+
+        @Override
+        public boolean tryReserveMemory(long delta)
+        {
+            return tryReserveMemoryFunction.test(delta);
+        }
+    }
+
+    private boolean tryReserveMemoryNotSupported(long bytes)
+    {
+        throw new UnsupportedOperationException("tryReserveMemory is not supported");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/memory/LegacyQueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/LegacyQueryContext.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskStateMachine;
+import com.facebook.presto.memory.context.MemoryReservationHandler;
+import com.facebook.presto.memory.context.MemoryTrackingContext;
+import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spiller.SpillSpaceTracker;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.stats.GcMonitor;
+import io.airlift.units.DataSize;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.LongFunction;
+import java.util.function.LongPredicate;
+
+import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalUserMemoryLimit;
+import static com.facebook.presto.ExceededSpillLimitException.exceededPerQueryLocalLimit;
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newRootAggregatedMemoryContext;
+import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.airlift.units.DataSize.succinctBytes;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+//TODO Remove this class and QueryContext interface once the system pool is removed completely.
+@Deprecated
+@ThreadSafe
+public class LegacyQueryContext
+        implements QueryContext
+{
+    private static final long GUARANTEED_MEMORY = new DataSize(1, MEGABYTE).toBytes();
+
+    private final QueryId queryId;
+    private final GcMonitor gcMonitor;
+    private final Executor notificationExecutor;
+    private final ScheduledExecutorService yieldExecutor;
+    private final long maxSpill;
+    private final SpillSpaceTracker spillSpaceTracker;
+    private final Map<TaskId, TaskContext> taskContexts = new ConcurrentHashMap();
+    private final MemoryPool systemMemoryPool;
+
+    // TODO: This field should be final. However, due to the way QueryContext is constructed the memory limit is not known in advance
+    @GuardedBy("this")
+    private long maxMemory;
+
+    private final MemoryTrackingContext queryMemoryContext;
+
+    @GuardedBy("this")
+    private MemoryPool memoryPool;
+
+    @GuardedBy("this")
+    private long spillUsed;
+
+    public LegacyQueryContext(
+            QueryId queryId,
+            DataSize maxMemory,
+            MemoryPool memoryPool,
+            MemoryPool systemMemoryPool,
+            GcMonitor gcMonitor,
+            Executor notificationExecutor,
+            ScheduledExecutorService yieldExecutor,
+            DataSize maxSpill,
+            SpillSpaceTracker spillSpaceTracker)
+    {
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.maxMemory = requireNonNull(maxMemory, "maxMemory is null").toBytes();
+        this.memoryPool = requireNonNull(memoryPool, "memoryPool is null");
+        this.systemMemoryPool = requireNonNull(systemMemoryPool, "systemMemoryPool is null");
+        this.gcMonitor = requireNonNull(gcMonitor, "gcMonitor is null");
+        this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
+        this.yieldExecutor = requireNonNull(yieldExecutor, "yieldExecutor is null");
+        this.maxSpill = requireNonNull(maxSpill, "maxSpill is null").toBytes();
+        this.spillSpaceTracker = requireNonNull(spillSpaceTracker, "spillSpaceTracker is null");
+        this.queryMemoryContext = new MemoryTrackingContext(
+                newRootAggregatedMemoryContext(new QueryMemoryReservationHandler(this::updateUserMemory, this::tryUpdateUserMemory), GUARANTEED_MEMORY),
+                newRootAggregatedMemoryContext(new QueryMemoryReservationHandler(this::updateRevocableMemory, this::tryReserveMemoryNotSupported), 0L),
+                newRootAggregatedMemoryContext(new QueryMemoryReservationHandler(this::updateSystemMemory, this::tryReserveMemoryNotSupported), 0L));
+    }
+
+    // TODO: This method should be removed, and the correct limit set in the constructor. However, due to the way QueryContext is constructed the memory limit is not known in advance
+    @Override
+    public synchronized void setResourceOvercommit()
+    {
+        // Allow the query to use the entire pool. This way the worker will kill the query, if it uses the entire local general pool.
+        // The coordinator will kill the query if the cluster runs out of memory.
+        maxMemory = memoryPool.getMaxBytes();
+    }
+
+    private synchronized ListenableFuture<?> updateUserMemory(long delta)
+    {
+        if (delta >= 0) {
+            if (queryMemoryContext.getUserMemory() + delta > maxMemory) {
+                throw exceededLocalUserMemoryLimit(succinctBytes(maxMemory));
+            }
+            return memoryPool.reserve(queryId, delta);
+        }
+        memoryPool.free(queryId, -delta);
+        return NOT_BLOCKED;
+    }
+
+    private synchronized ListenableFuture<?> updateRevocableMemory(long delta)
+    {
+        if (delta >= 0) {
+            return memoryPool.reserveRevocable(queryId, delta);
+        }
+        memoryPool.freeRevocable(queryId, -delta);
+        return NOT_BLOCKED;
+    }
+
+    private synchronized ListenableFuture<?> updateSystemMemory(long delta)
+    {
+        if (delta >= 0) {
+            systemMemoryPool.reserve(queryId, delta);
+            // Since various operators and the output buffers now support blocking when the system pool is full
+            // we return NOT_BLOCKED to prevent them from blocking, which is the legacy behavior.
+            return NOT_BLOCKED;
+        }
+        systemMemoryPool.free(queryId, -delta);
+        return NOT_BLOCKED;
+    }
+
+    //TODO move spill tracking to the new memory tracking framework
+    @Override
+    public synchronized ListenableFuture<?> reserveSpill(long bytes)
+    {
+        checkArgument(bytes >= 0, "bytes is negative");
+        if (spillUsed + bytes > maxSpill) {
+            throw exceededPerQueryLocalLimit(succinctBytes(maxSpill));
+        }
+        ListenableFuture<?> future = spillSpaceTracker.reserve(bytes);
+        spillUsed += bytes;
+        return future;
+    }
+
+    private synchronized boolean tryUpdateUserMemory(long delta)
+    {
+        if (delta <= 0) {
+            ListenableFuture<?> future = updateUserMemory(delta);
+            verify(future.isDone(), "future should be done");
+            return true;
+        }
+        if (queryMemoryContext.getUserMemory() + delta > maxMemory) {
+            return false;
+        }
+        return memoryPool.tryReserve(queryId, delta);
+    }
+
+    @Override
+    public synchronized void freeSpill(long bytes)
+    {
+        checkArgument(spillUsed - bytes >= 0, "tried to free more memory than is reserved");
+        spillUsed -= bytes;
+        spillSpaceTracker.free(bytes);
+    }
+
+    @Override
+    public synchronized void setMemoryPool(MemoryPool pool)
+    {
+        // This method first acquires the monitor of this instance.
+        // After that in this method if we acquire the monitors of the
+        // user/revocable memory contexts in the queryMemoryContext instance
+        // (say, by calling queryMemoryContext.getUserMemory()) it's possible
+        // to have a deadlock. Because, the driver threads running the operators
+        // will allocate memory concurrently through the child memory context -> ... ->
+        // root memory context -> this.updateUserMemory() calls, and will acquire
+        // the monitors of the user/revocable memory contexts in the queryMemoryContext instance
+        // first, and then the monitor of this, which may cause deadlocks.
+        // That's why instead of calling methods on queryMemoryContext to get the
+        // user/revocable memory reservations, we call the MemoryPool to get the same
+        // information.
+        requireNonNull(pool, "pool is null");
+        if (memoryPool == pool) {
+            // Don't unblock our tasks and thrash the pools, if this is a no-op
+            return;
+        }
+        MemoryPool originalPool = memoryPool;
+        long originalReserved = originalPool.getQueryMemoryReservation(queryId);
+        long originalRevocableReserved = originalPool.getQueryRevocableMemoryReservation(queryId);
+        memoryPool = pool;
+        ListenableFuture<?> future = pool.reserve(queryId, originalReserved);
+        originalPool.free(queryId, originalReserved);
+        pool.reserveRevocable(queryId, originalRevocableReserved);
+        originalPool.freeRevocable(queryId, originalRevocableReserved);
+        future.addListener(() -> {
+            // Unblock all the tasks, if they were waiting for memory, since we're in a new pool.
+            taskContexts.values().forEach(TaskContext::moreMemoryAvailable);
+        }, directExecutor());
+    }
+
+    @Override
+    public synchronized MemoryPool getMemoryPool()
+    {
+        return memoryPool;
+    }
+
+    @Override
+    public TaskContext addTaskContext(TaskStateMachine taskStateMachine, Session session, boolean verboseStats, boolean cpuTimerEnabled)
+    {
+        TaskContext taskContext = TaskContext.createTaskContext(
+                this,
+                taskStateMachine,
+                gcMonitor,
+                notificationExecutor,
+                yieldExecutor,
+                session,
+                queryMemoryContext.newMemoryTrackingContext(),
+                verboseStats,
+                cpuTimerEnabled);
+        taskContexts.put(taskStateMachine.getTaskId(), taskContext);
+        return taskContext;
+    }
+
+    @Override
+    public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)
+    {
+        return visitor.visitQueryContext(this, context);
+    }
+
+    @Override
+    public <C, R> List<R> acceptChildren(QueryContextVisitor<C, R> visitor, C context)
+    {
+        return taskContexts.values()
+                .stream()
+                .map(taskContext -> taskContext.accept(visitor, context))
+                .collect(toList());
+    }
+
+    @Override
+    public TaskContext getTaskContextByTaskId(TaskId taskId)
+    {
+        TaskContext taskContext = taskContexts.get(taskId);
+        verify(taskContext != null, "task does not exist");
+        return taskContext;
+    }
+
+    private static class QueryMemoryReservationHandler
+            implements MemoryReservationHandler
+    {
+        private final LongFunction<ListenableFuture<?>> reserveMemoryFunction;
+        private final LongPredicate tryReserveMemoryFunction;
+
+        public QueryMemoryReservationHandler(LongFunction<ListenableFuture<?>> reserveMemoryFunction, LongPredicate tryReserveMemoryFunction)
+        {
+            this.reserveMemoryFunction = requireNonNull(reserveMemoryFunction, "reserveMemoryFunction is null");
+            this.tryReserveMemoryFunction = requireNonNull(tryReserveMemoryFunction, "tryReserveMemoryFunction is null");
+        }
+
+        @Override
+        public ListenableFuture<?> reserveMemory(long delta)
+        {
+            return reserveMemoryFunction.apply(delta);
+        }
+
+        @Override
+        public boolean tryReserveMemory(long delta)
+        {
+            return tryReserveMemoryFunction.test(delta);
+        }
+    }
+
+    private boolean tryReserveMemoryNotSupported(long bytes)
+    {
+        throw new UnsupportedOperationException("tryReserveMemory is not supported");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/memory/LocalMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/LocalMemoryManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.memory;
 
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.memory.MemoryPoolInfo;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
@@ -26,6 +27,7 @@ import java.util.Map;
 
 import static com.facebook.presto.memory.NodeMemoryConfig.QUERY_MAX_MEMORY_PER_NODE_CONFIG;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -36,17 +38,40 @@ public final class LocalMemoryManager
     public static final MemoryPoolId RESERVED_POOL = new MemoryPoolId("reserved");
     public static final MemoryPoolId SYSTEM_POOL = new MemoryPoolId("system");
 
-    private final DataSize maxMemory;
-    private final Map<MemoryPoolId, MemoryPool> pools;
+    private DataSize maxMemory;
+    private Map<MemoryPoolId, MemoryPool> pools;
 
     @Inject
     public LocalMemoryManager(NodeMemoryConfig config, ReservedSystemMemoryConfig systemMemoryConfig)
     {
         requireNonNull(config, "config is null");
-        requireNonNull(systemMemoryConfig, "systemMemoryConfig is null");
-        long maxHeap = Runtime.getRuntime().maxMemory();
-        checkArgument(systemMemoryConfig.getReservedSystemMemory().toBytes() < maxHeap, "Reserved memory %s is greater than available heap %s", systemMemoryConfig.getReservedSystemMemory(), new DataSize(maxHeap, BYTE));
-        maxMemory = new DataSize(maxHeap - systemMemoryConfig.getReservedSystemMemory().toBytes(), BYTE);
+        long availableMemory = Runtime.getRuntime().maxMemory();
+        if (config.isLegacySystemPoolEnabled()) {
+            configureLegacyMemoryPools(config, systemMemoryConfig, availableMemory);
+        }
+        else {
+            configureMemoryPools(config, availableMemory);
+        }
+    }
+
+    private void configureMemoryPools(NodeMemoryConfig config, long availableMemory)
+    {
+        validateHeapHeadroom(config, availableMemory);
+        maxMemory = new DataSize(availableMemory - config.getHeapHeadroom().toBytes(), BYTE);
+        checkArgument(config.getMaxQueryMemoryPerNode().toBytes() <= config.getMaxQueryTotalMemoryPerNode().toBytes(),
+                "Max query memory per node cannot be greater than the max query total memory per node.");
+        ImmutableMap.Builder<MemoryPoolId, MemoryPool> builder = ImmutableMap.builder();
+        builder.put(RESERVED_POOL, new MemoryPool(RESERVED_POOL, config.getMaxQueryTotalMemoryPerNode()));
+        long generalPoolSize = maxMemory.toBytes() - config.getMaxQueryTotalMemoryPerNode().toBytes();
+        verify(generalPoolSize > 0, "general memory pool size is 0");
+        builder.put(GENERAL_POOL, new MemoryPool(GENERAL_POOL, new DataSize(generalPoolSize, BYTE)));
+        this.pools = builder.build();
+    }
+
+    private void configureLegacyMemoryPools(NodeMemoryConfig config, ReservedSystemMemoryConfig systemMemoryConfig, long availableMemory)
+    {
+        checkArgument(systemMemoryConfig.getReservedSystemMemory().toBytes() < availableMemory, "Reserved memory %s is greater than available heap %s", systemMemoryConfig.getReservedSystemMemory(), new DataSize(availableMemory, BYTE));
+        maxMemory = new DataSize(availableMemory - systemMemoryConfig.getReservedSystemMemory().toBytes(), BYTE);
 
         ImmutableMap.Builder<MemoryPoolId, MemoryPool> builder = ImmutableMap.builder();
         checkArgument(config.getMaxQueryMemoryPerNode().toBytes() <= maxMemory.toBytes(), format("%s set to %s, but only %s of useable heap available", QUERY_MAX_MEMORY_PER_NODE_CONFIG, config.getMaxQueryMemoryPerNode(), maxMemory));
@@ -55,6 +80,22 @@ public final class LocalMemoryManager
         builder.put(GENERAL_POOL, new MemoryPool(GENERAL_POOL, generalPoolSize));
         builder.put(SYSTEM_POOL, new MemoryPool(SYSTEM_POOL, systemMemoryConfig.getReservedSystemMemory()));
         this.pools = builder.build();
+    }
+
+    @VisibleForTesting
+    static void validateHeapHeadroom(NodeMemoryConfig config, long availableMemory)
+    {
+        long maxQueryTotalMemoryPerNode = config.getMaxQueryTotalMemoryPerNode().toBytes();
+        long heapHeadroom = config.getHeapHeadroom().toBytes();
+        // (availableMemory - maxQueryTotalMemoryPerNode) bytes will be available for the general pool and the
+        // headroom/untracked allocations, so the heapHeadroom cannot be larger than that space.
+        if (heapHeadroom < 0 || heapHeadroom + maxQueryTotalMemoryPerNode > availableMemory) {
+            throw new IllegalArgumentException(
+                    format("Invalid memory configuration. The sum of max total query memory per node (%s) and heap headroom (%s) cannot be larger than the available heap memory (%s)",
+                            maxQueryTotalMemoryPerNode,
+                            heapHeadroom,
+                            availableMemory));
+        }
     }
 
     public MemoryInfo getInfo()

--- a/presto-main/src/main/java/com/facebook/presto/memory/LowMemoryKiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/LowMemoryKiller.java
@@ -50,7 +50,7 @@ public interface LowMemoryKiller
             return memoryPoolId;
         }
 
-        public long getUserMemoryReservation()
+        public long getMemoryReservation()
         {
             return memoryReservation;
         }

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -243,7 +243,7 @@ public class MemoryPool
         return reservedRevocableBytes;
     }
 
-    synchronized long getQueryUserMemoryReservation(QueryId queryId)
+    synchronized long getQueryMemoryReservation(QueryId queryId)
     {
         return queryMemoryReservations.getOrDefault(queryId, 0L);
     }

--- a/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.memory;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 
 import javax.validation.constraints.NotNull;
@@ -23,9 +24,16 @@ import static io.airlift.units.DataSize.Unit.BYTE;
 // This is separate from MemoryManagerConfig because it's difficult to test the default value of maxQueryMemoryPerNode
 public class NodeMemoryConfig
 {
+    public static final long AVAILABLE_HEAP_MEMORY = Runtime.getRuntime().maxMemory();
     public static final String QUERY_MAX_MEMORY_PER_NODE_CONFIG = "query.max-memory-per-node";
 
-    private DataSize maxQueryMemoryPerNode = new DataSize(Runtime.getRuntime().maxMemory() * 0.1, BYTE);
+    private boolean isLegacySystemPoolEnabled;
+
+    private DataSize maxQueryMemoryPerNode = new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE);
+
+    // This is a per-query limit for the user plus system allocations.
+    private DataSize maxQueryTotalMemoryPerNode = new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE);
+    private DataSize heapHeadroom = new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE);
 
     @NotNull
     public DataSize getMaxQueryMemoryPerNode()
@@ -37,6 +45,45 @@ public class NodeMemoryConfig
     public NodeMemoryConfig setMaxQueryMemoryPerNode(DataSize maxQueryMemoryPerNode)
     {
         this.maxQueryMemoryPerNode = maxQueryMemoryPerNode;
+        return this;
+    }
+
+    public boolean isLegacySystemPoolEnabled()
+    {
+        return isLegacySystemPoolEnabled;
+    }
+
+    @Config("deprecated.legacy-system-pool-enabled")
+    public NodeMemoryConfig setLegacySystemPoolEnabled(boolean legacySystemPoolEnabled)
+    {
+        isLegacySystemPoolEnabled = legacySystemPoolEnabled;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getMaxQueryTotalMemoryPerNode()
+    {
+        return maxQueryTotalMemoryPerNode;
+    }
+
+    @Config("query.max-total-memory-per-node")
+    public NodeMemoryConfig setMaxQueryTotalMemoryPerNode(DataSize maxQueryTotalMemoryPerNode)
+    {
+        this.maxQueryTotalMemoryPerNode = maxQueryTotalMemoryPerNode;
+        return this;
+    }
+
+    public DataSize getHeapHeadroom()
+    {
+        return heapHeadroom;
+    }
+
+    @NotNull
+    @Config("memory.heap-headroom-per-node")
+    @ConfigDescription("The amount of heap memory to set aside as headroom/buffer (e.g., for untracked allocations)")
+    public NodeMemoryConfig setHeapHeadroom(DataSize heapHeadroom)
+    {
+        this.heapHeadroom = heapHeadroom;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
@@ -16,268 +16,33 @@ package com.facebook.presto.memory;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskStateMachine;
-import com.facebook.presto.memory.context.MemoryReservationHandler;
-import com.facebook.presto.memory.context.MemoryTrackingContext;
 import com.facebook.presto.operator.TaskContext;
-import com.facebook.presto.spi.QueryId;
-import com.facebook.presto.spiller.SpillSpaceTracker;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.airlift.stats.GcMonitor;
-import io.airlift.units.DataSize;
-
-import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.LongFunction;
-import java.util.function.LongPredicate;
 
-import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalLimit;
-import static com.facebook.presto.ExceededSpillLimitException.exceededPerQueryLocalLimit;
-import static com.facebook.presto.memory.context.AggregatedMemoryContext.newRootAggregatedMemoryContext;
-import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Verify.verify;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
-import static io.airlift.units.DataSize.succinctBytes;
-import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
-
-@ThreadSafe
-public class QueryContext
+/**
+ * This interface and the LegacyQueryContext implementation are written to ease the removal of the system memory pool.
+ * Once the system pool is removed they should both be removed.
+ */
+@Deprecated
+public interface QueryContext
 {
-    private static final long GUARANTEED_MEMORY = new DataSize(1, MEGABYTE).toBytes();
+    ListenableFuture<?> reserveSpill(long bytes);
 
-    private final QueryId queryId;
-    private final GcMonitor gcMonitor;
-    private final Executor notificationExecutor;
-    private final ScheduledExecutorService yieldExecutor;
-    private final long maxSpill;
-    private final SpillSpaceTracker spillSpaceTracker;
-    private final Map<TaskId, TaskContext> taskContexts = new ConcurrentHashMap();
-    private final MemoryPool systemMemoryPool;
+    void freeSpill(long bytes);
 
-    // TODO: This field should be final. However, due to the way QueryContext is constructed the memory limit is not known in advance
-    @GuardedBy("this")
-    private long maxMemory;
+    void setResourceOvercommit();
 
-    private final MemoryTrackingContext queryMemoryContext;
+    void setMemoryPool(MemoryPool pool);
 
-    @GuardedBy("this")
-    private MemoryPool memoryPool;
+    TaskContext getTaskContextByTaskId(TaskId taskId);
 
-    @GuardedBy("this")
-    private long spillUsed;
+    TaskContext addTaskContext(TaskStateMachine taskStateMachine, Session session, boolean verboseStats, boolean cpuTimerEnabled);
 
-    public QueryContext(
-            QueryId queryId,
-            DataSize maxMemory,
-            MemoryPool memoryPool,
-            MemoryPool systemMemoryPool,
-            GcMonitor gcMonitor,
-            Executor notificationExecutor,
-            ScheduledExecutorService yieldExecutor,
-            DataSize maxSpill,
-            SpillSpaceTracker spillSpaceTracker)
-    {
-        this.queryId = requireNonNull(queryId, "queryId is null");
-        this.maxMemory = requireNonNull(maxMemory, "maxMemory is null").toBytes();
-        this.memoryPool = requireNonNull(memoryPool, "memoryPool is null");
-        this.systemMemoryPool = requireNonNull(systemMemoryPool, "systemMemoryPool is null");
-        this.gcMonitor = requireNonNull(gcMonitor, "gcMonitor is null");
-        this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
-        this.yieldExecutor = requireNonNull(yieldExecutor, "yieldExecutor is null");
-        this.maxSpill = requireNonNull(maxSpill, "maxSpill is null").toBytes();
-        this.spillSpaceTracker = requireNonNull(spillSpaceTracker, "spillSpaceTracker is null");
-        this.queryMemoryContext = new MemoryTrackingContext(
-                newRootAggregatedMemoryContext(new QueryMemoryReservationHandler(this::updateUserMemory, this::tryUpdateUserMemory), GUARANTEED_MEMORY),
-                newRootAggregatedMemoryContext(new QueryMemoryReservationHandler(this::updateRevocableMemory, this::tryReserveMemoryNotSupported), 0L),
-                newRootAggregatedMemoryContext(new QueryMemoryReservationHandler(this::updateSystemMemory, this::tryReserveMemoryNotSupported), 0L));
-    }
+    MemoryPool getMemoryPool();
 
-    // TODO: This method should be removed, and the correct limit set in the constructor. However, due to the way QueryContext is constructed the memory limit is not known in advance
-    public synchronized void setResourceOvercommit()
-    {
-        // Allow the query to use the entire pool. This way the worker will kill the query, if it uses the entire local general pool.
-        // The coordinator will kill the query if the cluster runs out of memory.
-        maxMemory = memoryPool.getMaxBytes();
-    }
+    <C, R> R accept(QueryContextVisitor<C, R> visitor, C context);
 
-    @VisibleForTesting
-    MemoryTrackingContext getQueryMemoryContext()
-    {
-        return queryMemoryContext;
-    }
-
-    private synchronized ListenableFuture<?> updateUserMemory(long delta)
-    {
-        if (delta >= 0) {
-            if (queryMemoryContext.getUserMemory() + delta > maxMemory) {
-                throw exceededLocalLimit(succinctBytes(maxMemory));
-            }
-            return memoryPool.reserve(queryId, delta);
-        }
-        memoryPool.free(queryId, -delta);
-        return NOT_BLOCKED;
-    }
-
-    private synchronized ListenableFuture<?> updateRevocableMemory(long delta)
-    {
-        if (delta >= 0) {
-            return memoryPool.reserveRevocable(queryId, delta);
-        }
-        memoryPool.freeRevocable(queryId, -delta);
-        return NOT_BLOCKED;
-    }
-
-    private synchronized ListenableFuture<?> updateSystemMemory(long delta)
-    {
-        if (delta >= 0) {
-            return systemMemoryPool.reserve(queryId, delta);
-        }
-        systemMemoryPool.free(queryId, -delta);
-        return NOT_BLOCKED;
-    }
-
-    //TODO move spill tracking to the new memory tracking framework
-    public synchronized ListenableFuture<?> reserveSpill(long bytes)
-    {
-        checkArgument(bytes >= 0, "bytes is negative");
-        if (spillUsed + bytes > maxSpill) {
-            throw exceededPerQueryLocalLimit(succinctBytes(maxSpill));
-        }
-        ListenableFuture<?> future = spillSpaceTracker.reserve(bytes);
-        spillUsed += bytes;
-        return future;
-    }
-
-    private synchronized boolean tryUpdateUserMemory(long delta)
-    {
-        if (delta <= 0) {
-            ListenableFuture<?> future = updateUserMemory(delta);
-            verify(future.isDone(), "future should be done");
-            return true;
-        }
-        if (queryMemoryContext.getUserMemory() + delta > maxMemory) {
-            return false;
-        }
-        return memoryPool.tryReserve(queryId, delta);
-    }
-
-    public synchronized void freeSpill(long bytes)
-    {
-        checkArgument(spillUsed - bytes >= 0, "tried to free more memory than is reserved");
-        spillUsed -= bytes;
-        spillSpaceTracker.free(bytes);
-    }
-
-    public synchronized void setMemoryPool(MemoryPool pool)
-    {
-        // This method first acquires the monitor of this instance.
-        // After that in this method if we acquire the monitors of the
-        // user/revocable memory contexts in the queryMemoryContext instance
-        // (say, by calling queryMemoryContext.getUserMemory()) it's possible
-        // to have a deadlock. Because, the driver threads running the operators
-        // will allocate memory concurrently through the child memory context -> ... ->
-        // root memory context -> this.updateUserMemory() calls, and will acquire
-        // the monitors of the user/revocable memory contexts in the queryMemoryContext instance
-        // first, and then the monitor of this, which may cause deadlocks.
-        // That's why instead of calling methods on queryMemoryContext to get the
-        // user/revocable memory reservations, we call the MemoryPool to get the same
-        // information.
-        requireNonNull(pool, "pool is null");
-        if (memoryPool == pool) {
-            // Don't unblock our tasks and thrash the pools, if this is a no-op
-            return;
-        }
-        MemoryPool originalPool = memoryPool;
-        long originalReserved = originalPool.getQueryUserMemoryReservation(queryId);
-        long originalRevocableReserved = originalPool.getQueryRevocableMemoryReservation(queryId);
-        memoryPool = pool;
-        ListenableFuture<?> future = pool.reserve(queryId, originalReserved);
-        originalPool.free(queryId, originalReserved);
-        pool.reserveRevocable(queryId, originalRevocableReserved);
-        originalPool.freeRevocable(queryId, originalRevocableReserved);
-        future.addListener(() -> {
-            // Unblock all the tasks, if they were waiting for memory, since we're in a new pool.
-            taskContexts.values().forEach(TaskContext::moreMemoryAvailable);
-        }, directExecutor());
-    }
-
-    public synchronized MemoryPool getMemoryPool()
-    {
-        return memoryPool;
-    }
-
-    public TaskContext addTaskContext(TaskStateMachine taskStateMachine, Session session, boolean verboseStats, boolean cpuTimerEnabled)
-    {
-        TaskContext taskContext = TaskContext.createTaskContext(
-                this,
-                taskStateMachine,
-                gcMonitor,
-                notificationExecutor,
-                yieldExecutor,
-                session,
-                queryMemoryContext.newMemoryTrackingContext(),
-                verboseStats,
-                cpuTimerEnabled);
-        taskContexts.put(taskStateMachine.getTaskId(), taskContext);
-        return taskContext;
-    }
-
-    public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)
-    {
-        return visitor.visitQueryContext(this, context);
-    }
-
-    public <C, R> List<R> acceptChildren(QueryContextVisitor<C, R> visitor, C context)
-    {
-        return taskContexts.values()
-                .stream()
-                .map(taskContext -> taskContext.accept(visitor, context))
-                .collect(toList());
-    }
-
-    public TaskContext getTaskContextByTaskId(TaskId taskId)
-    {
-        TaskContext taskContext = taskContexts.get(taskId);
-        verify(taskContext != null, "task does not exist");
-        return taskContext;
-    }
-
-    private static class QueryMemoryReservationHandler
-            implements MemoryReservationHandler
-    {
-        private final LongFunction<ListenableFuture<?>> reserveMemoryFunction;
-        private final LongPredicate tryReserveMemoryFunction;
-
-        public QueryMemoryReservationHandler(LongFunction<ListenableFuture<?>> reserveMemoryFunction, LongPredicate tryReserveMemoryFunction)
-        {
-            this.reserveMemoryFunction = requireNonNull(reserveMemoryFunction, "reserveMemoryFunction is null");
-            this.tryReserveMemoryFunction = requireNonNull(tryReserveMemoryFunction, "tryReserveMemoryFunction is null");
-        }
-
-        @Override
-        public ListenableFuture<?> reserveMemory(long delta)
-        {
-            return reserveMemoryFunction.apply(delta);
-        }
-
-        @Override
-        public boolean tryReserveMemory(long delta)
-        {
-            return tryReserveMemoryFunction.test(delta);
-        }
-    }
-
-    private boolean tryReserveMemoryNotSupported(long bytes)
-    {
-        throw new UnsupportedOperationException("tryReserveMemory is not supported");
-    }
+    <C, R> List<R> acceptChildren(QueryContextVisitor<C, R> visitor, C context);
 }

--- a/presto-main/src/main/java/com/facebook/presto/memory/TotalReservationLowMemoryKiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/TotalReservationLowMemoryKiller.java
@@ -30,7 +30,7 @@ public class TotalReservationLowMemoryKiller
         QueryId biggestQuery = null;
         long maxMemory = 0;
         for (QueryMemoryInfo query : queries) {
-            long bytesUsed = query.getUserMemoryReservation();
+            long bytesUsed = query.getMemoryReservation();
             if (bytesUsed > maxMemory && GENERAL_POOL.equals(query.getMemoryPoolId())) {
                 biggestQuery = query.getQueryId();
                 maxMemory = bytesUsed;

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -525,4 +525,10 @@ public class TaskContext
     {
         return taskMemoryContext;
     }
+
+    @VisibleForTesting
+    public QueryContext getQueryContext()
+    {
+        return queryContext;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
@@ -16,8 +16,8 @@ package com.facebook.presto.testing;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskStateMachine;
+import com.facebook.presto.memory.DefaultQueryContext;
 import com.facebook.presto.memory.MemoryPool;
-import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
@@ -58,12 +58,12 @@ public final class TestingTaskContext
                 .build();
     }
 
-    public static TaskContext createTaskContext(QueryContext queryContext, Executor executor, Session session)
+    public static TaskContext createTaskContext(DefaultQueryContext queryContext, Executor executor, Session session)
     {
         return createTaskContext(queryContext, session, new TaskStateMachine(new TaskId("query", 0, 0), executor));
     }
 
-    private static TaskContext createTaskContext(QueryContext queryContext, Session session, TaskStateMachine taskStateMachine)
+    private static TaskContext createTaskContext(DefaultQueryContext queryContext, Session session, TaskStateMachine taskStateMachine)
     {
         return queryContext.addTaskContext(
                 taskStateMachine,
@@ -82,10 +82,11 @@ public final class TestingTaskContext
         private final Executor notificationExecutor;
         private final ScheduledExecutorService yieldExecutor;
         private final Session session;
+        private QueryId queryId = new QueryId("test_query");
         private TaskStateMachine taskStateMachine;
         private DataSize queryMaxMemory = new DataSize(256, MEGABYTE);
+        private DataSize queryMaxTotalMemory = new DataSize(512, MEGABYTE);
         private DataSize memoryPoolSize = new DataSize(1, GIGABYTE);
-        private DataSize systemMemoryPoolSize = new DataSize(1, GIGABYTE);
         private DataSize maxSpillSize = new DataSize(1, GIGABYTE);
         private DataSize queryMaxSpillSize = new DataSize(1, GIGABYTE);
 
@@ -115,12 +116,6 @@ public final class TestingTaskContext
             return this;
         }
 
-        public Builder setSystemMemoryPoolSize(DataSize systemMemoryPoolSize)
-        {
-            this.systemMemoryPoolSize = systemMemoryPoolSize;
-            return this;
-        }
-
         public Builder setMaxSpillSize(DataSize maxSpillSize)
         {
             this.maxSpillSize = maxSpillSize;
@@ -133,16 +128,21 @@ public final class TestingTaskContext
             return this;
         }
 
+        public Builder setQueryId(QueryId queryId)
+        {
+            this.queryId = queryId;
+            return this;
+        }
+
         public TaskContext build()
         {
             MemoryPool memoryPool = new MemoryPool(new MemoryPoolId("test"), memoryPoolSize);
-            MemoryPool systemMemoryPool = new MemoryPool(new MemoryPoolId("testSystem"), systemMemoryPoolSize);
             SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(maxSpillSize);
-            QueryContext queryContext = new QueryContext(
-                    new QueryId("test_query"),
+            DefaultQueryContext queryContext = new DefaultQueryContext(
+                    queryId,
                     queryMaxMemory,
+                    queryMaxTotalMemory,
                     memoryPool,
-                    systemMemoryPool,
                     GC_MONITOR,
                     notificationExecutor,
                     yieldExecutor,

--- a/presto-main/src/main/resources/webapp/assets/worker.js
+++ b/presto-main/src/main/resources/webapp/assets/worker.js
@@ -389,15 +389,11 @@ let WorkerStatus = React.createClass({
                         <h3>Memory Pools</h3>
                         <hr className="h3-hr"/>
                         <div className="row">
-                            <div className="col-xs-4">
+                            <div className="col-xs-6">
                                 { this.renderPoolBar("General", serverInfo.memoryInfo.pools.general) }
                                 { this.renderPoolQueries(serverInfo.memoryInfo.pools.general) }
                             </div>
-                            <div className="col-xs-4">
-                                { this.renderPoolBar("System", serverInfo.memoryInfo.pools.system) }
-                                { this.renderPoolQueries(serverInfo.memoryInfo.pools.system) }
-                            </div>
-                            <div className="col-xs-4">
+                            <div className="col-xs-6">
                                 { this.renderPoolBar("Reserved", serverInfo.memoryInfo.pools.reserved) }
                                 { this.renderPoolQueries(serverInfo.memoryInfo.pools.reserved) }
                             </div>

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -131,6 +131,7 @@ public class MockQueryExecution
                         new DataSize(19, BYTE),
                         new DataSize(20, BYTE),
                         new DataSize(21, BYTE),
+                        new DataSize(22, BYTE),
 
                         true,
                         new Duration(20, NANOSECONDS),
@@ -214,6 +215,12 @@ public class MockQueryExecution
 
     @Override
     public long getUserMemoryReservation()
+    {
+        return memoryUsage;
+    }
+
+    @Override
+    public long getTotalMemoryReservation()
     {
         return memoryUsage;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -19,8 +19,8 @@ import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.execution.buffer.LazyOutputBuffer;
 import com.facebook.presto.execution.buffer.OutputBuffer;
+import com.facebook.presto.memory.DefaultQueryContext;
 import com.facebook.presto.memory.MemoryPool;
-import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.TableHandle;
@@ -179,9 +179,16 @@ public class MockRemoteTaskFactory
             this.taskStateMachine = new TaskStateMachine(requireNonNull(taskId, "taskId is null"), requireNonNull(executor, "executor is null"));
 
             MemoryPool memoryPool = new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE));
-            MemoryPool memorySystemPool = new MemoryPool(new MemoryPoolId("testSystem"), new DataSize(1, GIGABYTE));
             SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(new DataSize(1, GIGABYTE));
-            QueryContext queryContext = new QueryContext(taskId.getQueryId(), new DataSize(1, MEGABYTE), memoryPool, memorySystemPool, new TestingGcMonitor(), executor, scheduledExecutor, new DataSize(1, MEGABYTE), spillSpaceTracker);
+            DefaultQueryContext queryContext = new DefaultQueryContext(taskId.getQueryId(),
+                    new DataSize(1, MEGABYTE),
+                    new DataSize(2, MEGABYTE),
+                    memoryPool,
+                    new TestingGcMonitor(),
+                    executor,
+                    scheduledExecutor,
+                    new DataSize(1, MEGABYTE),
+                    spillSpaceTracker);
             this.taskContext = queryContext.addTaskContext(taskStateMachine, TEST_SESSION, true, true);
 
             this.location = URI.create("fake://task/" + taskId);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -16,8 +16,8 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.executor.TaskExecutor;
+import com.facebook.presto.memory.DefaultQueryContext;
 import com.facebook.presto.memory.MemoryPool;
-import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.OperatorContext;
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.facebook.presto.execution.TaskTestUtils.createTestQueryMonitor;
 import static com.facebook.presto.execution.TaskTestUtils.createTestingPlanner;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
-import static com.facebook.presto.memory.LocalMemoryManager.SYSTEM_POOL;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -189,7 +188,7 @@ public class TestMemoryRevokingScheduler
     {
         // Given
         SqlTask sqlTask1 = newSqlTask();
-        MemoryPool anotherMemoryPool = new MemoryPool(SYSTEM_POOL, new DataSize(10, BYTE));
+        MemoryPool anotherMemoryPool = new MemoryPool(new MemoryPoolId("test"), new DataSize(10, BYTE));
         sqlTask1.getQueryContext().setMemoryPool(anotherMemoryPool);
         OperatorContext operatorContext1 = createContexts(sqlTask1);
 
@@ -290,11 +289,10 @@ public class TestMemoryRevokingScheduler
                 taskId,
                 location,
                 "fake",
-                new QueryContext(
-                        new QueryId("query"),
+                new DefaultQueryContext(new QueryId("query"),
                         new DataSize(1, MEGABYTE),
+                        new DataSize(2, MEGABYTE),
                         memoryPool,
-                        new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE)),
                         new TestingGcMonitor(),
                         executor,
                         scheduledExecutor,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -157,6 +157,7 @@ public class TestQueryStats
             new DataSize(19, BYTE),
             new DataSize(20, BYTE),
             new DataSize(21, BYTE),
+            new DataSize(22, BYTE),
 
             true,
             new Duration(20, NANOSECONDS),
@@ -227,8 +228,9 @@ public class TestQueryStats
 
         assertEquals(actual.getCumulativeUserMemory(), 17.0);
         assertEquals(actual.getUserMemoryReservation(), new DataSize(18, BYTE));
-        assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(19, BYTE));
-        assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(20, BYTE));
+        assertEquals(actual.getTotalMemoryReservation(), new DataSize(19, BYTE));
+        assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(20, BYTE));
+        assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(21, BYTE));
 
         assertEquals(actual.getTotalScheduledTime(), new Duration(20, NANOSECONDS));
         assertEquals(actual.getTotalCpuTime(), new Duration(21, NANOSECONDS));

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -19,8 +19,8 @@ import com.facebook.presto.TaskSource;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.BufferState;
 import com.facebook.presto.execution.executor.TaskExecutor;
+import com.facebook.presto.memory.DefaultQueryContext;
 import com.facebook.presto.memory.MemoryPool;
-import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spiller.SpillSpaceTracker;
@@ -296,11 +296,10 @@ public class TestSqlTask
                 taskId,
                 location,
                 "fake",
-                new QueryContext(
-                        new QueryId("query"),
+                new DefaultQueryContext(new QueryId("query"),
                         new DataSize(1, MEGABYTE),
+                        new DataSize(2, MEGABYTE),
                         new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE)),
-                        new MemoryPool(new MemoryPoolId("testSystem"), new DataSize(1, GIGABYTE)),
                         new TestingGcMonitor(),
                         taskNotificationExecutor,
                         driverYieldExecutor,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -25,8 +25,8 @@ import com.facebook.presto.execution.buffer.PagesSerdeFactory;
 import com.facebook.presto.execution.buffer.PartitionedOutputBuffer;
 import com.facebook.presto.execution.buffer.SerializedPage;
 import com.facebook.presto.execution.executor.TaskExecutor;
+import com.facebook.presto.memory.DefaultQueryContext;
 import com.facebook.presto.memory.MemoryPool;
-import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.DriverContext;
@@ -594,10 +594,11 @@ public class TestSqlTaskExecution
 
     private TaskContext newTestingTaskContext(ScheduledExecutorService taskNotificationExecutor, ScheduledExecutorService driverYieldExecutor, TaskStateMachine taskStateMachine)
     {
-        QueryContext queryContext = new QueryContext(
+        DefaultQueryContext queryContext = new DefaultQueryContext(
                 new QueryId("queryid"),
                 new DataSize(1, MEGABYTE),
-                new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE)), new MemoryPool(new MemoryPoolId("testSystem"), new DataSize(1, GIGABYTE)),
+                new DataSize(2, MEGABYTE),
+                new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE)),
                 new TestingGcMonitor(),
                 taskNotificationExecutor,
                 driverYieldExecutor,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
@@ -50,6 +50,7 @@ public class TestStageStats
             12.0,
             new DataSize(13, BYTE),
             new DataSize(14, BYTE),
+            new DataSize(15, BYTE),
 
             new Duration(15, NANOSECONDS),
             new Duration(16, NANOSECONDS),
@@ -112,7 +113,8 @@ public class TestStageStats
 
         assertEquals(actual.getCumulativeUserMemory(), 12.0);
         assertEquals(actual.getUserMemoryReservation(), new DataSize(13, BYTE));
-        assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(14, BYTE));
+        assertEquals(actual.getTotalMemoryReservation(), new DataSize(14, BYTE));
+        assertEquals(actual.getPeakUserMemoryReservation(), new DataSize(15, BYTE));
 
         assertEquals(actual.getTotalScheduledTime(), new Duration(15, NANOSECONDS));
         assertEquals(actual.getTotalCpuTime(), new Duration(16, NANOSECONDS));

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -16,11 +16,14 @@ package com.facebook.presto.execution.buffer;
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.OutputBuffers.OutputBufferId;
 import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
+import com.facebook.presto.memory.context.MemoryReservationHandler;
 import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.BigintType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.DataSize;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -28,6 +31,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.presto.OutputBuffers.BROADCAST_PARTITION_ID;
@@ -51,10 +55,14 @@ import static com.facebook.presto.execution.buffer.BufferTestUtils.enqueuePage;
 import static com.facebook.presto.execution.buffer.BufferTestUtils.getBufferResult;
 import static com.facebook.presto.execution.buffer.BufferTestUtils.getFuture;
 import static com.facebook.presto.execution.buffer.BufferTestUtils.sizeOfPages;
+import static com.facebook.presto.execution.buffer.TestingPagesSerdeFactory.testingPagesSerde;
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newRootAggregatedMemoryContext;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -63,6 +71,7 @@ import static org.testng.Assert.fail;
 
 public class TestBroadcastOutputBuffer
 {
+    private static final PagesSerde PAGES_SERDE = testingPagesSerde();
     private static final String TASK_INSTANCE_ID = "task-instance-id";
 
     private static final ImmutableList<BigintType> TYPES = ImmutableList.of(BIGINT);
@@ -934,6 +943,155 @@ public class TestBroadcastOutputBuffer
     }
 
     @Test
+    public void testSharedBufferBlocking()
+    {
+        SettableFuture<?> blockedFuture = SettableFuture.create();
+        MockMemoryReservationHandler reservationHandler = new MockMemoryReservationHandler(blockedFuture);
+        AggregatedMemoryContext memoryContext = newRootAggregatedMemoryContext(reservationHandler, 0L);
+
+        Page page = createPage(1);
+        long pageSize = PAGES_SERDE.serialize(page).getRetainedSizeInBytes();
+
+        // create a buffer that can only hold two pages
+        BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), new DataSize(pageSize * 2, BYTE), memoryContext, directExecutor());
+        OutputBufferMemoryManager memoryManager = buffer.getMemoryManager();
+
+        // adding the first page will block as no memory is available (MockMemoryReservationHandler will return a future that is not done)
+        enqueuePage(buffer, page);
+
+        // more memory is available
+        blockedFuture.set(null);
+        memoryManager.onMemoryAvailable();
+        assertTrue(memoryManager.getBufferBlockedFuture().isDone(), "buffer shouldn't be blocked");
+
+        // we should be able to add one more page after more memory is available
+        addPage(buffer, page);
+
+        // the buffer is full now
+        enqueuePage(buffer, page);
+    }
+
+    @Test
+    public void testSharedBufferBlocking2()
+    {
+        // start with a complete future
+        SettableFuture<?> blockedFuture = SettableFuture.create();
+        blockedFuture.set(null);
+        MockMemoryReservationHandler reservationHandler = new MockMemoryReservationHandler(blockedFuture);
+        AggregatedMemoryContext memoryContext = newRootAggregatedMemoryContext(reservationHandler, 0L);
+
+        Page page = createPage(1);
+        long pageSize = PAGES_SERDE.serialize(page).getRetainedSizeInBytes();
+
+        // create a buffer that can only hold two pages
+        BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), new DataSize(pageSize * 2, BYTE), memoryContext, directExecutor());
+        OutputBufferMemoryManager memoryManager = buffer.getMemoryManager();
+
+        // add two pages to fill up the buffer (memory is available)
+        addPage(buffer, page);
+        addPage(buffer, page);
+
+        // fill up the memory pool
+        blockedFuture = SettableFuture.create();
+        reservationHandler.updateBlockedFuture(blockedFuture);
+
+        // allocate one more byte to make the buffer full
+        memoryManager.updateMemoryUsage(1L);
+
+        // more memory is available
+        blockedFuture.set(null);
+        memoryManager.onMemoryAvailable();
+
+        // memoryManager should still return a blocked future as the buffer is still full
+        assertFalse(memoryManager.getBufferBlockedFuture().isDone(), "buffer should be blocked");
+
+        // remove all pages from the memory manager and the 1 byte that we added above
+        memoryManager.updateMemoryUsage(-pageSize * 2 - 1);
+
+        // now we have both buffer space and memory available, so memoryManager shouldn't be blocked
+        assertTrue(memoryManager.getBufferBlockedFuture().isDone(), "buffer shouldn't be blocked");
+
+        // we should be able to add two pages after more memory is available
+        addPage(buffer, page);
+        addPage(buffer, page);
+
+        // the buffer is full now
+        enqueuePage(buffer, page);
+    }
+
+    @Test
+    public void testSharedBufferBlockingNoBlockOnFull()
+    {
+        SettableFuture<?> blockedFuture = SettableFuture.create();
+        MockMemoryReservationHandler reservationHandler = new MockMemoryReservationHandler(blockedFuture);
+        AggregatedMemoryContext memoryContext = newRootAggregatedMemoryContext(reservationHandler, 0L);
+
+        Page page = createPage(1);
+        long pageSize = PAGES_SERDE.serialize(page).getRetainedSizeInBytes();
+
+        // create a buffer that can only hold two pages
+        BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), new DataSize(pageSize * 2, BYTE), memoryContext, directExecutor());
+        OutputBufferMemoryManager memoryManager = buffer.getMemoryManager();
+
+        memoryManager.setNoBlockOnFull();
+
+        // even if setNoBlockOnFull() is called the buffer should block on memory when we add the first page
+        // as no memory is available (MockMemoryReservationHandler will return a future that is not done)
+        enqueuePage(buffer, page);
+
+        // more memory is available
+        blockedFuture.set(null);
+        memoryManager.onMemoryAvailable();
+        assertTrue(memoryManager.getBufferBlockedFuture().isDone(), "buffer shouldn't be blocked");
+
+        // we should be able to add one more page after more memory is available
+        addPage(buffer, page);
+
+        // the buffer is full now, but setNoBlockOnFull() is called so the buffer shouldn't block
+        addPage(buffer, page);
+    }
+
+    private static class MockMemoryReservationHandler
+            implements MemoryReservationHandler
+    {
+        private ListenableFuture<?> blockedFuture;
+
+        public MockMemoryReservationHandler(ListenableFuture<?> blockedFuture)
+        {
+            this.blockedFuture = requireNonNull(blockedFuture, "blockedFuture is null");
+        }
+
+        @Override
+        public ListenableFuture<?> reserveMemory(long delta)
+        {
+            return blockedFuture;
+        }
+
+        @Override
+        public boolean tryReserveMemory(long delta)
+        {
+            return true;
+        }
+
+        public void updateBlockedFuture(ListenableFuture<?> blockedFuture)
+        {
+            this.blockedFuture = requireNonNull(blockedFuture);
+        }
+    }
+
+    private BroadcastOutputBuffer createBroadcastBuffer(OutputBuffers outputBuffers, DataSize dataSize, AggregatedMemoryContext memoryContext, Executor notificationExecutor)
+    {
+        BroadcastOutputBuffer buffer = new BroadcastOutputBuffer(
+                TASK_INSTANCE_ID,
+                new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
+                dataSize,
+                () -> memoryContext.newLocalMemoryContext(),
+                notificationExecutor);
+        buffer.setOutputBuffers(outputBuffers);
+        return buffer;
+    }
+
+    @Test
     public void testBufferFinishesWhenClientBuffersDestroyed()
     {
         BroadcastOutputBuffer buffer = createBroadcastBuffer(
@@ -960,6 +1118,7 @@ public class TestBroadcastOutputBuffer
         buffer.abort(THIRD);
         assertTrue(buffer.isFinished());
     }
+
     private BroadcastOutputBuffer createBroadcastBuffer(OutputBuffers outputBuffers, DataSize dataSize)
     {
         BroadcastOutputBuffer buffer = new BroadcastOutputBuffer(

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -70,7 +70,6 @@ public class TestMemoryPools
     private QueryId fakeQueryId;
     private LocalQueryRunner localQueryRunner;
     private MemoryPool userPool;
-    private MemoryPool systemPool;
     private List<Driver> drivers;
     private TaskContext taskContext;
 
@@ -90,14 +89,12 @@ public class TestMemoryPools
         localQueryRunner.createCatalog("tpch", new TpchConnectorFactory(1), ImmutableMap.of());
 
         userPool = new MemoryPool(new MemoryPoolId("test"), TEN_MEGABYTES);
-        systemPool = new MemoryPool(new MemoryPoolId("testSystem"), TEN_MEGABYTES);
         fakeQueryId = new QueryId("fake");
         SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(new DataSize(1, GIGABYTE));
-        QueryContext queryContext = new QueryContext(
-                new QueryId("query"),
+        DefaultQueryContext queryContext = new DefaultQueryContext(new QueryId("query"),
                 TEN_MEGABYTES,
+                new DataSize(20, MEGABYTE),
                 userPool,
-                systemPool,
                 new TestingGcMonitor(),
                 localQueryRunner.getExecutor(),
                 localQueryRunner.getScheduler(),
@@ -196,7 +193,7 @@ public class TestMemoryPools
         setupConsumeRevocableMemory(ONE_BYTE, 10);
         assertTrue(userPool.tryReserve(fakeQueryId, TEN_MEGABYTES_WITHOUT_TWO_BYTES.toBytes()));
 
-        // we expect 2 iterations as we have 2 bytes remaining in system pool and we allocate 1 byte per page
+        // we expect 2 iterations as we have 2 bytes remaining in memory pool and we allocate 1 byte per page
         assertEquals(runDriversUntilBlocked(waitingForRevocableSystemMemory()), 2);
         assertTrue(userPool.getFreeBytes() <= 0, String.format("Expected empty pool but got [%d]", userPool.getFreeBytes()));
 
@@ -217,7 +214,7 @@ public class TestMemoryPools
         RevocableMemoryOperator revocableMemoryOperator = setupConsumeRevocableMemory(ONE_BYTE, 5);
         assertTrue(userPool.tryReserve(fakeQueryId, TEN_MEGABYTES_WITHOUT_TWO_BYTES.toBytes()));
 
-        // we expect 2 iterations as we have 2 bytes remaining in system pool and we allocate 1 byte per page
+        // we expect 2 iterations as we have 2 bytes remaining in memory pool and we allocate 1 byte per page
         assertEquals(runDriversUntilBlocked(waitingForRevocableSystemMemory()), 2);
         revocableMemoryOperator.getOperatorContext().requestMemoryRevoking();
 

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
@@ -13,24 +13,42 @@
  */
 package com.facebook.presto.memory;
 
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskStateMachine;
 import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spiller.SpillSpaceTracker;
 import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.units.DataSize;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 import static com.facebook.presto.memory.LocalMemoryManager.RESERVED_POOL;
 import static com.facebook.presto.memory.LocalMemoryManager.SYSTEM_POOL;
+import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestQueryContext
 {
+    private final ScheduledExecutorService taskNotificationExecutor = newScheduledThreadPool(1, threadsNamed("task-notification-%s"));
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        taskNotificationExecutor.shutdownNow();
+    }
+
     @DataProvider
     public Object[][] testSetMemoryPoolOptions()
     {
@@ -51,11 +69,11 @@ public class TestQueryContext
         }
 
         try (LocalQueryRunner localQueryRunner = new LocalQueryRunner(TEST_SESSION)) {
-            QueryContext queryContext = new QueryContext(
+            DefaultQueryContext queryContext = new DefaultQueryContext(
                     new QueryId("query"),
                     new DataSize(10, BYTE),
+                    new DataSize(20, BYTE),
                     new MemoryPool(GENERAL_POOL, new DataSize(10, BYTE)),
-                    new MemoryPool(SYSTEM_POOL, new DataSize(10, BYTE)),
                     new TestingGcMonitor(),
                     localQueryRunner.getExecutor(),
                     localQueryRunner.getScheduler(),
@@ -77,6 +95,39 @@ public class TestQueryContext
             // Free memory
             userMemoryContext.close();
             revocableMemoryContext.close();
+        }
+    }
+
+    @Test
+    public void testLegacyQueryContext()
+    {
+        MemoryPool generalPool = new MemoryPool(GENERAL_POOL, new DataSize(10_000, BYTE));
+        MemoryPool systemPool = new MemoryPool(SYSTEM_POOL, new DataSize(10_000, BYTE));
+        try (LocalQueryRunner localQueryRunner = new LocalQueryRunner(TEST_SESSION)) {
+            LegacyQueryContext queryContext = new LegacyQueryContext(
+                    new QueryId("query"),
+                    new DataSize(10, BYTE),
+                    generalPool,
+                    systemPool,
+                    new TestingGcMonitor(),
+                    localQueryRunner.getExecutor(),
+                    localQueryRunner.getScheduler(),
+                    new DataSize(0, BYTE),
+                    new SpillSpaceTracker(new DataSize(0, BYTE)));
+            TaskStateMachine taskStateMachine = new TaskStateMachine(TaskId.valueOf("task-id"), taskNotificationExecutor);
+            TaskContext taskContext = queryContext.addTaskContext(taskStateMachine, TEST_SESSION, false, false);
+            LocalMemoryContext systemContext = taskContext.localSystemMemoryContext();
+            ListenableFuture<?> blocked = systemContext.setBytes(10_000);
+
+            // even if the system pool is full, we don't block system allocations for LegacyQueryContext
+            assertTrue(blocked.isDone());
+            assertEquals(systemPool.getReservedBytes(), 10_000);
+            assertEquals(generalPool.getReservedBytes(), 0);
+
+            systemContext.close();
+
+            assertEquals(systemPool.getReservedBytes(), 0);
+            assertEquals(generalPool.getReservedBytes(), 0);
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.presto.ScheduledSplit;
+import com.facebook.presto.Session;
+import com.facebook.presto.TaskSource;
+import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.metadata.Split;
+import com.facebook.presto.operator.Driver;
+import com.facebook.presto.operator.DriverContext;
+import com.facebook.presto.operator.Operator;
+import com.facebook.presto.operator.TableScanOperator;
+import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.FixedPageSource;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.split.PageSourceProvider;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.PageConsumerOperator;
+import com.facebook.presto.testing.TestingTaskContext;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+
+import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestSystemMemoryBlocking
+{
+    private static final QueryId QUERY_ID = new QueryId("test_query");
+
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduledExecutor;
+    private DriverContext driverContext;
+    private MemoryPool memoryPool;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        TaskContext taskContext = TestingTaskContext.builder(executor, scheduledExecutor, TEST_SESSION)
+                .setQueryMaxMemory(DataSize.valueOf("100MB"))
+                .setMemoryPoolSize(DataSize.valueOf("10B"))
+                .setQueryId(QUERY_ID)
+                .build();
+        memoryPool = taskContext.getQueryContext().getMemoryPool();
+        driverContext = taskContext
+                .addPipelineContext(0, true, true)
+                .addDriverContext();
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testTableScanSystemMemoryBlocking()
+    {
+        PlanNodeId sourceId = new PlanNodeId("source");
+        final List<Type> types = ImmutableList.of(VARCHAR);
+        TableScanOperator source = new TableScanOperator(driverContext.addOperatorContext(1, new PlanNodeId("test"), "values"),
+                sourceId,
+                new PageSourceProvider()
+                {
+                    @Override
+                    public ConnectorPageSource createPageSource(Session session, Split split, List<ColumnHandle> columns)
+                    {
+                        return new FixedPageSource(rowPagesBuilder(types)
+                                .addSequencePage(10, 1)
+                                .addSequencePage(10, 1)
+                                .addSequencePage(10, 1)
+                                .addSequencePage(10, 1)
+                                .addSequencePage(10, 1)
+                                .build());
+                    }
+                },
+                types,
+                ImmutableList.of());
+        PageConsumerOperator sink = createSinkOperator(source);
+        Driver driver = Driver.createDriver(driverContext, source, sink);
+        assertSame(driver.getDriverContext(), driverContext);
+        assertFalse(driver.isFinished());
+        Split testSplit = new Split(new ConnectorId("test"), TestingTransactionHandle.create(), new TestSplit());
+        driver.updateSource(new TaskSource(sourceId, ImmutableSet.of(new ScheduledSplit(0, sourceId, testSplit)), true));
+
+        ListenableFuture blocked = driver.processFor(new Duration(1, NANOSECONDS));
+
+        // the driver shouldn't block in the first call as it will be able to move a page between source and the sink operator
+        // but the operator should be blocked
+        assertTrue(blocked.isDone());
+        assertFalse(source.getOperatorContext().isWaitingForMemory().isDone());
+
+        // in the subsequent calls both the driver and the operator should be blocked
+        // and they should stay blocked until more memory becomes available
+        for (int i = 0; i < 10; i++) {
+            blocked = driver.processFor(new Duration(1, NANOSECONDS));
+            assertFalse(blocked.isDone());
+            assertFalse(source.getOperatorContext().isWaitingForMemory().isDone());
+        }
+
+        // free up some memory
+        memoryPool.free(QUERY_ID, memoryPool.getReservedBytes());
+
+        // the operator should be unblocked
+        assertTrue(source.getOperatorContext().isWaitingForMemory().isDone());
+
+        // the driver shouldn't be blocked
+        blocked = driver.processFor(new Duration(1, NANOSECONDS));
+        assertTrue(blocked.isDone());
+    }
+
+    private PageConsumerOperator createSinkOperator(Operator source)
+    {
+        // materialize the output to catch some type errors
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(driverContext.getSession(), source.getTypes());
+        return new PageConsumerOperator(driverContext.addOperatorContext(2, new PlanNodeId("test"), "sink"), resultBuilder::page, Function.identity());
+    }
+
+    private static class TestSplit
+            implements ConnectorSplit
+    {
+        @Override
+        public boolean isRemotelyAccessible()
+        {
+            return false;
+        }
+
+        @Override
+        public List<HostAddress> getAddresses()
+        {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public Object getInfo()
+        {
+            return null;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
@@ -195,7 +195,6 @@ public class BenchmarkPartitionedOutputOperator
         {
             return TestingTaskContext.builder(EXECUTOR, SCHEDULER, TEST_SESSION)
                     .setMemoryPoolSize(MAX_MEMORY)
-                    .setSystemMemoryPoolSize(MAX_MEMORY)
                     .build()
                     .addPipelineContext(0, true, true)
                     .addDriverContext();

--- a/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
@@ -14,8 +14,8 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.memory.DefaultQueryContext;
 import com.facebook.presto.memory.MemoryPool;
-import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
@@ -79,11 +79,11 @@ public final class GroupByHashYieldAssertion
         // mock an adjustable memory pool
         QueryId queryId = new QueryId("test_query");
         MemoryPool memoryPool = new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE));
-        QueryContext queryContext = new QueryContext(
+        DefaultQueryContext queryContext = new DefaultQueryContext(
                 queryId,
                 new DataSize(512, MEGABYTE),
+                new DataSize(1024, MEGABYTE),
                 memoryPool,
-                new MemoryPool(new MemoryPoolId("test-system"), new DataSize(512, MEGABYTE)),
                 new TestingGcMonitor(),
                 EXECUTOR,
                 SCHEDULED_EXECUTOR,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -948,7 +948,7 @@ public class TestHashJoinOperator
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true).addDriverContext(), probeInput, expected, true, getHashChannels(probePages, buildPages));
     }
 
-    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of.*", dataProvider = "testMemoryLimitProvider")
+    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local user memory limit of.*", dataProvider = "testMemoryLimitProvider")
     public void testMemoryLimit(boolean parallelBuild, boolean buildHashEnabled)
     {
         TaskContext taskContext = TestingTaskContext.createTaskContext(executor, scheduledExecutor, TEST_SESSION, new DataSize(100, BYTE));

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashSemiJoinOperator.java
@@ -321,7 +321,7 @@ public class TestHashSemiJoinOperator
         OperatorAssertion.assertOperatorEquals(joinOperatorFactory, driverContext, probeInput, expected, hashEnabled, ImmutableList.of(probeTypes.size()));
     }
 
-    @Test(dataProvider = "hashEnabledValues", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of.*")
+    @Test(dataProvider = "hashEnabledValues", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local user memory limit of.*")
     public void testMemoryLimit(boolean hashEnabled)
     {
         DriverContext driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION, new DataSize(100, BYTE))

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
@@ -161,7 +161,7 @@ public class TestOrderByOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 10B")
+    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local user memory limit of 10B")
     public void testMemoryLimit()
     {
         List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
@@ -204,7 +204,7 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local memory limit of 10B")
+    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded local user memory limit of 10B")
     public void testMemoryLimit()
     {
         List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -75,6 +75,7 @@ public class TestBasicQueryInfo
                                 DataSize.valueOf("22GB"),
                                 DataSize.valueOf("23GB"),
                                 DataSize.valueOf("24GB"),
+                                DataSize.valueOf("25GB"),
                                 true,
                                 Duration.valueOf("23m"),
                                 Duration.valueOf("24m"),
@@ -133,7 +134,7 @@ public class TestBasicQueryInfo
 
         assertEquals(basicInfo.getQueryStats().getCumulativeUserMemory(), 20.0);
         assertEquals(basicInfo.getQueryStats().getUserMemoryReservation(), DataSize.valueOf("21GB"));
-        assertEquals(basicInfo.getQueryStats().getPeakUserMemoryReservation(), DataSize.valueOf("22GB"));
+        assertEquals(basicInfo.getQueryStats().getPeakUserMemoryReservation(), DataSize.valueOf("23GB"));
         assertEquals(basicInfo.getQueryStats().getTotalCpuTime(), Duration.valueOf("24m"));
 
         assertEquals(basicInfo.getQueryStats().isFullyBlocked(), true);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -126,6 +126,7 @@ public class TestQueryStateInfo
                         DataSize.valueOf("22GB"),
                         DataSize.valueOf("23GB"),
                         DataSize.valueOf("24GB"),
+                        DataSize.valueOf("25GB"),
                         true,
                         Duration.valueOf("23m"),
                         Duration.valueOf("24m"),

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/AbstractAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/AbstractAggregatedMemoryContext.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory.context;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.lang.String.format;
+
+@ThreadSafe
+abstract class AbstractAggregatedMemoryContext
+        implements AggregatedMemoryContext
+{
+    static final ListenableFuture<?> NOT_BLOCKED = Futures.immediateFuture(null);
+
+    @GuardedBy("this")
+    private long usedBytes;
+    @GuardedBy("this")
+    private boolean closed;
+
+    @Override
+    public AbstractAggregatedMemoryContext newAggregatedMemoryContext()
+    {
+        return new ChildAggregatedMemoryContext(this);
+    }
+
+    @Override
+    public LocalMemoryContext newLocalMemoryContext()
+    {
+        return new SimpleLocalMemoryContext(this);
+    }
+
+    @Override
+    public synchronized long getBytes()
+    {
+        return usedBytes;
+    }
+
+    @Override
+    public synchronized void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        closeContext();
+        usedBytes = 0;
+    }
+
+    @Override
+    public synchronized String toString()
+    {
+        return toStringHelper(this)
+                .add("usedBytes", usedBytes)
+                .add("closed", closed)
+                .toString();
+    }
+
+    synchronized void addBytes(long bytes)
+    {
+        usedBytes = addExact(usedBytes, bytes);
+    }
+
+    abstract ListenableFuture<?> updateBytes(long bytes);
+
+    abstract boolean tryUpdateBytes(long delta);
+
+    @Nullable
+    abstract AbstractAggregatedMemoryContext getParent();
+
+    abstract void closeContext();
+
+    static long addExact(long usedBytes, long bytes)
+    {
+        try {
+            return Math.addExact(usedBytes, bytes);
+        }
+        catch (ArithmeticException e) {
+            throw new RuntimeException(format("Overflow detected. usedBytes: %d, bytes: %d", usedBytes, bytes), e);
+        }
+    }
+}

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/AggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/AggregatedMemoryContext.java
@@ -13,91 +13,23 @@
  */
 package com.facebook.presto.memory.context;
 
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.ThreadSafe;
-
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.lang.String.format;
-
-@ThreadSafe
-public abstract class AggregatedMemoryContext
+public interface AggregatedMemoryContext
 {
-    static final ListenableFuture<?> NOT_BLOCKED = Futures.immediateFuture(null);
-
-    @GuardedBy("this")
-    private long usedBytes;
-    @GuardedBy("this")
-    private boolean closed;
-
-    public static AggregatedMemoryContext newSimpleAggregatedMemoryContext()
+    static AggregatedMemoryContext newSimpleAggregatedMemoryContext()
     {
         return new SimpleAggregatedMemoryContext();
     }
 
-    public AggregatedMemoryContext newAggregatedMemoryContext()
-    {
-        return new ChildAggregatedMemoryContext(this);
-    }
-
-    public static AggregatedMemoryContext newRootAggregatedMemoryContext(MemoryReservationHandler reservationHandler, long guaranteedMemoryInBytes)
+    static AggregatedMemoryContext newRootAggregatedMemoryContext(MemoryReservationHandler reservationHandler, long guaranteedMemoryInBytes)
     {
         return new RootAggregatedMemoryContext(reservationHandler, guaranteedMemoryInBytes);
     }
 
-    public LocalMemoryContext newLocalMemoryContext()
-    {
-        return new SimpleLocalMemoryContext(this);
-    }
+    AggregatedMemoryContext newAggregatedMemoryContext();
 
-    public synchronized long getBytes()
-    {
-        return usedBytes;
-    }
+    LocalMemoryContext newLocalMemoryContext();
 
-    public synchronized void close()
-    {
-        if (closed) {
-            return;
-        }
-        closed = true;
-        closeContext();
-        usedBytes = 0;
-    }
+    long getBytes();
 
-    @Override
-    public synchronized String toString()
-    {
-        return toStringHelper(this)
-                .add("usedBytes", usedBytes)
-                .add("closed", closed)
-                .toString();
-    }
-
-    synchronized void addBytes(long bytes)
-    {
-        usedBytes = addExact(usedBytes, bytes);
-    }
-
-    abstract ListenableFuture<?> updateBytes(long bytes);
-
-    abstract boolean tryUpdateBytes(long delta);
-
-    @Nullable
-    abstract AggregatedMemoryContext getParent();
-
-    abstract void closeContext();
-
-    static long addExact(long usedBytes, long bytes)
-    {
-        try {
-            return Math.addExact(usedBytes, bytes);
-        }
-        catch (ArithmeticException e) {
-            throw new RuntimeException(format("Overflow detected. usedBytes: %d, bytes: %d", usedBytes, bytes), e);
-        }
-    }
+    void close();
 }

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/RootAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/RootAggregatedMemoryContext.java
@@ -18,7 +18,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import static java.util.Objects.requireNonNull;
 
 class RootAggregatedMemoryContext
-        extends AggregatedMemoryContext
+        extends AbstractAggregatedMemoryContext
 {
     private final MemoryReservationHandler reservationHandler;
     private final long guaranteedMemory;
@@ -29,6 +29,7 @@ class RootAggregatedMemoryContext
         this.guaranteedMemory = guaranteedMemory;
     }
 
+    @Override
     synchronized ListenableFuture<?> updateBytes(long bytes)
     {
         ListenableFuture<?> future = reservationHandler.reserveMemory(bytes);
@@ -40,6 +41,7 @@ class RootAggregatedMemoryContext
         return future;
     }
 
+    @Override
     synchronized boolean tryUpdateBytes(long delta)
     {
         if (reservationHandler.tryReserveMemory(delta)) {
@@ -49,11 +51,13 @@ class RootAggregatedMemoryContext
         return false;
     }
 
-    synchronized AggregatedMemoryContext getParent()
+    @Override
+    synchronized AbstractAggregatedMemoryContext getParent()
     {
         return null;
     }
 
+    @Override
     void closeContext()
     {
         reservationHandler.reserveMemory(-getBytes());

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/SimpleAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/SimpleAggregatedMemoryContext.java
@@ -19,24 +19,28 @@ import com.google.common.util.concurrent.ListenableFuture;
  * SimpleAggregatedMemoryContext doesn't have a parent or a reservation handler. It just counts bytes.
  */
 class SimpleAggregatedMemoryContext
-        extends AggregatedMemoryContext
+        extends AbstractAggregatedMemoryContext
 {
+    @Override
     synchronized ListenableFuture<?> updateBytes(long bytes)
     {
         addBytes(bytes);
         return NOT_BLOCKED;
     }
 
+    @Override
     synchronized boolean tryUpdateBytes(long delta)
     {
         addBytes(delta);
         return true;
     }
 
-    synchronized AggregatedMemoryContext getParent()
+    @Override
+    synchronized AbstractAggregatedMemoryContext getParent()
     {
         return null;
     }
 
+    @Override
     void closeContext() {}
 }

--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -42,6 +42,7 @@ plugin.bundles=\
 presto.version=testversion
 distributed-joins-enabled=true
 query.max-memory-per-node=1GB
+query.max-total-memory-per-node=1.25GB
 query.max-memory=1GB
 redistribute-writes=false
 reorder-joins=true

--- a/presto-product-tests/conf/presto/etc/multinode-master.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-master.properties
@@ -13,6 +13,7 @@ node-scheduler.include-coordinator=false
 http-server.http.port=8080
 query.max-memory=1GB
 query.max-memory-per-node=512MB
+query.max-total-memory-per-node=1GB
 discovery-server.enabled=true
 discovery.uri=http://presto-master:8080
 reorder-joins=true

--- a/presto-product-tests/conf/presto/etc/multinode-tls-master.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-tls-master.properties
@@ -16,6 +16,7 @@ discovery.uri=https://presto-master.docker.cluster:7778
 
 query.max-memory=1GB
 query.max-memory-per-node=512MB
+query.max-total-memory-per-node=1GB
 
 http-server.http.enabled=false
 http-server.https.enabled=true

--- a/presto-product-tests/conf/presto/etc/multinode-tls-worker.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-tls-worker.properties
@@ -15,6 +15,7 @@ discovery.uri=https://presto-master.docker.cluster:7778
 
 query.max-memory=1GB
 query.max-memory-per-node=512MB
+query.max-total-memory-per-node=1GB
 
 http-server.http.enabled=false
 http-server.https.enabled=true

--- a/presto-product-tests/conf/presto/etc/multinode-worker.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-worker.properties
@@ -12,5 +12,6 @@ coordinator=false
 http-server.http.port=8081
 query.max-memory=1GB
 query.max-memory-per-node=512MB
+query.max-total-memory-per-node=1GB
 discovery-server.enabled=false
 discovery.uri=http://presto-master:8080

--- a/presto-product-tests/conf/presto/etc/singlenode-kerberized.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-kerberized.properties
@@ -13,6 +13,7 @@ coordinator=true
 node-scheduler.include-coordinator=true
 query.max-memory=1GB
 query.max-memory-per-node=512MB
+query.max-total-memory-per-node=1GB
 discovery-server.enabled=true
 discovery.uri=https://presto-master.docker.cluster:7778
 

--- a/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
@@ -13,6 +13,7 @@ coordinator=true
 node-scheduler.include-coordinator=true
 query.max-memory=1GB
 query.max-memory-per-node=512MB
+query.max-total-memory-per-node=1GB
 discovery-server.enabled=true
 discovery.uri=https://presto-master:8443
 

--- a/presto-product-tests/conf/presto/etc/singlenode.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode.properties
@@ -13,6 +13,7 @@ node-scheduler.include-coordinator=true
 http-server.http.port=8080
 query.max-memory=2GB
 query.max-memory-per-node=1GB
+query.max-total-memory-per-node=1.25GB
 discovery-server.enabled=true
 discovery.uri=http://presto-master:8080
 reorder-joins=true

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSink.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSink.java
@@ -32,10 +32,10 @@ public interface ConnectorPageSink
     }
 
     /**
-     * Get the total memory that needs to be reserved in the system memory pool.
+     * Get the total memory that needs to be reserved in the general memory pool.
      * This memory should include any buffers, etc. that are used for reading data.
      *
-     * @return the system memory used so far in table read
+     * @return the memory used so far in table read
      */
     default long getSystemMemoryUsage()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSource.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSource.java
@@ -45,10 +45,10 @@ public interface ConnectorPageSource
     Page getNextPage();
 
     /**
-     * Get the total memory that needs to be reserved in the system memory pool.
+     * Get the total memory that needs to be reserved in the general memory pool.
      * This memory should include any buffers, etc. that are used for reading data.
      *
-     * @return the system memory used so far in table read
+     * @return the memory used so far in table read
      */
     long getSystemMemoryUsage();
 

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -39,7 +39,6 @@ import static com.facebook.presto.execution.QueryState.FINISHED;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 import static com.facebook.presto.memory.LocalMemoryManager.RESERVED_POOL;
-import static com.facebook.presto.memory.LocalMemoryManager.SYSTEM_POOL;
 import static com.facebook.presto.operator.BlockedReason.WAITING_FOR_MEMORY;
 import static com.facebook.presto.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
@@ -75,6 +74,7 @@ public class TestMemoryManager
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("query.max-memory-per-node", "1kB")
+                .put("query.max-total-memory-per-node", "1kB")
                 .put("query.max-memory", "1kB")
                 .build();
 
@@ -176,8 +176,6 @@ public class TestMemoryManager
                 assertEquals(reserved.getMaxBytes(), reserved.getFreeBytes());
                 MemoryPool general = worker.getLocalMemoryManager().getPool(GENERAL_POOL);
                 assertEquals(general.getMaxBytes(), general.getFreeBytes());
-                MemoryPool system = worker.getLocalMemoryManager().getPool(SYSTEM_POOL);
-                assertEquals(system.getMaxBytes(), system.getFreeBytes());
             }
         }
     }
@@ -235,17 +233,12 @@ public class TestMemoryManager
                 }
             }
 
-            // Release the memory in the reserved pool and the system pool
+            // Release the memory in the reserved pool
             for (TestingPrestoServer server : queryRunner.getServers()) {
                 MemoryPool reserved = server.getLocalMemoryManager().getPool(RESERVED_POOL);
                 // Free up the entire pool
                 reserved.free(fakeQueryId, reserved.getMaxBytes());
                 assertTrue(reserved.getFreeBytes() > 0);
-
-                MemoryPool system = server.getLocalMemoryManager().getPool(SYSTEM_POOL);
-                // Free up the entire pool
-                system.free(fakeQueryId, system.getMaxBytes());
-                assertTrue(system.getFreeBytes() > 0);
             }
 
             // Make sure both queries finish now that there's memory free in the reserved pool.
@@ -267,8 +260,6 @@ public class TestMemoryManager
                 // Free up the memory we reserved earlier
                 general.free(fakeQueryId, general.getMaxBytes());
                 assertEquals(general.getMaxBytes(), general.getFreeBytes());
-                MemoryPool system = worker.getLocalMemoryManager().getPool(SYSTEM_POOL);
-                assertEquals(system.getMaxBytes(), system.getFreeBytes());
             }
         }
     }
@@ -307,7 +298,7 @@ public class TestMemoryManager
         }
     }
 
-    @Test(timeOut = 60_000, expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Query exceeded local memory limit of 1kB.*")
+    @Test(timeOut = 60_000, expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Query exceeded local user memory limit of 1kB.*")
     public void testQueryMemoryPerNodeLimit()
             throws Exception
     {

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyQueryContext.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyQueryContext.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.SqlTaskManager;
+import com.facebook.presto.execution.TestingSessionContext;
+import com.facebook.presto.memory.LegacyQueryContext;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.waitForQueryState;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.airlift.testing.Assertions.assertInstanceOf;
+
+@Test(singleThreaded = true)
+public class TestLegacyQueryContext
+{
+    private DistributedQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        queryRunner = TpchQueryRunnerBuilder.builder().setExtraProperties(ImmutableMap.of("deprecated.legacy-system-pool-enabled", "true")).build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+    }
+
+    @Test(timeOut = 60_000L)
+    public void testLegacyQueryContext()
+            throws Exception
+    {
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        QueryId queryId = queryManager.createQuery(new TestingSessionContext(TEST_SESSION),
+                "SELECT * FROM lineitem").getQueryId();
+
+        waitForQueryState(queryRunner, queryId, RUNNING);
+
+        // cancel query
+        queryManager.failQuery(queryId, new PrestoException(GENERIC_INTERNAL_ERROR, "mock exception"));
+
+        // assert that LegacyQueryContext is used instead of the DefaultQueryContext
+        SqlTaskManager taskManager = (SqlTaskManager) queryRunner.getServers().get(0).getTaskManager();
+        assertInstanceOf(taskManager.getQueryContext(queryId), LegacyQueryContext.class);
+    }
+}


### PR DESCRIPTION
Only 714578a needs a review, the other commits have already been reviewed.

Commit 714578a adds a new config property `deprecated.legacy-system-pool-enabled` to enable the system memory pool (by default the system pool is disabled). This flag will help us roll this change out in a safer way. To support the system pool I added a new class `LegacyQueryContext`, which has the old behavior, and the `DefaultQueryContext` has the new behavior (system allocations go to general pool). There is some code duplication among these context classes, but this is a temporary (and a somewhat clean) solution and once we have more confidence in this change I am going to delete the `LegacyQueryContext` and we will have a single `QueryContext`. So, once the system pool is removed completely I am going to clean up these classes.

Open issues:
- This patch also added support for blocking for system allocations to various operators and output buffers. When `deprecated.legacy-system-pool-enabled=true` (old behavior), do we want to also disable this blocking behavior? I guess an easy way to do it is to return `NOT_BLOCKED` in `LegacyQueryContext::updateSystemMemory()`. If we want to have the config to rollback this change 100% then it makes sense to also revert the blocking behavior.