### PR TITLE
Optimize array equals for bigint/double types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayEqualOperator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.function.TypeParameterSpecialization;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 
@@ -52,6 +53,66 @@ public final class ArrayEqualOperator
             Object rightElement = readNativeValue(type, rightArray, i);
             try {
                 if (!(boolean) equalsFunction.invoke(leftElement, rightElement)) {
+                    return false;
+                }
+            }
+            catch (Throwable t) {
+                throw internalError(t);
+            }
+        }
+        return true;
+    }
+
+    @TypeParameter("E")
+    @TypeParameterSpecialization(name = "E", nativeContainerType = long.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean equalsLong(
+            @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"E", "E"}) MethodHandle equalsFunction,
+            @TypeParameter("E") Type type,
+            @SqlType("array(E)") Block leftArray,
+            @SqlType("array(E)") Block rightArray)
+    {
+        if (leftArray.getPositionCount() != rightArray.getPositionCount()) {
+            return false;
+        }
+
+        for (int i = 0; i < leftArray.getPositionCount(); i++) {
+            checkElementNotNull(leftArray.isNull(i), ARRAY_NULL_ELEMENT_MSG);
+            checkElementNotNull(rightArray.isNull(i), ARRAY_NULL_ELEMENT_MSG);
+            long leftElement = type.getLong(leftArray, i);
+            long rightElement = type.getLong(rightArray, i);
+            try {
+                if (!(boolean) equalsFunction.invokeExact(leftElement, rightElement)) {
+                    return false;
+                }
+            }
+            catch (Throwable t) {
+                throw internalError(t);
+            }
+        }
+        return true;
+    }
+
+    @TypeParameter("E")
+    @TypeParameterSpecialization(name = "E", nativeContainerType = double.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean equalsDouble(
+            @OperatorDependency(operator = EQUAL, returnType = StandardTypes.BOOLEAN, argumentTypes = {"E", "E"}) MethodHandle equalsFunction,
+            @TypeParameter("E") Type type,
+            @SqlType("array(E)") Block leftArray,
+            @SqlType("array(E)") Block rightArray)
+    {
+        if (leftArray.getPositionCount() != rightArray.getPositionCount()) {
+            return false;
+        }
+
+        for (int i = 0; i < leftArray.getPositionCount(); i++) {
+            checkElementNotNull(leftArray.isNull(i), ARRAY_NULL_ELEMENT_MSG);
+            checkElementNotNull(rightArray.isNull(i), ARRAY_NULL_ELEMENT_MSG);
+            double leftElement = type.getDouble(leftArray, i);
+            double rightElement = type.getDouble(rightArray, i);
+            try {
+                if (!(boolean) equalsFunction.invokeExact(leftElement, rightElement)) {
                     return false;
                 }
             }


### PR DESCRIPTION
Using `ArrayComparisonBenchmark`, before:
```
array_equals ::  110.131 cpu ms ::    0B peak memory :: in   15K,      0B,    136K/s,      0B/s :: out     1,      9B,       9/s,     81B/s
```
After:
```
array_equals ::   99.742 cpu ms ::    0B peak memory :: in   15K,      0B,    150K/s,      0B/s :: out     1,      9B,      10/s,     90B/s
```

Results in roughly 10% better performance -- decrease in CPU time (from 110.131 cpu ms to 99.742 cpu ms) and increase in throughput (from 136K rows/s to 150K rows/s).


