### PR TITLE
Fuse xxhash64 calls to avoid intermediate objects

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
@@ -255,6 +255,20 @@ public final class VarbinaryFunctions
         return hash;
     }
 
+    @ScalarFunction(value = "$xxhash64", hidden = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxhash64Internal(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return XxHash64.hash(slice);
+    }
+
+    @ScalarFunction(value = "$xxhash64", hidden = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxhash64Internal(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        return XxHash64.hash(value);
+    }
+
     @Description("decode hex encoded binary data")
     @ScalarFunction("from_hex")
     @SqlType(StandardTypes.VARBINARY)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionT
 import com.facebook.presto.sql.planner.iterative.rule.EliminateCrossJoins;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroLimit;
 import com.facebook.presto.sql.planner.iterative.rule.EvaluateZeroSample;
+import com.facebook.presto.sql.planner.iterative.rule.FuseHashFunctions;
 import com.facebook.presto.sql.planner.iterative.rule.GatherAndMergeWindows;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementBernoulliSampleAsFilter;
 import com.facebook.presto.sql.planner.iterative.rule.ImplementFilteredAggregations;
@@ -216,7 +217,10 @@ public class PlanOptimizers
                 stats,
                 statsCalculator,
                 estimatedExchangesCostCalculator,
-                new SimplifyExpressions(metadata, sqlParser).rules());
+                ImmutableSet.<Rule<?>>builder()
+                        .addAll(new SimplifyExpressions(metadata, sqlParser).rules())
+                        .addAll(new FuseHashFunctions().rules())
+                        .build());
 
         builder.add(
                 // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/FuseHashFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/FuseHashFunctions.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.google.common.collect.ImmutableList;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class FuseHashFunctions
+        extends ExpressionRewriteRuleSet
+{
+    public FuseHashFunctions()
+    {
+        super(createRewrite());
+    }
+
+    public static Expression rewrite(Expression expression)
+    {
+        return createRewrite().rewrite(expression, null);
+    }
+
+    private static ExpressionRewriter createRewrite()
+    {
+        return (expression, context) -> ExpressionTreeRewriter.rewriteWith(new com.facebook.presto.sql.tree.ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteFunctionCall(FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                if (node.getName().equals(QualifiedName.of("from_big_endian_64"))) {
+                    return rewriteFromBigEndian64(node, context, treeRewriter);
+                }
+                return node;
+            }
+        }, expression);
+    }
+
+    private static Expression rewriteFromBigEndian64(FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        Expression argument = treeRewriter.rewrite(getOnlyElement(node.getArguments()), context);
+        if (argument instanceof FunctionCall) {
+            FunctionCall function = (FunctionCall) argument;
+            if (function.getName().equals(QualifiedName.of("xxhash64"))) {
+                return rewriteXxhash64(function, context, treeRewriter);
+            }
+        }
+        return node;
+    }
+
+    private static Expression rewriteXxhash64(FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+    {
+        Expression argument = treeRewriter.rewrite(getOnlyElement(node.getArguments()), context);
+        if (argument instanceof FunctionCall) {
+            FunctionCall function = (FunctionCall) argument;
+            if (function.getName().equals(QualifiedName.of("to_big_endian_64"))) {
+                argument = treeRewriter.rewrite(getOnlyElement(function.getArguments()), context);
+            }
+            return new FunctionCall(QualifiedName.of("$xxhash64"), ImmutableList.of(argument));
+        }
+        return node;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestFuseHashFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestFuseHashFunctions.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestFuseHashFunctions
+        extends BaseRuleTest
+{
+    @Test
+    public void testRewriteBinary()
+    {
+        // from_big_endian_64(xxhash64(from_utf8('hello')))
+        Expression before = new FunctionCall(QualifiedName.of("from_big_endian_64"), ImmutableList.of(
+                new FunctionCall(QualifiedName.of("xxhash64"), ImmutableList.of(
+                        new FunctionCall(QualifiedName.of("to_utf8"), ImmutableList.of(
+                                new StringLiteral("hello")))))));
+
+        // $xxhash64(from_utf8('hello'))
+        Expression after = new FunctionCall(QualifiedName.of("$xxhash64"), ImmutableList.of(
+                new FunctionCall(QualifiedName.of("to_utf8"), ImmutableList.of(
+                        new StringLiteral("hello")))));
+        assertEquals(FuseHashFunctions.rewrite(before), after);
+    }
+
+    @Test
+    public void testRewriteBigint()
+    {
+        // from_big_endian_64(xxhash64(to_big_endian_64(123)))
+        Expression before = new FunctionCall(QualifiedName.of("from_big_endian_64"), ImmutableList.of(
+                new FunctionCall(QualifiedName.of("xxhash64"), ImmutableList.of(
+                        new FunctionCall(QualifiedName.of("to_big_endian_64"), ImmutableList.of(
+                                new LongLiteral("123")))))));
+
+        // $xxhash64(123)
+        Expression after = new FunctionCall(QualifiedName.of("$xxhash64"), ImmutableList.of(new LongLiteral("123")));
+        assertEquals(FuseHashFunctions.rewrite(before), after);
+    }
+}


### PR DESCRIPTION
This avoids creating intermediate varbinary objects for the following:

* from_big_endian_64(xxhash64(...))
* from_big_endian_64(xxhash64(to_big_endian_64(...)))