### PR TITLE
Set mapred.min.split.size property for skip.header.line.count

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -358,6 +358,8 @@ public class BackgroundHiveSplitLoader
         if (headerCount > 0) {
             // do not split file when skip.header.line.count is used
             jobConf.setLong("mapreduce.input.fileinputformat.split.minsize", Long.MAX_VALUE);
+            // TODO remove this when Hadoop 1.x is not supported
+            jobConf.setLong("mapred.min.split.size", Long.MAX_VALUE);
         }
     }
 


### PR DESCRIPTION
`mapred.min.split.size` is the legacy name of `mapreduce.input.fileinputformat.split.minsize`.

cc @kokosing 