### PR TITLE
Add IGNORE NULLS clause to various Window functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/window.rst
+++ b/presto-docs/src/main/sphinx/functions/window.rst
@@ -90,6 +90,12 @@ Ranking Functions
 Value Functions
 ---------------
 
+Value functions provide an option to specify how null values should be treated when evaluating the
+function. Nulls can either be ignored (``IGNORE NULLS``) or respected (``RESPECT NULLS``). By default,
+null values are respected. If ``IGNORE NULLS`` is specified, all rows where the value expresssion is
+null are excluded from the calculation. If ``IGNORE NULLS`` is specified and the value expression is
+null for all rows, the ``default_value`` is returned, or if it is not specified, ``null`` is returned.
+
 .. function:: first_value(x) -> [same as input]
 
     Returns the first value of the window.
@@ -110,14 +116,14 @@ Value Functions
 
     Returns the value at ``offset`` rows after the current row in the window.
     Offsets start at ``0``, which is the current row. The
-    offset can be any scalar expression.  The default ``offset`` is ``1``. If the
+    offset can be any scalar expression. The default ``offset`` is ``1``. If the
     offset is null or larger than the window, the ``default_value`` is returned,
     or if it is not specified ``null`` is returned.
 
 .. function:: lag(x[, offset [, default_value]]) -> [same as input]
 
     Returns the value at ``offset`` rows before the current row in the window
-    Offsets start at ``0``, which is the current row.  The
-    offset can be any scalar expression.  The default ``offset`` is ``1``. If the
+    Offsets start at ``0``, which is the current row. The
+    offset can be any scalar expression. The default ``offset`` is ``1``. If the
     offset is null or larger than the window, the ``default_value`` is returned,
     or if it is not specified ``null`` is returned.

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowFunctionDefinition.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowFunctionDefinition.java
@@ -30,10 +30,11 @@ public class WindowFunctionDefinition
     private final Type type;
     private final FrameInfo frameInfo;
     private final List<Integer> argumentChannels;
+    private final boolean ignoreNulls;
 
     public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, FrameInfo frameInfo, List<Integer> inputs)
     {
-        return new WindowFunctionDefinition(functionSupplier, type, frameInfo, inputs);
+        return new WindowFunctionDefinition(functionSupplier, type, frameInfo, false, inputs);
     }
 
     public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, FrameInfo frameInfo, Integer... inputs)
@@ -41,7 +42,17 @@ public class WindowFunctionDefinition
         return window(functionSupplier, type, frameInfo, Arrays.asList(inputs));
     }
 
-    WindowFunctionDefinition(WindowFunctionSupplier functionSupplier, Type type, FrameInfo frameInfo, List<Integer> argumentChannels)
+    public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, FrameInfo frameInfo, boolean ignoreNulls, List<Integer> inputs)
+    {
+        return new WindowFunctionDefinition(functionSupplier, type, frameInfo, ignoreNulls, inputs);
+    }
+
+    public static WindowFunctionDefinition window(WindowFunctionSupplier functionSupplier, Type type, FrameInfo frameInfo, boolean ignoreNulls, Integer... inputs)
+    {
+        return window(functionSupplier, type, frameInfo, ignoreNulls, Arrays.asList(inputs));
+    }
+
+    WindowFunctionDefinition(WindowFunctionSupplier functionSupplier, Type type, FrameInfo frameInfo, boolean ignoreNulls, List<Integer> argumentChannels)
     {
         requireNonNull(functionSupplier, "functionSupplier is null");
         requireNonNull(type, "type is null");
@@ -51,6 +62,7 @@ public class WindowFunctionDefinition
         this.functionSupplier = functionSupplier;
         this.type = type;
         this.frameInfo = frameInfo;
+        this.ignoreNulls = ignoreNulls;
         this.argumentChannels = ImmutableList.copyOf(argumentChannels);
     }
 
@@ -66,6 +78,6 @@ public class WindowFunctionDefinition
 
     public WindowFunction createWindowFunction()
     {
-        return functionSupplier.createWindowFunction(argumentChannels);
+        return functionSupplier.createWindowFunction(argumentChannels, ignoreNulls);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/AbstractWindowFunctionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/AbstractWindowFunctionSupplier.java
@@ -46,7 +46,7 @@ public abstract class AbstractWindowFunctionSupplier
     }
 
     @Override
-    public final WindowFunction createWindowFunction(List<Integer> argumentChannels)
+    public final WindowFunction createWindowFunction(List<Integer> argumentChannels, boolean ignoreNulls)
     {
         requireNonNull(argumentChannels, "inputs is null");
         checkArgument(argumentChannels.size() == signature.getArgumentTypes().size(),
@@ -55,12 +55,12 @@ public abstract class AbstractWindowFunctionSupplier
                 signature.getNameSuffix(),
                 argumentChannels.size());
 
-        return newWindowFunction(argumentChannels);
+        return newWindowFunction(argumentChannels, ignoreNulls);
     }
 
     /**
      * Create window function instance using the supplied arguments.  The
      * inputs have already validated.
      */
-    protected abstract WindowFunction newWindowFunction(List<Integer> inputs);
+    protected abstract WindowFunction newWindowFunction(List<Integer> inputs, boolean ignoreNulls);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
@@ -94,7 +94,7 @@ public class AggregateWindowFunction
         return new AbstractWindowFunctionSupplier(signature, null)
         {
             @Override
-            protected WindowFunction newWindowFunction(List<Integer> inputs)
+            protected WindowFunction newWindowFunction(List<Integer> inputs, boolean ignoreNulls)
             {
                 return new AggregateWindowFunction(function, inputs);
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/FirstValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/FirstValueFunction.java
@@ -40,6 +40,23 @@ public class FirstValueFunction
             return;
         }
 
-        windowIndex.appendTo(argumentChannel, frameStart, output);
+        int valuePosition = frameStart;
+
+        if (ignoreNulls) {
+            while (valuePosition >= 0 && valuePosition <= frameEnd) {
+                if (!windowIndex.isNull(argumentChannel, valuePosition)) {
+                    break;
+                }
+
+                valuePosition++;
+            }
+
+            if (valuePosition > frameEnd) {
+                output.appendNull();
+                return;
+            }
+        }
+
+        windowIndex.appendTo(argumentChannel, valuePosition, output);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/LagFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/LagFunction.java
@@ -50,9 +50,26 @@ public class LagFunction
             long offset = (offsetChannel < 0) ? 1 : windowIndex.getLong(offsetChannel, currentPosition);
             checkCondition(offset >= 0, INVALID_FUNCTION_ARGUMENT, "Offset must be at least 0");
 
-            long valuePosition = currentPosition - offset;
+            long valuePosition;
 
-            if ((valuePosition >= 0) && (valuePosition <= currentPosition)) {
+            if (ignoreNulls && (offset > 0)) {
+                long count = 0;
+                valuePosition = currentPosition - 1;
+                while (withinPartition(valuePosition, currentPosition)) {
+                    if (!windowIndex.isNull(valueChannel, toIntExact(valuePosition))) {
+                        count++;
+                        if (count == offset) {
+                            break;
+                        }
+                    }
+                    valuePosition--;
+                }
+            }
+            else {
+                valuePosition = currentPosition - offset;
+            }
+
+            if (withinPartition(valuePosition, currentPosition)) {
                 windowIndex.appendTo(valueChannel, toIntExact(valuePosition), output);
             }
             else if (defaultChannel >= 0) {
@@ -62,5 +79,10 @@ public class LagFunction
                 output.appendNull();
             }
         }
+    }
+
+    private boolean withinPartition(long valuePosition, long currentPosition)
+    {
+        return valuePosition >= 0 && valuePosition <= currentPosition;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/LastValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/LastValueFunction.java
@@ -40,6 +40,23 @@ public class LastValueFunction
             return;
         }
 
