### PR TITLE
Disallow duplicate keys to map constructor

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -160,6 +160,7 @@ public class TestParquetPredicateUtils
                 INTEGER,
                 methodHandle(TestParquetPredicateUtils.class, "throwUnsupportedOperationException"),
                 methodHandle(TestParquetPredicateUtils.class, "throwUnsupportedOperationException"),
+                methodHandle(TestParquetPredicateUtils.class, "throwUnsupportedOperationException"),
                 methodHandle(TestParquetPredicateUtils.class, "throwUnsupportedOperationException"));
 
         TupleDomain<HiveColumnHandle> domain = withColumnDomains(ImmutableMap.of(columnHandle, Domain.notNull(mapType)));

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
@@ -19,10 +19,13 @@ import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.DuplicateMapKeyException;
+import com.facebook.presto.spi.block.MapBlockBuilder;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
@@ -49,7 +52,16 @@ public final class MapConstructor
 {
     public static final MapConstructor MAP_CONSTRUCTOR = new MapConstructor();
 
-    private static final MethodHandle METHOD_HANDLE = methodHandle(MapConstructor.class, "createMap", MapType.class, MethodHandle.class, MethodHandle.class, State.class, Block.class, Block.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(
+            MapConstructor.class,
+            "createMap",
+            MapType.class,
+            MethodHandle.class,
+            MethodHandle.class,
+            State.class,
+            ConnectorSession.class,
+            Block.class,
+            Block.class);
     private static final String DESCRIPTION = "Constructs a map from the given key/value arrays";
 
     public MapConstructor()
@@ -104,7 +116,14 @@ public final class MapConstructor
     }
 
     @UsedByGeneratedCode
-    public static Block createMap(MapType mapType, MethodHandle keyEqual, MethodHandle keyHashCode, State state, Block keyBlock, Block valueBlock)
+    public static Block createMap(
+            MapType mapType,
+            MethodHandle keyEqual,
+            MethodHandle keyHashCode,
+            State state,
+            ConnectorSession session,
+            Block keyBlock,
+            Block valueBlock)
     {
         checkCondition(keyBlock.getPositionCount() == valueBlock.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "Key and value arrays must be the same length");
         PageBuilder pageBuilder = state.getPageBuilder();
@@ -112,7 +131,7 @@ public final class MapConstructor
             pageBuilder.reset();
         }
 
-        BlockBuilder mapBlockBuilder = pageBuilder.getBlockBuilder(0);
+        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) pageBuilder.getBlockBuilder(0);
         BlockBuilder blockBuilder = mapBlockBuilder.beginBlockEntry();
         for (int i = 0; i < keyBlock.getPositionCount(); i++) {
             if (keyBlock.isNull(i)) {
@@ -124,8 +143,15 @@ public final class MapConstructor
             mapType.getKeyType().appendTo(keyBlock, i, blockBuilder);
             mapType.getValueType().appendTo(valueBlock, i, blockBuilder);
         }
-        mapBlockBuilder.closeEntry();
-        pageBuilder.declarePosition();
+        try {
+            mapBlockBuilder.closeEntryStrict();
+        }
+        catch (DuplicateMapKeyException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getDetailedMessage(mapType.getKeyType(), session), e);
+        }
+        finally {
+            pageBuilder.declarePosition();
+        }
 
         return mapType.getObject(mapBlockBuilder, mapBlockBuilder.getPositionCount() - 1);
     }

--- a/presto-main/src/main/java/com/facebook/presto/type/MapParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/MapParametricType.java
@@ -56,12 +56,14 @@ public final class MapParametricType
         Type valueType = secondParameter.getType();
         MethodHandle keyNativeEquals = typeManager.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
         MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+        MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
         MethodHandle keyNativeHashCode = typeManager.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
         MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
         return new MapType(
                 keyType,
                 valueType,
                 keyBlockNativeEquals,
+                keyBlockEquals,
                 keyNativeHashCode,
                 keyBlockHashCode);
     }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestMapOperators.java
@@ -110,6 +110,10 @@ public class TestMapOperators
                 100.0));
 
         assertInvalidFunction("MAP(ARRAY [1], ARRAY [2, 4])", "Key and value arrays must be the same length");
