### PR TITLE
Make client query submission idempotent

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -47,7 +47,7 @@ public interface QueryManager
 
     QueryId createQueryId();
 
-    QueryInfo createQuery(QueryId queryId, SessionContext sessionContext, String query);
+    ListenableFuture<?> createQuery(QueryId queryId, SessionContext sessionContext, String query);
 
     void failQuery(QueryId queryId, Throwable cause);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -45,7 +45,9 @@ public interface QueryManager
 
     void recordHeartbeat(QueryId queryId);
 
-    QueryInfo createQuery(SessionContext sessionContext, String query);
+    QueryId createQueryId();
+
+    QueryInfo createQuery(QueryId queryId, SessionContext sessionContext, String query);
 
     void failQuery(QueryId queryId, Throwable cause);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -357,13 +357,18 @@ public class SqlQueryManager
     }
 
     @Override
-    public QueryInfo createQuery(SessionContext sessionContext, String query)
+    public QueryId createQueryId()
     {
+        return queryIdGenerator.createNextQueryId();
+    }
+
+    @Override
+    public QueryInfo createQuery(QueryId queryId, SessionContext sessionContext, String query)
+    {
+        requireNonNull(queryId, "queryId is null");
         requireNonNull(sessionContext, "sessionFactory is null");
         requireNonNull(query, "query is null");
         checkArgument(!query.isEmpty(), "query must not be empty string");
-
-        QueryId queryId = queryIdGenerator.createNextQueryId();
 
         Session session = null;
         SelectionContext<?> selectionContext;

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/PurgeQueriesRunnable.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/PurgeQueriesRunnable.java
@@ -47,6 +47,9 @@ class PurgeQueriesRunnable
             // registered between fetching the live queries and inspecting the queryIds set.
             for (QueryId queryId : ImmutableSet.copyOf(queries.keySet())) {
                 Query query = queries.get(queryId);
+                if (!query.isSubmissionFinished()) {
+                    continue;
+                }
                 Optional<QueryState> state = queryManager.getQueryState(queryId);
 
                 // free up resources if the query completed

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -183,8 +183,8 @@ class Query
 
         this.queryManager = queryManager;
 
-        QueryInfo queryInfo = queryManager.createQuery(sessionContext, query);
-        queryId = queryInfo.getQueryId();
+        queryId = queryManager.createQueryId();
+        QueryInfo queryInfo = queryManager.createQuery(queryId, sessionContext, query);
         session = queryInfo.getSession().toSession(sessionPropertyManager);
         this.exchangeClient = exchangeClient;
         this.resultsProcessorExecutor = resultsProcessorExecutor;

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.transaction.TransactionId;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -75,6 +76,7 @@ import static com.facebook.presto.util.Failures.toFailure;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
 import static io.airlift.concurrent.MoreFutures.addTimeout;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.String.format;
@@ -96,10 +98,16 @@ class Query
     private final ScheduledExecutorService timeoutExecutor;
 
     @GuardedBy("this")
-    private final PagesSerde serde;
+    private PagesSerde serde;
 
     private final AtomicLong resultId = new AtomicLong();
-    private final Session session;
+
+    private final ListenableFuture<?> submissionFuture;
+    private final SessionPropertyManager sessionPropertyManager;
+    private final BlockEncodingSerde blockEncodingSerde;
+
+    @GuardedBy("this")
+    private Session session;
 
     @GuardedBy("this")
     private QueryResults lastResult;
@@ -114,25 +122,25 @@ class Query
     private List<Type> types;
 
     @GuardedBy("this")
-    private Optional<String> setCatalog;
+    private Optional<String> setCatalog = Optional.empty();
 
     @GuardedBy("this")
-    private Optional<String> setSchema;
+    private Optional<String> setSchema = Optional.empty();
 
     @GuardedBy("this")
-    private Map<String, String> setSessionProperties;
+    private Map<String, String> setSessionProperties = ImmutableMap.of();
 
     @GuardedBy("this")
-    private Set<String> resetSessionProperties;
+    private Set<String> resetSessionProperties = ImmutableSet.of();
 
     @GuardedBy("this")
-    private Map<String, String> addedPreparedStatements;
+    private Map<String, String> addedPreparedStatements = ImmutableMap.of();
 
     @GuardedBy("this")
-    private Set<String> deallocatedPreparedStatements;
+    private Set<String> deallocatedPreparedStatements = ImmutableSet.of();
 
     @GuardedBy("this")
-    private Optional<TransactionId> startedTransactionId;
+    private Optional<TransactionId> startedTransactionId = Optional.empty();
 
     @GuardedBy("this")
     private boolean clearTransactionId;
@@ -152,13 +160,16 @@ class Query
     {
         Query result = new Query(sessionContext, query, queryManager, sessionPropertyManager, exchangeClient, dataProcessorExecutor, timeoutExecutor, blockEncodingSerde);
 
-        result.queryManager.addOutputInfoListener(result.getQueryId(), result::setQueryOutputInfo);
+        // register listeners after submission finishes
+        addSuccessCallback(result.submissionFuture, () -> {
+            result.queryManager.addOutputInfoListener(result.getQueryId(), result::setQueryOutputInfo);
 
-        result.queryManager.addStateChangeListener(result.getQueryId(), state -> {
-            if (state.isDone()) {
-                QueryInfo queryInfo = queryManager.getQueryInfo(result.getQueryId());
-                result.closeExchangeClientIfNecessary(queryInfo);
-            }
+            result.queryManager.addStateChangeListener(result.getQueryId(), state -> {
+                if (state.isDone()) {
+                    QueryInfo queryInfo = queryManager.getQueryInfo(result.getQueryId());
+                    result.closeExchangeClientIfNecessary(queryInfo);
+                }
+            });
         });
 
         return result;
@@ -177,25 +188,37 @@ class Query
         requireNonNull(sessionContext, "sessionContext is null");
         requireNonNull(query, "query is null");
         requireNonNull(queryManager, "queryManager is null");
+        requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         requireNonNull(exchangeClient, "exchangeClient is null");
         requireNonNull(resultsProcessorExecutor, "resultsProcessorExecutor is null");
         requireNonNull(timeoutExecutor, "timeoutExecutor is null");
+        requireNonNull(blockEncodingSerde, "serde is null");
 
         this.queryManager = queryManager;
+        this.sessionPropertyManager = sessionPropertyManager;
 
         queryId = queryManager.createQueryId();
-        QueryInfo queryInfo = queryManager.createQuery(queryId, sessionContext, query);
-        session = queryInfo.getSession().toSession(sessionPropertyManager);
+        submissionFuture = queryManager.createQuery(queryId, sessionContext, query);
         this.exchangeClient = exchangeClient;
         this.resultsProcessorExecutor = resultsProcessorExecutor;
         this.timeoutExecutor = timeoutExecutor;
-        requireNonNull(blockEncodingSerde, "serde is null");
-        this.serde = new PagesSerdeFactory(blockEncodingSerde, isExchangeCompressionEnabled(session)).createPagesSerde();
+        this.blockEncodingSerde = blockEncodingSerde;
+    }
+
+    public boolean isSubmissionFinished()
+    {
+        return submissionFuture.isDone();
     }
 
     public void cancel()
     {
-        queryManager.cancelQuery(queryId);
+        // if submission is not finished, send cancel after it is finished
+        if (submissionFuture.isDone()) {
+            submissionFuture.addListener(() -> queryManager.cancelQuery(queryId), resultsProcessorExecutor);
+        }
+        else {
+            queryManager.cancelQuery(queryId);
+        }
         dispose();
     }
 
@@ -272,6 +295,11 @@ class Query
 
     private synchronized ListenableFuture<?> getFutureStateChange()
     {
+        // if query query submission has not finished, wait for it to finish
+        if (!submissionFuture.isDone()) {
+            return submissionFuture;
+        }
+
         // if the exchange client is open, wait for data
         if (!exchangeClient.isClosed()) {
             return exchangeClient.isBlocked();
@@ -287,10 +315,12 @@ class Query
     {
         // is the a repeated request for the last results?
         String requestedPath = uriInfo.getAbsolutePath().getPath();
-        if (lastResultPath != null && requestedPath.equals(lastResultPath)) {
-            // tell query manager we are still interested in the query
-            queryManager.getQueryInfo(queryId);
-            queryManager.recordHeartbeat(queryId);
+        if (requestedPath.equals(lastResultPath)) {
+            if (submissionFuture.isDone()) {
+                // tell query manager we are still interested in the query
+                queryManager.getQueryInfo(queryId);
+                queryManager.recordHeartbeat(queryId);
+            }
             return Optional.of(lastResult);
         }
 
@@ -315,6 +345,39 @@ class Query
             if (cachedResult.isPresent()) {
                 return cachedResult.get();
             }
+        }
+
+        URI queryHtmlUri = uriInfo.getRequestUriBuilder()
+                .scheme(scheme)
+                .replacePath("ui/query.html")
+                .replaceQuery(queryId.toString())
+                .build();
+
+        // if query query submission has not finished, return simple empty result
+        if (!submissionFuture.isDone()) {
+            QueryResults queryResults = new QueryResults(
+                    queryId.toString(),
+                    queryHtmlUri,
+                    null,
+                    createNextResultsUri(scheme, uriInfo),
+                    null,
+                    null,
+                    StatementStats.builder()
+                            .setState(QueryState.QUEUED.toString())
+                            .setQueued(true)
+                            .setScheduled(false)
+                            .build(),
+                    null,
+                    null,
+                    null);
+
+            cacheLastResults(queryResults);
+            return queryResults;
+        }
+
+        if (session == null) {
+            session = queryManager.getQueryInfo(queryId).getSession().toSession(sessionPropertyManager);
+            serde = new PagesSerdeFactory(blockEncodingSerde, isExchangeCompressionEnabled(session)).createPagesSerde();
         }
 
         // Remove as many pages as possible from the exchange until just greater than DESIRED_RESULT_BYTES
@@ -379,12 +442,6 @@ class Query
             nextResultsUri = createNextResultsUri(scheme, uriInfo);
         }
 
-        URI queryHtmlUri = uriInfo.getRequestUriBuilder()
-                .scheme(scheme)
-                .replacePath("ui/query.html")
-                .replaceQuery(queryId.toString())
-                .build();
-
         // update catalog and schema
         setCatalog = queryInfo.getSetCatalog();
         setSchema = queryInfo.getSetSchema();
@@ -414,6 +471,12 @@ class Query
                 queryInfo.getUpdateType(),
                 updateCount);
 
+        cacheLastResults(queryResults);
+        return queryResults;
+    }
+
+    private synchronized void cacheLastResults(QueryResults queryResults)
+    {
         // cache the last results
         if (lastResult != null && lastResult.getNextUri() != null) {
             lastResultPath = lastResult.getNextUri().getPath();
@@ -422,7 +485,6 @@ class Query
             lastResultPath = null;
         }
         lastResult = queryResults;
-        return queryResults;
     }
 
     private synchronized void closeExchangeClientIfNecessary(QueryInfo queryInfo)

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
@@ -120,12 +120,11 @@ public class StatementResource
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
-    public void createQuery(
+    public Response createQuery(
             String statement,
             @HeaderParam(X_FORWARDED_PROTO) String proto,
             @Context HttpServletRequest servletRequest,
-            @Context UriInfo uriInfo,
-            @Suspended AsyncResponse asyncResponse)
+            @Context UriInfo uriInfo)
     {
         if (isNullOrEmpty(statement)) {
             throw new WebApplicationException(Response
@@ -152,7 +151,8 @@ public class StatementResource
                 blockEncodingSerde);
         queries.put(query.getQueryId(), query);
 
-        asyncQueryResults(query, OptionalLong.empty(), new Duration(1, MILLISECONDS), uriInfo, proto, asyncResponse);
+        QueryResults queryResults = query.getNextResult(OptionalLong.empty(), uriInfo, proto);
+        return toResponse(query, queryResults);
     }
 
     @GET

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServer.java
@@ -27,6 +27,7 @@ import io.airlift.http.client.HttpUriBuilder;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.StatusResponseHandler;
 import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.json.JsonCodec;
 import io.airlift.testing.Closeables;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -65,6 +66,7 @@ import static org.testng.Assert.assertNull;
 @Test(singleThreaded = true)
 public class TestServer
 {
+    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
     private TestingPrestoServer server;
     private HttpClient client;
 
@@ -97,7 +99,10 @@ public class TestServer
                 .setHeader(PRESTO_TIME_ZONE, invalidTimeZone)
                 .build();
 
-        QueryResults queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+        while (queryResults.getNextUri() != null) {
+            queryResults = client.execute(prepareGet().setUri(queryResults.getNextUri()).build(), createJsonResponseHandler(QUERY_RESULTS_CODEC));
+        }
         QueryError queryError = queryResults.getError();
         assertNotNull(queryError);
 
@@ -135,7 +140,17 @@ public class TestServer
                 .addHeader(PRESTO_PREPARED_STATEMENT, "foo=select * from bar")
                 .build();
 
-        QueryResults queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+        ImmutableList.Builder<List<Object>> data = ImmutableList.builder();
+        while (queryResults.getNextUri() != null) {
+            queryResults = client.execute(prepareGet().setUri(queryResults.getNextUri()).build(), createJsonResponseHandler(QUERY_RESULTS_CODEC));
+
+            if (queryResults.getData() != null) {
+                data.addAll(queryResults.getData());
+            }
+        }
+        assertNull(queryResults.getError());
 
         // get the query info
         QueryInfo queryInfo = server.getQueryManager().getQueryInfo(new QueryId(queryResults.getId()));
@@ -155,20 +170,6 @@ public class TestServer
                 .put("foo", "select * from bar")
                 .build());
 
-        ImmutableList.Builder<List<Object>> data = ImmutableList.builder();
-        if (queryResults.getData() != null) {
-            data.addAll(queryResults.getData());
-        }
-
-        while (queryResults.getNextUri() != null) {
-            queryResults = client.execute(prepareGet().setUri(queryResults.getNextUri()).build(), createJsonResponseHandler(jsonCodec(QueryResults.class)));
-
-            if (queryResults.getData() != null) {
-                data.addAll(queryResults.getData());
-            }
-        }
-        assertNull(queryResults.getError());
-
         // only the system catalog exists by default
         List<List<Object>> rows = data.build();
         assertEquals(rows, ImmutableList.of(ImmutableList.of("system")));
@@ -185,7 +186,7 @@ public class TestServer
                 .setHeader(PRESTO_TRANSACTION_ID, "none")
                 .build();
 
-        JsonResponse<QueryResults> queryResults = client.execute(request, createFullJsonResponseHandler(jsonCodec(QueryResults.class)));
+        JsonResponse<QueryResults> queryResults = client.execute(request, createFullJsonResponseHandler(QUERY_RESULTS_CODEC));
         ImmutableList.Builder<List<Object>> data = ImmutableList.builder();
         while (true) {
             if (queryResults.getValue().getData() != null) {
@@ -195,7 +196,7 @@ public class TestServer
             if (queryResults.getValue().getNextUri() == null) {
                 break;
             }
-            queryResults = client.execute(prepareGet().setUri(queryResults.getValue().getNextUri()).build(), createFullJsonResponseHandler(jsonCodec(QueryResults.class)));
+            queryResults = client.execute(prepareGet().setUri(queryResults.getValue().getNextUri()).build(), createFullJsonResponseHandler(QUERY_RESULTS_CODEC));
         }
         assertNull(queryResults.getValue().getError());
         assertNotNull(queryResults.getHeader(PRESTO_STARTED_TRANSACTION_ID));
@@ -211,9 +212,9 @@ public class TestServer
                 .setHeader(PRESTO_SOURCE, "source")
                 .build();
 
-        QueryResults queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_CODEC));
         while (queryResults.getNextUri() != null) {
-            queryResults = client.execute(prepareGet().setUri(queryResults.getNextUri()).build(), createJsonResponseHandler(jsonCodec(QueryResults.class)));
+            queryResults = client.execute(prepareGet().setUri(queryResults.getNextUri()).build(), createJsonResponseHandler(QUERY_RESULTS_CODEC));
         }
 
         assertNotNull(queryResults.getError());

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -54,6 +54,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueryRunnerUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueryRunnerUtil.java
@@ -31,7 +31,8 @@ public final class TestQueryRunnerUtil
 
     public static QueryId createQuery(DistributedQueryRunner queryRunner, Session session, String sql)
     {
-        return queryRunner.getCoordinator().getQueryManager().createQuery(new TestingSessionContext(session), sql).getQueryId();
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        return queryManager.createQuery(queryManager.createQueryId(), new TestingSessionContext(session), sql).getQueryId();
     }
 
     public static void cancelQuery(DistributedQueryRunner queryRunner, QueryId queryId)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueryRunnerUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueryRunnerUtil.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class TestQueryRunnerUtil
@@ -32,7 +33,9 @@ public final class TestQueryRunnerUtil
     public static QueryId createQuery(DistributedQueryRunner queryRunner, Session session, String sql)
     {
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-        return queryManager.createQuery(queryManager.createQueryId(), new TestingSessionContext(session), sql).getQueryId();
+        QueryId queryId = queryManager.createQueryId();
+        getFutureValue(queryManager.createQuery(queryId, new TestingSessionContext(session), sql));
+        return queryId;
     }
 
     public static void cancelQuery(DistributedQueryRunner queryRunner, QueryId queryId)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyQueryContext.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyQueryContext.java
@@ -54,10 +54,13 @@ public class TestLegacyQueryContext
             throws Exception
     {
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-        QueryId queryId = queryManager.createQuery(
-                queryManager.createQueryId(), 
+
+        QueryId queryId = queryManager.createQueryId();
+        queryManager.createQuery(
+                queryId,
                 new TestingSessionContext(TEST_SESSION),
-                "SELECT * FROM lineitem").getQueryId();
+                "SELECT * FROM lineitem")
+                .get();
 
         waitForQueryState(queryRunner, queryId, RUNNING);
 

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyQueryContext.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyQueryContext.java
@@ -54,7 +54,9 @@ public class TestLegacyQueryContext
             throws Exception
     {
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-        QueryId queryId = queryManager.createQuery(new TestingSessionContext(TEST_SESSION),
+        QueryId queryId = queryManager.createQuery(
+                queryManager.createQueryId(), 
+                new TestingSessionContext(TEST_SESSION),
                 "SELECT * FROM lineitem").getQueryId();
 
         waitForQueryState(queryRunner, queryId, RUNNING);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -107,7 +107,9 @@ public class TestMetadataManager
             throws Exception
     {
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-        QueryId queryId = queryManager.createQuery(new TestingSessionContext(TEST_SESSION),
+        QueryId queryId = queryManager.createQuery(
+                queryManager.createQueryId(),
+                new TestingSessionContext(TEST_SESSION),
                 "SELECT * FROM lineitem").getQueryId();
 
         // wait until query starts running

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -107,10 +107,12 @@ public class TestMetadataManager
             throws Exception
     {
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-        QueryId queryId = queryManager.createQuery(
-                queryManager.createQueryId(),
+        QueryId queryId = queryManager.createQueryId();
+        queryManager.createQuery(
+                queryId,
                 new TestingSessionContext(TEST_SESSION),
-                "SELECT * FROM lineitem").getQueryId();
+                "SELECT * FROM lineitem")
+                .get();
 
         // wait until query starts running
         while (true) {

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -58,10 +58,12 @@ public class TestQueryManager
             throws Exception
     {
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-        QueryId queryId = queryManager.createQuery(
-                queryManager.createQueryId(),
+        QueryId queryId = queryManager.createQueryId();
+        queryManager.createQuery(
+                queryId,
                 new TestingSessionContext(TEST_SESSION),
-                "SELECT * FROM lineitem").getQueryId();
+                "SELECT * FROM lineitem")
+                .get();
 
         // wait until query starts running
         while (true) {

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -58,7 +58,9 @@ public class TestQueryManager
             throws Exception
     {
         QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-        QueryId queryId = queryManager.createQuery(new TestingSessionContext(TEST_SESSION),
+        QueryId queryId = queryManager.createQuery(
+                queryManager.createQueryId(),
+                new TestingSessionContext(TEST_SESSION),
                 "SELECT * FROM lineitem").getQueryId();
 
         // wait until query starts running


### PR DESCRIPTION
When a query posted via the StatementResource, we delay the actual submission of the query to the QueryManager until the first get data request from the client.  This means that the client has received the query ID and has started the protocol.

Additionally, the query submission is moved to a background thread so the client is not blocked during query parsing and analysis.