### PR TITLE
Refactor Hive write path, target path and write mode decision

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
+import com.facebook.presto.hive.LocationHandle.WriteMode;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
 import com.facebook.presto.hive.metastore.Table;
@@ -30,6 +31,9 @@ import static com.facebook.presto.hive.HiveWriteUtils.createTemporaryPath;
 import static com.facebook.presto.hive.HiveWriteUtils.getTableDefaultLocation;
 import static com.facebook.presto.hive.HiveWriteUtils.isS3FileSystem;
 import static com.facebook.presto.hive.HiveWriteUtils.pathExists;
+import static com.facebook.presto.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_EXISTING_DIRECTORY;
+import static com.facebook.presto.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_NEW_DIRECTORY;
+import static com.facebook.presto.hive.LocationHandle.WriteMode.STAGE_AND_MOVE_TO_TARGET_DIRECTORY;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -55,15 +59,13 @@ public class HiveLocationService
             throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format("Target directory for table '%s.%s' already exists: %s", schemaName, tableName, targetPath));
         }
 
-        Path writePath;
         if (shouldUseTemporaryDirectory(context, targetPath)) {
-            writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
+            Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
+            return new LocationHandle(targetPath, writePath, false, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
         else {
-            writePath = targetPath;
+            return new LocationHandle(targetPath, targetPath, false, DIRECT_TO_TARGET_NEW_DIRECTORY);
         }
-
-        return new LocationHandle(targetPath, Optional.of(writePath), false);
     }
 
     @Override
@@ -72,15 +74,13 @@ public class HiveLocationService
         HdfsContext context = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
         Path targetPath = new Path(table.getStorage().getLocation());
 
-        Optional<Path> writePath;
         if (shouldUseTemporaryDirectory(context, targetPath)) {
-            writePath = Optional.of(createTemporaryPath(context, hdfsEnvironment, targetPath));
+            Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
+            return new LocationHandle(targetPath, writePath, true, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
         else {
-            writePath = Optional.empty();
+            return new LocationHandle(targetPath, targetPath, true, DIRECT_TO_TARGET_EXISTING_DIRECTORY);
         }
-
-        return new LocationHandle(targetPath, writePath, true);
     }
 
     private boolean shouldUseTemporaryDirectory(HdfsContext context, Path path)
@@ -90,38 +90,40 @@ public class HiveLocationService
     }
 
     @Override
-    public Path targetPath(LocationHandle locationHandle, Partition partition, String partitionName)
+    public WriteInfo getQueryWriteInfo(LocationHandle locationHandle)
     {
-        return new Path(partition.getStorage().getLocation());
+        return new WriteInfo(locationHandle.getTargetPath(), locationHandle.getWritePath(), locationHandle.getWriteMode());
     }
 
     @Override
-    public Path targetPath(LocationHandle locationHandle, Optional<String> partitionName)
+    public WriteInfo getTableWriteInfo(LocationHandle locationHandle)
     {
-        if (!partitionName.isPresent()) {
-            return locationHandle.getTargetPath();
+        return new WriteInfo(locationHandle.getTargetPath(), locationHandle.getWritePath(), locationHandle.getWriteMode());
+    }
+
+    @Override
+    public WriteInfo getPartitionWriteInfo(LocationHandle locationHandle, Optional<Partition> partition, String partitionName)
+    {
+        if (partition.isPresent()) {
+            // existing partition
+            WriteMode writeMode = locationHandle.getWriteMode();
+            Path targetPath = new Path(partition.get().getStorage().getLocation());
+            Path writePath;
+            if (writeMode.isWritePathSameAsTargetPath()) {
+                writePath = targetPath;
+            }
+            else {
+                writePath = new Path(locationHandle.getWritePath(), partitionName);
+            }
+
+            return new WriteInfo(targetPath, writePath, writeMode);
         }
-        return new Path(locationHandle.getTargetPath(), partitionName.get());
-    }
-
-    @Override
-    public Path targetPathRoot(LocationHandle locationHandle)
-    {
-        return locationHandle.getTargetPath();
-    }
-
-    @Override
-    public Optional<Path> writePath(LocationHandle locationHandle, Optional<String> partitionName)
-    {
-        if (!partitionName.isPresent()) {
-            return locationHandle.getWritePath();
+        else {
+            // new partition
+            return new WriteInfo(
+                    new Path(locationHandle.getTargetPath(), partitionName),
+                    new Path(locationHandle.getWritePath(), partitionName),
+                    locationHandle.getWriteMode());
         }
-        return locationHandle.getWritePath().map(path -> new Path(path, partitionName.get()));
-    }
-
-    @Override
-    public Optional<Path> writePathRoot(LocationHandle locationHandle)
-    {
-        return locationHandle.getWritePath();
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
+import com.facebook.presto.hive.LocationService.WriteInfo;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.HivePageSinkMetadataProvider;
 import com.facebook.presto.hive.metastore.Partition;
@@ -64,6 +65,8 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 import static com.facebook.presto.hive.HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static com.facebook.presto.hive.HiveType.toHiveTypes;
 import static com.facebook.presto.hive.HiveWriteUtils.getField;
+import static com.facebook.presto.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_EXISTING_DIRECTORY;
+import static com.facebook.presto.hive.LocationHandle.WriteMode.STAGE_AND_MOVE_TO_TARGET_DIRECTORY;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
 import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
 import static com.facebook.presto.hive.util.ConfigurationUtils.toJobConf;
@@ -182,8 +185,9 @@ public class HiveWriterFactory
         Path writePath;
         if (isCreateTable) {
             this.table = null;
-            writePath = locationService.writePathRoot(locationHandle)
-                    .orElseThrow(() -> new IllegalArgumentException("CREATE TABLE must have a write path"));
+            WriteInfo writeInfo = locationService.getQueryWriteInfo(locationHandle);
+            checkArgument(writeInfo.getWriteMode() != DIRECT_TO_TARGET_EXISTING_DIRECTORY, "CREATE TABLE write mode cannot be DIRECT_TO_TARGET_EXISTING_DIRECTORY");
+            writePath = writeInfo.getWritePath();
         }
         else {
             Optional<Table> table = pageSinkMetadataProvider.getTable();
@@ -191,8 +195,7 @@ public class HiveWriterFactory
                 throw new PrestoException(HIVE_INVALID_METADATA, format("Table %s.%s was dropped during insert", schemaName, tableName));
             }
             this.table = table.get();
-            writePath = locationService.writePathRoot(locationHandle)
-                    .orElseGet(() -> locationService.targetPathRoot(locationHandle));
+            writePath = locationService.getQueryWriteInfo(locationHandle).getWritePath();
         }
 
         this.bucketCount = requireNonNull(bucketCount, "bucketCount is null");
@@ -259,8 +262,7 @@ public class HiveWriterFactory
 
         boolean isNew;
         Properties schema;
-        Path target;
-        Path write;
+        WriteInfo writeInfo;
         StorageFormat outputStorageFormat;
         if (!partition.isPresent()) {
             if (table == null) {
@@ -276,19 +278,26 @@ public class HiveWriterFactory
                         .map(HiveType::getHiveTypeName)
                         .map(HiveTypeName::toString)
                         .collect(joining(":")));
-                target = locationService.targetPath(locationHandle, partitionName);
-                write = locationService.writePath(locationHandle, partitionName).get();
 
-                if (partitionName.isPresent() && !target.equals(write)) {
-                    // When target path is different from write path,
-                    // verify that the target directory for the partition does not already exist
-                    if (HiveWriteUtils.pathExists(new HdfsContext(session, schemaName, tableName), hdfsEnvironment, target)) {
-                        throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format(
-                                "Target directory for new partition '%s' of table '%s.%s' already exists: %s",
-                                partitionName,
-                                schemaName,
-                                tableName,
-                                target));
+                if (!partitionName.isPresent()) {
+                    // new unpartitioned table
+                    writeInfo = locationService.getTableWriteInfo(locationHandle);
+                }
+                else {
+                    // a new partition in a new partitioned table
+                    writeInfo = locationService.getPartitionWriteInfo(locationHandle, partition, partitionName.get());
+
+                    if (!writeInfo.getWriteMode().isWritePathSameAsTargetPath()) {
+                        // When target path is different from write path,
+                        // verify that the target directory for the partition does not already exist
+                        if (HiveWriteUtils.pathExists(new HdfsContext(session, schemaName, tableName), hdfsEnvironment, writeInfo.getTargetPath())) {
+                            throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format(
+                                    "Target directory for new partition '%s' of table '%s.%s' already exists: %s",
+                                    partitionName,
+                                    schemaName,
+                                    tableName,
+                                    writeInfo.getTargetPath()));
+                        }
                     }
                 }
             }
@@ -296,7 +305,9 @@ public class HiveWriterFactory
                 // Write to: a new partition in an existing partitioned table,
                 //           or an existing unpartitioned table
                 if (partitionName.isPresent()) {
+                    // a new partition in an existing partitioned table
                     isNew = true;
+                    writeInfo = locationService.getPartitionWriteInfo(locationHandle, partition, partitionName.get());
                 }
                 else {
                     if (bucketNumber.isPresent()) {
@@ -306,10 +317,10 @@ public class HiveWriterFactory
                         throw new PrestoException(HIVE_PARTITION_READ_ONLY, "Unpartitioned Hive tables are immutable");
                     }
                     isNew = false;
+                    writeInfo = locationService.getTableWriteInfo(locationHandle);
                 }
+
                 schema = getHiveSchema(table);
-                target = locationService.targetPath(locationHandle, partitionName);
-                write = locationService.writePath(locationHandle, partitionName).orElse(target);
             }
 
             if (partitionName.isPresent()) {
@@ -357,15 +368,14 @@ public class HiveWriterFactory
             outputStorageFormat = partition.get().getStorage().getStorageFormat();
             schema = getHiveSchema(partition.get(), table);
 
-            target = locationService.targetPath(locationHandle, partition.get(), partitionName.get());
-            write = locationService.writePath(locationHandle, partitionName).orElse(target);
+            writeInfo = locationService.getPartitionWriteInfo(locationHandle, partition, partitionName.get());
         }
 
         validateSchema(partitionName, schema);
 
         String fileNameWithExtension = fileName + getFileExtension(conf, outputStorageFormat);
 
-        Path path = new Path(write, fileNameWithExtension);
+        Path path = new Path(writeInfo.getWritePath(), fileNameWithExtension);
 
         HiveFileWriter hiveFileWriter = null;
         for (HiveFileWriterFactory fileWriterFactory : fileWriterFactories) {
@@ -426,7 +436,15 @@ public class HiveWriterFactory
                     hiveWriter.getRowCount()));
         };
 