-        windowIndex.appendTo(argumentChannel, frameEnd, output);
+        int valuePosition = frameEnd;
+
+        if (ignoreNulls) {
+            while (valuePosition >= frameStart) {
+                if (!windowIndex.isNull(argumentChannel, valuePosition)) {
+                    break;
+                }
+
+                valuePosition--;
+            }
+
+            if (valuePosition < frameStart) {
+                output.appendNull();
+                return;
+            }
+        }
+
+        windowIndex.appendTo(argumentChannel, valuePosition, output);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/NthValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/NthValueFunction.java
@@ -46,8 +46,25 @@ public class NthValueFunction
             long offset = windowIndex.getLong(offsetChannel, currentPosition);
             checkCondition(offset >= 1, INVALID_FUNCTION_ARGUMENT, "Offset must be at least 1");
 
-            // offset is base 1
-            long valuePosition = frameStart + (offset - 1);
+            long valuePosition;
+
+            if (ignoreNulls) {
+                long count = 0;
+                valuePosition = frameStart;
+                while (valuePosition >= 0 && valuePosition <= frameEnd) {
+                    if (!windowIndex.isNull(valueChannel, toIntExact(valuePosition))) {
+                        count++;
+                        if (count == offset) {
+                            break;
+                        }
+                    }
+                    valuePosition++;
+                }
+            }
+            else {
+                // offset is base 1
+                valuePosition = frameStart + (offset - 1);
+            }
 
             if ((valuePosition >= frameStart) && (valuePosition <= frameEnd)) {
                 windowIndex.appendTo(valueChannel, toIntExact(valuePosition), output);

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/ReflectionWindowFunctionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/ReflectionWindowFunctionSupplier.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.window;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.QualifiedFunctionName;
 import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.ValueWindowFunction;
 import com.facebook.presto.spi.function.WindowFunction;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.Lists;
@@ -55,15 +56,23 @@ public class ReflectionWindowFunctionSupplier<T extends WindowFunction>
     }
 
     @Override
-    protected T newWindowFunction(List<Integer> inputs)
+    protected T newWindowFunction(List<Integer> inputs, boolean ignoreNulls)
     {
         try {
+            T windowFunction;
+
             if (getSignature().getArgumentTypes().isEmpty()) {
-                return constructor.newInstance();
+                windowFunction = constructor.newInstance();
             }
             else {
-                return constructor.newInstance(inputs);
+                windowFunction = constructor.newInstance(inputs);
             }
+
+            if (windowFunction instanceof ValueWindowFunction) {
+                ((ValueWindowFunction) windowFunction).setIgnoreNulls(ignoreNulls);
+            }
+
+            return windowFunction;
         }
         catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/WindowAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/WindowAnnotationsParser.java
@@ -44,7 +44,9 @@ public final class WindowAnnotationsParser
                 .collect(toImmutableList());
     }
 
-    private static SqlWindowFunction parse(Class<? extends WindowFunction> clazz, WindowFunctionSignature window)
+    private static SqlWindowFunction parse(
+            Class<? extends WindowFunction> clazz,
+            WindowFunctionSignature window)
     {
         List<TypeVariableConstraint> typeVariables = ImmutableList.of();
         if (!window.typeVariable().isEmpty()) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/WindowFunctionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/WindowFunctionSupplier.java
@@ -24,5 +24,5 @@ public interface WindowFunctionSupplier
 
     String getDescription();
 
-    WindowFunction createWindowFunction(List<Integer> argumentChannels);
+    WindowFunction createWindowFunction(List<Integer> argumentChannels, boolean ignoreNulls);
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -910,7 +910,7 @@ public class ExpressionInterpreter
 
             // do not optimize non-deterministic functions
             if (optimize && (!functionMetadata.isDeterministic() || hasUnresolvedValue(argumentValues) || node.getName().equals(QualifiedName.of("fail")))) {
-                return new FunctionCall(node.getName(), node.getWindow(), node.isDistinct(), toExpressions(argumentValues, argumentTypes));
+                return new FunctionCall(node.getName(), node.getWindow(), node.isDistinct(), node.isIgnoreNulls(), toExpressions(argumentValues, argumentTypes));
             }
 
             Object result;
@@ -934,7 +934,7 @@ public class ExpressionInterpreter
             }
 
             if (optimize && !isSerializable(result, type(node))) {
-                return new FunctionCall(node.getName(), node.getWindow(), node.isDistinct(), toExpressions(argumentValues, argumentTypes));
+                return new FunctionCall(node.getName(), node.getWindow(), node.isDistinct(), node.isIgnoreNulls(), toExpressions(argumentValues, argumentTypes));
             }
             return result;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -948,8 +948,9 @@ public class LocalExecutionPlanner
 
                 FrameInfo frameInfo = new FrameInfo(frame.getType(), frame.getStartType(), frameStartChannel, frame.getEndType(), frameEndChannel);
 
-                CallExpression call = entry.getValue().getFunctionCall();
-                FunctionHandle functionHandle = entry.getValue().getFunctionHandle();
+                WindowNode.Function function = entry.getValue();
+                CallExpression call = function.getFunctionCall();
+                FunctionHandle functionHandle = function.getFunctionHandle();
                 ImmutableList.Builder<Integer> arguments = ImmutableList.builder();
                 for (RowExpression argument : call.getArguments()) {
                     checkState(argument instanceof VariableReferenceExpression);
@@ -959,7 +960,7 @@ public class LocalExecutionPlanner
                 FunctionManager functionManager = metadata.getFunctionManager();
                 WindowFunctionSupplier windowFunctionSupplier = functionManager.getWindowFunctionImplementation(functionHandle);
                 Type type = metadata.getType(functionManager.getFunctionMetadata(functionHandle).getReturnType());
-                windowFunctionsBuilder.add(window(windowFunctionSupplier, type, frameInfo, arguments.build()));
+                windowFunctionsBuilder.add(window(windowFunctionSupplier, type, frameInfo, function.isIgnoreNulls(), arguments.build()));
                 windowFunctionOutputVariablesBuilder.add(variable);
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -825,7 +825,8 @@ class QueryPlanner
                             analysis.getFunctionHandle(windowFunction),
                             returnType,
                             ((FunctionCall) rewritten).getArguments().stream().map(OriginalExpressionUtils::castToRowExpression).collect(toImmutableList())),
