### PR TITLE
Update to ASM 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -619,7 +619,7 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>6.0</version>
+                <version>6.1.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This expression fails with ASM 6.0 in ClassReader constructor:
`new ClassReader(classLoader.getResourceAsStream('java/lang/Object.class'))`.
It throws IllegalArgumentException in Java 10.0.1.

Downgrading Java to 9.0.4 or upgrading ASM to 6.1.1 fixes the problem.