-        return new HiveWriter(hiveFileWriter, partitionName, isNew, fileNameWithExtension, write.toString(), target.toString(), onCommit, hiveWriterStats);
+        return new HiveWriter(
+                hiveFileWriter,
+                partitionName,
+                isNew,
+                fileNameWithExtension,
+                writeInfo.getWritePath().toString(),
+                writeInfo.getTargetPath().toString(),
+                onCommit,
+                hiveWriterStats);
     }
 
     private void validateSchema(Optional<String> partitionName, Properties schema)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/LocationHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/LocationHandle.java
@@ -17,35 +17,43 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.fs.Path;
 
-import java.util.Optional;
-
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class LocationHandle
 {
     private final Path targetPath;
-    private final Optional<Path> writePath;
+    private final Path writePath;
     private final boolean isExistingTable;
+    private final WriteMode writeMode;
 
     public LocationHandle(
             Path targetPath,
-            Optional<Path> writePath,
-            boolean isExistingTable)
+            Path writePath,
+            boolean isExistingTable,
+            WriteMode writeMode)
     {
+        if (writeMode.isWritePathSameAsTargetPath() && !targetPath.equals(writePath)) {
+            throw new IllegalArgumentException(format("targetPath is expected to be same as writePath for writeMode %s", writeMode));
+        }
         this.targetPath = requireNonNull(targetPath, "targetPath is null");
         this.writePath = requireNonNull(writePath, "writePath is null");
         this.isExistingTable = isExistingTable;
+        this.writeMode = requireNonNull(writeMode, "writeMode is null");
     }
 
     @JsonCreator
     public LocationHandle(
             @JsonProperty("targetPath") String targetPath,
-            @JsonProperty("writePath") Optional<String> writePath,
-            @JsonProperty("isExistingTable") boolean isExistingTable)
+            @JsonProperty("writePath") String writePath,
+            @JsonProperty("isExistingTable") boolean isExistingTable,
+            @JsonProperty("writeMode") WriteMode writeMode)
     {
-        this.targetPath = new Path(requireNonNull(targetPath, "targetPath is null"));
-        this.writePath = requireNonNull(writePath, "writePath is null").map(Path::new);
-        this.isExistingTable = isExistingTable;
+        this(
+                new Path(requireNonNull(targetPath, "targetPath is null")),
+                new Path(requireNonNull(writePath, "writePath is null")),
+                isExistingTable,
+                writeMode);
     }
 
     // This method should only be called by LocationService