-                    frame);
+                    frame,
+                    windowFunction.isIgnoreNulls());
 
             ImmutableList.Builder<VariableReferenceExpression> orderByVariables = ImmutableList.builder();
             orderByVariables.addAll(orderings.keySet());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
@@ -264,7 +264,8 @@ public class RowExpressionRewriteRuleSet
                                         callExpression.getFunctionHandle(),
                                         callExpression.getType(),
                                         newArguments.build()),
-                                entry.getValue().getFrame()));
+                                entry.getValue().getFrame(),
+                                entry.getValue().isIgnoreNulls()));
             }
             if (anyRewritten) {
                 return Result.ofPlanNode(new WindowNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -225,7 +225,8 @@ public class UnaliasSymbolReferences
                                         callExpression.getFunctionHandle(),
                                         callExpression.getType(),
                                         rewrittenArguments),
-                                canonicalFrame));
+                                canonicalFrame,
+                                entry.getValue().isIgnoreNulls()));
             }
 
             return new WindowNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
@@ -342,14 +342,17 @@ public class WindowNode
     {
         private final CallExpression functionCall;
         private final Frame frame;
+        private final boolean ignoreNulls;
 
         @JsonCreator
         public Function(
                 @JsonProperty("functionCall") CallExpression functionCall,
-                @JsonProperty("frame") Frame frame)
+                @JsonProperty("frame") Frame frame,
+                @JsonProperty("ignoreNulls") boolean ignoreNulls)
         {
             this.functionCall = requireNonNull(functionCall, "functionCall is null");
             this.frame = requireNonNull(frame, "Frame is null");
+            this.ignoreNulls = ignoreNulls;
         }
 
         @JsonProperty
@@ -373,7 +376,7 @@ public class WindowNode
         @Override
         public int hashCode()
         {
-            return Objects.hash(functionCall, frame);
+            return Objects.hash(functionCall, frame, ignoreNulls);
         }
 
         @Override
@@ -387,7 +390,13 @@ public class WindowNode
             }
             Function other = (Function) obj;
             return Objects.equals(this.functionCall, other.functionCall) &&
-                    Objects.equals(this.frame, other.frame);
+                    Objects.equals(this.frame, other.frame) &&
+                    Objects.equals(this.ignoreNulls, other.ignoreNulls);
+        }
+
+        public boolean isIgnoreNulls()
+        {
+            return ignoreNulls;
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestFirstValueFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestFirstValueFunction.java
@@ -129,4 +129,272 @@ public class TestFirstValueFunction
                         .row(null, null, 7L)
                         .build());
     }
+
+    @Test
+    public void testFirstValueUnboundedIgnoreNulls()
+    {
+        assertWindowQuery("first_value(orderdate) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, VARCHAR)
+                        .row(3, "F", "1993-10-14")
+                        .row(5, "F", "1993-10-14")
+                        .row(6, "F", "1993-10-14")
+                        .row(33, "F", "1993-10-14")
+                        .row(1, "O", "1996-01-02")
+                        .row(2, "O", "1996-01-02")
+                        .row(4, "O", "1996-01-02")
+                        .row(7, "O", "1996-01-02")
+                        .row(32, "O", "1996-01-02")
+                        .row(34, "O", "1996-01-02")
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderdate) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(3L, "F", "1993-10-14")
+                        .row(5L, "F", "1993-10-14")
+                        .row(6L, "F", "1993-10-14")
+                        .row(null, "F", "1993-10-14")
+                        .row(34L, "O", "1998-07-21")
+                        .row(null, "O", "1998-07-21")
+                        .row(1L, null, null)
+                        .row(7L, null, "1996-01-10")
+                        .row(null, null, "1996-01-10")
+                        .row(null, null, "1996-01-10")
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderdate) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(3L, "F", "1993-10-14")
+                        .row(5L, "F", "1993-10-14")
+                        .row(6L, "F", "1993-10-14")
+                        .row(null, "F", "1993-10-14")
+                        .row(34L, "O", "1998-07-21")
+                        .row(null, "O", "1998-07-21")
+                        .row(1L, null, "1996-01-10")
+                        .row(7L, null, "1996-01-10")
+                        .row(null, null, "1996-01-10")
+                        .row(null, null, "1996-01-10")
+                        .build());
+
+        assertWindowQuery("first_value(orderkey) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, INTEGER)
+                        .row(3, "F", 3)
+                        .row(5, "F", 3)
+                        .row(6, "F", 3)
+                        .row(33, "F", 3)
+                        .row(1, "O", 1)
+                        .row(2, "O", 1)
+                        .row(4, "O", 1)
+                        .row(7, "O", 1)
+                        .row(32, "O", 1)
+                        .row(34, "O", 1)
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderkey) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 3L)
+                        .row(5L, "F", 3L)
+                        .row(6L, "F", 3L)
+                        .row(null, "F", 3L)
+                        .row(34L, "O", 34L)
+                        .row(null, "O", 34L)
+                        .row(1L, null, 1L)
+                        .row(7L, null, 1L)
+                        .row(null, null, 1L)
+                        .row(null, null, 1L)
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderkey) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey NULLS FIRST " +
+                        "ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(null, "F", 3L)
+                        .row(3L, "F", 3L)
+                        .row(5L, "F", 3L)
+                        .row(6L, "F", 3L)
+                        .row(null, "O", 34L)
+                        .row(34L, "O", 34L)
+                        .row(null, null, 1L)
+                        .row(null, null, 1L)
+                        .row(1L, null, 1L)
+                        .row(7L, null, 1L)
+                        .build());
+
+        // Timestamp
+        assertWindowQuery("date_format(first_value(cast(orderdate as TIMESTAMP)) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey), '%Y-%m-%d')",
+                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, VARCHAR)
+                        .row(3, "F", "1993-10-14")
+                        .row(5, "F", "1993-10-14")
+                        .row(6, "F", "1993-10-14")
+                        .row(33, "F", "1993-10-14")
+                        .row(1, "O", "1996-01-02")
+                        .row(2, "O", "1996-01-02")
+                        .row(4, "O", "1996-01-02")
+                        .row(7, "O", "1996-01-02")
+                        .row(32, "O", "1996-01-02")
+                        .row(34, "O", "1996-01-02")
+                        .build());
+    }
+
+    @Test
+    public void testFirstValueBoundedIgnoreNulls()
+    {
+        assertWindowQuery("first_value(orderkey) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING)",
+                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, INTEGER)
+                        .row(3, "F", 3)
+                        .row(5, "F", 3)
+                        .row(6, "F", 3)
+                        .row(33, "F", 5)
+                        .row(1, "O", 1)
+                        .row(2, "O", 1)
+                        .row(4, "O", 1)
+                        .row(7, "O", 2)
+                        .row(32, "O", 4)
+                        .row(34, "O", 7)
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderkey) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey NULLS FIRST " +
+                        "ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(null, "F", 3L)
+                        .row(3L, "F", 3L)
+                        .row(5L, "F", 3L)
+                        .row(6L, "F", 5L)
+                        .row(null, "O", 34L)
+                        .row(34L, "O", 34L)
+                        .row(null, null, null)
+                        .row(null, null, 1L)
+                        .row(1L, null, 1L)
+                        .row(7L, null, 1L)
+                        .build());
+    }
+
+    @Test
+    public void testFirstValueUnboundedRespectNulls()
+    {
+        assertWindowQuery("first_value(orderdate) RESPECT NULLS  OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, VARCHAR)
+                        .row(3, "F", "1993-10-14")
+                        .row(5, "F", "1993-10-14")
+                        .row(6, "F", "1993-10-14")
+                        .row(33, "F", "1993-10-14")
+                        .row(1, "O", "1996-01-02")
+                        .row(2, "O", "1996-01-02")
+                        .row(4, "O", "1996-01-02")
+                        .row(7, "O", "1996-01-02")
+                        .row(32, "O", "1996-01-02")
+                        .row(34, "O", "1996-01-02")
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderdate) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(3L, "F", "1993-10-14")
+                        .row(5L, "F", "1993-10-14")
+                        .row(6L, "F", "1993-10-14")
+                        .row(null, "F", "1993-10-14")
+                        .row(34L, "O", "1998-07-21")
+                        .row(null, "O", "1998-07-21")
+                        .row(1L, null, null)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderdate) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(3L, "F", "1993-10-14")
+                        .row(5L, "F", "1993-10-14")
+                        .row(6L, "F", "1993-10-14")
+                        .row(null, "F", "1993-10-14")
+                        .row(34L, "O", "1998-07-21")
+                        .row(null, "O", "1998-07-21")
+                        .row(1L, null, null)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+
+        assertWindowQuery("first_value(orderkey) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, INTEGER)
+                        .row(3, "F", 3)
+                        .row(5, "F", 3)
+                        .row(6, "F", 3)
+                        .row(33, "F", 3)
+                        .row(1, "O", 1)
+                        .row(2, "O", 1)
+                        .row(4, "O", 1)
+                        .row(7, "O", 1)
+                        .row(32, "O", 1)
+                        .row(34, "O", 1)
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderkey) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 3L)
+                        .row(5L, "F", 3L)
+                        .row(6L, "F", 3L)
+                        .row(null, "F", 3L)
+                        .row(34L, "O", 34L)
+                        .row(null, "O", 34L)
+                        .row(1L, null, 1L)
+                        .row(7L, null, 1L)
+                        .row(null, null, 1L)
+                        .row(null, null, 1L)
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderkey) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey NULLS FIRST " +
+                        "ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(null, "F", null)
+                        .row(3L, "F", null)
+                        .row(5L, "F", null)
+                        .row(6L, "F", null)
+                        .row(null, "O", null)
+                        .row(34L, "O", null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .row(1L, null, null)
+                        .row(7L, null, null)
+                        .build());
+
+        // Timestamp
+        assertWindowQuery("date_format(first_value(cast(orderdate as TIMESTAMP)) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey), '%Y-%m-%d')",
+                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, VARCHAR)
+                        .row(3, "F", "1993-10-14")
+                        .row(5, "F", "1993-10-14")
+                        .row(6, "F", "1993-10-14")
+                        .row(33, "F", "1993-10-14")
+                        .row(1, "O", "1996-01-02")
+                        .row(2, "O", "1996-01-02")
+                        .row(4, "O", "1996-01-02")
+                        .row(7, "O", "1996-01-02")
+                        .row(32, "O", "1996-01-02")
+                        .row(34, "O", "1996-01-02")
+                        .build());
+    }
+
+    @Test
+    public void testFirstValueBoundedRespectNulls()
+    {
+        assertWindowQuery("first_value(orderkey) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING)",
+                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, INTEGER)
+                        .row(3, "F", 3)
+                        .row(5, "F", 3)
+                        .row(6, "F", 3)
+                        .row(33, "F", 5)
+                        .row(1, "O", 1)
+                        .row(2, "O", 1)
+                        .row(4, "O", 1)
+                        .row(7, "O", 2)
+                        .row(32, "O", 4)
+                        .row(34, "O", 7)
+                        .build());
+        assertWindowQueryWithNulls("first_value(orderkey) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey NULLS FIRST " +
+                        "ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(null, "F", null)
+                        .row(3L, "F", null)
+                        .row(5L, "F", 3L)
+                        .row(6L, "F", 5L)
+                        .row(null, "O", null)
+                        .row(34L, "O", null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .row(1L, null, null)
+                        .row(7L, null, 1L)
+                        .build());
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestLagFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestLagFunction.java
@@ -121,6 +121,7 @@ public class TestLagFunction
                         .row(32, "O", 4)
                         .row(34, "O", 7)
                         .build());
