### PR TITLE
Fix Hive type translation for rows with unnamed fields

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
@@ -20,11 +20,13 @@ import com.facebook.presto.spi.type.NamedTypeSignature;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.facebook.presto.spi.type.VarcharType;
-import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.facebook.presto.hive.HiveType.HIVE_BINARY;
 import static com.facebook.presto.hive.HiveType.HIVE_BOOLEAN;
@@ -132,16 +134,16 @@ public class HiveTypeTranslator
             return getMapTypeInfo(keyType, valueType);
         }
         if (isRowType(type)) {
-            ImmutableList.Builder<String> fieldNames = ImmutableList.builder();
+            List<String> fieldNames = new ArrayList<>();
             for (TypeSignatureParameter parameter : type.getTypeSignature().getParameters()) {
                 if (!parameter.isNamedTypeSignature()) {
                     throw new IllegalArgumentException(format("Expected all parameters to be named type, but got %s", parameter));
                 }
                 NamedTypeSignature namedTypeSignature = parameter.getNamedTypeSignature();
-                fieldNames.add(namedTypeSignature.getName().get());
+                fieldNames.add(namedTypeSignature.getName().orElse(null));
             }
             return getStructTypeInfo(
-                    fieldNames.build(),
+                    fieldNames,
                     type.getTypeParameters().stream()
                             .map(this::translate)
                             .collect(toList()));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTypeTranslator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveTypeTranslator.java
@@ -55,6 +55,7 @@ public class TestHiveTypeTranslator
                 .put("array(timestamp)", HiveType.valueOf("array<timestamp>"))
                 .put("map(boolean,varbinary)", HiveType.valueOf("map<boolean,binary>"))
                 .put("row(col0 integer,col1 varbinary)", HiveType.valueOf("struct<col0:int,col1:binary>"))
+                .put("row(integer)", HiveType.valueOf("struct<null:int>"))
                 .build();
 
         typeTranslationMap = new HashMap<>();


### PR DESCRIPTION
```
CREATE TABLE test_tmp AS SELECT ZIP(x, y) as zipped FROM (VALUES (array['a'], array['b'])) as T(x, y);
Query 20180510_182945_67345_ej58r failed: No value present
java.util.NoSuchElementException: No value present
        at java.base/java.util.Optional.get(Optional.java:151)
        at com.facebook.presto.hive.HiveTypeTranslator.translate(HiveTypeTranslator.java:141)
```

Since row field names are optional now, for the case when a field name is not present this change uses NULL as the field name in the corresponding Hive struct.