### PR TITLE
Bind /ui as a static resource instead of /

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -130,7 +130,7 @@ public class CoordinatorModule
     @Override
     protected void setup(Binder binder)
     {
-        httpServerBinder(binder).bindResource("/", "webapp").withWelcomeFile("index.html");
+        httpServerBinder(binder).bindResource("/ui", "webapp").withWelcomeFile("index.html");
 
         // presto coordinator announcement
         discoveryBinder(binder).bindHttpAnnouncement("presto-coordinator");
@@ -143,6 +143,9 @@ public class CoordinatorModule
 
         // query execution visualizer
         jaxrsBinder(binder).bind(QueryExecutionResource.class);
+
+        // main webapp entry point
+        jaxrsBinder(binder).bind(WebAppResource.class);
 
         // query manager
         jaxrsBinder(binder).bind(QueryResource.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/WebAppResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/WebAppResource.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
+import static javax.ws.rs.core.UriBuilder.fromPath;
+
+@Path("/")
+public class WebAppResource
+{
+    @GET
+    public Response redirectIndexHtml()
+    {
+        return Response.status(MOVED_PERMANENTLY)
+                .location(fromPath("/ui/index.html").build())
+                .build();
+    }
+}

--- a/presto-main/src/main/resources/webapp/assets/plan.js
+++ b/presto-main/src/main/resources/webapp/assets/plan.js
@@ -166,7 +166,7 @@ let LivePlan = React.createClass({
             }.bind(this));
     },
     handleStageClick: function(stageCssId) {
-        window.open("/stage.html?" + stageCssId,'_blank');
+        window.open("stage.html?" + stageCssId,'_blank');
     },
     componentDidMount: function() {
         this.refreshLoop();
@@ -299,7 +299,7 @@ let LivePlan = React.createClass({
                                         &nbsp;
                                         <a href={ "stage.html?" + query.queryId } className="btn btn-info navbar-btn">Stage Performance</a>
                                         &nbsp;
-                                        <a href={ "/timeline.html?" + query.queryId } className="btn btn-info navbar-btn" target="_blank">Splits</a>
+                                        <a href={ "timeline.html?" + query.queryId } className="btn btn-info navbar-btn" target="_blank">Splits</a>
                                         &nbsp;
                                         <a href={ "/v1/query/" + query.queryId + "?pretty" } className="btn btn-info navbar-btn" target="_blank">JSON</a>
                                     </td>

--- a/presto-main/src/main/resources/webapp/assets/query.js
+++ b/presto-main/src/main/resources/webapp/assets/query.js
@@ -75,7 +75,7 @@ let TaskList = React.createClass({
                             </a>
                         </Td>
                         <Td column="host" value={ getHostname(task.taskStatus.self) }>
-                            <a href={ "/worker.html?" + task.taskStatus.nodeId } className="font-light" target="_blank">
+                            <a href={ "worker.html?" + task.taskStatus.nodeId } className="font-light" target="_blank">
                                 { showPortNumbers ? getHostAndPort(task.taskStatus.self) : getHostname(task.taskStatus.self) }
                             </a>
                         </Td>
@@ -987,7 +987,7 @@ let QueryDetail = React.createClass({
                                         &nbsp;
                                         <a href={ "stage.html?" + query.queryId } className="btn btn-info navbar-btn">Stage Performance</a>
                                         &nbsp;
-                                        <a href={ "/timeline.html?" + query.queryId } className="btn btn-info navbar-btn" target="_blank">Splits</a>
+                                        <a href={ "timeline.html?" + query.queryId } className="btn btn-info navbar-btn" target="_blank">Splits</a>
                                         &nbsp;
                                         <a href={ "/v1/query/" + query.queryId + "?pretty" } className="btn btn-info navbar-btn" target="_blank">JSON</a>
                                     </td>

--- a/presto-main/src/main/resources/webapp/assets/stage.js
+++ b/presto-main/src/main/resources/webapp/assets/stage.js
@@ -672,7 +672,7 @@ let StagePerformance = React.createClass({
                                     &nbsp;
                                     <a href={ "stage.html?" + query.queryId } className="btn btn-info navbar-btn nav-disabled">Stage Performance</a>
                                     &nbsp;
-                                    <a href={ "/timeline.html?" + query.queryId } className="btn btn-info navbar-btn" target="_blank">Splits</a>
+                                    <a href={ "timeline.html?" + query.queryId } className="btn btn-info navbar-btn" target="_blank">Splits</a>
                                     &nbsp;
                                     <a href={ "/v1/query/" + query.queryId + "?pretty" } className="btn btn-info navbar-btn" target="_blank">JSON</a>
                                 </td>

--- a/presto-main/src/main/resources/webapp/assets/worker.js
+++ b/presto-main/src/main/resources/webapp/assets/worker.js
@@ -130,7 +130,7 @@ let WorkerStatus = React.createClass({
                 <td>
                     <div className="row query-memory-list-header">
                         <div className="col-xs-7">
-                            <a href={"/query.html?" + query} target="_blank">
+                            <a href={"query.html?" + query} target="_blank">
                                 { query }
                             </a>
                         </div>


### PR DESCRIPTION
Previously, the path / was bound as a static resource, which was causing
all HTTP requests (whether to a static or a non-static resource) to go
through the io.airlift.http.server.ClassPathResourceHandler. This handler
upon receiving a request looks up that path through its class loader
using the getClassLoader().getResource() method. In Java 9 the
BuiltinClassLoader caches these lookups eventually resulting in a huge
cache, which may cause GC issues (see BuiltinClassLoader::findMiscResource
and the resourceCache field).

This change binds only the /ui path as a static resource. Therefore,
requests to other paths will not go through the ClassPathResourceHandler.

(see BuiltinClassLoader