+
         assertWindowQueryWithNulls("lag(orderkey, 2, -1) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
                 resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
                         .row(3L, "F", -1L)
@@ -189,6 +190,109 @@ public class TestLagFunction
                         .row(7, "O", "1996-01-10")
                         .row(32, "O", "1995-07-16")
                         .row(34, "O", "1998-07-21")
+                        .build());
+    }
+
+    @Test
+    public void testLagFunctionWithNullTreatment()
+    {
+        assertWindowQueryWithNulls("lag(orderkey, 1, -1) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", -1L)
+                        .row(5L, "F", 3L)
+                        .row(6L, "F", 5L)
+                        .row(null, "F", 6L)
+                        .row(34L, "O", -1L)
+                        .row(null, "O", 34L)
+                        .row(1L, null, -1L)
+                        .row(7L, null, 1L)
+                        .row(null, null, 7L)
+                        .row(null, null, null)
+                        .build());
+
+        assertWindowQueryWithNulls("lag(orderstatus, 1, null) RESPECT NULLS OVER (ORDER BY orderkey, orderstatus)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(1L, null, null)
+                        .row(3L, "F", null)
+                        .row(5L, "F", "F")
+                        .row(6L, "F", "F")
+                        .row(7L, null, "F")
+                        .row(34L, "O", null)
+                        .row(null, "F", "O")
+                        .row(null, "O", "F")
+                        .row(null, null, "O")
+                        .row(null, null, null)
+                        .build());
+
+        assertWindowQueryWithNulls("lag(orderstatus, 0) RESPECT NULLS OVER (ORDER BY orderkey, orderstatus)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(1L, null, null)
+                        .row(3L, "F", "F")
+                        .row(5L, "F", "F")
+                        .row(6L, "F", "F")
+                        .row(7L, null, null)
+                        .row(34L, "O", "O")
+                        .row(null, "F", "F")
+                        .row(null, "O", "O")
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+
+        assertWindowQueryWithNulls("lag(orderkey, 1, -1) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", -1L)
+                        .row(5L, "F", 3L)
+                        .row(6L, "F", 5L)
+                        .row(null, "F", 6L)
+                        .row(34L, "O", -1L)
+                        .row(null, "O", 34L)
+                        .row(1L, null, -1L)
+                        .row(7L, null, 1L)
+                        .row(null, null, 7L)
+                        .row(null, null, 7L)
+                        .build());
+
+        assertWindowQueryWithNulls("lag(orderstatus, 1, null) IGNORE NULLS OVER (ORDER BY orderkey, orderstatus)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(1L, null, null)
+                        .row(3L, "F", null)
+                        .row(5L, "F", "F")
+                        .row(6L, "F", "F")
+                        .row(7L, null, "F")
+                        .row(34L, "O", "F")
+                        .row(null, "F", "O")
+                        .row(null, "O", "F")
+                        .row(null, null, "O")
+                        .row(null, null, "O")
+                        .build());
+
+        assertWindowQueryWithNulls("lag(orderstatus, 0) IGNORE NULLS OVER (ORDER BY orderkey, orderstatus)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(1L, null, null)
+                        .row(3L, "F", "F")
+                        .row(5L, "F", "F")
+                        .row(6L, "F", "F")
+                        .row(7L, null, null)
+                        .row(34L, "O", "O")
+                        .row(null, "F", "F")
+                        .row(null, "O", "O")
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+
+        assertWindowQueryWithNulls("lag(orderkey, 1, -1) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey), " +
+                "lag(orderkey, 1, -1) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", -1L, -1L)
+                        .row(5L, "F", 3L, 3L)
+                        .row(6L, "F", 5L, 5L)
+                        .row(null, "F", 6L, 6L)
+                        .row(34L, "O", -1L, -1L)
+                        .row(null, "O", 34L, 34L)
+                        .row(1L, null, -1L, -1L)
+                        .row(7L, null, 1L, 1L)
+                        .row(null, null, 7L, 7L)
+                        .row(null, null, null, 7L)
                         .build());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestLastValueFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestLastValueFunction.java