@@ -55,9 +63,15 @@ public class LocationHandle
     }
 
     // This method should only be called by LocationService
-    Optional<Path> getWritePath()
+    Path getWritePath()
     {
         return writePath;
+    }
+
+    // This method should only be called by LocationService
+    public WriteMode getWriteMode()
+    {
+        return writeMode;
     }
 
     // This method should only be called by LocationService
@@ -73,14 +87,60 @@ public class LocationHandle
     }
 
     @JsonProperty("writePath")
-    public Optional<String> getJsonSerializableWritePath()
+    public String getJsonSerializableWritePath()
     {
-        return writePath.map(Path::toString);
+        return writePath.toString();
     }
 
     @JsonProperty("isExistingTable")
     public boolean getJsonSerializableIsExistingTable()
     {
         return isExistingTable;
+    }
+
+    @JsonProperty("writeMode")
+    public WriteMode getJsonSerializableWriteMode()
+    {
+        return writeMode;
+    }
+
+    public enum WriteMode
+    {
+        /**
+         * common mode for new table or existing table (both new and existing partition)
+         */
+        STAGE_AND_MOVE_TO_TARGET_DIRECTORY(true),
+        /**
+         * for new table in S3
+         */
+        DIRECT_TO_TARGET_NEW_DIRECTORY(false),
+        /**
+         * for existing table in S3 (both new and existing partition)
+         */
+        DIRECT_TO_TARGET_EXISTING_DIRECTORY(true),
+        /**/;
+
+        // NOTE: Insert overwrite simulation (partition drops and partition additions in the same
+        // transaction get merged and become one or more partition alterations, and get submitted to
+        // metastore in close succession of each other) is not supported for S3. S3 uses the last
+        // mode for insert into existing table. This is hard to support because the directory
+        // containing the old data cannot be deleted until commit. Nor can the old data be moved
+        // (assuming Hive HDFS directory naming convention shall not be violated). As a result,
+        // subsequent insertion will have to write to directory belonging to existing partition.
+        // This undermines the benefit of having insert overwrite simulation. This also makes
+        // dropping of old partition at commit time hard because data added after the logical
+        // "drop" time was added to the directories to be dropped.
+
+        private final boolean writePathSameAsTargetPath;
+
+        WriteMode(boolean writePathSameAsTargetPath)
+        {
+            this.writePathSameAsTargetPath = writePathSameAsTargetPath;
+        }
+
+        public boolean isWritePathSameAsTargetPath()
+        {
+            return writePathSameAsTargetPath;
+        }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/LocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/LocationService.java
@@ -21,6 +21,8 @@ import org.apache.hadoop.fs.Path;
 
 import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
+
 public interface LocationService
 {
     LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName);
@@ -28,34 +30,53 @@ public interface LocationService
     LocationHandle forExistingTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table);
 
     /**
-     * Target path for the specified existing partition.
+     * targetPath and writePath will be root directory of all partition and table paths
+     * that may be returned by {@link #getTableWriteInfo(LocationHandle)} and {@link #getPartitionWriteInfo(LocationHandle, Optional, String)} method.
      */
