### PR TITLE
Add cache for parameterized type

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloModule.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloModule.java
@@ -47,7 +47,6 @@ import javax.inject.Provider;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.UNEXPECTED_ACCUMULO_ERROR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
@@ -123,9 +122,7 @@ public class AccumuloModule
         @Override
         protected Type _deserialize(String value, DeserializationContext context)
         {
-            Type type = typeManager.getType(parseTypeSignature(value));
-            checkArgument(type != null, "Unknown type %s", value);
-            return type;
+            return typeManager.getType(parseTypeSignature(value));
         }
     }
 

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleModule.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleModule.java
@@ -24,7 +24,6 @@ import com.google.inject.Scopes;
 import javax.inject.Inject;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static io.airlift.json.JsonCodec.listJsonCodec;
@@ -75,9 +74,7 @@ public class ExampleModule
         @Override
         protected Type _deserialize(String value, DeserializationContext context)
         {
-            Type type = typeManager.getType(parseTypeSignature(value));
-            checkArgument(type != null, "Unknown type %s", value);
-            return type;
+            return typeManager.getType(parseTypeSignature(value));
         }
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
@@ -26,7 +26,6 @@ import com.google.inject.multibindings.Multibinder;
 import javax.inject.Inject;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
@@ -84,9 +83,7 @@ public class KafkaConnectorModule
         @Override
         protected Type _deserialize(String value, DeserializationContext context)
         {
-            Type type = typeManager.getType(parseTypeSignature(value));
-            checkArgument(type != null, "Unknown type %s", value);
-            return type;
+            return typeManager.getType(parseTypeSignature(value));
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -65,8 +65,14 @@ public class AddColumnTask
         Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle.get());
 
         ColumnDefinition element = statement.getColumn();