@@ -97,6 +97,42 @@ public class TestLastValueFunction
     }
 
     @Test
+    public void testLastValueUnboundedIgnoreNulls()
+    {
+        assertUnboundedWindowQueryWithNulls("last_value(orderkey) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 6L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", 6L)
+                        .row(null, "F", 6L)
+                        .row(34L, "O", 34L)
+                        .row(null, "O", 34L)
+                        .row(1L, null, 7L)
+                        .row(7L, null, 7L)
+                        .row(null, null, 7L)
+                        .row(null, null, 7L)
+                        .build());
+    }
+
+    @Test
+    public void testLastValueUnboundedRespectNulls()
+    {
+        assertUnboundedWindowQueryWithNulls("last_value(orderkey) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", null)
+                        .row(5L, "F", null)
+                        .row(6L, "F", null)
+                        .row(null, "F", null)
+                        .row(34L, "O", null)
+                        .row(null, "O", null)
+                        .row(1L, null, null)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+    }
+
+    @Test
     public void testLastValueBounded()
     {
         assertWindowQuery("last_value(orderkey) OVER (PARTITION BY orderstatus ORDER BY orderkey " +
@@ -123,6 +159,72 @@ public class TestLastValueFunction
                         .row(34L, "O", null)
                         .row(null, "O", null)
                         .row(1L, null, null)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+    }
+
+    @Test
+    public void testLastValueBoundedIgnoreNulls()
+    {
+        assertWindowQueryWithNulls("last_value(orderkey) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 6L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", 6L)
+                        .row(null, "F", 6L)
+                        .row(34L, "O", 34L)
+                        .row(null, "O", 34L)
+                        .row(1L, null, 7L)
+                        .row(7L, null, 7L)
+                        .row(null, null, 7L)
+                        .row(null, null, 7L)
+                        .build());
+        assertWindowQueryWithNulls("last_value(orderkey) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 5L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", 6L)
+                        .row(null, "F", 6L)
+                        .row(34L, "O", 34L)
+                        .row(null, "O", 34L)
+                        .row(1L, null, 7L)
+                        .row(7L, null, 7L)
+                        .row(null, null, 7L)
+                        .row(null, null, null)
+                        .build());
+    }
+
+    @Test
+    public void testLastValueBoundedRespectNulls()
+    {
+        assertWindowQueryWithNulls("last_value(orderkey) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 6L)
+                        .row(5L, "F", null)
+                        .row(6L, "F", null)
+                        .row(null, "F", null)
+                        .row(34L, "O", null)
+                        .row(null, "O", null)
+                        .row(1L, null, null)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+        assertWindowQueryWithNulls("last_value(orderkey) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 5L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", null)
+                        .row(null, "F", null)
+                        .row(34L, "O", null)
+                        .row(null, "O", null)
+                        .row(1L, null, 7L)
                         .row(7L, null, null)
                         .row(null, null, null)
                         .row(null, null, null)

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestLeadFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestLeadFunction.java
@@ -121,6 +121,7 @@ public class TestLeadFunction
                         .row(32, "O", -1)
                         .row(34, "O", -1)
                         .build());
+
         assertWindowQueryWithNulls("lead(orderkey, 2, -1) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
                 resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
                         .row(3L, "F", 6L)
@@ -189,6 +190,109 @@ public class TestLeadFunction
                         .row(7, "O", "1996-01-10")
                         .row(32, "O", "1995-07-16")
                         .row(34, "O", "1998-07-21")
+                        .build());
+    }
+
+    @Test
+    public void testLeadFunctionWithNullTreatment()
+    {
+        assertWindowQueryWithNulls("lead(orderkey, 1, -1) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 5L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", null)
+                        .row(null, "F", -1L)
+                        .row(34L, "O", null)
+                        .row(null, "O", -1L)
+                        .row(1L, null, 7L)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, -1L)
+                        .build());
+
+        assertWindowQueryWithNulls("lead(orderstatus, 1, null) RESPECT NULLS OVER (ORDER BY orderkey, orderstatus)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(1L, null, "F")
+                        .row(3L, "F", "F")
+                        .row(5L, "F", "F")
+                        .row(6L, "F", null)
+                        .row(7L, null, "O")
+                        .row(34L, "O", "F")
+                        .row(null, "F", "O")
+                        .row(null, "O", null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+
+        assertWindowQueryWithNulls("lead(orderstatus, 0) RESPECT NULLS OVER (ORDER BY orderkey, orderstatus)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(1L, null, null)
+                        .row(3L, "F", "F")
+                        .row(5L, "F", "F")
+                        .row(6L, "F", "F")
+                        .row(7L, null, null)
+                        .row(34L, "O", "O")
+                        .row(null, "F", "F")
+                        .row(null, "O", "O")
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+
+        assertWindowQueryWithNulls("lead(orderkey, 1, -1) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 5L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", -1L)
+                        .row(null, "F", -1L)
+                        .row(34L, "O", -1L)
+                        .row(null, "O", -1L)
+                        .row(1L, null, 7L)
+                        .row(7L, null, -1L)
+                        .row(null, null, -1L)
+                        .row(null, null, -1L)
+                        .build());
+
+        assertWindowQueryWithNulls("lead(orderkey, 1, null) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 5L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", null)
+                        .row(null, "F", null)
+                        .row(34L, "O", null)
+                        .row(null, "O", null)
+                        .row(1L, null, 7L)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+
+        assertWindowQueryWithNulls("lead(orderkey, 0) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 3L)
+                        .row(5L, "F", 5L)
+                        .row(6L, "F", 6L)
+                        .row(null, "F", null)
+                        .row(34L, "O", 34L)
+                        .row(null, "O", null)
+                        .row(1L, null, 1L)
+                        .row(7L, null, 7L)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+
+        assertWindowQueryWithNulls("lead(orderkey, 1, -1) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey), " +
+                        "lead(orderkey, 1, -1) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 5L, 5L)
+                        .row(5L, "F", 6L, 6L)
+                        .row(6L, "F", null, -1L)
+                        .row(null, "F", -1L, -1L)
+                        .row(34L, "O", null, -1L)
+                        .row(null, "O", -1L, -1L)
+                        .row(1L, null, 7L, 7L)
+                        .row(7L, null, null, -1L)
+                        .row(null, null, null, -1L)
+                        .row(null, null, -1L, -1L)
                         .build());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/window/TestNthValueFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/window/TestNthValueFunction.java
@@ -116,6 +116,42 @@ public class TestNthValueFunction
     }
 
     @Test
+    public void testNthValueUnboundedIgnoreNulls()
+    {
+        assertUnboundedWindowQueryWithNulls("nth_value(orderkey, 3) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(3L, "F", 6L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", 6L)
+                        .row(null, "F", 6L)
+                        .row(34L, "O", null)
+                        .row(null, "O", null)
+                        .row(1L, null, null)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+    }
+
+    @Test
+    public void testNthValueUnboundedRespectNulls()
+    {
+        assertUnboundedWindowQueryWithNulls("nth_value(orderkey, 3) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, VARCHAR)
+                        .row(3L, "F", 6L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", 6L)
+                        .row(null, "F", 6L)
+                        .row(34L, "O", null)
+                        .row(null, "O", null)
+                        .row(1L, null, null)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+    }
+
+    @Test
     public void testNthValueBounded()
     {
         assertWindowQuery("nth_value(orderkey, 4) OVER (PARTITION BY orderstatus ORDER BY orderkey " +
@@ -160,6 +196,44 @@ public class TestNthValueFunction
                         .row(7, "O", "1996-12-01")
                         .row(32, "O", "1996-12-01")
                         .row(34, "O", "1996-12-01")
+                        .build());
+    }
+
+    @Test
+    public void testNthValueBoundedIgnoreNulls()
+    {
+        assertWindowQueryWithNulls("nth_value(orderkey, 3) IGNORE NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", 6L)
+                        .row(5L, "F", 6L)
+                        .row(6L, "F", 6L)
+                        .row(null, "F", null)
+                        .row(34L, "O", null)
+                        .row(null, "O", null)
+                        .row(1L, null, null)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
+                        .build());
+    }
+
+    @Test
+    public void testNthValueBoundedRespectNulls()
+    {
+        assertWindowQueryWithNulls("nth_value(orderkey, 4) RESPECT NULLS OVER (PARTITION BY orderstatus ORDER BY orderkey " +
+                        "ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, BIGINT)
+                        .row(3L, "F", null)
+                        .row(5L, "F", null)
+                        .row(6L, "F", null)
+                        .row(null, "F", null)
+                        .row(34L, "O", null)
+                        .row(null, "O", null)
+                        .row(1L, null, null)
+                        .row(7L, null, null)
+                        .row(null, null, null)
+                        .row(null, null, null)
                         .build());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -160,7 +160,7 @@ public class TestTypeValidator
                 Optional.empty(),
                 Optional.empty());
 
-        WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, DOUBLE, variableC), frame);
+        WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, DOUBLE, variableC), frame, false);
 
         WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
 