+        assertInvalidFunction("MAP(ARRAY [1, 2, 3, 2], ARRAY [4, 5, 6, 7])", "Duplicate keys (2) are not allowed");
+        assertInvalidFunction(
+                "MAP(ARRAY [ARRAY [1, 2], ARRAY [1, 3], ARRAY [1, 2]], ARRAY [1, 2, 3])",
+                "Duplicate keys ([1, 2]) are not allowed");
 
         assertCachedInstanceHasBoundedRetainedSize("MAP(ARRAY ['1','3'], ARRAY [2,4])");
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DuplicateMapKeyException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DuplicateMapKeyException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.type.Type;
+
+import static java.lang.String.format;
+
+public class DuplicateMapKeyException
+        extends Exception
+{
+    private final Block block;
+    private final int position;
+
+    public DuplicateMapKeyException(Block block, int position)
+    {
+        super("Duplicate keys are not allowed");
+        this.block = block;
+        this.position = position;
+    }
+
+    public String getDetailedMessage(Type keyType, ConnectorSession session)
+    {
+        return format("Duplicate keys (%s) are not allowed", keyType.getObjectValue(session, block, position));
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -35,6 +35,7 @@ public class MapBlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapBlockBuilder.class).instanceSize();
 
+    private final MethodHandle keyBlockEquals;
     private final MethodHandle keyBlockHashCode;
 
     @Nullable
@@ -53,6 +54,7 @@ public class MapBlockBuilder
             Type keyType,
             Type valueType,
             MethodHandle keyBlockNativeEquals,
+            MethodHandle keyBlockEquals,
             MethodHandle keyNativeHashCode,
             MethodHandle keyBlockHashCode,
             BlockBuilderStatus blockBuilderStatus,
@@ -61,6 +63,7 @@ public class MapBlockBuilder
         this(
                 keyType,
                 keyBlockNativeEquals,
+                keyBlockEquals,
                 keyNativeHashCode,
                 keyBlockHashCode,
                 blockBuilderStatus,
@@ -74,6 +77,7 @@ public class MapBlockBuilder
     private MapBlockBuilder(
             Type keyType,
             MethodHandle keyBlockNativeEquals,
+            MethodHandle keyBlockEquals,
             MethodHandle keyNativeHashCode,
             MethodHandle keyBlockHashCode,
             @Nullable BlockBuilderStatus blockBuilderStatus,
@@ -85,8 +89,8 @@ public class MapBlockBuilder
     {
         super(keyType, keyNativeHashCode, keyBlockNativeEquals);
 
-        requireNonNull(keyBlockHashCode, "keyBlockHashCode is null");
-        this.keyBlockHashCode = keyBlockHashCode;
+        this.keyBlockEquals = requireNonNull(keyBlockEquals, "keyBlockEquals is null");
+        this.keyBlockHashCode = requireNonNull(keyBlockHashCode, "keyBlockHashCode is null");
         this.blockBuilderStatus = blockBuilderStatus;
 
         this.positionCount = 0;
@@ -193,6 +197,38 @@ public class MapBlockBuilder
         int aggregatedEntryCount = offsets[positionCount];
         int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
         buildHashTable(keyBlockBuilder, previousAggregatedEntryCount, entryCount, keyBlockHashCode, hashTables, previousAggregatedEntryCount * HASH_MULTIPLIER, entryCount * HASH_MULTIPLIER);
+        return this;
+    }
+
+    /**
+     * This method will check duplicate keys and close entry.
+     * <p>
+     * When duplicate keys are discovered, the block is guaranteed to be in
+     * a consistent state before {@link DuplicateMapKeyException} is thrown.
+     * In other words, one can continue to use this BlockBuilder.
+     */
+    public BlockBuilder closeEntryStrict()
+            throws DuplicateMapKeyException
+    {
+        if (!currentEntryOpened) {
+            throw new IllegalStateException("Expected entry to be opened but was closed");
+        }
+
+        entryAdded(false);
+        currentEntryOpened = false;
+
+        ensureHashTableSize();
+        int previousAggregatedEntryCount = offsets[positionCount - 1];
+        int aggregatedEntryCount = offsets[positionCount];
+        int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
+        buildHashTableStrict(
+                keyBlockBuilder,
+                previousAggregatedEntryCount, entryCount,
+                keyBlockEquals,
+                keyBlockHashCode,
+                hashTables,
+                previousAggregatedEntryCount * HASH_MULTIPLIER,
+                entryCount * HASH_MULTIPLIER);
         return this;
     }
 
@@ -359,6 +395,7 @@ public class MapBlockBuilder
         return new MapBlockBuilder(
                 keyType,
                 keyBlockNativeEquals,
+                keyBlockEquals,
                 keyNativeHashCode,
                 keyBlockHashCode,
                 blockBuilderStatus,
@@ -376,9 +413,11 @@ public class MapBlockBuilder
         return hashTable;
     }
 
+    /**
+     * This method assumes that {@code keyBlock} has no duplicated entries (in the specified range)
+     */
     static void buildHashTable(Block keyBlock, int keyOffset, int keyCount, MethodHandle keyBlockHashCode, int[] outputHashTable, int hashTableOffset, int hashTableSize)
     {
-        // This method assumes that keyBlock has no duplicated entries (in the specified range)
         for (int i = 0; i < keyCount; i++) {
             if (keyBlock.isNull(keyOffset + i)) {
                 throw new IllegalArgumentException("map keys cannot be null");
@@ -401,6 +440,66 @@ public class MapBlockBuilder
                     outputHashTable[hashTableOffset + hash] = i;
                     break;
                 }
+                hash++;
+                if (hash == hashTableSize) {
+                    hash = 0;
+                }
+            }
+        }
+    }
+
+    /**
+     * This method checks whether {@code keyBlock} has duplicated entries (in the specified range)
+     */
+    private static void buildHashTableStrict(
+            Block keyBlock,
+            int keyOffset,
+            int keyCount,
+            MethodHandle keyBlockEquals,
+            MethodHandle keyBlockHashCode,
+            int[] outputHashTable,
+            int hashTableOffset,
+            int hashTableSize)
+            throws DuplicateMapKeyException
+    {
+        for (int i = 0; i < keyCount; i++) {
+            if (keyBlock.isNull(keyOffset + i)) {
+                throw new IllegalArgumentException("map keys cannot be null");
+            }
+
+            long hashCode;
+            try {
+                hashCode = (long) keyBlockHashCode.invokeExact(keyBlock, keyOffset + i);
+            }
+            catch (Throwable throwable) {
+                if (throwable instanceof RuntimeException) {
+                    throw (RuntimeException) throwable;
+                }
+                throw new RuntimeException(throwable);
+            }
+
+            int hash = (int) Math.floorMod(hashCode, hashTableSize);
+            while (true) {
+                if (outputHashTable[hashTableOffset + hash] == -1) {
+                    outputHashTable[hashTableOffset + hash] = i;
+                    break;
+                }
+
+                boolean isDuplicateKey;
+                try {
+                    isDuplicateKey = (boolean) keyBlockEquals.invokeExact(keyBlock, i, keyBlock, outputHashTable[hashTableOffset + hash]);
+                }
+                catch (RuntimeException e) {
+                    throw e;
+                }
+                catch (Throwable throwable) {
+                    throw new RuntimeException(throwable);
+                }
+
+                if (isDuplicateKey) {
+                    throw new DuplicateMapKeyException(keyBlock, i);
+                }
+
                 hash++;
                 if (hash == hashTableSize) {
                     hash = 0;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -193,10 +193,6 @@ public class MapBlockBuilder
         int aggregatedEntryCount = offsets[positionCount];
         int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
         buildHashTable(keyBlockBuilder, previousAggregatedEntryCount, entryCount, keyBlockHashCode, hashTables, previousAggregatedEntryCount * HASH_MULTIPLIER, entryCount * HASH_MULTIPLIER);
-        if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(entryCount * HASH_MULTIPLIER * Integer.BYTES);
-        }
-
         return this;
     }
 
@@ -210,18 +206,12 @@ public class MapBlockBuilder
         currentEntryOpened = false;
 
         ensureHashTableSize();
-        int previousAggregatedEntryCount = offsets[positionCount - 1];
-        int aggregatedEntryCount = offsets[positionCount];
-        int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
 
         // Directly copy instead of building hashtable
         int hashTableOffset = offsets[positionCount - 1] * HASH_MULTIPLIER;
         int hashTableSize = (offsets[positionCount] - offsets[positionCount - 1]) * HASH_MULTIPLIER;
         for (int i = 0; i < hashTableSize; i++) {
             hashTables[hashTableOffset + i] = providedHashTable[providedHashTableOffset + i];
-        }
-        if (blockBuilderStatus != null) {
-            blockBuilderStatus.addBytes(entryCount * HASH_MULTIPLIER * Integer.BYTES);
         }
 
         return this;
@@ -254,6 +244,7 @@ public class MapBlockBuilder
 
         if (blockBuilderStatus != null) {
             blockBuilderStatus.addBytes(Integer.BYTES + Byte.BYTES);
+            blockBuilderStatus.addBytes((offsets[positionCount] - offsets[positionCount - 1]) * HASH_MULTIPLIER * Integer.BYTES);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -45,8 +45,15 @@ public class MapType
     private final MethodHandle keyNativeHashCode;
     private final MethodHandle keyBlockHashCode;
     private final MethodHandle keyBlockNativeEquals;
+    private final MethodHandle keyBlockEquals;
 
-    public MapType(Type keyType, Type valueType, MethodHandle keyBlockNativeEquals, MethodHandle keyNativeHashCode, MethodHandle keyBlockHashCode)
+    public MapType(
+            Type keyType,
+            Type valueType,
+            MethodHandle keyBlockNativeEquals,
+            MethodHandle keyBlockEquals,
+            MethodHandle keyNativeHashCode,
+            MethodHandle keyBlockHashCode)
     {
         super(new TypeSignature(StandardTypes.MAP,
                         TypeSignatureParameter.of(keyType.getTypeSignature()),
@@ -63,12 +70,21 @@ public class MapType
         this.keyBlockNativeEquals = keyBlockNativeEquals;
         this.keyNativeHashCode = keyNativeHashCode;
         this.keyBlockHashCode = keyBlockHashCode;
+        this.keyBlockEquals = keyBlockEquals;
     }
 
     @Override
     public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
     {
-        return new MapBlockBuilder(keyType, valueType, keyBlockNativeEquals, keyNativeHashCode, keyBlockHashCode, blockBuilderStatus, expectedEntries);
+        return new MapBlockBuilder(
+                keyType,
+                valueType,
+                keyBlockNativeEquals,
+                keyBlockEquals,
+                keyNativeHashCode,
+                keyBlockHashCode,
+                blockBuilderStatus,
+                expectedEntries);
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestMapType.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestMapType.java
@@ -31,12 +31,14 @@ public class TestMapType
                 createVarcharType(42),
                 MethodHandleUtil.methodHandle(TestMapType.class, "throwUnsupportedOperation"),
                 MethodHandleUtil.methodHandle(TestMapType.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestMapType.class, "throwUnsupportedOperation"),
                 MethodHandleUtil.methodHandle(TestMapType.class, "throwUnsupportedOperation"));
         assertEquals(mapType.getDisplayName(), "map(bigint, varchar(42))");
 
         mapType = new MapType(
                 BIGINT,
                 VARCHAR,
+                MethodHandleUtil.methodHandle(TestMapType.class, "throwUnsupportedOperation"),
                 MethodHandleUtil.methodHandle(TestMapType.class, "throwUnsupportedOperation"),
                 MethodHandleUtil.methodHandle(TestMapType.class, "throwUnsupportedOperation"),
                 MethodHandleUtil.methodHandle(TestMapType.class, "throwUnsupportedOperation"));

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestRowType.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestRowType.java
@@ -38,6 +38,7 @@ public class TestRowType
                         DOUBLE,
                         methodHandle(TestRowType.class, "throwUnsupportedOperation"),
                         methodHandle(TestRowType.class, "throwUnsupportedOperation"),
+                        methodHandle(TestRowType.class, "throwUnsupportedOperation"),
                         methodHandle(TestRowType.class, "throwUnsupportedOperation"))));
 
         RowType row = RowType.from(fields);
@@ -56,6 +57,7 @@ public class TestRowType
                 new MapType(
                         BOOLEAN,
                         DOUBLE,
+                        methodHandle(TestRowType.class, "throwUnsupportedOperation"),
                         methodHandle(TestRowType.class, "throwUnsupportedOperation"),
                         methodHandle(TestRowType.class, "throwUnsupportedOperation"),
                         methodHandle(TestRowType.class, "throwUnsupportedOperation")));


### PR DESCRIPTION
Currently map constructor does not check duplicate keys and will
return an illegal MapBlock on input with duplicate keys.