-        Type type = metadata.getType(parseTypeSignature(element.getType()));
-        if ((type == null) || type.equals(UNKNOWN)) {
+        Type type;
+        try {
+            type = metadata.getType(parseTypeSignature(element.getType()));
+        }
+        catch (IllegalArgumentException e) {
+            throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", element.getType(), element.getName());
+        }
+        if (type.equals(UNKNOWN)) {
             throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", element.getType(), element.getName());
         }
         if (columnHandles.containsKey(element.getName().getValue().toLowerCase(ENGLISH))) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -102,8 +102,14 @@ public class CreateTableTask
             if (element instanceof ColumnDefinition) {
                 ColumnDefinition column = (ColumnDefinition) element;
                 String name = column.getName().getValue().toLowerCase(Locale.ENGLISH);
-                Type type = metadata.getType(parseTypeSignature(column.getType()));
-                if ((type == null) || type.equals(UNKNOWN)) {
+                Type type;
+                try {
+                    type = metadata.getType(parseTypeSignature(column.getType()));
+                }
+                catch (IllegalArgumentException e) {
+                    throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", column.getType(), column.getName());
+                }
+                if (type.equals(UNKNOWN)) {
                     throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", column.getType(), column.getName());
                 }
                 if (columns.containsKey(name)) {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -682,12 +682,10 @@ public class FunctionRegistry
 
             // lookup the type
             Type type = typeManager.getType(parseTypeSignature(typeName));
-            requireNonNull(type, format("Type %s not registered", typeName));
 
             // verify we have one parameter of the proper type
             checkArgument(parameterTypes.size() == 1, "Expected one argument to literal function, but got %s", parameterTypes);
             Type parameterType = typeManager.getType(parameterTypes.get(0).getTypeSignature());
-            requireNonNull(parameterType, format("Type %s not found", parameterTypes.get(0)));
 
             return getMagicLiteralFunctionSignature(type);
         }
@@ -978,7 +976,6 @@ public class FunctionRegistry
 
             // lookup the type
             Type type = typeManager.getType(parseTypeSignature(typeName));
-            requireNonNull(type, format("Type %s not registered", typeName));
 
             // verify we have one parameter of the proper type
             checkArgument(parameterTypes.size() == 1, "Expected one argument to literal function, but got %s", parameterTypes);

--- a/presto-main/src/main/java/com/facebook/presto/metadata/ProcedureRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/ProcedureRegistry.java
@@ -95,7 +95,6 @@ public class ProcedureRegistry
         for (int i = 0; i < procedure.getArguments().size(); i++) {
             Argument argument = procedure.getArguments().get(i);
             Type type = typeManager.getType(argument.getType());
-            checkArgument(type != null, "Unknown argument type: %s", argument.getType());
 
             Class<?> argumentType = Primitives.unwrap(parameters.get(i));
             Class<?> expectedType = getObjectType(type);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -687,8 +687,11 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitGenericLiteral(GenericLiteral node, StackableAstVisitorContext<Context> context)
         {
-            Type type = typeManager.getType(parseTypeSignature(node.getType()));
-            if (type == null) {
+            Type type;
+            try {
+                type = typeManager.getType(parseTypeSignature(node.getType()));
+            }
+            catch (IllegalArgumentException e) {
                 throw new SemanticException(TYPE_MISMATCH, node, "Unknown type: " + node.getType());
             }
 
@@ -946,8 +949,11 @@ public class ExpressionAnalyzer
         @Override
         public Type visitCast(Cast node, StackableAstVisitorContext<Context> context)
         {
-            Type type = typeManager.getType(parseTypeSignature(node.getType()));
-            if (type == null) {
+            Type type;
+            try {
+                type = typeManager.getType(parseTypeSignature(node.getType()));
+            }
+            catch (IllegalArgumentException e) {
                 throw new SemanticException(TYPE_MISMATCH, node, "Unknown type: " + node.getType());
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -246,8 +246,11 @@ public final class SqlToRowExpressionTranslator
         @Override
         protected RowExpression visitGenericLiteral(GenericLiteral node, Void context)
         {
-            Type type = typeManager.getType(parseTypeSignature(node.getType()));
-            if (type == null) {
+            Type type;
+            try {
+                type = typeManager.getType(parseTypeSignature(node.getType()));
+            }
+            catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Unsupported type: " + node.getType());
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -184,28 +184,19 @@ public final class TypeRegistry
 
         for (TypeSignatureParameter parameter : signature.getParameters()) {
             TypeParameter typeParameter = TypeParameter.of(parameter, this);
-            if (typeParameter == null) {
-                return null;
-            }
             parameters.add(typeParameter);
         }
 
         ParametricType parametricType = parametricTypes.get(signature.getBase().toLowerCase(Locale.ENGLISH));
         if (parametricType == null) {
-            return null;
+            throw new IllegalArgumentException("Unknown type " + signature);
         }
 
-        try {
-            Type instantiatedType = parametricType.createType(this, parameters);
+        Type instantiatedType = parametricType.createType(this, parameters);
 
-            // TODO: reimplement this check? Currently "varchar(Integer.MAX_VALUE)" fails with "varchar"
-            //checkState(instantiatedType.equalsSignature(signature), "Instantiated parametric type name (%s) does not match expected name (%s)", instantiatedType, signature);
-            return instantiatedType;
-        }
-        catch (IllegalArgumentException e) {
-            // TODO: check whether a type constructor actually exists rather than failing when it doesn't. This will be possible in the next version of the type system
-            return null;
-        }
+        // TODO: reimplement this check? Currently "varchar(Integer.MAX_VALUE)" fails with "varchar"
+        //checkState(instantiatedType.equalsSignature(signature), "Instantiated parametric type name (%s) does not match expected name (%s)", instantiatedType, signature);
+        return instantiatedType;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -102,9 +102,7 @@ public final class TypeUtils
 
     public static Type resolveType(TypeSignature typeName, TypeManager typeManager)
     {
-        Type type = typeManager.getType(typeName);
-        checkArgument(type != null, "Type '%s' not found", typeName);
-        return type;
+        return typeManager.getType(typeName);
     }
 
     public static List<Type> resolveTypes(List<TypeSignature> typeNames, TypeManager typeManager)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTypeRegistry.java
@@ -53,7 +53,6 @@ import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -65,8 +64,17 @@ public class TestTypeRegistry
     @Test
     public void testNonexistentType()
     {
-        TypeManager typeManager = new TypeRegistry();
-        assertNull(typeManager.getType(parseTypeSignature("not a real type")));
+        try {
+            TypeManager typeManager = new TypeRegistry();
+            typeManager.getType(parseTypeSignature("not a real type"));
+            fail("Expect to throw IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().matches("Unknown type.*"));
+        }
+        catch (Throwable t) {
+            fail("Expect to throw IllegalArgumentException, got " + t.getClass());
+        }
     }
 
     @Test

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryModule.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryModule.java
@@ -25,7 +25,6 @@ import com.google.inject.Scopes;
 import javax.inject.Inject;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.util.Objects.requireNonNull;
 
@@ -74,9 +73,7 @@ public class MemoryModule
         @Override
         protected Type _deserialize(String value, DeserializationContext context)
         {
-            Type type = typeManager.getType(parseTypeSignature(value));
-            checkArgument(type != null, "Unknown type %s", value);
-            return type;
+            return typeManager.getType(parseTypeSignature(value));
         }
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/Distribution.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/Distribution.java
@@ -90,8 +90,11 @@ public class Distribution
 
             ImmutableList.Builder<Type> types = ImmutableList.builder();
             for (String typeName : typeNames) {
-                Type type = typeManager.getType(parseTypeSignature(typeName));
-                if (type == null) {
+                Type type;
+                try {
+                    type = typeManager.getType(parseTypeSignature(typeName));
+                }
+                catch (IllegalArgumentException e) {
                     throw new PrestoException(RAPTOR_ERROR, "Unknown distribution column type: " + typeName);
                 }
                 types.add(type);

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/TableColumn.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/TableColumn.java
@@ -29,7 +29,6 @@ import java.util.OptionalInt;
 import static com.facebook.presto.raptor.util.DatabaseUtil.getOptionalInt;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class TableColumn
@@ -137,7 +136,6 @@ public class TableColumn
 
             String typeName = r.getString("data_type");
             Type type = typeManager.getType(parseTypeSignature(typeName));
-            checkArgument(type != null, "Unknown type %s", typeName);
 
             return new TableColumn(
                     table,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeParameter.java
@@ -53,18 +53,12 @@ public class TypeParameter
         switch (parameter.getKind()) {
             case TYPE: {
                 Type type = typeManager.getType(parameter.getTypeSignature());
-                if (type == null) {
-                    return null;
-                }
                 return of(type);
             }
             case LONG:
                 return of(parameter.getLongLiteral());
             case NAMED_TYPE: {
                 Type type = typeManager.getType(parameter.getNamedTypeSignature().getTypeSignature());
-                if (type == null) {
-                    return null;
-                }
                 return of(new NamedType(
                         parameter.getNamedTypeSignature().getName(),
                         type));

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeDeserializer.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingTypeDeserializer.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public final class TestingTypeDeserializer
@@ -34,8 +33,6 @@ public final class TestingTypeDeserializer
     @Override
     protected Type _deserialize(String value, DeserializationContext context)
     {
-        Type type = typeManager.getType(parseTypeSignature(value));
-        checkArgument(type != null, "Unknown type %s", value);
-        return type;
+        return typeManager.getType(parseTypeSignature(value));
     }
 }


### PR DESCRIPTION
To avoid repeatedly resolving operator and creating BoundMethodHandle
when deserializing MapBlock, we use the MethodHandles store in
MapType. Caching MapType is required to accomplish this.