@@ -301,7 +301,7 @@ public class TestTypeValidator
                 Optional.empty(),
                 Optional.empty());
 
-        WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, BIGINT, variableA), frame);
+        WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, BIGINT, variableA), frame, false);
 
         WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
 
@@ -332,7 +332,7 @@ public class TestTypeValidator
                 Optional.empty(),
                 Optional.empty());
 
-        WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, BIGINT, variableC), frame);
+        WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, BIGINT, variableC), frame, false);
 
         WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
@@ -228,6 +228,7 @@ public class TestMergeAdjacentWindows
                         functionHandle,
                         BIGINT,
                         Arrays.stream(symbols).map(symbol -> new VariableReferenceExpression(symbol, BIGINT)).collect(Collectors.toList())),
-                frame);
+                frame,
+                false);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
@@ -226,7 +226,8 @@ public class TestPruneWindowColumns
                                                 CURRENT_ROW,
                                                 Optional.of(endValue1),
                                                 Optional.of(new SymbolReference(startValue1.getName())).map(Expression::toString),
-                                                Optional.of(new SymbolReference(endValue2.getName())).map(Expression::toString))),
+                                                Optional.of(new SymbolReference(endValue2.getName())).map(Expression::toString)),
+                                        false),
                                 output2,
                                 new WindowNode.Function(
                                         call(FUNCTION_NAME, FUNCTION_HANDLE, BIGINT, input2),
@@ -237,7 +238,8 @@ public class TestPruneWindowColumns
                                                 CURRENT_ROW,
                                                 Optional.of(endValue2),
                                                 Optional.of(new SymbolReference(startValue2.getName())).map(Expression::toString),
-                                                Optional.of(new SymbolReference(endValue2.getName())).map(Expression::toString)))),
+                                                Optional.of(new SymbolReference(endValue2.getName())).map(Expression::toString)),
+                                        false)),
                         hash,
                         p.values(
                                 filteredInputs,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
@@ -78,7 +78,7 @@ public class TestSwapAdjacentWindowsBySpecifications
                                 ImmutableList.of(p.variable("a")),
                                 Optional.empty()),
                         ImmutableMap.of(p.variable("avg_1"),
-                                new WindowNode.Function(call("avg", functionHandle, DOUBLE, ImmutableList.of()), frame)),
+                                new WindowNode.Function(call("avg", functionHandle, DOUBLE, ImmutableList.of()), frame, false)),
                         p.values(p.variable("a"))))
                 .doesNotFire();
     }
@@ -139,6 +139,7 @@ public class TestSwapAdjacentWindowsBySpecifications
     {
         return new WindowNode.Function(
                 call("avg", functionHandle, BIGINT, symbols.stream().map(symbol -> new VariableReferenceExpression(symbol.getName(), BIGINT)).collect(Collectors.toList())),
-                frame);
+                frame,
+                false);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
@@ -114,7 +114,7 @@ public class TestWindowNode
                 ImmutableList.of(columnA),
                 Optional.of(new OrderingScheme(ImmutableList.of(new Ordering(columnB, SortOrder.ASC_NULLS_FIRST)))));
         CallExpression call = call("sum", functionHandle, BIGINT, new VariableReferenceExpression(columnC.getName(), BIGINT));
