### PR TITLE
move memory connector warnings to a limitations sections

### DIFF
--- a/presto-docs/src/main/sphinx/connector/memory.rst
+++ b/presto-docs/src/main/sphinx/connector/memory.rst
@@ -5,41 +5,6 @@ Memory Connector
 The Memory connector stores all data and metadata in RAM on workers
 and both are discarded when Presto restarts.
 
-.. warning::
-
-    This connector is in early experimental stage it is not recommended
-    to use it in a production environment. The intended use of this
-    connector at this point is purely for testing.
-
-.. warning::
-
-    After ``DROP TABLE`` memory is not released immediately. It is released
-    after next write access to memory connector.
-
-.. warning::
-
-    When one worker fails/restarts all data that were stored in it's
-    memory will be lost forever. To prevent silent data loss this
-    connector will throw an error on any read access to such corrupted
-    table.
-
-.. warning::
-
-    When query fails for any reason during writing to memory table,
-    table will be in undefined state. Such table should be dropped and
-    recreated manually. Reading attempt from such table may fail or may
-    return partial data.
-
-.. warning::
-
-    When coordinator fails/restarts all metadata about tables will
-    be lost, but tables' data will be still present on the workers
-    however they will be inaccessible.
-
-.. warning::
-
-    This connector will not work properly with multiple coordinators,
-    since each coordinator will have a different metadata.
 
 Configuration
 -------------
@@ -75,3 +40,24 @@ Select from the Memory connector::
 Drop table::
 
     DROP TABLE memory.default.nation;
+
+
+Memory Connector Limitations
+----------------------------
+
+    * After ``DROP TABLE`` memory is not released immediately. It is
+      released after next write access to memory connector.
+    * When one worker fails/restarts all data that were stored in its
+      memory will be lost forever. To prevent silent data loss this
+      connector will throw an error on any read access to such
+      corrupted table.
+    * When query fails for any reason during writing to memory table,
+      table will be in undefined state. Such table should be dropped
+      and recreated manually. Reading attempt from such table may fail
+      or may return partial data.
+    * When coordinator fails/restarts all metadata about tables will
+      be lost, but tables' data will be still present on the workers
+      however they will be inaccessible.
+    * This connector will not work properly with multiple
+      coordinators, since each coordinator will have a different
+      metadata.


### PR DESCRIPTION
Create a limitations sections to make the memory connector documentation more readable.