### PR TITLE
Use reference count in pages index

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -581,10 +581,12 @@ public class PagesIndex
     // TODO: This is similar to what OrderByOperator does, look into reusing this logic in OrderByOperator as well.
     public Iterator<Page> getSortedPages()
     {
-        return new AbstractIterator<Page>() {
+        return new AbstractIterator<Page>()
+        {
             private int currentPosition;
             private PageBuilder pageBuilder = new PageBuilder(types);
             private int[] outputChannels = new int[types.size()];
+
             {
                 Arrays.setAll(outputChannels, IntUnaryOperator.identity());
             }


### PR DESCRIPTION
This addresses retained size accounting issue when deserialized pages are directly passed to `PagesIndex`.
This could happen in Order By operator, but also in other operators using pages index when task_concurrency=1.

Related to: https://github.com/prestodb/presto/issues/10337