-        Map<VariableReferenceExpression, WindowNode.Function> functions = ImmutableMap.of(windowVariable, new WindowNode.Function(call, frame));
+        Map<VariableReferenceExpression, WindowNode.Function> functions = ImmutableMap.of(windowVariable, new WindowNode.Function(call, frame, false));
         Optional<VariableReferenceExpression> hashVariable = Optional.of(columnB);
         Set<VariableReferenceExpression> prePartitionedInputs = ImmutableSet.of(columnA);
         WindowNode windowNode = new WindowNode(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyNoOriginalExpression.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestVerifyNoOriginalExpression.java
@@ -119,7 +119,8 @@ public class TestVerifyNoOriginalExpression
                 originalEndValue);
         WindowNode.Function function = new WindowNode.Function(
                 comparisonCallExpression,
-                frame);
+                frame,
+                false);
         ImmutableList<VariableReferenceExpression> partitionBy = ImmutableList.of(VARIABLE_REFERENCE_EXPRESSION);
         Optional<OrderingScheme> orderingScheme = Optional.empty();
         ImmutableMap<VariableReferenceExpression, WindowNode.Function> functions = ImmutableMap.of(VARIABLE_REFERENCE_EXPRESSION, function);

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -333,7 +333,7 @@ primaryExpression
     | ROW '(' expression (',' expression)* ')'                                            #rowConstructor
     | qualifiedName '(' ASTERISK ')' filter? over?                                        #functionCall
     | qualifiedName '(' (setQuantifier? expression (',' expression)*)?
-        (ORDER BY sortItem (',' sortItem)*)? ')' filter? over?                            #functionCall
+        (ORDER BY sortItem (',' sortItem)*)? ')' filter? (nullTreatment? over)?           #functionCall
     | identifier '->' expression                                                          #lambda
     | '(' (identifier (',' identifier)*)? ')' '->' expression                             #lambda
     | '(' query ')'                                                                       #subqueryExpression
@@ -363,6 +363,11 @@ primaryExpression
 string
     : STRING                                #basicStringLiteral
     | UNICODE_STRING (UESCAPE STRING)?      #unicodeStringLiteral
+    ;
+
+nullTreatment
+    : IGNORE NULLS
+    | RESPECT NULLS
     ;
 
 timeZoneSpecifier
@@ -515,14 +520,14 @@ nonReserved
     | FILTER | FIRST | FOLLOWING | FORMAT | FUNCTION | FUNCTIONS
     | GRANT | GRANTED | GRANTS | GRAPHVIZ
     | HOUR
-    | IF | INCLUDING | INPUT | INTERVAL | IO | ISOLATION
+    | IF | IGNORE | INCLUDING | INPUT | INTERVAL | IO | ISOLATION
     | JSON
     | LANGUAGE | LAST | LATERAL | LEVEL | LIMIT | LOGICAL
     | MAP | MINUTE | MONTH
     | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
     | ONLY | OPTION | ORDINALITY | OUTPUT | OVER
     | PARTITION | PARTITIONS | POSITION | PRECEDING | PRIVILEGES | PROPERTIES
-    | RANGE | READ | RENAME | REPEATABLE | REPLACE | RESET | RESTRICT | RETURN | RETURNS | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS
+    | RANGE | READ | RENAME | REPEATABLE | REPLACE | RESET | RESPECT | RESTRICT | RETURN | RETURNS | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS
     | SCHEMA | SCHEMAS | SECOND | SERIALIZABLE | SESSION | SET | SETS | SQL
     | SHOW | SOME | START | STATS | SUBSTRING | SYSTEM
     | TABLES | TABLESAMPLE | TEXT | TIME | TIMESTAMP | TO | TRANSACTION | TRY_CAST | TYPE
@@ -607,6 +612,7 @@ GROUPING: 'GROUPING';
 HAVING: 'HAVING';
 HOUR: 'HOUR';
 IF: 'IF';
+IGNORE: 'IGNORE';
 IN: 'IN';
 INCLUDING: 'INCLUDING';
 INNER: 'INNER';
@@ -668,6 +674,7 @@ RENAME: 'RENAME';
 REPEATABLE: 'REPEATABLE';
 REPLACE: 'REPLACE';
 RESET: 'RESET';
+RESPECT: 'RESPECT';
 RESTRICT: 'RESTRICT';
 RETURN: 'RETURN';
 RETURNS: 'RETURNS';

--- a/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/ExpressionFormatter.java
@@ -370,6 +370,10 @@ public final class ExpressionFormatter
 
             builder.append(')');
 
+            if (node.isIgnoreNulls()) {
+                builder.append(" IGNORE NULLS");
+            }
+
             if (node.getFilter().isPresent()) {
                 builder.append(" FILTER ").append(visitFilter(node.getFilter().get(), context));
             }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1445,6 +1445,8 @@ class AstBuilder
 
         boolean distinct = isDistinct(context.setQuantifier());
 
+        boolean ignoreNulls = context.nullTreatment() != null && context.nullTreatment().IGNORE() != null;
+
         if (name.toString().equalsIgnoreCase("if")) {
             check(context.expression().size() == 2 || context.expression().size() == 3, "Invalid number of arguments for 'if' function", context);
             check(!window.isPresent(), "OVER clause not valid for 'if' function", context);
@@ -1518,6 +1520,7 @@ class AstBuilder
                 filter,
                 orderBy,
                 distinct,
+                ignoreNulls,
                 visit(context.expression(), Expression.class));
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -539,7 +539,7 @@ public final class ExpressionTreeRewriter<C>
 
             if (!sameElements(node.getArguments(), arguments) || !sameElements(rewrittenWindow, node.getWindow())
                     || !sameElements(filter, node.getFilter())) {
-                return new FunctionCall(node.getName(), rewrittenWindow, filter, node.getOrderBy().map(orderBy -> rewriteOrderBy(orderBy, context)), node.isDistinct(), arguments);
+                return new FunctionCall(node.getName(), rewrittenWindow, filter, node.getOrderBy().map(orderBy -> rewriteOrderBy(orderBy, context)), node.isDistinct(), node.isIgnoreNulls(), arguments);
             }
             return node;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionCall.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionCall.java
@@ -29,44 +29,55 @@ public class FunctionCall
     private final Optional<Expression> filter;
     private final Optional<OrderBy> orderBy;
     private final boolean distinct;
+    private final boolean ignoreNulls;
     private final List<Expression> arguments;
 
     public FunctionCall(QualifiedName name, List<Expression> arguments)
     {
-        this(Optional.empty(), name, Optional.empty(), Optional.empty(), Optional.empty(), false, arguments);
+        this(Optional.empty(), name, Optional.empty(), Optional.empty(), Optional.empty(), false, false, arguments);
     }
 
     public FunctionCall(NodeLocation location, QualifiedName name, List<Expression> arguments)
     {
-        this(Optional.of(location), name, Optional.empty(), Optional.empty(), Optional.empty(), false, arguments);
+        this(Optional.of(location), name, Optional.empty(), Optional.empty(), Optional.empty(), false, false, arguments);
     }
 
     public FunctionCall(QualifiedName name, boolean distinct, List<Expression> arguments)
     {
-        this(Optional.empty(), name, Optional.empty(), Optional.empty(), Optional.empty(), distinct, arguments);
+        this(Optional.empty(), name, Optional.empty(), Optional.empty(), Optional.empty(), distinct, false, arguments);
     }
 
     public FunctionCall(QualifiedName name, boolean distinct, List<Expression> arguments, Optional<Expression> filter)
     {
-        this(Optional.empty(), name, Optional.empty(), filter, Optional.empty(), distinct, arguments);
+        this(Optional.empty(), name, Optional.empty(), filter, Optional.empty(), distinct, false, arguments);
     }
 
