### PR TITLE
Write file header and footer with stripe data

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileWriter.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.OrcWriterStats;
+import com.facebook.presto.orc.OutputStreamOrcDataSink;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.Type;
@@ -76,7 +77,7 @@ public class TempFileWriter
                 .collect(toImmutableList());
 
         return new OrcWriter(
-                output,
+                new OutputStreamOrcDataSink(output),
                 columnNames,
                 types,
                 ORC,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -581,7 +581,7 @@ public abstract class AbstractTestHiveClient
 
     protected final void setup(String host, int port, String databaseName, String timeZone)
     {
-        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        HiveClientConfig hiveClientConfig = getHiveClientConfig();
         hiveClientConfig.setTimeZone(timeZone);
         String proxy = System.getProperty("hive.metastore.thrift.client.socks-proxy");
         if (proxy != null) {
@@ -621,7 +621,7 @@ public abstract class AbstractTestHiveClient
                 false,
                 true,
                 1000,
-                new HiveClientConfig().getMaxPartitionsPerScan(),
+                getHiveClientConfig().getMaxPartitionsPerScan(),
                 TYPE_MANAGER,
                 locationService,
                 new TableParameterCodec(),
@@ -652,7 +652,7 @@ public abstract class AbstractTestHiveClient
                 metastoreClient,
                 new GroupByHashPageIndexerFactory(JOIN_COMPILER),
                 TYPE_MANAGER,
-                new HiveClientConfig(),
+                getHiveClientConfig(),
                 locationService,
                 partitionUpdateCodec,
                 new TestingNodeManager("fake-environment"),
@@ -662,9 +662,17 @@ public abstract class AbstractTestHiveClient
         pageSourceProvider = new HivePageSourceProvider(hiveClientConfig, hdfsEnvironment, getDefaultHiveRecordCursorProvider(hiveClientConfig), getDefaultHiveDataStreamFactories(hiveClientConfig), TYPE_MANAGER);
     }
 
+    /**
+     * Allow subclass to change default configuration.
+     */
+    protected HiveClientConfig getHiveClientConfig()
+    {
+        return new HiveClientConfig();
+    }
+
     protected ConnectorSession newSession()
     {
-        return new TestingConnectorSession(new HiveSessionProperties(new HiveClientConfig(), new OrcFileWriterConfig()).getSessionProperties());
+        return new TestingConnectorSession(new HiveSessionProperties(getHiveClientConfig(), new OrcFileWriterConfig()).getSessionProperties());
     }
 
     protected Transaction newTransaction()
@@ -2133,7 +2141,7 @@ public abstract class AbstractTestHiveClient
         int bucketCount = 3;
 
         try (Transaction transaction = newTransaction()) {
-            HiveClientConfig hiveConfig = new HiveClientConfig()
+            HiveClientConfig hiveConfig = getHiveClientConfig()
                     .setSortedWritingEnabled(true)
                     .setWriterSortBufferSize(new DataSize(1, MEGABYTE));
             ConnectorSession session = new TestingConnectorSession(new HiveSessionProperties(hiveConfig, new OrcFileWriterConfig()).getSessionProperties());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -35,6 +35,7 @@ import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.OrcWriterStats;
+import com.facebook.presto.orc.OutputStreamOrcDataSink;
 import com.facebook.presto.rcfile.AircompressorCodecFactory;
 import com.facebook.presto.rcfile.HadoopCodecFactory;
 import com.facebook.presto.rcfile.RcFileEncoding;
@@ -502,7 +503,7 @@ public enum FileFormat
                 throws IOException
         {
             writer = new OrcWriter(
-                    new FileOutputStream(targetFile),
+                    new OutputStreamOrcDataSink(new FileOutputStream(targetFile)),
                     columnNames,
                     types,
                     ORC,
@@ -539,7 +540,7 @@ public enum FileFormat
                 throws IOException
         {
             writer = new OrcWriter(
-                    new FileOutputStream(targetFile),
+                    new OutputStreamOrcDataSink(new FileOutputStream(targetFile)),
                     columnNames,
                     types,
                     DWRF,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSink.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSink.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.stream.DataOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface OrcDataSink
+{
+    /**
+     * Current size of output data
+     */
+    long size();
+
+    /**
+     * Write a stripe and optionally header and footer data
+     */
+    void write(List<DataOutput> outputData)
+            throws IOException;
+
+    /**
+     * ORC file is complete
+     */
+    void close()
+            throws IOException;
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -32,6 +32,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
@@ -103,7 +104,7 @@ public class OrcOutputBuffer
 
     public int writeDataTo(SliceOutput outputStream)
     {
-        flushBufferToOutputStream();
+        checkState(bufferPosition == 0, "Buffer must be closed before writeDataTo can be called");
         for (Slice slice : compressedOutputStream.getSlices()) {
             outputStream.writeBytes(slice);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -102,6 +102,12 @@ public class OrcOutputBuffer
         }
     }
 
+    public long getOutputDataSize()
+    {
+        checkState(bufferPosition == 0, "Buffer must be flushed before getOutputDataSize can be called");
+        return compressedOutputStream.size();
+    }
+
     public int writeDataTo(SliceOutput outputStream)
     {
         checkState(bufferPosition == 0, "Buffer must be closed before writeDataTo can be called");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -105,7 +105,6 @@ public class OrcWriter
 
     private final List<ColumnWriter> columnWriters;
     private final DictionaryCompressionOptimizer dictionaryCompressionOptimizer;
-    private long stripeStartOffset;
     private int stripeRowCount;
     private int rowGroupRowCount;
     private int bufferedBytes;
@@ -191,7 +190,6 @@ public class OrcWriter
 
         // this is not required but nice to have
         output.writeBytes(MAGIC);
-        stripeStartOffset = output.longSize();
 
         for (Entry<String, String> entry : this.userMetadata.entrySet()) {
             recordValidation(validation -> validation.addMetadataProperty(entry.getKey(), utf8Slice(entry.getValue())));
@@ -364,6 +362,7 @@ public class OrcWriter
 
         // create final stripe statistics
         StripeStatistics statistics = new StripeStatistics(toDenseList(columnStatistics, orcTypes.size()));
+        long stripeStartOffset = output.longSize();
         recordValidation(validation -> validation.addStripeStatistics(stripeStartOffset, statistics));
         StripeInformation stripeInformation = new StripeInformation(stripeRowCount, stripeStartOffset, indexLength, dataLength, footer.length());
         ClosedStripe closedStripe = new ClosedStripe(stripeInformation, statistics);
@@ -379,7 +378,6 @@ public class OrcWriter
         dictionaryCompressionOptimizer.reset();
         rowGroupRowCount = 0;
         stripeRowCount = 0;
-        stripeStartOffset = output.longSize();
         bufferedBytes = toIntExact(columnWriters.stream().mapToLong(ColumnWriter::getBufferedBytes).sum());
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -51,7 +51,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -340,13 +339,10 @@ public class OrcWriter
         // write streams
         List<Stream> allStreams = new ArrayList<>();
         for (OutputDataStream outputDataStream : concat(indexStreams, dataStreams)) {
-            Optional<Stream> stream = outputDataStream.writeData(output);
-            if (!stream.isPresent()) {
-                continue;
-            }
+            outputDataStream.writeData(output);
             // The ordering is critical because the stream only contain a length with no offset.
-            allStreams.add(stream.get());
-            verify(stream.get().getLength() == outputDataStream.getSizeInBytes(), "Data stream did not write expected size");
+            allStreams.add(outputDataStream.getStream());
+            verify(outputDataStream.getStream().getLength() == outputDataStream.getSizeInBytes(), "Data stream did not write expected size");
         }
 
         Map<Integer, ColumnEncoding> columnEncodings = new HashMap<>();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -66,6 +66,7 @@ import static com.facebook.presto.orc.metadata.PostScript.MAGIC;
 import static com.facebook.presto.orc.writer.ColumnWriters.createColumnWriter;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Integer.min;
 import static java.lang.Math.toIntExact;
@@ -342,7 +343,8 @@ public class OrcWriter
             }
             // The ordering is critical because the stream only contain a length with no offset.
             allStreams.add(stream.get());
-            dataLength += stream.get().getLength();
+            verify(stream.get().getLength() == outputDataStream.getSizeInBytes(), "Data stream did not write expected size");
+            dataLength += outputDataStream.getSizeInBytes();
         }
 
         Map<Integer, ColumnEncoding> columnEncodings = new HashMap<>();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -64,7 +64,6 @@ import static com.facebook.presto.orc.metadata.PostScript.MAGIC;
 import static com.facebook.presto.orc.writer.ColumnWriters.createColumnWriter;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.concat;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Integer.min;
@@ -342,7 +341,6 @@ public class OrcWriter
             outputDataStream.writeData(output);
             // The ordering is critical because the stream only contain a length with no offset.
             allStreams.add(outputDataStream.getStream());
-            verify(outputDataStream.getStream().getLength() == outputDataStream.getSizeInBytes(), "Data stream did not write expected size");
         }
 
         Map<Integer, ColumnEncoding> columnEncodings = new HashMap<>();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OutputStreamOrcDataSink.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OutputStreamOrcDataSink.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.stream.DataOutput;
+import io.airlift.slice.OutputStreamSliceOutput;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class OutputStreamOrcDataSink
+        implements OrcDataSink
+{
+    private final OutputStreamSliceOutput output;
+
+    public OutputStreamOrcDataSink(OutputStream outputStream)
+    {
+        this.output = new OutputStreamSliceOutput(requireNonNull(outputStream, "outputStream is null"));
+    }
+
+    @Override
+    public long size()
+    {
+        return output.longSize();
+    }
+
+    @Override
+    public void write(List<DataOutput> outputData)
+    {
+        outputData.forEach(data -> data.writeData(output));
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        output.close();
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
@@ -14,13 +14,15 @@
 package com.facebook.presto.orc.metadata;
 
 import com.facebook.presto.orc.OrcOutputBuffer;
-import io.airlift.slice.SliceOutput;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
 
 import java.io.IOException;
 import java.util.List;
 
+import static java.lang.Math.toIntExact;
+
 public class CompressedMetadataWriter
-        implements MetadataWriter
 {
     private final MetadataWriter metadataWriter;
     private final OrcOutputBuffer buffer;
@@ -31,57 +33,55 @@ public class CompressedMetadataWriter
         this.buffer = new OrcOutputBuffer(compression, bufferSize);
     }
 
-    @Override
     public List<Integer> getOrcMetadataVersion()
     {
         return metadataWriter.getOrcMetadataVersion();
     }
 
-    @Override
-    public int writePostscript(SliceOutput output, int footerLength, int metadataLength, CompressionKind compression, int compressionBlockSize)
+    public Slice writePostscript(int footerLength, int metadataLength, CompressionKind compression, int compressionBlockSize)
             throws IOException
     {
         // postscript is not compressed
-        return metadataWriter.writePostscript(output, footerLength, metadataLength, compression, compressionBlockSize);
+        DynamicSliceOutput output = new DynamicSliceOutput(64);
+        metadataWriter.writePostscript(output, footerLength, metadataLength, compression, compressionBlockSize);
+        return output.slice();
     }
 
-    @Override
-    public int writeMetadata(SliceOutput output, Metadata metadata)
+    public Slice writeMetadata(Metadata metadata)
             throws IOException
     {
-        buffer.reset();
         metadataWriter.writeMetadata(buffer, metadata);
-        buffer.close();
-        return buffer.writeDataTo(output);
+        return getSliceOutput();
     }
 
-    @Override
-    public int writeFooter(SliceOutput output, Footer footer)
+    public Slice writeFooter(Footer footer)
             throws IOException
     {
-        buffer.reset();
         metadataWriter.writeFooter(buffer, footer);
-        buffer.close();
-        return buffer.writeDataTo(output);
+        return getSliceOutput();
     }
 
-    @Override
-    public int writeStripeFooter(SliceOutput output, StripeFooter footer)
+    public Slice writeStripeFooter(StripeFooter footer)
             throws IOException
     {
-        buffer.reset();
         metadataWriter.writeStripeFooter(buffer, footer);
-        buffer.close();
-        return buffer.writeDataTo(output);
+        return getSliceOutput();
     }
 
-    @Override
-    public int writeRowIndexes(SliceOutput output, List<RowGroupIndex> rowGroupIndexes)
+    public Slice writeRowIndexes(List<RowGroupIndex> rowGroupIndexes)
             throws IOException
     {
-        buffer.reset();
         metadataWriter.writeRowIndexes(buffer, rowGroupIndexes);
+        return getSliceOutput();
+    }
+
+    private Slice getSliceOutput()
+    {
         buffer.close();
-        return buffer.writeDataTo(output);
+        DynamicSliceOutput output = new DynamicSliceOutput(toIntExact(buffer.getOuputDataSize()));
+        buffer.writeDataTo(output);
+        Slice slice = output.slice();
+        buffer.reset();
+        return slice;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
@@ -78,7 +78,7 @@ public class CompressedMetadataWriter
     private Slice getSliceOutput()
     {
         buffer.close();
-        DynamicSliceOutput output = new DynamicSliceOutput(toIntExact(buffer.getOuputDataSize()));
+        DynamicSliceOutput output = new DynamicSliceOutput(toIntExact(buffer.getOutputDataSize()));
         buffer.writeDataTo(output);
         Slice slice = output.slice();
         buffer.reset();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
@@ -51,6 +51,7 @@ public class CompressedMetadataWriter
     {
         buffer.reset();
         metadataWriter.writeMetadata(buffer, metadata);
+        buffer.close();
         return buffer.writeDataTo(output);
     }
 
@@ -60,6 +61,7 @@ public class CompressedMetadataWriter
     {
         buffer.reset();
         metadataWriter.writeFooter(buffer, footer);
+        buffer.close();
         return buffer.writeDataTo(output);
     }
 
@@ -69,6 +71,7 @@ public class CompressedMetadataWriter
     {
         buffer.reset();
         metadataWriter.writeStripeFooter(buffer, footer);
+        buffer.close();
         return buffer.writeDataTo(output);
     }
 
@@ -78,6 +81,7 @@ public class CompressedMetadataWriter
     {
         buffer.reset();
         metadataWriter.writeRowIndexes(buffer, rowGroupIndexes);
+        buffer.close();
         return buffer.writeDataTo(output);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
@@ -17,14 +17,11 @@ import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.ByteStreamCheckpoint;
 import com.facebook.presto.orc.metadata.CompressionKind;
-import com.facebook.presto.orc.metadata.Stream;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -158,17 +155,10 @@ public class BooleanOutputStream
     }
 
     @Override
-    public long getDataStreamBytes()
+    public OutputDataStream getOutputDataStream(int column)
     {
         checkState(closed);
-        return byteOutputStream.getDataStreamBytes();
-    }
-
-    @Override
-    public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
-    {
-        checkState(closed);
-        return byteOutputStream.writeDataStreams(column, outputStream);
+        return byteOutputStream.getOutputDataStream(column);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
@@ -155,10 +155,10 @@ public class BooleanOutputStream
     }
 
     @Override
-    public OutputDataStream getOutputDataStream(int column)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
         checkState(closed);
-        return byteOutputStream.getOutputDataStream(column);
+        return byteOutputStream.getStreamDataOutput(column);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
@@ -158,6 +158,13 @@ public class BooleanOutputStream
     }
 
     @Override
+    public long getDataStreamBytes()
+    {
+        checkState(closed);
+        return byteOutputStream.getDataStreamBytes();
+    }
+
+    @Override
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkState(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -64,6 +64,7 @@ public class ByteArrayOutputStream
     public void close()
     {
         closed = true;
+        buffer.close();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -83,10 +83,7 @@ public class ByteArrayOutputStream
     @Override
     public OutputDataStream getOutputDataStream(int column)
     {
-        return new OutputDataStream(
-                buffer::writeDataTo,
-                new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), false),
-                buffer.getOutputDataSize());
+        return new OutputDataStream(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -20,15 +20,14 @@ import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
-import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.toIntExact;
 
 /**
  * This is a concatenation of all byte array content, and a separate length stream will be used to get the boundaries.
@@ -82,18 +81,12 @@ public class ByteArrayOutputStream
     }
 
     @Override
-    public long getDataStreamBytes()
+    public OutputDataStream getOutputDataStream(int column)
     {
-        checkState(closed);
-        return buffer.getOutputDataSize();
-    }
-
-    @Override
-    public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
-    {
-        checkState(closed);
-        int length = buffer.writeDataTo(outputStream);
-        return Optional.of(new Stream(column, streamKind, length, false));
+        return new OutputDataStream(
+                buffer::writeDataTo,
+                new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), false),
+                buffer.getOutputDataSize());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -81,9 +81,9 @@ public class ByteArrayOutputStream
     }
 
     @Override
-    public OutputDataStream getOutputDataStream(int column)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new OutputDataStream(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -82,6 +82,13 @@ public class ByteArrayOutputStream
     }
 
     @Override
+    public long getDataStreamBytes()
+    {
+        checkState(closed);
+        return buffer.getOutputDataSize();
+    }
+
+    @Override
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkState(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -148,6 +148,13 @@ public class ByteOutputStream
     }
 
     @Override
+    public long getDataStreamBytes()
+    {
+        checkState(closed);
+        return buffer.getOutputDataSize();
+    }
+
+    @Override
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkState(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -149,10 +149,7 @@ public class ByteOutputStream
     @Override
     public OutputDataStream getOutputDataStream(int column)
     {
-        return new OutputDataStream(
-                buffer::writeDataTo,
-                new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false),
-                buffer.getOutputDataSize());
+        return new OutputDataStream(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -137,6 +137,7 @@ public class ByteOutputStream
     {
         closed = true;
         flushSequence();
+        buffer.close();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -19,15 +19,14 @@ import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.metadata.Stream;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SizeOf;
-import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.toIntExact;
 
 public class ByteOutputStream
         implements ValueOutputStream<ByteStreamCheckpoint>
@@ -148,18 +147,12 @@ public class ByteOutputStream
     }
 
     @Override
-    public long getDataStreamBytes()
+    public OutputDataStream getOutputDataStream(int column)
     {
-        checkState(closed);
-        return buffer.getOutputDataSize();
-    }
-
-    @Override
-    public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
-    {
-        checkState(closed);
-        int length = buffer.writeDataTo(outputStream);
-        return Optional.of(new Stream(column, DATA, length, false));
+        return new OutputDataStream(
+                buffer::writeDataTo,
+                new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false),
+                buffer.getOutputDataSize());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -147,9 +147,9 @@ public class ByteOutputStream
     }
 
     @Override
-    public OutputDataStream getOutputDataStream(int column)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new OutputDataStream(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DataOutput.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DataOutput.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+
+import static java.util.Objects.requireNonNull;
+
+public interface DataOutput
+{
+    static DataOutput createDataOutput(Slice slice)
+    {
+        requireNonNull(slice, "slice is null");
+        return new DataOutput()
+        {
+            @Override
+            public long getSizeInBytes()
+            {
+                return slice.length();
+            }
+
+            @Override
+            public void writeData(SliceOutput sliceOutput)
+            {
+                sliceOutput.writeBytes(slice);
+            }
+        };
+    }
+
+    long getSizeInBytes();
+
+    void writeData(SliceOutput sliceOutput);
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
@@ -111,10 +111,7 @@ public class DecimalOutputStream
     @Override
     public OutputDataStream getOutputDataStream(int column)
     {
-        return new OutputDataStream(
-                buffer::writeDataTo,
-                new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), true),
-                buffer.getOutputDataSize());
+        return new OutputDataStream(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
@@ -109,9 +109,9 @@ public class DecimalOutputStream
     }
 
     @Override
-    public OutputDataStream getOutputDataStream(int column)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new OutputDataStream(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
@@ -20,17 +20,16 @@ import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.spi.type.Decimals;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
-import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.stream.LongDecode.writeVLong;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.toIntExact;
 
 /**
  * This is only for mantissa/significant of a decimal and not the exponent.
@@ -110,18 +109,12 @@ public class DecimalOutputStream
     }
 
     @Override
-    public long getDataStreamBytes()
+    public OutputDataStream getOutputDataStream(int column)
     {
-        checkState(closed);
-        return buffer.getOutputDataSize();
-    }
-
-    @Override
-    public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
-    {
-        checkState(closed);
-        int length = buffer.writeDataTo(outputStream);
-        return Optional.of(new Stream(column, DATA, length, true));
+        return new OutputDataStream(
+                buffer::writeDataTo,
+                new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), true),
+                buffer.getOutputDataSize());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
@@ -99,6 +99,7 @@ public class DecimalOutputStream
     public void close()
     {
         closed = true;
+        buffer.close();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
@@ -110,6 +110,13 @@ public class DecimalOutputStream
     }
 
     @Override
+    public long getDataStreamBytes()
+    {
+        checkState(closed);
+        return buffer.getOutputDataSize();
+    }
+
+    @Override
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkState(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
@@ -52,6 +52,7 @@ public class DoubleOutputStream
     public void close()
     {
         closed = true;
+        buffer.close();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
@@ -18,15 +18,14 @@ import com.facebook.presto.orc.checkpoint.DoubleStreamCheckpoint;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.metadata.Stream;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.toIntExact;
 
 public class DoubleOutputStream
         implements ValueOutputStream<DoubleStreamCheckpoint>
@@ -70,18 +69,12 @@ public class DoubleOutputStream
     }
 
     @Override
-    public long getDataStreamBytes()
+    public OutputDataStream getOutputDataStream(int column)
     {
-        checkState(closed);
-        return buffer.getOutputDataSize();
-    }
-
-    @Override
-    public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
-    {
-        checkState(closed);
-        int length = buffer.writeDataTo(outputStream);
-        return Optional.of(new Stream(column, DATA, length, false));
+        return new OutputDataStream(
+                buffer::writeDataTo,
+                new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false),
+                buffer.getOutputDataSize());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
@@ -69,9 +69,9 @@ public class DoubleOutputStream
     }
 
     @Override
-    public OutputDataStream getOutputDataStream(int column)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new OutputDataStream(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
@@ -71,10 +71,7 @@ public class DoubleOutputStream
     @Override
     public OutputDataStream getOutputDataStream(int column)
     {
-        return new OutputDataStream(
-                buffer::writeDataTo,
-                new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false),
-                buffer.getOutputDataSize());
+        return new OutputDataStream(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
@@ -70,6 +70,13 @@ public class DoubleOutputStream
     }
 
     @Override
+    public long getDataStreamBytes()
+    {
+        checkState(closed);
+        return buffer.getOutputDataSize();
+    }
+
+    @Override
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkState(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
@@ -18,15 +18,14 @@ import com.facebook.presto.orc.checkpoint.FloatStreamCheckpoint;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.metadata.Stream;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.toIntExact;
 
 public class FloatOutputStream
         implements ValueOutputStream<FloatStreamCheckpoint>
@@ -70,18 +69,12 @@ public class FloatOutputStream
     }
 
     @Override
-    public long getDataStreamBytes()
+    public OutputDataStream getOutputDataStream(int column)
     {
-        checkState(closed);
-        return buffer.getOutputDataSize();
-    }
-
-    @Override
-    public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
-    {
-        checkState(closed);
-        int length = buffer.writeDataTo(outputStream);
-        return Optional.of(new Stream(column, DATA, length, false));
+        return new OutputDataStream(
+                buffer::writeDataTo,
+                new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false),
+                buffer.getOutputDataSize());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
@@ -70,6 +70,13 @@ public class FloatOutputStream
     }
 
     @Override
+    public long getDataStreamBytes()
+    {
+        checkState(closed);
+        return buffer.getOutputDataSize();
+    }
+
+    @Override
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkState(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
@@ -69,9 +69,9 @@ public class FloatOutputStream
     }
 
     @Override
-    public OutputDataStream getOutputDataStream(int column)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new OutputDataStream(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
@@ -52,6 +52,7 @@ public class FloatOutputStream
     public void close()
     {
         closed = true;
+        buffer.close();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
@@ -71,10 +71,7 @@ public class FloatOutputStream
     @Override
     public OutputDataStream getOutputDataStream(int column)
     {
-        return new OutputDataStream(
-                buffer::writeDataTo,
-                new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false),
-                buffer.getOutputDataSize());
+        return new OutputDataStream(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -78,9 +78,9 @@ public class LongOutputStreamDwrf
     }
 
     @Override
-    public OutputDataStream getOutputDataStream(int column)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new OutputDataStream(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -80,10 +80,7 @@ public class LongOutputStreamDwrf
     @Override
     public OutputDataStream getOutputDataStream(int column)
     {
-        return new OutputDataStream(
-                buffer::writeDataTo,
-                new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true),
-                buffer.getOutputDataSize());
+        return new OutputDataStream(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -79,6 +79,13 @@ public class LongOutputStreamDwrf
     }
 
     @Override
+    public long getDataStreamBytes()
+    {
+        checkState(closed);
+        return buffer.getOutputDataSize();
+    }
+
+    @Override
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkState(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -68,6 +68,7 @@ public class LongOutputStreamDwrf
     public void close()
     {
         closed = true;
+        buffer.close();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -20,15 +20,14 @@ import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.orc.stream.LongDecode.writeVLong;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class LongOutputStreamDwrf
@@ -79,18 +78,12 @@ public class LongOutputStreamDwrf
     }
 
     @Override
-    public long getDataStreamBytes()
+    public OutputDataStream getOutputDataStream(int column)
     {
-        checkState(closed);
-        return buffer.getOutputDataSize();
-    }
-
-    @Override
-    public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
-    {
-        checkState(closed);
-        int length = buffer.writeDataTo(outputStream);
-        return Optional.of(new Stream(column, streamKind, length, true));
+        return new OutputDataStream(
+                buffer::writeDataTo,
+                new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true),
+                buffer.getOutputDataSize());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -188,9 +188,9 @@ public class LongOutputStreamV1
     }
 
     @Override
-    public OutputDataStream getOutputDataStream(int column)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new OutputDataStream(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -21,16 +21,15 @@ import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SizeOf;
-import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.orc.stream.LongDecode.writeVLong;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class LongOutputStreamV1
@@ -189,18 +188,12 @@ public class LongOutputStreamV1
     }
 
     @Override
-    public long getDataStreamBytes()
+    public OutputDataStream getOutputDataStream(int column)
     {
-        checkState(closed);
-        return buffer.getOutputDataSize();
-    }
-
-    @Override
-    public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
-    {
-        checkState(closed);
-        int length = buffer.writeDataTo(outputStream);
-        return Optional.of(new Stream(column, streamKind, length, true));
+        return new OutputDataStream(
+                buffer::writeDataTo,
+                new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true),
+                buffer.getOutputDataSize());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -178,6 +178,7 @@ public class LongOutputStreamV1
     {
         closed = true;
         flushSequence();
+        buffer.close();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -189,6 +189,13 @@ public class LongOutputStreamV1
     }
 
     @Override
+    public long getDataStreamBytes()
+    {
+        checkState(closed);
+        return buffer.getOutputDataSize();
+    }
+
+    @Override
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkState(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -190,10 +190,7 @@ public class LongOutputStreamV1
     @Override
     public OutputDataStream getOutputDataStream(int column)
     {
-        return new OutputDataStream(
-                buffer::writeDataTo,
-                new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true),
-                buffer.getOutputDataSize());
+        return new OutputDataStream(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -749,11 +749,7 @@ public class LongOutputStreamV2
     @Override
     public OutputDataStream getOutputDataStream(int column)
     {
-        checkState(closed);
-        return new OutputDataStream(
-                buffer::writeDataTo,
-                new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true),
-                buffer.getOutputDataSize());
+        return new OutputDataStream(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -26,7 +26,6 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.orc.stream.LongOutputStreamV2.SerializationUtils.encodeBitWidth;
 import static com.facebook.presto.orc.stream.LongOutputStreamV2.SerializationUtils.findClosestNumBits;
@@ -39,6 +38,7 @@ import static com.facebook.presto.orc.stream.LongOutputStreamV2.SerializationUti
 import static com.facebook.presto.orc.stream.LongOutputStreamV2.SerializationUtils.zigzagEncode;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class LongOutputStreamV2
@@ -747,18 +747,13 @@ public class LongOutputStreamV2
     }
 
     @Override
-    public long getDataStreamBytes()
+    public OutputDataStream getOutputDataStream(int column)
     {
         checkState(closed);
-        return buffer.getOutputDataSize();
-    }
-
-    @Override
-    public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
-    {
-        checkState(closed);
-        int length = buffer.writeDataTo(outputStream);
-        return Optional.of(new Stream(column, streamKind, length, true));
+        return new OutputDataStream(
+                buffer::writeDataTo,
+                new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true),
+                buffer.getOutputDataSize());
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -747,9 +747,9 @@ public class LongOutputStreamV2
     }
 
     @Override
-    public OutputDataStream getOutputDataStream(int column)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new OutputDataStream(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -747,6 +747,13 @@ public class LongOutputStreamV2
     }
 
     @Override
+    public long getDataStreamBytes()
+    {
+        checkState(closed);
+        return buffer.getOutputDataSize();
+    }
+
+    @Override
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkState(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -736,6 +736,7 @@ public class LongOutputStreamV2
     {
         closed = true;
         flush();
+        buffer.close();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OutputDataStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OutputDataStream.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.stream;
 
 import com.facebook.presto.orc.metadata.Stream;
+import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 
 import javax.annotation.Nonnull;
@@ -28,6 +29,16 @@ public final class OutputDataStream
 {
     private final Function<SliceOutput, Optional<Stream>> writer;
     private final long sizeInBytes;
+
+    public OutputDataStream(Slice slice, Stream stream)
+    {
+        this(
+                sliceOutput -> {
+                    sliceOutput.writeBytes(slice);
+                    return Optional.of(stream);
+                },
+                slice.length());
+    }
 
     public OutputDataStream(Function<SliceOutput, Optional<Stream>> writer, long sizeInBytes)
     {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OutputDataStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OutputDataStream.java
@@ -21,7 +21,6 @@ import javax.annotation.Nonnull;
 
 import java.util.function.ToLongFunction;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
@@ -30,7 +29,6 @@ public final class OutputDataStream
 {
     private final ToLongFunction<SliceOutput> writer;
     private final Stream stream;
-    private final long sizeInBytes;
 
     public OutputDataStream(Slice slice, Stream stream)
     {
@@ -39,27 +37,24 @@ public final class OutputDataStream
                     sliceOutput.writeBytes(slice);
                     return slice.length();
                 },
-                stream,
-                slice.length());
+                stream);
     }
 
-    public OutputDataStream(ToLongFunction<SliceOutput> writer, Stream stream, long sizeInBytes)
+    public OutputDataStream(ToLongFunction<SliceOutput> writer, Stream stream)
     {
         this.writer = requireNonNull(writer, "writer is null");
         this.stream = requireNonNull(stream, "stream is null");
-        checkArgument(sizeInBytes >= 0, "sizeInBytes is negative");
-        this.sizeInBytes = sizeInBytes;
     }
 
     @Override
     public int compareTo(@Nonnull OutputDataStream otherStream)
     {
-        return Long.compare(sizeInBytes, otherStream.sizeInBytes);
+        return Long.compare(getSizeInBytes(), otherStream.getSizeInBytes());
     }
 
     public long getSizeInBytes()
     {
-        return sizeInBytes;
+        return stream.getLength();
     }
 
     public Stream getStream()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
@@ -101,6 +101,15 @@ public class PresentOutputStream
         return Optional.of(booleanOutputStream.getCheckpoints());
     }
 
+    public long getDataStreamBytes()
+    {
+        checkArgument(closed);
+        if (booleanOutputStream == null) {
+            return 0;
+        }
+        return booleanOutputStream.getDataStreamBytes();
+    }
+
     public Optional<Stream> writeDataStreams(int column, SliceOutput outputStream)
     {
         checkArgument(closed);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
@@ -115,8 +115,7 @@ public class PresentOutputStream
                     outputDataStream.writeData(sliceOutput);
                     return stream.getLength();
                 },
-                stream,
-                outputDataStream.getSizeInBytes()));
+                stream));
     }
 
     public long getBufferedBytes()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
@@ -101,18 +101,18 @@ public class PresentOutputStream
         return Optional.of(booleanOutputStream.getCheckpoints());
     }
 
-    public Optional<OutputDataStream> getOutputDataStream(int column)
+    public Optional<StreamDataOutput> getStreamDataOutput(int column)
     {
         checkArgument(closed);
         if (booleanOutputStream == null) {
             return Optional.empty();
         }
-        OutputDataStream outputDataStream = booleanOutputStream.getOutputDataStream(column);
+        StreamDataOutput streamDataOutput = booleanOutputStream.getStreamDataOutput(column);
         // rewrite the DATA stream created by the boolean output stream to a PRESENT stream
-        Stream stream = new Stream(column, PRESENT, toIntExact(outputDataStream.getSizeInBytes()), outputDataStream.getStream().isUseVInts());
-        return Optional.of(new OutputDataStream(
+        Stream stream = new Stream(column, PRESENT, toIntExact(streamDataOutput.getSizeInBytes()), streamDataOutput.getStream().isUseVInts());
+        return Optional.of(new StreamDataOutput(
                 sliceOutput -> {
-                    outputDataStream.writeData(sliceOutput);
+                    streamDataOutput.writeData(sliceOutput);
                     return stream.getLength();
                 },
                 stream));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/StreamDataOutput.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/StreamDataOutput.java
@@ -24,13 +24,13 @@ import java.util.function.ToLongFunction;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
-public final class OutputDataStream
-        implements Comparable<OutputDataStream>
+public final class StreamDataOutput
+        implements Comparable<StreamDataOutput>
 {
     private final ToLongFunction<SliceOutput> writer;
     private final Stream stream;
 
-    public OutputDataStream(Slice slice, Stream stream)
+    public StreamDataOutput(Slice slice, Stream stream)
     {
         this(
                 sliceOutput -> {
@@ -40,14 +40,14 @@ public final class OutputDataStream
                 stream);
     }
 
-    public OutputDataStream(ToLongFunction<SliceOutput> writer, Stream stream)
+    public StreamDataOutput(ToLongFunction<SliceOutput> writer, Stream stream)
     {
         this.writer = requireNonNull(writer, "writer is null");
         this.stream = requireNonNull(stream, "stream is null");
     }
 
     @Override
-    public int compareTo(@Nonnull OutputDataStream otherStream)
+    public int compareTo(@Nonnull StreamDataOutput otherStream)
     {
         return Long.compare(getSizeInBytes(), otherStream.getSizeInBytes());
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/StreamDataOutput.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/StreamDataOutput.java
@@ -25,7 +25,7 @@ import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public final class StreamDataOutput
-        implements Comparable<StreamDataOutput>
+        implements DataOutput, Comparable<StreamDataOutput>
 {
     private final ToLongFunction<SliceOutput> writer;
     private final Stream stream;
@@ -52,6 +52,7 @@ public final class StreamDataOutput
         return Long.compare(getSizeInBytes(), otherStream.getSizeInBytes());
     }
 
+    @Override
     public long getSizeInBytes()
     {
         return stream.getLength();
@@ -62,6 +63,7 @@ public final class StreamDataOutput
         return stream;
     }
 
+    @Override
     public void writeData(SliceOutput sliceOutput)
     {
         long size = writer.applyAsLong(sliceOutput);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
@@ -14,11 +14,8 @@
 package com.facebook.presto.orc.stream;
 
 import com.facebook.presto.orc.checkpoint.StreamCheckpoint;
-import com.facebook.presto.orc.metadata.Stream;
-import io.airlift.slice.SliceOutput;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ValueOutputStream<C extends StreamCheckpoint>
 {
@@ -28,9 +25,7 @@ public interface ValueOutputStream<C extends StreamCheckpoint>
 
     List<C> getCheckpoints();
 
-    long getDataStreamBytes();
-
-    Optional<Stream> writeDataStreams(int column, SliceOutput outputStream);
+    OutputDataStream getOutputDataStream(int column);
 
     long getBufferedBytes();
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
@@ -25,7 +25,7 @@ public interface ValueOutputStream<C extends StreamCheckpoint>
 
     List<C> getCheckpoints();
 
-    OutputDataStream getOutputDataStream(int column);
+    StreamDataOutput getStreamDataOutput(int column);
 
     long getBufferedBytes();
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
@@ -28,6 +28,8 @@ public interface ValueOutputStream<C extends StreamCheckpoint>
 
     List<C> getCheckpoints();
 
+    long getDataStreamBytes();
+
     Optional<Stream> writeDataStreams(int column, SliceOutput outputStream);
 
     long getBufferedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -23,8 +23,8 @@ import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.BooleanStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.BooleanOutputStream;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -132,7 +132,7 @@ public class BooleanColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -152,7 +152,7 @@ public class BooleanColumnWriter
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
-        return ImmutableList.of(new OutputDataStream(slice, stream));
+        return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
     private static List<Integer> createBooleanColumnPositionList(
@@ -167,13 +167,13 @@ public class BooleanColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getOutputDataStream(column));
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -171,8 +171,8 @@ public class BooleanColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -15,8 +15,8 @@ package com.facebook.presto.orc.writer;
 
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.CompressionKind;
-import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
@@ -29,7 +29,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
@@ -132,7 +132,7 @@ public class BooleanColumnWriter
     }
 
     @Override
-    public List<Stream> writeIndexStreams(SliceOutput outputStream, MetadataWriter metadataWriter)
+    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -150,8 +150,9 @@ public class BooleanColumnWriter
             rowGroupIndexes.add(new RowGroupIndex(positions, columnStatistics));
         }
 
-        int length = metadataWriter.writeRowIndexes(outputStream, rowGroupIndexes.build());
-        return ImmutableList.of(new Stream(column, StreamKind.ROW_INDEX, length, false));
+        Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
+        return ImmutableList.of(new OutputDataStream(slice, stream));
     }
 
     private static List<Integer> createBooleanColumnPositionList(

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -172,8 +172,8 @@ public class BooleanColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getOutputDataStream(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -16,8 +16,8 @@ package com.facebook.presto.orc.writer;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.ByteStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.CompressionKind;
-import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
@@ -29,7 +29,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
@@ -131,7 +131,7 @@ public class ByteColumnWriter
     }
 
     @Override
-    public List<Stream> writeIndexStreams(SliceOutput outputStream, MetadataWriter metadataWriter)
+    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -149,8 +149,9 @@ public class ByteColumnWriter
             rowGroupIndexes.add(new RowGroupIndex(positions, columnStatistics));
         }
 
-        int length = metadataWriter.writeRowIndexes(outputStream, rowGroupIndexes.build());
-        return ImmutableList.of(new Stream(column, StreamKind.ROW_INDEX, length, false));
+        Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
+        return ImmutableList.of(new OutputDataStream(slice, stream));
     }
 
     private static List<Integer> createByteColumnPositionList(

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -23,8 +23,8 @@ import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.ByteOutputStream;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -131,7 +131,7 @@ public class ByteColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -151,7 +151,7 @@ public class ByteColumnWriter
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
-        return ImmutableList.of(new OutputDataStream(slice, stream));
+        return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
     private static List<Integer> createByteColumnPositionList(
@@ -166,13 +166,13 @@ public class ByteColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getOutputDataStream(column));
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -170,8 +170,8 @@ public class ByteColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -171,8 +171,8 @@ public class ByteColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getOutputDataStream(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc.writer;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
-import com.facebook.presto.orc.stream.OutputDataStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.google.common.collect.ImmutableList;
 
@@ -48,13 +48,13 @@ public interface ColumnWriter
      * order in which they were written.  The ordering is critical because
      * the stream only contain a length with no offset.
      */
-    List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException;
 
     /**
      * Get the data streams to be written.
      */
-    List<OutputDataStream> getOutputDataStreams();
+    List<StreamDataOutput> getDataStreams();
 
     long getBufferedBytes();
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
@@ -14,13 +14,11 @@
 package com.facebook.presto.orc.writer;
 
 import com.facebook.presto.orc.metadata.ColumnEncoding;
-import com.facebook.presto.orc.metadata.MetadataWriter;
-import com.facebook.presto.orc.metadata.Stream;
+import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.spi.block.Block;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.SliceOutput;
 
 import java.io.IOException;
 import java.util.List;
@@ -50,7 +48,7 @@ public interface ColumnWriter
      * order in which they were written.  The ordering is critical because
      * the stream only contain a length with no offset.
      */
-    List<Stream> writeIndexStreams(SliceOutput outputStream, MetadataWriter metadataWriter)
+    List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException;
 
     /**

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
@@ -224,9 +224,9 @@ public class DecimalColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> scaleStream.writeDataStreams(column, sliceOutput), scaleStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getOutputDataStream(column));
+        outputDataStreams.add(scaleStream.getOutputDataStream(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
@@ -224,9 +224,9 @@ public class DecimalColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> scaleStream.writeDataStreams(column, sliceOutput), scaleStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> scaleStream.writeDataStreams(column, sliceOutput), scaleStream.getDataStreamBytes()));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
@@ -29,8 +29,8 @@ import com.facebook.presto.orc.metadata.statistics.ShortDecimalStatisticsBuilder
 import com.facebook.presto.orc.stream.DecimalOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStreamV2;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
@@ -180,7 +180,7 @@ public class DecimalColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -202,7 +202,7 @@ public class DecimalColumnWriter
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
-        return ImmutableList.of(new OutputDataStream(slice, stream));
+        return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
     private static List<Integer> createDecimalColumnPositionList(
@@ -219,14 +219,14 @@ public class DecimalColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getOutputDataStream(column));
-        outputDataStreams.add(scaleStream.getOutputDataStream(column));
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
+        outputDataStreams.add(scaleStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -24,8 +24,8 @@ import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.DoubleStatisticsBuilder;
 import com.facebook.presto.orc.stream.DoubleOutputStream;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -133,7 +133,7 @@ public class DoubleColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -153,7 +153,7 @@ public class DoubleColumnWriter
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
-        return ImmutableList.of(new OutputDataStream(slice, stream));
+        return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
     private static List<Integer> createDoubleColumnPositionList(
@@ -168,13 +168,13 @@ public class DoubleColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getOutputDataStream(column));
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -172,8 +172,8 @@ public class DoubleColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -173,8 +173,8 @@ public class DoubleColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getOutputDataStream(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -175,8 +175,8 @@ public class FloatColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getOutputDataStream(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -24,8 +24,8 @@ import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.DoubleStatisticsBuilder;
 import com.facebook.presto.orc.stream.FloatOutputStream;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -135,7 +135,7 @@ public class FloatColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -155,7 +155,7 @@ public class FloatColumnWriter
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
-        return ImmutableList.of(new OutputDataStream(slice, stream));
+        return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
     private static List<Integer> createFloatColumnPositionList(
@@ -170,13 +170,13 @@ public class FloatColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getOutputDataStream(column));
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -174,8 +174,8 @@ public class FloatColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -16,8 +16,8 @@ package com.facebook.presto.orc.writer;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.FloatStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.CompressionKind;
-import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
@@ -30,7 +30,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
@@ -135,7 +135,7 @@ public class FloatColumnWriter
     }
 
     @Override
-    public List<Stream> writeIndexStreams(SliceOutput outputStream, MetadataWriter metadataWriter)
+    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -153,8 +153,9 @@ public class FloatColumnWriter
             rowGroupIndexes.add(new RowGroupIndex(positions, columnStatistics));
         }
 
-        int length = metadataWriter.writeRowIndexes(outputStream, rowGroupIndexes.build());
-        return ImmutableList.of(new Stream(column, StreamKind.ROW_INDEX, length, false));
+        Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
+        return ImmutableList.of(new OutputDataStream(slice, stream));
     }
 
     private static List<Integer> createFloatColumnPositionList(

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -24,8 +24,8 @@ import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.LongOutputStream;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.ColumnarArray;
 import com.google.common.collect.ImmutableList;
@@ -168,7 +168,7 @@ public class ListColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -189,9 +189,9 @@ public class ListColumnWriter
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
 
-        ImmutableList.Builder<OutputDataStream> indexStreams = ImmutableList.builder();
-        indexStreams.add(new OutputDataStream(slice, stream));
-        indexStreams.addAll(elementWriter.writeIndexStreams(metadataWriter));
+        ImmutableList.Builder<StreamDataOutput> indexStreams = ImmutableList.builder();
+        indexStreams.add(new StreamDataOutput(slice, stream));
+        indexStreams.addAll(elementWriter.getIndexStreams(metadataWriter));
         return indexStreams.build();
     }
 
@@ -207,14 +207,14 @@ public class ListColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(lengthStream.getOutputDataStream(column));
-        outputDataStreams.addAll(elementWriter.getOutputDataStreams());
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getStreamDataOutput(column));
+        outputDataStreams.addAll(elementWriter.getDataStreams());
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -17,8 +17,8 @@ import com.facebook.presto.orc.OrcEncoding;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.CompressionKind;
-import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
@@ -30,7 +30,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.ColumnarArray;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
@@ -168,7 +168,7 @@ public class ListColumnWriter
     }
 
     @Override
-    public List<Stream> writeIndexStreams(SliceOutput outputStream, MetadataWriter metadataWriter)
+    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -186,12 +186,12 @@ public class ListColumnWriter
             rowGroupIndexes.add(new RowGroupIndex(positions, columnStatistics));
         }
 
-        int length = metadataWriter.writeRowIndexes(outputStream, rowGroupIndexes.build());
-        Stream stream = new Stream(column, StreamKind.ROW_INDEX, length, false);
+        Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
 
-        ImmutableList.Builder<Stream> indexStreams = ImmutableList.builder();
-        indexStreams.add(stream);
-        indexStreams.addAll(elementWriter.writeIndexStreams(outputStream, metadataWriter));
+        ImmutableList.Builder<OutputDataStream> indexStreams = ImmutableList.builder();
+        indexStreams.add(new OutputDataStream(slice, stream));
+        indexStreams.addAll(elementWriter.writeIndexStreams(metadataWriter));
         return indexStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -212,8 +212,8 @@ public class ListColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getOutputDataStream(column));
         outputDataStreams.addAll(elementWriter.getOutputDataStreams());
         return outputDataStreams.build();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -212,8 +212,8 @@ public class ListColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getDataStreamBytes()));
         outputDataStreams.addAll(elementWriter.getOutputDataStreams());
         return outputDataStreams.build();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -189,8 +189,8 @@ public class LongColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getOutputDataStream(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -188,8 +188,8 @@ public class LongColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -27,8 +27,8 @@ import com.facebook.presto.orc.metadata.statistics.LongValueStatisticsBuilder;
 import com.facebook.presto.orc.stream.LongOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStreamDwrf;
 import com.facebook.presto.orc.stream.LongOutputStreamV2;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -149,7 +149,7 @@ public class LongColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -169,7 +169,7 @@ public class LongColumnWriter
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
-        return ImmutableList.of(new OutputDataStream(slice, stream));
+        return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
     private static List<Integer> createLongColumnPositionList(
@@ -184,13 +184,13 @@ public class LongColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getOutputDataStream(column));
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -223,8 +223,8 @@ public class MapColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getDataStreamBytes()));
         outputDataStreams.addAll(keyWriter.getOutputDataStreams());
         outputDataStreams.addAll(valueWriter.getOutputDataStreams());
         return outputDataStreams.build();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -24,8 +24,8 @@ import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.LongOutputStream;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.ColumnarMap;
 import com.google.common.collect.ImmutableList;
@@ -178,7 +178,7 @@ public class MapColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -199,10 +199,10 @@ public class MapColumnWriter
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
 
-        ImmutableList.Builder<OutputDataStream> indexStreams = ImmutableList.builder();
-        indexStreams.add(new OutputDataStream(slice, stream));
-        indexStreams.addAll(keyWriter.writeIndexStreams(metadataWriter));
-        indexStreams.addAll(valueWriter.writeIndexStreams(metadataWriter));
+        ImmutableList.Builder<StreamDataOutput> indexStreams = ImmutableList.builder();
+        indexStreams.add(new StreamDataOutput(slice, stream));
+        indexStreams.addAll(keyWriter.getIndexStreams(metadataWriter));
+        indexStreams.addAll(valueWriter.getIndexStreams(metadataWriter));
         return indexStreams.build();
     }
 
@@ -218,15 +218,15 @@ public class MapColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(lengthStream.getOutputDataStream(column));
-        outputDataStreams.addAll(keyWriter.getOutputDataStreams());
-        outputDataStreams.addAll(valueWriter.getOutputDataStreams());
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getStreamDataOutput(column));
+        outputDataStreams.addAll(keyWriter.getDataStreams());
+        outputDataStreams.addAll(valueWriter.getDataStreams());
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -223,8 +223,8 @@ public class MapColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getOutputDataStream(column));
         outputDataStreams.addAll(keyWriter.getOutputDataStreams());
         outputDataStreams.addAll(valueWriter.getOutputDataStreams());
         return outputDataStreams.build();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -438,10 +438,10 @@ public class SliceDictionaryColumnWriter
 
         // actually write data
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dictionaryLengthStream.writeDataStreams(column, sliceOutput), dictionaryLengthStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dictionaryDataStream.writeDataStreams(column, sliceOutput), dictionaryDataStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getOutputDataStream(column));
+        outputDataStreams.add(dictionaryLengthStream.getOutputDataStream(column));
+        outputDataStreams.add(dictionaryDataStream.getOutputDataStream(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -438,10 +438,10 @@ public class SliceDictionaryColumnWriter
 
         // actually write data
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dictionaryLengthStream.writeDataStreams(column, sliceOutput), dictionaryLengthStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dictionaryDataStream.writeDataStreams(column, sliceOutput), dictionaryDataStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dictionaryLengthStream.writeDataStreams(column, sliceOutput), dictionaryLengthStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dictionaryDataStream.writeDataStreams(column, sliceOutput), dictionaryDataStream.getDataStreamBytes()));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -27,8 +27,8 @@ import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.SliceColumnStatisticsBuilder;
 import com.facebook.presto.orc.stream.ByteArrayOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStream;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -152,7 +152,7 @@ public class SliceDirectColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -174,7 +174,7 @@ public class SliceDirectColumnWriter
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
-        return ImmutableList.of(new OutputDataStream(slice, stream));
+        return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
     private static List<Integer> createSliceColumnPositionList(
@@ -191,14 +191,14 @@ public class SliceDirectColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(lengthStream.getOutputDataStream(column));
-        outputDataStreams.add(dataStream.getOutputDataStream(column));
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getStreamDataOutput(column));
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -196,9 +196,9 @@ public class SliceDirectColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -196,9 +196,9 @@ public class SliceDirectColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> lengthStream.writeDataStreams(column, sliceOutput), lengthStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> dataStream.writeDataStreams(column, sliceOutput), dataStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getOutputDataStream(column));
+        outputDataStreams.add(dataStream.getOutputDataStream(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -210,7 +210,7 @@ public class StructColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
         for (ColumnWriter structField : structFields) {
             outputDataStreams.addAll(structField.getOutputDataStreams());
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -21,8 +21,8 @@ import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.ColumnarRow;
 import com.google.common.collect.ImmutableList;
@@ -168,7 +168,7 @@ public class StructColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -187,10 +187,10 @@ public class StructColumnWriter
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
 
-        ImmutableList.Builder<OutputDataStream> indexStreams = ImmutableList.builder();
-        indexStreams.add(new OutputDataStream(slice, stream));
+        ImmutableList.Builder<StreamDataOutput> indexStreams = ImmutableList.builder();
+        indexStreams.add(new StreamDataOutput(slice, stream));
         for (ColumnWriter structField : structFields) {
-            indexStreams.addAll(structField.writeIndexStreams(metadataWriter));
+            indexStreams.addAll(structField.getIndexStreams(metadataWriter));
         }
         return indexStreams.build();
     }
@@ -205,14 +205,14 @@ public class StructColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
         for (ColumnWriter structField : structFields) {
-            outputDataStreams.addAll(structField.getOutputDataStreams());
+            outputDataStreams.addAll(structField.getDataStreams());
         }
         return outputDataStreams.build();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -15,8 +15,8 @@ package com.facebook.presto.orc.writer;
 
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.CompressionKind;
-import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
@@ -27,7 +27,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.ColumnarRow;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
@@ -168,7 +168,7 @@ public class StructColumnWriter
     }
 
     @Override
-    public List<Stream> writeIndexStreams(SliceOutput outputStream, MetadataWriter metadataWriter)
+    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -184,13 +184,13 @@ public class StructColumnWriter
             rowGroupIndexes.add(new RowGroupIndex(positions, columnStatistics));
         }
 
-        int length = metadataWriter.writeRowIndexes(outputStream, rowGroupIndexes.build());
-        Stream stream = new Stream(column, StreamKind.ROW_INDEX, length, false);
+        Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
 
-        ImmutableList.Builder<Stream> indexStreams = ImmutableList.builder();
-        indexStreams.add(stream);
+        ImmutableList.Builder<OutputDataStream> indexStreams = ImmutableList.builder();
+        indexStreams.add(new OutputDataStream(slice, stream));
         for (ColumnWriter structField : structFields) {
-            indexStreams.addAll(structField.writeIndexStreams(outputStream, metadataWriter));
+            indexStreams.addAll(structField.writeIndexStreams(metadataWriter));
         }
         return indexStreams.build();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -210,7 +210,7 @@ public class StructColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
         for (ColumnWriter structField : structFields) {
             outputDataStreams.addAll(structField.getOutputDataStreams());
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -26,8 +26,8 @@ import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.stream.LongOutputStream;
 import com.facebook.presto.orc.stream.LongOutputStreamV1;
 import com.facebook.presto.orc.stream.LongOutputStreamV2;
-import com.facebook.presto.orc.stream.OutputDataStream;
 import com.facebook.presto.orc.stream.PresentOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -184,7 +184,7 @@ public class TimestampColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
+    public List<StreamDataOutput> getIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -206,7 +206,7 @@ public class TimestampColumnWriter
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
         Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
-        return ImmutableList.of(new OutputDataStream(slice, stream));
+        return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
     private static List<Integer> createTimestampColumnPositionList(
@@ -223,14 +223,14 @@ public class TimestampColumnWriter
     }
 
     @Override
-    public List<OutputDataStream> getOutputDataStreams()
+    public List<StreamDataOutput> getDataStreams()
     {
         checkState(closed);
 
-        ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(secondsStream.getOutputDataStream(column));
-        outputDataStreams.add(nanosStream.getOutputDataStream(column));
+        ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(secondsStream.getStreamDataOutput(column));
+        outputDataStreams.add(nanosStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -228,9 +228,9 @@ public class TimestampColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> secondsStream.writeDataStreams(column, sliceOutput), secondsStream.getDataStreamBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> nanosStream.writeDataStreams(column, sliceOutput), nanosStream.getDataStreamBytes()));
+        presentStream.getOutputDataStream(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(secondsStream.getOutputDataStream(column));
+        outputDataStreams.add(nanosStream.getOutputDataStream(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -17,8 +17,8 @@ import com.facebook.presto.orc.OrcEncoding;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.CompressionKind;
-import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
@@ -32,7 +32,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slice;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
@@ -184,7 +184,7 @@ public class TimestampColumnWriter
     }
 
     @Override
-    public List<Stream> writeIndexStreams(SliceOutput outputStream, MetadataWriter metadataWriter)
+    public List<OutputDataStream> writeIndexStreams(CompressedMetadataWriter metadataWriter)
             throws IOException
     {
         checkState(closed);
@@ -204,8 +204,9 @@ public class TimestampColumnWriter
             rowGroupIndexes.add(new RowGroupIndex(positions, columnStatistics));
         }
 
-        int length = metadataWriter.writeRowIndexes(outputStream, rowGroupIndexes.build());
-        return ImmutableList.of(new Stream(column, StreamKind.ROW_INDEX, length, false));
+        Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
+        return ImmutableList.of(new OutputDataStream(slice, stream));
     }
 
     private static List<Integer> createTimestampColumnPositionList(

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -227,9 +227,9 @@ public class TimestampColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<OutputDataStream> outputDataStreams = ImmutableList.builder();
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> secondsStream.writeDataStreams(column, sliceOutput), secondsStream.getBufferedBytes()));
-        outputDataStreams.add(new OutputDataStream(sliceOutput -> nanosStream.writeDataStreams(column, sliceOutput), nanosStream.getBufferedBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> presentStream.writeDataStreams(column, sliceOutput), presentStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> secondsStream.writeDataStreams(column, sliceOutput), secondsStream.getDataStreamBytes()));
+        outputDataStreams.add(new OutputDataStream(sliceOutput -> nanosStream.writeDataStreams(column, sliceOutput), nanosStream.getDataStreamBytes()));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -626,7 +626,7 @@ public class OrcTester
 
         OrcWriter writer;
         writer = new OrcWriter(
-                new FileOutputStream(outputFile),
+                new OutputStreamOrcDataSink(new FileOutputStream(outputFile)),
                 ImmutableList.of("test"),
                 ImmutableList.of(type),
                 format.getOrcEncoding(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
@@ -72,6 +72,7 @@ public class TestOrcOutputBuffer
 
         // make sure we didn't miss anything
         DynamicSliceOutput output = new DynamicSliceOutput(6000);
+        sliceOutput.close();
         assertEquals(sliceOutput.writeDataTo(output), 200 + 200 + 1200 + 2000 + 2500);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -55,7 +55,7 @@ public class TestOrcWriter
         for (OrcWriteValidationMode validationMode : OrcWriteValidationMode.values()) {
             TempFile tempFile = new TempFile();
             OrcWriter writer = new OrcWriter(
-                    new FileOutputStream(tempFile.getFile()),
+                new OutputStreamOrcDataSink(new FileOutputStream(tempFile.getFile())),
                     ImmutableList.of("test1", "test2", "test3", "test4", "test5"),
                     ImmutableList.of(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR),
                     ORC,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -55,7 +55,7 @@ public class TestOrcWriter
         for (OrcWriteValidationMode validationMode : OrcWriteValidationMode.values()) {
             TempFile tempFile = new TempFile();
             OrcWriter writer = new OrcWriter(
-                new OutputStreamOrcDataSink(new FileOutputStream(tempFile.getFile())),
+                    new OutputStreamOrcDataSink(new FileOutputStream(tempFile.getFile())),
                     ImmutableList.of("test1", "test2", "test3", "test4", "test5"),
                     ImmutableList.of(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR),
                     ORC,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
@@ -23,7 +23,6 @@ import io.airlift.slice.Slice;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -50,11 +49,12 @@ public abstract class AbstractTestValueStream<T, C extends StreamCheckpoint, W e
             outputStream.close();
 
             DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
-            Optional<Stream> stream = outputStream.writeDataStreams(33, sliceOutput);
-            assertTrue(stream.isPresent());
-            assertEquals(stream.get().getStreamKind(), StreamKind.DATA);
-            assertEquals(stream.get().getColumn(), 33);
-            assertEquals(stream.get().getLength(), sliceOutput.size());
+            OutputDataStream outputDataStream = outputStream.getOutputDataStream(33);
+            outputDataStream.writeData(sliceOutput);
+            Stream stream = outputDataStream.getStream();
+            assertEquals(stream.getStreamKind(), StreamKind.DATA);
+            assertEquals(stream.getColumn(), 33);
+            assertEquals(stream.getLength(), sliceOutput.size());
 
             List<C> checkpoints = outputStream.getCheckpoints();
             assertEquals(checkpoints.size(), groups.size());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
@@ -49,9 +49,9 @@ public abstract class AbstractTestValueStream<T, C extends StreamCheckpoint, W e
             outputStream.close();
 
             DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
-            OutputDataStream outputDataStream = outputStream.getOutputDataStream(33);
-            outputDataStream.writeData(sliceOutput);
-            Stream stream = outputDataStream.getStream();
+            StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33);
+            streamDataOutput.writeData(sliceOutput);
+            Stream stream = streamDataOutput.getStream();
             assertEquals(stream.getStreamKind(), StreamKind.DATA);
             assertEquals(stream.getColumn(), 33);
             assertEquals(stream.getLength(), sliceOutput.size());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
@@ -34,7 +34,6 @@ import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimp
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestBooleanStream
         extends AbstractTestValueStream<Boolean, BooleanStreamCheckpoint, BooleanOutputStream, BooleanInputStream>
@@ -91,11 +90,12 @@ public class TestBooleanStream
             outputStream.close();
 
             DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
-            Optional<Stream> stream = outputStream.writeDataStreams(33, sliceOutput);
-            assertTrue(stream.isPresent());
-            assertEquals(stream.get().getStreamKind(), StreamKind.DATA);
-            assertEquals(stream.get().getColumn(), 33);
-            assertEquals(stream.get().getLength(), sliceOutput.size());
+            OutputDataStream outputDataStream = outputStream.getOutputDataStream(33);
+            outputDataStream.writeData(sliceOutput);
+            Stream stream = outputDataStream.getStream();
+            assertEquals(stream.getStreamKind(), StreamKind.DATA);
+            assertEquals(stream.getColumn(), 33);
+            assertEquals(stream.getLength(), sliceOutput.size());
 
             BooleanInputStream valueStream = createValueStream(sliceOutput.slice());
             for (int index = 0; index < expectedValues.size(); index++) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
@@ -90,9 +90,9 @@ public class TestBooleanStream
             outputStream.close();
 
             DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
-            OutputDataStream outputDataStream = outputStream.getOutputDataStream(33);
-            outputDataStream.writeData(sliceOutput);
-            Stream stream = outputDataStream.getStream();
+            StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33);
+            streamDataOutput.writeData(sliceOutput);
+            Stream stream = streamDataOutput.getStream();
             assertEquals(stream.getStreamKind(), StreamKind.DATA);
             assertEquals(stream.getColumn(), 33);
             assertEquals(stream.getLength(), sliceOutput.size());


### PR DESCRIPTION
Reorganize ORC code to write full stripe, with optional file header and footer,
in one chunk.  This allows the underlying storage system to rely on large fully
buffered writes to improve performance.