### PR TITLE
Add peak memory usage to presto-cli output

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -73,6 +73,7 @@ Splits:   646 queued, 34 running, 175 done
 CPU Time: 33.7s total,  191K rows/s, 16.6MB/s, 22% active
 Per Node: 2.5 parallelism,  473K rows/s, 41.1MB/s
 Parallelism: 2.5
+Peak Memory: 1.97GB
 0:13 [6.45M rows,  560MB] [ 473K rows/s, 41.1MB/s] [=========>>           ] 20%
 
      STAGES   ROWS  ROWS/s  BYTES  BYTES/s   PEND    RUN   DONE
@@ -193,7 +194,11 @@ Parallelism: 2.5
                     formatDataRate(bytes(stats.getProcessedBytes() / nodes), wallTime, true));
             reprintLine(perNodeSummary);
 
+            // Parallelism: 5.3
             out.println(String.format("Parallelism: %.1f", parallelism));
+
+            //Peak Memory: 1.97GB
+            reprintLine("Peak Memory: " + formatDataSize(bytes(stats.getPeakMemoryBytes()), true));
         }
 
         // 0:32 [2.12GB, 15M rows] [67MB/s, 463K rows/s]
@@ -280,7 +285,11 @@ Parallelism: 2.5
                         formatDataRate(bytes(stats.getProcessedBytes() / nodes), wallTime, true));
                 reprintLine(perNodeSummary);
 
+                // Parallelism: 5.3
                 reprintLine(String.format("Parallelism: %.1f", parallelism));
+
+                //Peak Memory: 1.97GB
+                reprintLine("Peak Memory: " + formatDataSize(bytes(stats.getPeakMemoryBytes()), true));
             }
 
             verify(terminalWidth >= 75); // otherwise handled above
@@ -318,8 +327,6 @@ Parallelism: 2.5
 
                 reprintLine(progressLine);
             }
-
-            // todo Mem: 1949M shared, 7594M private
 
             // blank line
             reprintLine("");


### PR DESCRIPTION
Tested locally, terminal output was as follows:
```
Splits: 100 total, 0 done (0.00%)
CPU Time: 270.9s total,  157K rows/s, 6.47MB/s, 34% active
Per Node: 1.3 parallelism,  208K rows/s,  8.6MB/s
Parallelism: 5.3
Peak Memory: 1.97GB
0:51 [42.4M rows, 1.71GB] [833K rows/s, 34.4MB/s]