### PR TITLE
Remove ORC min row count wtih min stripe size

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -27,6 +27,18 @@ public class OrcFileWriterConfig
         return options;
     }
 
+    public DataSize getStripeMinSize()
+    {
+        return options.getStripeMinSize();
+    }
+
+    @Config("hive.orc.writer.stripe-min-size")
+    public OrcFileWriterConfig setStripeMinSize(DataSize stripeMinSize)
+    {
+        options = options.withStripeMinSize(stripeMinSize);
+        return this;
+    }
+
     public DataSize getStripeMaxSize()
     {
         return options.getStripeMaxSize();
@@ -36,18 +48,6 @@ public class OrcFileWriterConfig
     public OrcFileWriterConfig setStripeMaxSize(DataSize stripeMaxSize)
     {
         options = options.withStripeMaxSize(stripeMaxSize);
-        return this;
-    }
-
-    public int getStripeMinRowCount()
-    {
-        return options.getStripeMinRowCount();
-    }
-
-    @Config("hive.orc.writer.stripe-min-rows")
-    public OrcFileWriterConfig setStripeMinRowCount(int stripeMinRowCount)
-    {
-        options = options.withStripeMinRowCount(stripeMinRowCount);
         return this;
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -32,8 +32,8 @@ public class TestOrcFileWriterConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(OrcFileWriterConfig.class)
+                .setStripeMinSize(new DataSize(32, MEGABYTE))
                 .setStripeMaxSize(new DataSize(64, MEGABYTE))
-                .setStripeMinRowCount(100_000)
                 .setStripeMaxRowCount(10_000_000)
                 .setRowGroupMaxRowCount(10_000)
                 .setDictionaryMaxMemory(new DataSize(16, MEGABYTE))
@@ -45,8 +45,8 @@ public class TestOrcFileWriterConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.orc.writer.stripe-min-size", "13MB")
                 .put("hive.orc.writer.stripe-max-size", "27MB")
-                .put("hive.orc.writer.stripe-min-rows", "33")
                 .put("hive.orc.writer.stripe-max-rows", "44")
                 .put("hive.orc.writer.row-group-max-rows", "11")
                 .put("hive.orc.writer.dictionary-max-memory", "13MB")
@@ -55,8 +55,8 @@ public class TestOrcFileWriterConfig
                 .build();
 
         OrcFileWriterConfig expected = new OrcFileWriterConfig()
+                .setStripeMinSize(new DataSize(13, MEGABYTE))
                 .setStripeMaxSize(new DataSize(27, MEGABYTE))
-                .setStripeMinRowCount(33)
                 .setStripeMaxRowCount(44)
                 .setRowGroupMaxRowCount(11)
                 .setDictionaryMaxMemory(new DataSize(13, MEGABYTE))

--- a/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
@@ -39,19 +39,18 @@ public class DictionaryCompressionOptimizer
     private final Set<DictionaryColumnManager> allWriters;
     private final Set<DictionaryColumnManager> dictionaryWriters = new HashSet<>();
 
+    private final int stripeMinBytes;
     private final int stripeMaxBytes;
-    private final int stripeMinRowCount;
     private final int stripeMaxRowCount;
     private final int dictionaryMemoryMaxBytesLow;
     private final int dictionaryMemoryMaxBytesHigh;
 
     private int dictionaryMemoryBytes;
-    private int stripeRowCount;
 
     public DictionaryCompressionOptimizer(
             Set<? extends DictionaryColumn> writers,
+            int stripeMinBytes,
             int stripeMaxBytes,
-            int stripeMinRowCount,
             int stripeMaxRowCount,
             int dictionaryMemoryMaxBytes)
     {
@@ -60,13 +59,13 @@ public class DictionaryCompressionOptimizer
                 .map(DictionaryColumnManager::new)
                 .collect(toSet()));
 
-        checkArgument(stripeMaxBytes >= 0, "stripeMaxBytes is negative");
+        checkArgument(stripeMinBytes >= 0, "stripeMinBytes is negative");
+        this.stripeMinBytes = stripeMinBytes;
+
+        checkArgument(stripeMaxBytes >= stripeMinBytes, "stripeMaxBytes is less than stripeMinBytes");
         this.stripeMaxBytes = stripeMaxBytes;
 
-        checkArgument(stripeMinRowCount >= 0, "stripeMinRowCount is negative");
-        this.stripeMinRowCount = stripeMinRowCount;
-
-        checkArgument(stripeMaxRowCount >= stripeMinRowCount, "stripeMaxRowCount is less than stripeMinRowCount");
+        checkArgument(stripeMaxRowCount >= 0, "stripeMaxRowCount is negative");
         this.stripeMaxRowCount = stripeMaxRowCount;
 
         checkArgument(dictionaryMemoryMaxBytes >= 0, "dictionaryMemoryMaxBytes is negative");
@@ -81,11 +80,11 @@ public class DictionaryCompressionOptimizer
         return dictionaryMemoryBytes;
     }
 
-    public boolean isFull()
+    public boolean isFull(long bufferedBytes)
     {
         // if the strip is big enough to flush, stop before we hit the absolute max, so we are
         // not forced to convert a dictionary to direct to fit in memory
-        if (stripeRowCount > stripeMinRowCount) {
+        if (bufferedBytes > stripeMinBytes) {
             return dictionaryMemoryBytes > dictionaryMemoryMaxBytesLow;
         }
         // strip is small, grow to the high water mark (so at the very least we have more information)
@@ -114,7 +113,6 @@ public class DictionaryCompressionOptimizer
 
         // update the dictionary growth history
         dictionaryWriters.forEach(column -> column.updateHistory(stripeRowCount));
-        this.stripeRowCount = stripeRowCount;
 
         if (dictionaryMemoryBytes <= dictionaryMemoryMaxBytesLow) {
             return;
@@ -139,11 +137,11 @@ public class DictionaryCompressionOptimizer
             if (projection.getColumnToConvert().getCompressionRatio() >= DICTIONARY_ALWAYS_KEEP_COMPRESSION_RATIO) {
                 return;
             }
-            convertToDirect(projection.getColumnToConvert());
+            nonDictionaryBufferedBytes += convertToDirect(projection.getColumnToConvert());
         }
 
         // if the stripe is larger then the minimum row count, we are not required to convert any more dictionary columns to direct
-        if (stripeRowCount >= stripeMinRowCount) {
+        if (nonDictionaryBufferedBytes + dictionaryMemoryBytes >= stripeMinBytes) {
             // check if we can get better compression by converting a dictionary column to direct.  This can happen when then there are multiple
             // dictionary columns and one does not compress well, so if we convert it to direct we can continue to use the existing dictionaries
             // for the other columns.
@@ -153,7 +151,7 @@ public class DictionaryCompressionOptimizer
                 if (projection.getPredictedFileCompressionRatio() < currentCompressionRatio) {
                     return;
                 }
-                convertToDirect(projection.getColumnToConvert());
+                nonDictionaryBufferedBytes += convertToDirect(projection.getColumnToConvert());
             }
         }
     }
@@ -166,11 +164,12 @@ public class DictionaryCompressionOptimizer
                 .forEach(this::convertToDirect);
     }
 
-    private void convertToDirect(DictionaryColumnManager dictionaryWriter)
+    private long convertToDirect(DictionaryColumnManager dictionaryWriter)
     {
         dictionaryMemoryBytes -= dictionaryWriter.getDictionaryBytes();
-        dictionaryWriter.convertToDirect();
+        long directBytes = dictionaryWriter.convertToDirect();
         dictionaryWriters.remove(dictionaryWriter);
+        return directBytes;
     }
 
     private double currentCompressionRatio(int allOtherBytes)
@@ -285,7 +284,7 @@ public class DictionaryCompressionOptimizer
 
         int getDictionaryBytes();
 
-        void convertToDirect();
+        long convertToDirect();
     }
 
     private static class DictionaryColumnManager
