### PR TITLE
Fix incorrect pushdown of aggregation through outer join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DistinctOutputQueryUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/DistinctOutputQueryUtil.java
@@ -23,7 +23,6 @@ import com.facebook.presto.sql.planner.plan.IntersectNode;
 import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
-import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.TopNNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 
@@ -108,12 +107,6 @@ public final class DistinctOutputQueryUtil
         public Boolean visitIntersect(IntersectNode node, Void context)
         {
             return true;
-        }
-
-        @Override
-        public Boolean visitProject(ProjectNode node, Void context)
-        {
-            return node.isIdentity() && lookupFunction.apply(node.getSource()).accept(this, null);
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestAggregationOverJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestAggregationOverJoin.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.query;
+
+import org.testng.annotations.Test;
+
+public class TestAggregationOverJoin
+{
+    @Test
+    public void test()
+    {
+        // https://github.com/prestodb/presto/issues/10592
+        new QueryAssertions().assertQuery(
+                "WITH " +
+                        "    t (a, b) AS (VALUES (1, 'a'), (1, 'b')), " +
+                        "    u (a) AS (VALUES 1) " +
+                        "SELECT DISTINCT v.a " +
+                        "FROM ( " +
+                        "    SELECT DISTINCT a, b " +
+                        "    FROM t) v " +
+                        "LEFT JOIN u on v.a = u.a",
+                "VALUES 1");
+    }
+}


### PR DESCRIPTION
PushAggregationThroughOuterJoin was incorrectly inferring that
a plan of the following shape produces distinct outputs on the
outer branch of the join:

- Aggregate
        group by x
   - LeftJoin
       - Project x = x
           - Aggregate
                group by x, y
       - ...

It was only testing whether the projection had identities, but it wasn't
ensuring that all inputs to the projection were present in the output.
In the example above, given:

(1, 10)
(1, 20)
(1, 20)

the pairs that come out the the aggregation will be unique, but the values
of each individual column will not. This breaks the assumption made by
that optimizer.

We fix the issue by removing projections from consideration. If there
is a no-op identity projection, it will be taken care of by
RemoveRedundantIdentityProjections.

Fixes #10592