### PR TITLE
Fix distinct from operator for map

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapDistinctFromOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapDistinctFromOperator.java
@@ -14,6 +14,7 @@ package com.facebook.presto.operator.scalar;
  */
 
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.function.IsNull;
 import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlNullable;
@@ -48,10 +49,10 @@ public final class MapDistinctFromOperator
             @TypeParameter("K") Type keyType,
             @TypeParameter("V") Type valueType,
             @SqlNullable @SqlType("map(K,V)") Block leftMapBlock,
-            @SqlNullable @SqlType("map(K,V)") Block rightMapBlock)
+            @IsNull boolean leftMapNull,
+            @SqlNullable @SqlType("map(K,V)") Block rightMapBlock,
+            @IsNull boolean rightMapNull)
     {
-        boolean leftMapNull = leftMapBlock == null;
-        boolean rightMapNull = rightMapBlock == null;
         if (leftMapNull != rightMapNull) {
             return true;
         }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -704,6 +704,11 @@ public class TestMapOperators
         assertFunction("MAP(ARRAY[1, 3], ARRAY['kittens','puppies']) IS DISTINCT FROM MAP(ARRAY[1, 2], ARRAY['kittens', 'pupp111'])", BOOLEAN, true);
         assertFunction("MAP(ARRAY[1, 3], ARRAY['kittens','puppies']) IS DISTINCT FROM MAP(ARRAY[1, 2], ARRAY['kittens', NULL])", BOOLEAN, true);
         assertFunction("MAP(ARRAY[1, 3], ARRAY['kittens','puppies']) IS DISTINCT FROM MAP(ARRAY[1, 2], ARRAY[NULL, NULL])", BOOLEAN, true);
+
+        assertFunction("MAP(ARRAY[1, 3], ARRAY[MAP(ARRAY['kittens'], ARRAY[1e0]), MAP(ARRAY['puppies'], ARRAY[3e0])]) " +
+                "IS DISTINCT FROM MAP(ARRAY[1, 3], ARRAY[MAP(ARRAY['kittens'], ARRAY[1e0]), MAP(ARRAY['puppies'], ARRAY[3e0])])", BOOLEAN, false);
+        assertFunction("MAP(ARRAY[1, 3], ARRAY[MAP(ARRAY['kittens'], ARRAY[1e0]), MAP(ARRAY['puppies'], ARRAY[3e0])]) " +
+                "IS DISTINCT FROM MAP(ARRAY[1, 3], ARRAY[MAP(ARRAY['kittens'], ARRAY[1e0]), MAP(ARRAY['puppies'], ARRAY[4e0])])", BOOLEAN, true);
     }
 
     @Test


### PR DESCRIPTION
All implementations must be implemented with null flag convention due to deficiencies in Presto engine implementation.

cc @elonazoulay 