### PR TITLE
Destroy exchange sources for finished tasks on the coordinator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
@@ -19,11 +19,14 @@ import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
 
+import java.util.List;
 import java.util.OptionalInt;
+import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
 
@@ -62,6 +65,12 @@ public class MemoryTrackingRemoteTaskFactory
 
         task.addStateChangeListener(new UpdatePeakMemory(stateMachine));
         return task;
+    }
+
+    @Override
+    public void destroyExchangeSources(List<ExchangeBufferLocation> locationsToDestroy, Consumer<PrestoException> onFailure)
+    {
+        remoteTaskFactory.destroyExchangeSources(locationsToDestroy, onFailure);
     }
 
     private static final class UpdatePeakMemory

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
@@ -18,11 +18,17 @@ import com.facebook.presto.Session;
 import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
 
+import java.net.URI;
+import java.util.List;
 import java.util.OptionalInt;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
 
 public interface RemoteTaskFactory
 {
@@ -35,4 +41,28 @@ public interface RemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             boolean summarizeTaskInfo);
+
+    void destroyExchangeSources(List<ExchangeBufferLocation> locationsToDestroy, Consumer<PrestoException> onFailure);
+
+    final class ExchangeBufferLocation
+    {
+        private final TaskId producerTaskId;
+        private final URI bufferLocation;
+
+        public ExchangeBufferLocation(TaskId producerTaskId, URI bufferLocation)
+        {
+            this.producerTaskId = requireNonNull(producerTaskId, "producerTaskId is null");
+            this.bufferLocation = requireNonNull(bufferLocation, "bufferLocation is null");
+        }
+
+        public TaskId getProducerTaskId()
+        {
+            return producerTaskId;
+        }
+
+        public URI getBufferLocation()
+        {
+            return bufferLocation;
+        }
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -516,17 +516,17 @@ public final class SqlStageExecution
     private static class ListenerManager<T>
     {
         private final List<Consumer<T>> listeners = new ArrayList<>();
-        private boolean freezed;
+        private boolean frozen;
 
         public synchronized void addListener(Consumer<T> listener)
         {
-            checkState(!freezed, "Listeners have been invoked");
+            checkState(!frozen, "Listeners have been invoked");
             listeners.add(listener);
         }
 
         public synchronized void invoke(T payload, Executor executor)
         {
-            freezed = true;
+            frozen = true;
             for (Consumer<T> listener : listeners) {
                 executor.execute(() -> listener.accept(payload));
             }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.RemoteTaskFactory.ExchangeBufferLocation;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.scheduler.SplitSchedulerStats;
 import com.facebook.presto.failureDetector.FailureDetector;
@@ -247,13 +248,23 @@ public final class SqlStageExecution
 
         this.sourceTasks.putAll(remoteSource.getId(), sourceTasks);
 
+        ImmutableList.Builder<ExchangeBufferLocation> buffersToDestroy = ImmutableList.builder();
         for (RemoteTask task : getAllTasks()) {
-            ImmutableMultimap.Builder<PlanNodeId, Split> newSplits = ImmutableMultimap.builder();
-            for (RemoteTask sourceTask : sourceTasks) {
-                URI exchangeLocation = sourceTask.getTaskStatus().getSelf();
-                newSplits.put(remoteSource.getId(), createRemoteSplitFor(task.getTaskId(), exchangeLocation));
+            if (task.getTaskStatus().getState().isDone()) {
+                // task is already finished, so we need to destroy the locations
+                for (RemoteTask sourceTask : sourceTasks) {
+                    URI location = exchangeSourceLocation(task.getTaskId(), sourceTask.getTaskStatus().getSelf());
+                    buffersToDestroy.add(new ExchangeBufferLocation(sourceTask.getTaskId(), location));
+                }
             }
-            task.addSplits(newSplits.build());
+            else {
+                ImmutableMultimap.Builder<PlanNodeId, Split> newSplits = ImmutableMultimap.builder();
+                for (RemoteTask sourceTask : sourceTasks) {
+                    URI exchangeLocation = sourceTask.getTaskStatus().getSelf();
+                    newSplits.put(remoteSource.getId(), createRemoteSplitFor(task.getTaskId(), exchangeLocation));
+                }
+                task.addSplits(newSplits.build());
+            }
         }
 
         if (noMoreExchangeLocations) {
@@ -267,6 +278,11 @@ public final class SqlStageExecution
                 }
             }
         }
+
+        // It is important to tell exchange producers to stop producing data for dead tasks, never created tasks,
+        // or tasks that finish while exchange is being setup (a.k.a races).  Without this, producers will fill
+        // their buffers and then hang waiting for these dead tasks to read the data.
+        remoteTaskFactory.destroyExchangeSources(buffersToDestroy.build(), stateMachine::transitionToFailed);
     }
 
     public synchronized void setOutputBuffers(OutputBuffers outputBuffers)
@@ -397,6 +413,16 @@ public final class SqlStageExecution
         return task;
     }
 