@@ -306,10 +305,10 @@ public class DictionaryCompressionOptimizer
             this.dictionaryColumn = dictionaryColumn;
         }
 
-        void convertToDirect()
+        long convertToDirect()
         {
             directEncoded = true;
-            dictionaryColumn.convertToDirect();
+            return dictionaryColumn.convertToDirect();
         }
 
         void reset()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -24,16 +24,16 @@ import static java.util.Objects.requireNonNull;
 
 public class OrcWriterOptions
 {
+    private static final DataSize DEFAULT_STRIPE_MIN_SIZE = new DataSize(32, MEGABYTE);
     private static final DataSize DEFAULT_STRIPE_MAX_SIZE = new DataSize(64, MEGABYTE);
-    private static final int DEFAULT_STRIPE_MIN_ROW_COUNT = 100_000;
     private static final int DEFAULT_STRIPE_MAX_ROW_COUNT = 10_000_000;
     private static final int DEFAULT_ROW_GROUP_MAX_ROW_COUNT = 10_000;
     private static final DataSize DEFAULT_DICTIONARY_MAX_MEMORY = new DataSize(16, MEGABYTE);
     public static final DataSize DEFAULT_MAX_STRING_STATISTICS_LIMIT = new DataSize(64, BYTE);
     private static final DataSize DEFAULT_MAX_COMPRESSION_BUFFER_SIZE = new DataSize(256, KILOBYTE);
 
+    private final DataSize stripeMinSize;
     private final DataSize stripeMaxSize;
-    private final int stripeMinRowCount;
     private final int stripeMaxRowCount;
     private final int rowGroupMaxRowCount;
     private final DataSize dictionaryMaxMemory;
@@ -43,8 +43,8 @@ public class OrcWriterOptions
     public OrcWriterOptions()
     {
         this(
+                DEFAULT_STRIPE_MIN_SIZE,
                 DEFAULT_STRIPE_MAX_SIZE,
-                DEFAULT_STRIPE_MIN_ROW_COUNT,
                 DEFAULT_STRIPE_MAX_ROW_COUNT,
                 DEFAULT_ROW_GROUP_MAX_ROW_COUNT,
                 DEFAULT_DICTIONARY_MAX_MEMORY,
@@ -53,24 +53,24 @@ public class OrcWriterOptions
     }
 
     private OrcWriterOptions(
+            DataSize stripeMinSize,
             DataSize stripeMaxSize,
-            int stripeMinRowCount,
             int stripeMaxRowCount,
             int rowGroupMaxRowCount,
             DataSize dictionaryMaxMemory,
             DataSize maxStringStatisticsLimit,
             DataSize maxCompressionBufferSize)
     {
+        requireNonNull(stripeMinSize, "stripeMinSize is null");
         requireNonNull(stripeMaxSize, "stripeMaxSize is null");
-        checkArgument(stripeMinRowCount >= 1, "stripeMinRowCount must be at least 1");
         checkArgument(stripeMaxRowCount >= 1, "stripeMaxRowCount must be at least 1");
         checkArgument(rowGroupMaxRowCount >= 1, "rowGroupMaxRowCount must be at least 1");
         requireNonNull(dictionaryMaxMemory, "dictionaryMaxMemory is null");
         requireNonNull(maxStringStatisticsLimit, "maxStringStatisticsLimit is null");
         requireNonNull(maxCompressionBufferSize, "maxCompressionBufferSize is null");
 
+        this.stripeMinSize = stripeMinSize;
         this.stripeMaxSize = stripeMaxSize;
-        this.stripeMinRowCount = stripeMinRowCount;
         this.stripeMaxRowCount = stripeMaxRowCount;
         this.rowGroupMaxRowCount = rowGroupMaxRowCount;
         this.dictionaryMaxMemory = dictionaryMaxMemory;
@@ -78,14 +78,14 @@ public class OrcWriterOptions
         this.maxCompressionBufferSize = maxCompressionBufferSize;
     }
 
+    public DataSize getStripeMinSize()
+    {
+        return stripeMinSize;
+    }
+
     public DataSize getStripeMaxSize()
     {
         return stripeMaxSize;
-    }
-
-    public int getStripeMinRowCount()
-    {
-        return stripeMinRowCount;
     }
 
     public int getStripeMaxRowCount()
@@ -113,47 +113,47 @@ public class OrcWriterOptions
         return maxCompressionBufferSize;
     }
 
-    public OrcWriterOptions withStripeMaxSize(DataSize stripeMaxSize)
+    public OrcWriterOptions withStripeMinSize(DataSize stripeMinSize)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
-    public OrcWriterOptions withStripeMinRowCount(int stripeMinRowCount)
+    public OrcWriterOptions withStripeMaxSize(DataSize stripeMaxSize)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withStripeMaxRowCount(int stripeMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withRowGroupMaxRowCount(int rowGroupMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withDictionaryMaxMemory(DataSize dictionaryMaxMemory)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withMaxStringStatisticsLimit(DataSize maxStringStatisticsLimit)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withMaxCompressionBufferSize(DataSize maxCompressionBufferSize)
     {
-        return new OrcWriterOptions(stripeMaxSize, stripeMinRowCount, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
+                .add("stripeMinSize", stripeMinSize)
                 .add("stripeMaxSize", stripeMaxSize)
-                .add("stripeMinRowCount", stripeMinRowCount)
                 .add("stripeMaxRowCount", stripeMaxRowCount)
                 .add("rowGroupMaxRowCount", rowGroupMaxRowCount)
                 .add("dictionaryMaxMemory", dictionaryMaxMemory)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -153,7 +153,7 @@ public class SliceDictionaryColumnWriter
     }
 
     @Override
-    public void convertToDirect()
+    public long convertToDirect()
     {
         checkState(!closed);
         checkState(!directEncoded);
@@ -182,6 +182,8 @@ public class SliceDictionaryColumnWriter
         statisticsBuilder = newStringStatisticsBuilder();
 
         directEncoded = true;
+
+        return directColumnWriter.getBufferedBytes();
     }
 
     private void writeDictionaryRowGroup(Block dictionary, int valueCount, IntBigArray dictionaryIndexes)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
@@ -44,7 +44,7 @@ public class TestDictionaryCompressionOptimizer
         int stripeMaxBytes = megabytes(100);
         int bytesPerRow = 1024;
         int expectedMaxRowCount = stripeMaxBytes / bytesPerRow;
-        DataSimulator simulator = new DataSimulator(stripeMaxBytes, 10_000, expectedMaxRowCount * 2, megabytes(16), bytesPerRow);
+        DataSimulator simulator = new DataSimulator(0, stripeMaxBytes, expectedMaxRowCount * 2, megabytes(16), bytesPerRow);
 
         for (int loop = 0; loop < 3; loop++) {
             assertFalse(simulator.isDictionaryMemoryFull());
@@ -77,7 +77,7 @@ public class TestDictionaryCompressionOptimizer
         // construct a simulator that will hit the row limit first
         int stripeMaxBytes = megabytes(1000);
         int expectedMaxRowCount = 1_000_000;
-        DataSimulator simulator = new DataSimulator(stripeMaxBytes, 10_000, expectedMaxRowCount, megabytes(16), 0, column);
+        DataSimulator simulator = new DataSimulator(0, stripeMaxBytes, expectedMaxRowCount, megabytes(16), 0, column);
 
         for (int loop = 0; loop < 3; loop++) {
             assertFalse(simulator.isDictionaryMemoryFull());
@@ -115,7 +115,7 @@ public class TestDictionaryCompressionOptimizer
         int stripeMaxBytes = megabytes(100);
         int bytesPerRow = estimateIndexBytesPerValue(dictionaryEntries);
         int expectedMaxRowCount = stripeMaxBytes / bytesPerRow;
-        DataSimulator simulator = new DataSimulator(stripeMaxBytes, 10_000, expectedMaxRowCount * 10, megabytes(16), 0, column);
+        DataSimulator simulator = new DataSimulator(0, stripeMaxBytes, expectedMaxRowCount * 10, megabytes(16), 0, column);
 
         for (int loop = 0; loop < 3; loop++) {
             assertFalse(simulator.isDictionaryMemoryFull());
@@ -154,7 +154,7 @@ public class TestDictionaryCompressionOptimizer
         int stripeMaxBytes = megabytes(100);
         int dictionaryMaxMemoryBytesLow = dictionaryMaxMemoryBytes - (int) DICTIONARY_MEMORY_MAX_RANGE.toBytes();
         int expectedMaxRowCount = (int) (dictionaryMaxMemoryBytesLow / bytesPerEntry / uniquePercentage);
-        DataSimulator simulator = new DataSimulator(stripeMaxBytes, expectedMaxRowCount / 2, expectedMaxRowCount * 2, dictionaryMaxMemoryBytes, 0, column);
+        DataSimulator simulator = new DataSimulator(0, stripeMaxBytes, expectedMaxRowCount * 2, dictionaryMaxMemoryBytes, 0, column);
 
         for (int loop = 0; loop < 3; loop++) {
             assertFalse(simulator.isDictionaryMemoryFull());
@@ -192,7 +192,7 @@ public class TestDictionaryCompressionOptimizer
         // construct a simulator that will hit the dictionary memory before hitting the minimum row limit
         int stripeMaxBytes = megabytes(100);
         int expectedMaxRowCount = (int) (dictionaryMaxMemoryBytes / bytesPerEntry / uniquePercentage);
-        DataSimulator simulator = new DataSimulator(stripeMaxBytes, Integer.MAX_VALUE, Integer.MAX_VALUE, dictionaryMaxMemoryBytes, 0, column);
+        DataSimulator simulator = new DataSimulator(0, stripeMaxBytes, Integer.MAX_VALUE, dictionaryMaxMemoryBytes, 0, column);
 
         for (int loop = 0; loop < 3; loop++) {
             assertFalse(simulator.isDictionaryMemoryFull());
@@ -230,7 +230,7 @@ public class TestDictionaryCompressionOptimizer
         int stripeMaxBytes = megabytes(100);
         int expectedRowCountAtFlip = (int) ((dictionaryMaxMemoryBytes - DICTIONARY_MEMORY_MAX_RANGE.toBytes()) / bytesPerEntry);
         int expectedMaxRowCountAtFull = stripeMaxBytes / bytesPerEntry;
-        DataSimulator simulator = new DataSimulator(stripeMaxBytes, 1, expectedMaxRowCountAtFull, dictionaryMaxMemoryBytes, 0, column);
+        DataSimulator simulator = new DataSimulator(0, stripeMaxBytes, expectedMaxRowCountAtFull, dictionaryMaxMemoryBytes, 0, column);
 
         for (int loop = 0; loop < 3; loop++) {
             assertFalse(simulator.isDictionaryMemoryFull());
@@ -278,7 +278,7 @@ public class TestDictionaryCompressionOptimizer
         int stripeMaxBytes = megabytes(100);
         int expectedRowCountAtFlip = (int) (dictionaryMaxMemoryBytes / (bytesPerEntry * 2 * directUniquePercentage));
         int expectedMaxRowCountAtFull = stripeMaxBytes / (bytesPerEntry * 2);
-        DataSimulator simulator = new DataSimulator(stripeMaxBytes, expectedMaxRowCountAtFull, expectedMaxRowCountAtFull * 2, dictionaryMaxMemoryBytes, 0, directColumn, dictionaryColumn);
+        DataSimulator simulator = new DataSimulator(stripeMaxBytes / 2, stripeMaxBytes, expectedMaxRowCountAtFull * 2, dictionaryMaxMemoryBytes, 0, directColumn, dictionaryColumn);
 
         for (int loop = 0; loop < 3; loop++) {
             assertFalse(simulator.isDictionaryMemoryFull());
@@ -334,7 +334,7 @@ public class TestDictionaryCompressionOptimizer
         int dictionaryMaxMemoryBytesLow = (int) (dictionaryMaxMemoryBytes - DICTIONARY_MEMORY_MAX_RANGE.toBytes());
         int expectedRowCountAtFlip = (int) ((dictionaryMaxMemoryBytesLow - (dictionaryEntries * dictionaryBytesPerEntry)) / (directBytesPerEntry * directUniquePercentage));
         int maxRowCount = 10_000_000;
-        DataSimulator simulator = new DataSimulator(stripeMaxBytes, 1, maxRowCount, dictionaryMaxMemoryBytes, 0, directColumn, dictionaryColumn);
+        DataSimulator simulator = new DataSimulator(0, stripeMaxBytes, maxRowCount, dictionaryMaxMemoryBytes, 0, directColumn, dictionaryColumn);
 
         for (int loop = 0; loop < 3; loop++) {
             assertFalse(simulator.isDictionaryMemoryFull());
@@ -391,8 +391,8 @@ public class TestDictionaryCompressionOptimizer
         private int rowCount;
 
         public DataSimulator(
+                int stripeMinBytes,
                 int stripeMaxBytes,
-                int stripeMinRowCount,
                 int stripeMaxRowCount,
                 int dictionaryMemoryMaxBytes,
                 int otherColumnsBytesPerRow,
@@ -403,13 +403,13 @@ public class TestDictionaryCompressionOptimizer
             this.otherColumnsBytesPerRow = otherColumnsBytesPerRow;
             this.dictionaryColumns = ImmutableSet.copyOf(dictionaryColumns);
 
-            this.optimizer = new DictionaryCompressionOptimizer(this.dictionaryColumns, stripeMaxBytes, stripeMinRowCount, stripeMaxRowCount, dictionaryMemoryMaxBytes);
+            this.optimizer = new DictionaryCompressionOptimizer(this.dictionaryColumns, stripeMinBytes, stripeMaxBytes, stripeMaxRowCount, dictionaryMemoryMaxBytes);
         }
 
         public void advanceToNextStateChange()
         {
             List<Boolean> directColumnFlags = getDirectColumnFlags();
-            while (!optimizer.isFull() && getBufferedBytes() < stripeMaxBytes && getRowCount() < stripeMaxRowCount && directColumnFlags.equals(getDirectColumnFlags())) {
+            while (!optimizer.isFull(getBufferedBytes()) && getBufferedBytes() < stripeMaxBytes && getRowCount() < stripeMaxRowCount && directColumnFlags.equals(getDirectColumnFlags())) {
                 rowCount += 1024;
                 for (TestDictionaryColumn dictionaryColumn : dictionaryColumns) {
                     dictionaryColumn.advanceTo(rowCount);
@@ -420,7 +420,7 @@ public class TestDictionaryCompressionOptimizer
 
         public boolean isDictionaryMemoryFull()
         {
-            return optimizer.isFull();
+            return optimizer.isFull(getBufferedBytes());
         }
 
         public void finalOptimize()
@@ -559,10 +559,11 @@ public class TestDictionaryCompressionOptimizer
         }
 
         @Override
-        public void convertToDirect()
+        public long convertToDirect()
         {
             assertFalse(direct);
             direct = true;
+            return getBufferedBytes();
         }
 
         public boolean isDirect()

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -59,9 +59,9 @@ public class TestOrcWriter
                 ORC,
                 NONE,
                 new OrcWriterOptions()
+                        .withStripeMinSize(new DataSize(0, MEGABYTE))
                         .withStripeMaxSize(new DataSize(32, MEGABYTE))
                         .withStripeMaxRowCount(ORC_STRIPE_SIZE)
-                        .withStripeMinRowCount(ORC_STRIPE_SIZE)
                         .withRowGroupMaxRowCount(ORC_ROW_GROUP_SIZE)
                         .withDictionaryMaxMemory(new DataSize(32, MEGABYTE)),
                 ImmutableMap.of(),


### PR DESCRIPTION
Instead of enforcing a min row count use a stripe size.  This is better heuristic for large
rows, and results in better compression since large rows can still use dictionary encoding.