### PR TITLE
Revert "Update to aircompressor 0.10"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>0.10</version>
+                <version>0.9</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This reverts commit 50d13df01d20ed1f4a8a9131c09d1301e9ac963b.

Reverting because this version appears to cause segfaults in test runs.