+    private void destroyExchangeSources(TaskId consumerTaskId, Collection<RemoteTask> producerTasks)
+    {
+        List<ExchangeBufferLocation> producerLocations = producerTasks.stream()
+                .map(RemoteTask::getTaskStatus)
+                .filter(status -> !status.getState().isDone())
+                .map(producer -> new ExchangeBufferLocation(producer.getTaskId(), exchangeSourceLocation(consumerTaskId, producer.getSelf())))
+                .collect(toImmutableList());
+        remoteTaskFactory.destroyExchangeSources(producerLocations, stateMachine::transitionToFailed);
+    }
+
     public Set<Node> getScheduledNodes()
     {
         return ImmutableSet.copyOf(tasks.keySet());
@@ -410,8 +436,13 @@ public final class SqlStageExecution
     private static Split createRemoteSplitFor(TaskId taskId, URI taskLocation)
     {
         // Fetch the results from the buffer assigned to the task based on id
-        URI splitLocation = uriBuilderFrom(taskLocation).appendPath("results").appendPath(String.valueOf(taskId.getId())).build();
+        URI splitLocation = exchangeSourceLocation(taskId, taskLocation);
         return new Split(REMOTE_CONNECTOR_ID, new RemoteTransactionHandle(), new RemoteSplit(splitLocation));
+    }
+
+    private static URI exchangeSourceLocation(TaskId taskId, URI taskLocation)
+    {
+        return uriBuilderFrom(taskLocation).appendPath("results").appendPath(String.valueOf(taskId.getId())).build();
     }
 
     @Override
@@ -462,6 +493,10 @@ public final class SqlStageExecution
                 if (finishedTasks.containsAll(allTasks)) {
                     stateMachine.transitionToFinished();
                 }
+            }
+
+            if (taskState.isDone()) {
+                destroyExchangeSources(taskStatus.getTaskId(), sourceTasks.values());
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -64,6 +64,7 @@ import com.facebook.presto.memory.TotalReservationLowMemoryKiller;
 import com.facebook.presto.memory.TotalReservationOnBlockedNodesLowMemoryKiller;
 import com.facebook.presto.operator.ForScheduler;
 import com.facebook.presto.server.protocol.StatementResource;
+import com.facebook.presto.server.remotetask.HttpRemoteTaskFactory;
 import com.facebook.presto.server.remotetask.RemoteTaskStats;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.resourceGroups.QueryType;

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.server;
+package com.facebook.presto.server.remotetask;
 
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
@@ -26,16 +26,19 @@ import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.TaskStatus;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.ForScheduler;
-import com.facebook.presto.server.remotetask.HttpRemoteTask;
-import com.facebook.presto.server.remotetask.RemoteTaskStats;
+import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -43,13 +46,19 @@ import org.weakref.jmx.Nested;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import java.util.List;
 import java.util.OptionalInt;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Consumer;
 
+import static io.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -57,6 +66,8 @@ import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 public class HttpRemoteTaskFactory
         implements RemoteTaskFactory
 {
+    private static final Logger log = Logger.get(HttpRemoteTaskFactory.class);
+
     private final HttpClient httpClient;
     private final LocationFactory locationFactory;
     private final JsonCodec<TaskStatus> taskStatusCodec;
@@ -125,7 +136,8 @@ public class HttpRemoteTaskFactory
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             boolean summarizeTaskInfo)
     {
-        return new HttpRemoteTask(session,
+        return new HttpRemoteTask(
+                session,
                 taskId,
                 node.getNodeIdentifier(),
                 locationFactory.createTaskLocation(node, taskId),
@@ -146,5 +158,51 @@ public class HttpRemoteTaskFactory
                 taskUpdateRequestCodec,
                 partitionedSplitCountTracker,
                 stats);
+    }
+
+    @Override
+    public void destroyExchangeSources(List<ExchangeBufferLocation> locationsToDestroy, Consumer<PrestoException> onFailure)
+    {
+        for (ExchangeBufferLocation exchangeBufferLocation : locationsToDestroy) {
+            Request request = prepareDelete()
+                    .setUri(exchangeBufferLocation.getBufferLocation())
+                    .build();
+            RequestErrorTracker errorTracker = new RequestErrorTracker(
+                    exchangeBufferLocation.getProducerTaskId(),
+                    exchangeBufferLocation.getBufferLocation(),
+                    maxErrorDuration,
+                    errorScheduledExecutor,
+                    "Cleanup exchange sources");
+            executeDestroyExchangeSourceRequest(errorTracker, request, onFailure);
+        }
+    }
+
+    private void executeDestroyExchangeSourceRequest(RequestErrorTracker errorTracker, Request request, Consumer<PrestoException> onFailure)
+    {
+        errorTracker.startRequest();
+        addExceptionCallback(httpClient.executeAsync(request, createFullJsonResponseHandler(taskInfoCodec)), failedReason -> {
+            if (failedReason instanceof RejectedExecutionException && httpClient.isClosed()) {
+                log.error("Unable to destroy exchange source at %s. HTTP client is closed", request.getUri());
+                return;
+            }
+
+            // record failure
+            try {
+                errorTracker.requestFailed(failedReason);
+            }
+            catch (PrestoException e) {
+                onFailure.accept(e);
+                return;
+            }
+
+            // if throttled due to error, asynchronously wait for timeout and try again
+            ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+            if (errorRateLimit.isDone()) {
+                executeDestroyExchangeSourceRequest(errorTracker, request, onFailure);
+            }
+            else {
+                errorRateLimit.addListener(() -> executeDestroyExchangeSourceRequest(errorTracker, request, onFailure), errorScheduledExecutor);
+            }
+        });
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -27,6 +27,7 @@ import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spiller.SpillSpaceTracker;
@@ -69,6 +70,7 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.OutputBuffers.BufferType.BROADCAST;
@@ -141,6 +143,11 @@ public class MockRemoteTaskFactory
             boolean summarizeTaskInfo)
     {
         return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, totalPartitions, partitionedSplitCountTracker);
+    }
+
+    @Override
+    public void destroyExchangeSources(List<ExchangeBufferLocation> locationsToDestroy, Consumer<PrestoException> onFailure)
+    {
     }
 
     public static final class MockRemoteTask

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -32,7 +32,6 @@ import com.facebook.presto.metadata.HandleJsonModule;
 import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.metadata.PrestoNode;
 import com.facebook.presto.metadata.Split;
-import com.facebook.presto.server.HttpRemoteTaskFactory;
 import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.type.Type;


### PR DESCRIPTION
A task can sometimes finish before the sources of the task are even scheduled, so
there is no active system that is resposible for destroying the finished task's
output buffers on the source task.  This patch changes the coordinator to attempt
destruction of all exchange sources when a task finishes and any future exchange
sources added during scheduling.