-    public FunctionCall(QualifiedName name, Optional<Window> window, boolean distinct, List<Expression> arguments)
+    public FunctionCall(QualifiedName name, Optional<Window> window, boolean distinct, boolean ignoreNulls, List<Expression> arguments)
     {
-        this(Optional.empty(), name, window, Optional.empty(), Optional.empty(), distinct, arguments);
+        this(Optional.empty(), name, window, Optional.empty(), Optional.empty(), distinct, ignoreNulls, arguments);
     }
 
     public FunctionCall(QualifiedName name, Optional<Window> window, Optional<Expression> filter, Optional<OrderBy> orderBy, boolean distinct, List<Expression> arguments)
     {
-        this(Optional.empty(), name, window, filter, orderBy, distinct, arguments);
+        this(Optional.empty(), name, window, filter, orderBy, distinct, false, arguments);
+    }
+
+    public FunctionCall(QualifiedName name, Optional<Window> window, Optional<Expression> filter, Optional<OrderBy> orderBy, boolean distinct, boolean ignoreNulls, List<Expression> arguments)
+    {
+        this(Optional.empty(), name, window, filter, orderBy, distinct, ignoreNulls, arguments);
     }
 
     public FunctionCall(NodeLocation location, QualifiedName name, Optional<Window> window, Optional<Expression> filter, Optional<OrderBy> orderBy, boolean distinct, List<Expression> arguments)
     {
-        this(Optional.of(location), name, window, filter, orderBy, distinct, arguments);
+        this(Optional.of(location), name, window, filter, orderBy, distinct, false, arguments);
     }
 
-    private FunctionCall(Optional<NodeLocation> location, QualifiedName name, Optional<Window> window, Optional<Expression> filter, Optional<OrderBy> orderBy, boolean distinct, List<Expression> arguments)
+    public FunctionCall(NodeLocation location, QualifiedName name, Optional<Window> window, Optional<Expression> filter, Optional<OrderBy> orderBy, boolean distinct, boolean ignoreNulls, List<Expression> arguments)
+    {
+        this(Optional.of(location), name, window, filter, orderBy, distinct, ignoreNulls, arguments);
+    }
+
+    private FunctionCall(Optional<NodeLocation> location, QualifiedName name, Optional<Window> window, Optional<Expression> filter, Optional<OrderBy> orderBy, boolean distinct, boolean ignoreNulls, List<Expression> arguments)
     {
         super(location);
         requireNonNull(name, "name is null");
@@ -80,6 +91,7 @@ public class FunctionCall
         this.filter = filter;
         this.orderBy = orderBy;
         this.distinct = distinct;
+        this.ignoreNulls = ignoreNulls;
         this.arguments = arguments;
     }
 
@@ -101,6 +113,11 @@ public class FunctionCall
     public boolean isDistinct()
     {
         return distinct;
+    }
+
+    public boolean isIgnoreNulls()
+    {
+        return ignoreNulls;
     }
 
     public List<Expression> getArguments()
@@ -145,12 +162,13 @@ public class FunctionCall
                 Objects.equals(filter, o.filter) &&
                 Objects.equals(orderBy, o.orderBy) &&
                 Objects.equals(distinct, o.distinct) &&
+                Objects.equals(ignoreNulls, o.ignoreNulls) &&
                 Objects.equals(arguments, o.arguments);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, distinct, window, filter, orderBy, arguments);
+        return Objects.hash(name, distinct, ignoreNulls, window, filter, orderBy, arguments);
     }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -135,6 +135,7 @@ import com.facebook.presto.sql.tree.TransactionAccessMode;
 import com.facebook.presto.sql.tree.Union;
 import com.facebook.presto.sql.tree.Unnest;
 import com.facebook.presto.sql.tree.Values;
+import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.With;
 import com.facebook.presto.sql.tree.WithQuery;
 import com.google.common.collect.ImmutableList;
@@ -2075,6 +2076,7 @@ public class TestSqlParser
                                                         new LongLiteral("4"))),
                                                 Optional.empty(),
                                                 false,
+                                                false,
                                                 ImmutableList.of(new Identifier("x")))),
                                 Optional.empty(),
                                 Optional.empty(),
@@ -2329,6 +2331,29 @@ public class TestSqlParser
         assertStatement("SET ROLE NONE", new SetRole(SetRole.Type.NONE, Optional.empty()));
         assertStatement("SET ROLE role", new SetRole(SetRole.Type.ROLE, Optional.of(new Identifier("role"))));
         assertStatement("SET ROLE \"role\"", new SetRole(SetRole.Type.ROLE, Optional.of(new Identifier("role"))));
+    }
+
+    @Test
+    public void testNullTreatment()
+    {
+        assertExpression("lead(x, 1) ignore nulls over()",
+                new FunctionCall(
+                        QualifiedName.of("lead"),
+                        Optional.of(new Window(ImmutableList.of(), Optional.empty(), Optional.empty())),
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
+                        true,
+                        ImmutableList.of(new Identifier("x"), new LongLiteral("1"))));
+        assertExpression("lead(x, 1) respect nulls over()",
+                new FunctionCall(
+                        QualifiedName.of("lead"),
+                        Optional.of(new Window(ImmutableList.of(), Optional.empty(), Optional.empty())),
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
+                        false,
+                        ImmutableList.of(new Identifier("x"), new LongLiteral("1"))));
     }
 
     private static void assertCast(String type)

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestStatementBuilder.java
@@ -94,6 +94,8 @@ public class TestStatementBuilder
                 ", sum(salary) over (partition by depname order by salary rows between current row and 3 following)\n" +
                 ", sum(salary) over (partition by depname range unbounded preceding)\n" +
                 ", sum(salary) over (rows between 2 preceding and unbounded following)\n" +
+                ", lag(salary, 1) ignore nulls over (partition by depname)\n" +
+                ", lag(salary, 1) respect nulls over (partition by depname)\n" +
                 "from emp");
 
         printStatement("" +

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/ValueWindowFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/ValueWindowFunction.java
@@ -20,6 +20,8 @@ public abstract class ValueWindowFunction
 {
     protected WindowIndex windowIndex;
 
+    protected boolean ignoreNulls;
+
     private int currentPosition;
 
     @Override
@@ -56,4 +58,14 @@ public abstract class ValueWindowFunction
      * @param currentPosition the current position for this row
      */
     public abstract void processRow(BlockBuilder output, int frameStart, int frameEnd, int currentPosition);
+
+    /**
+     * Set ignore nulls indicator.
+     *
+     * @param ignoreNulls true if nulls should be ignored
+     */
+    public void setIgnoreNulls(boolean ignoreNulls)
+    {
+        this.ignoreNulls = ignoreNulls;
+    }
 }


### PR DESCRIPTION
See https://github.com/prestodb/presto/issues/4554.

This PR adds the IGNORE/RESPECT NULLS clause to window functions LAG, LEAD, FIRST_VALUE, LAST_VALUE, and NTH_VALUE.