-    Path targetPath(LocationHandle locationHandle, Partition partition, String partitionName);
+    WriteInfo getQueryWriteInfo(LocationHandle locationHandle);
+
+    WriteInfo getTableWriteInfo(LocationHandle locationHandle);
 
     /**
-     * Target path for the specified new partition (or unpartitioned table).
+     * Returns {@code WriteInfo} for existing partition partition if {@code partition} is present,
+     * otherwise, returns {@code WriteInfo} for the new partition.
      */
-    Path targetPath(LocationHandle locationHandle, Optional<String> partitionName);
+    WriteInfo getPartitionWriteInfo(LocationHandle locationHandle, Optional<Partition> partition, String partitionName);
 
-    /**
-     * Root directory of all paths that may be returned by targetPath.
-     */
-    Path targetPathRoot(LocationHandle locationHandle);
+    class WriteInfo
+    {
+        private final Path targetPath;
+        private final Path writePath;
+        private final LocationHandle.WriteMode writeMode;
 
-    /**
-     * Temporary path for writing to the specified partition (or unpartitioned table).
-     * <p>
-     * When temporary path is not to be used, this function may return an empty Optional or
-     * a path same as the one returned from targetPath. When it is empty, special cleanups
-     * need to be carried out. Otherwise, it is not necessary.
-     * <p>
-     * A non-empty write path is required for new tables. However, it may be the same as
-     * targetPath.
-     */
-    Optional<Path> writePath(LocationHandle locationHandle, Optional<String> partitionName);
+        public WriteInfo(Path targetPath, Path writePath, LocationHandle.WriteMode writeMode)
+        {
+            this.targetPath = requireNonNull(targetPath, "targetPath is null");
+            this.writePath = requireNonNull(writePath, "writePath is null");
+            this.writeMode = requireNonNull(writeMode, "writeMode is null");
+        }
 
-    /**
-     * Root directory of all paths that may be returned by writePath.
-     */
-    Optional<Path> writePathRoot(LocationHandle locationHandle);
+        /**
+         * Target path for the partition, unpartitioned table, or the query.
+         */
+        public Path getTargetPath()
+        {
+            return targetPath;
+        }
+
+        /**
+         * Temporary path for writing to the partition, unpartitioned table or the query.
+         * <p>
+         * It may be the same as {@code targetPath}.
+         */
+        public Path getWritePath()
+        {
+            return writePath;
+        }
+
+        public LocationHandle.WriteMode getWriteMode()
+        {
+            return writeMode;
+        }
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.HiveBasicStatistics;
 import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.LocationHandle.WriteMode;
 import com.facebook.presto.hive.PartitionNotFoundException;
 import com.facebook.presto.hive.TableAlreadyExistsException;
 import com.facebook.presto.spi.ConnectorSession;
@@ -1745,24 +1746,6 @@ public class SemiTransactionalHiveMetastore
         SHARED_OPERATION_BUFFERED,
         EXCLUSIVE_OPERATION_BUFFERED,
         FINISHED,
-    }
-
-    public enum WriteMode
-    {
-        STAGE_AND_MOVE_TO_TARGET_DIRECTORY, // common mode for new table or existing table (both new and existing partition)
-        DIRECT_TO_TARGET_NEW_DIRECTORY, // for new table in S3
-        DIRECT_TO_TARGET_EXISTING_DIRECTORY, // for existing table in S3 (both new and existing partition)
-
-        // NOTE: Insert overwrite simulation (partition drops and partition additions in the same
-        // transaction get merged and become one or more partition alterations, and get submitted to
-        // metastore in close succession of each other) is not supported for S3. S3 uses the last
-        // mode for insert into existing table. This is hard to support because the directory
-        // containing the old data cannot be deleted until commit. Nor can the old data be moved
-        // (assuming Hive HDFS directory naming convention shall not be violated). As a result,
-        // subsequent insertion will have to write to directory belonging to existing partition.
-        // This undermines the benefit of having insert overwrite simulation. This also makes
-        // dropping of old partition at commit time hard because data added after the logical
-        // "drop" time was added to the directories to be dropped.
     }
 
     private enum ActionType

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientS3.java
@@ -401,7 +401,7 @@ public abstract class AbstractTestHiveClientS3
             metastoreClient.updateTableLocation(
                     database,
                     tableName.getTableName(),
-                    locationService.targetPath(((HiveOutputTableHandle) outputHandle).getLocationHandle(), Optional.empty()).toString());
+                    locationService.getTableWriteInfo(((HiveOutputTableHandle) outputHandle).getLocationHandle()).getTargetPath().toString());
         }
 
         try (Transaction transaction = newTransaction()) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_NEW_DIRECTORY;
 import static com.facebook.presto.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
@@ -233,7 +234,7 @@ public class TestHivePageSink
 
     private static ConnectorPageSink createPageSink(HiveTransactionHandle transaction, HiveClientConfig config, ExtendedHiveMetastore metastore, Path outputPath, HiveWriterStats stats)
     {
-        LocationHandle locationHandle = new LocationHandle(outputPath, Optional.of(outputPath), false);
+        LocationHandle locationHandle = new LocationHandle(outputPath, outputPath, false, DIRECT_TO_TARGET_NEW_DIRECTORY);
         HiveOutputTableHandle handle = new HiveOutputTableHandle(
                 SCHEMA_NAME,
                 TABLE_NAME,


### PR DESCRIPTION
Historically, we use the equality of `writePath` and `targetPath`
and whether `writePath` exists to decide the write mode.
This is difficult to understand. Thus the `WriteMode` enum was introduced.
However, this is only used in `SemiTransactionalMetastore`.

Also, `tagetPath` and `writePath` has to be fetched separately from `LocationService`.
And there are root path (query level) and non-root path (partition/table level).
These APIs are confusing.

This commit did the following refactors:
- Store the `WRITE_MODE` in `LocationHandle`.
- returns a `WriteInfo` contains `targetPath`, `writePath` and the `writeMode`.