### PR TITLE
Add memory aware query execution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryAwareQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryAwareQueryExecution.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.memory.ClusterMemoryManager;
+import com.facebook.presto.memory.VersionedMemoryPoolId;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.sql.planner.Plan;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.concurrent.SetThreadName;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
+import static com.facebook.presto.memory.LocalMemoryManager.RESERVED_POOL;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+
+public class MemoryAwareQueryExecution
+        implements QueryExecution
+{
+    private final ClusterMemoryManager memoryManager;
+    private final SqlQueryExecution delegate;
+    private final long peakMemoryEstimate;
+
+    @GuardedBy("this")
+    private boolean startedWaiting;
+
+    public MemoryAwareQueryExecution(ClusterMemoryManager memoryManager, SqlQueryExecution delegate)
+    {
+        this.memoryManager = memoryManager;
+        this.delegate = delegate;
+        this.peakMemoryEstimate = delegate.getSession().getResourceEstimates().getPeakMemory().map(DataSize::toBytes).orElse(0L);
+    }
+
+    @Override
+    public QueryId getQueryId()
+    {
+        return delegate.getQueryId();
+    }
+
+    @Override
+    public QueryInfo getQueryInfo()
+    {
+        return delegate.getQueryInfo();
+    }
+
+    @Override
+    public QueryState getState()
+    {
+        return delegate.getState();
+    }
+
+    @Override
+    public ListenableFuture<QueryState> getStateChange(QueryState currentState)
+    {
+        return delegate.getStateChange(currentState);
+    }
+
+    @Override
+    public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
+    {
+        delegate.addOutputInfoListener(listener);
+    }
+
+    @Override
+    public Optional<ResourceGroupId> getResourceGroup()
+    {
+        return delegate.getResourceGroup();
+    }
+
+    @Override
+    public void setResourceGroup(ResourceGroupId resourceGroupId)
+    {
+        delegate.setResourceGroup(resourceGroupId);
+    }
+
+    @Override
+    public Plan getQueryPlan()
+    {
+        return delegate.getQueryPlan();
+    }
+
+    @Override
+    public VersionedMemoryPoolId getMemoryPool()
+    {
+        return delegate.getMemoryPool();
+    }
+
+    @Override
+    public void setMemoryPool(VersionedMemoryPoolId poolId)
+    {
+        delegate.setMemoryPool(poolId);
+    }
+
+    @Override
+    public long getUserMemoryReservation()
+    {
+        return delegate.getUserMemoryReservation();
+    }
+
+    @Override
+    public long getTotalMemoryReservation()
+    {
+        return delegate.getTotalMemoryReservation();
+    }
+
+    @Override
+    public Duration getTotalCpuTime()
+    {
+        return delegate.getTotalCpuTime();
+    }
+
+    @Override
+    public Session getSession()
+    {
+        return delegate.getSession();
+    }
+
+    @Override
+    public synchronized void start()
+    {
+        try (SetThreadName ignored = new SetThreadName("Query-%s", delegate.getQueryId())) {
+            try {
+                if (memoryManager.preAllocateQueryMemory(delegate.getQueryId(), peakMemoryEstimate)) {
+                    delegate.addStateChangeListener(state -> {
+                        if (state.isDone()) {
+                            memoryManager.removePreAllocation(delegate.getQueryId());
+                        }
+                    });
+                    delegate.start();
+                    return;
+                }
+
+                if (!startedWaiting) {
+                    // This may cause starvation, since requests may not be granted in the order they arrive
+                    startedWaiting = true;
+                    delegate.startWaitingForResources();
+                    memoryManager.addChangeListener(GENERAL_POOL, none -> start());
+                    memoryManager.addChangeListener(RESERVED_POOL, none -> start());
+                }
+            }
+            catch (Throwable e) {
+                fail(e);
+                throwIfInstanceOf(e, Error.class);
+            }
+        }
+    }
+
+    @Override
+    public void fail(Throwable cause)
+    {
+        delegate.fail(cause);
+    }
+
+    @Override
+    public void cancelQuery()
+    {
+        delegate.cancelQuery();
+    }
+
+    @Override
+    public void cancelStage(StageId stageId)
+    {
+        delegate.cancelStage(stageId);
+    }
+
+    @Override
+    public void recordHeartbeat()
+    {
+        delegate.recordHeartbeat();
+    }
+
+    @Override
+    public void pruneInfo()
+    {
+        delegate.pruneInfo();
+    }
+
+    @Override
+    public void addStateChangeListener(StateMachine.StateChangeListener<QueryState> stateChangeListener)
+    {
+        delegate.addStateChangeListener(stateChangeListener);
+    }
+
+    @Override
+    public void addFinalQueryInfoListener(StateMachine.StateChangeListener<QueryInfo> stateChangeListener)
+    {
+        delegate.addFinalQueryInfoListener(stateChangeListener);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryState.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryState.java
@@ -25,6 +25,10 @@ public enum QueryState
      */
     QUEUED(false),
     /**
+     * Query is waiting for the required resources (beta).
+     */
+    WAITING_FOR_RESOURCES(false),
+    /**
      * Query is being planned.
      */
     PLANNING(false),

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -47,6 +47,7 @@ public class QueryStats
 
     private final Duration elapsedTime;
     private final Duration queuedTime;
+    private final Duration resourceWaitingTime;
     private final Duration analysisTime;
     private final Duration distributedPlanningTime;
     private final Duration totalPlanningTime;
@@ -101,6 +102,7 @@ public class QueryStats
         this.endTime = null;
         this.elapsedTime = null;
         this.queuedTime = null;
+        this.resourceWaitingTime = null;
         this.analysisTime = null;
         this.distributedPlanningTime = null;
         this.totalPlanningTime = null;
@@ -146,6 +148,7 @@ public class QueryStats
 
             @JsonProperty("elapsedTime") Duration elapsedTime,
             @JsonProperty("queuedTime") Duration queuedTime,
+            @JsonProperty("resourceWaitingTime") Duration resourceWaitingTime,
             @JsonProperty("analysisTime") Duration analysisTime,
             @JsonProperty("distributedPlanningTime") Duration distributedPlanningTime,
             @JsonProperty("totalPlanningTime") Duration totalPlanningTime,
@@ -198,6 +201,7 @@ public class QueryStats
 
         this.elapsedTime = elapsedTime;
         this.queuedTime = queuedTime;
+        this.resourceWaitingTime = resourceWaitingTime;
         this.analysisTime = analysisTime;
         this.distributedPlanningTime = distributedPlanningTime;
         this.totalPlanningTime = totalPlanningTime;
@@ -282,6 +286,12 @@ public class QueryStats
     public Duration getElapsedTime()
     {
         return elapsedTime;
+    }
+
+    @JsonProperty
+    public Duration getResourceWaitingTime()
+    {
+        return resourceWaitingTime;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -24,6 +24,7 @@ import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.SplitSchedulerStats;
 import com.facebook.presto.execution.scheduler.SqlQueryScheduler;
 import com.facebook.presto.failureDetector.FailureDetector;
+import com.facebook.presto.memory.ClusterMemoryManager;
 import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableHandle;
@@ -60,6 +61,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.SetThreadName;
 import io.airlift.log.Logger;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -84,7 +86,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @ThreadSafe
-public final class SqlQueryExecution
+public class SqlQueryExecution
         implements QueryExecution
 {
     private static final Logger log = Logger.get(SqlQueryExecution.class);
@@ -251,6 +253,20 @@ public final class SqlQueryExecution
     public Session getSession()
     {
         return stateMachine.getSession();
+    }
+
+    public void startWaitingForResources()
+    {
+        try (SetThreadName ignored = new SetThreadName("Query-%s", stateMachine.getQueryId())) {
+            try {
+                // transition to waiting for resources
+                stateMachine.transitionToWaitingForResources();
+            }
+            catch (Throwable e) {
+                fail(e);
+                throwIfInstanceOf(e, Error.class);
+            }
+        }
     }
 
     @Override
@@ -580,7 +596,7 @@ public final class SqlQueryExecution
     }
 
     public static class SqlQueryExecutionFactory
-            implements QueryExecutionFactory<SqlQueryExecution>
+            implements QueryExecutionFactory<QueryExecution>
     {
         private final SplitSchedulerStats schedulerStats;
         private final int scheduleSplitBatchSize;
@@ -600,6 +616,8 @@ public final class SqlQueryExecution
         private final FailureDetector failureDetector;
         private final NodeTaskMap nodeTaskMap;
         private final Map<String, ExecutionPolicy> executionPolicies;
+        private final ClusterMemoryManager clusterMemoryManager;
+        private final DataSize preAllocateMemoryThreshold;
 
         @Inject
         SqlQueryExecutionFactory(QueryManagerConfig config,
@@ -620,7 +638,8 @@ public final class SqlQueryExecution
                 NodeTaskMap nodeTaskMap,
                 QueryExplainer queryExplainer,
                 Map<String, ExecutionPolicy> executionPolicies,
-                SplitSchedulerStats schedulerStats)
+                SplitSchedulerStats schedulerStats,
+                ClusterMemoryManager clusterMemoryManager)
         {
             requireNonNull(config, "config is null");
             this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
@@ -635,25 +654,25 @@ public final class SqlQueryExecution
             requireNonNull(planOptimizers, "planOptimizers is null");
             this.remoteTaskFactory = requireNonNull(remoteTaskFactory, "remoteTaskFactory is null");
             this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
-            requireNonNull(featuresConfig, "featuresConfig is null");
             this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
             this.schedulerExecutor = requireNonNull(schedulerExecutor, "schedulerExecutor is null");
             this.failureDetector = requireNonNull(failureDetector, "failureDetector is null");
             this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
             this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
-
             this.executionPolicies = requireNonNull(executionPolicies, "schedulerPolicies is null");
+            this.clusterMemoryManager = requireNonNull(clusterMemoryManager, "clusterMemoryManager is null");
+            this.preAllocateMemoryThreshold = requireNonNull(featuresConfig, "featuresConfig is null").getPreAllocateMemoryThreshold();
             this.planOptimizers = planOptimizers.get();
         }
 
         @Override
-        public SqlQueryExecution createQueryExecution(QueryId queryId, String query, Session session, Statement statement, List<Expression> parameters)
+        public QueryExecution createQueryExecution(QueryId queryId, String query, Session session, Statement statement, List<Expression> parameters)
         {
             String executionPolicyName = SystemSessionProperties.getExecutionPolicy(session);
             ExecutionPolicy executionPolicy = executionPolicies.get(executionPolicyName);
             checkArgument(executionPolicy != null, "No execution policy %s", executionPolicy);
 
-            return new SqlQueryExecution(
+            SqlQueryExecution execution = new SqlQueryExecution(
                     queryId,
                     query,
                     session,
@@ -678,6 +697,13 @@ public final class SqlQueryExecution
                     executionPolicy,
                     parameters,
                     schedulerStats);
+
+            if (preAllocateMemoryThreshold.toBytes() > 0 && session.getResourceEstimates().getPeakMemory().isPresent() &&
+                    session.getResourceEstimates().getPeakMemory().get().compareTo(preAllocateMemoryThreshold) >= 0) {
+                return new MemoryAwareQueryExecution(clusterMemoryManager, execution);
+            }
+
+            return execution;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -38,6 +38,7 @@ import java.util.List;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.succinctBytes;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 @DefunctConfig({
@@ -105,6 +106,7 @@ public class FeaturesConfig
     private boolean parseDecimalLiteralsAsDouble;
     private boolean useMarkDistinct = true;
     private boolean preferPartialAggregation = true;
+    private DataSize preAllocateMemoryThreshold = succinctBytes(0);
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
 
@@ -746,6 +748,19 @@ public class FeaturesConfig
     public FeaturesConfig setArrayAggGroupImplementation(ArrayAggGroupImplementation groupByMode)
     {
         this.arrayAggGroupImplementation = groupByMode;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getPreAllocateMemoryThreshold()
+    {
+        return preAllocateMemoryThreshold;
+    }
+
+    @Config("experimental.preallocate-memory-threshold")
+    public FeaturesConfig setPreAllocateMemoryThreshold(DataSize preAllocateMemoryThreshold)
+    {
+        this.preAllocateMemoryThreshold = preAllocateMemoryThreshold;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -110,6 +110,7 @@ public class MockQueryExecution
                         new DateTime(4),
                         new Duration(6, NANOSECONDS),
                         new Duration(5, NANOSECONDS),
+                        new Duration(31, NANOSECONDS),
                         new Duration(7, NANOSECONDS),
                         new Duration(8, NANOSECONDS),
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -51,6 +51,7 @@ import static com.facebook.presto.execution.QueryState.PLANNING;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.execution.QueryState.STARTING;
+import static com.facebook.presto.execution.QueryState.WAITING_FOR_RESOURCES;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.USER_CANCELED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -95,6 +96,29 @@ public class TestQueryStateMachine
     {
         QueryStateMachine stateMachine = createQueryStateMachine();
         assertState(stateMachine, QUEUED);
+
+        assertTrue(stateMachine.transitionToPlanning());
+        assertState(stateMachine, PLANNING);
+
+        assertTrue(stateMachine.transitionToStarting());
+        assertState(stateMachine, STARTING);
+
+        assertTrue(stateMachine.transitionToRunning());
+        assertState(stateMachine, RUNNING);
+
+        assertTrue(stateMachine.transitionToFinishing());
+        tryGetFutureValue(stateMachine.getStateChange(FINISHING), 2, TimeUnit.SECONDS);
+        assertState(stateMachine, FINISHED);
+    }
+
+    @Test
+    public void testStateChangesWithResourceWaiting()
+    {
+        QueryStateMachine stateMachine = createQueryStateMachine();
+        assertState(stateMachine, QUEUED);
+
+        assertTrue(stateMachine.transitionToWaitingForResources());
+        assertState(stateMachine, WAITING_FOR_RESOURCES);
 
         assertTrue(stateMachine.transitionToPlanning());
         assertState(stateMachine, PLANNING);
@@ -362,8 +386,17 @@ public class TestQueryStateMachine
             assertNull(queryStats.getFinishingTime());
             assertNull(queryStats.getEndTime());
         }
+        else if (queryInfo.getState() == WAITING_FOR_RESOURCES) {
+            assertNotNull(queryStats.getQueuedTime());
+            assertNull(queryStats.getResourceWaitingTime());
+            assertNull(queryStats.getTotalPlanningTime());
+            assertNull(queryStats.getExecutionStartTime());
+            assertNull(queryStats.getFinishingTime());
+            assertNull(queryStats.getEndTime());
+        }
         else if (queryInfo.getState() == PLANNING) {
             assertNotNull(queryStats.getQueuedTime());
+            assertNotNull(queryStats.getResourceWaitingTime());
             assertNull(queryStats.getTotalPlanningTime());
             assertNull(queryStats.getExecutionStartTime());
             assertNull(queryStats.getFinishingTime());
@@ -371,6 +404,7 @@ public class TestQueryStateMachine
         }
         else if (queryInfo.getState() == STARTING) {
             assertNotNull(queryStats.getQueuedTime());
+            assertNotNull(queryStats.getResourceWaitingTime());
             assertNotNull(queryStats.getTotalPlanningTime());
             assertNull(queryStats.getExecutionStartTime());
             assertNull(queryStats.getFinishingTime());
@@ -378,6 +412,7 @@ public class TestQueryStateMachine
         }
         else if (queryInfo.getState() == RUNNING) {
             assertNotNull(queryStats.getQueuedTime());
+            assertNotNull(queryStats.getResourceWaitingTime());
             assertNotNull(queryStats.getTotalPlanningTime());
             assertNotNull(queryStats.getExecutionStartTime());
             assertNull(queryStats.getFinishingTime());
@@ -385,6 +420,7 @@ public class TestQueryStateMachine
         }
         else if (queryInfo.getState() == FINISHING) {
             assertNotNull(queryStats.getQueuedTime());
+            assertNotNull(queryStats.getResourceWaitingTime());
             assertNotNull(queryStats.getTotalPlanningTime());
             assertNotNull(queryStats.getExecutionStartTime());
             assertNull(queryStats.getFinishingTime());
@@ -392,6 +428,7 @@ public class TestQueryStateMachine
         }
         else {
             assertNotNull(queryStats.getQueuedTime());
+            assertNotNull(queryStats.getResourceWaitingTime());
             assertNotNull(queryStats.getTotalPlanningTime());
             assertNotNull(queryStats.getExecutionStartTime());
             assertNotNull(queryStats.getFinishingTime());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -136,6 +136,7 @@ public class TestQueryStats
             new DateTime(4),
             new Duration(6, NANOSECONDS),
             new Duration(5, NANOSECONDS),
+            new Duration(31, NANOSECONDS),
             new Duration(7, NANOSECONDS),
             new Duration(8, NANOSECONDS),
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -58,6 +58,7 @@ public class TestBasicQueryInfo
                                 DateTime.parse("1991-09-06T06:00-05:30"),
                                 Duration.valueOf("8m"),
                                 Duration.valueOf("7m"),
+                                Duration.valueOf("34m"),
                                 Duration.valueOf("9m"),
                                 Duration.valueOf("10m"),
                                 Duration.valueOf("11m"),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -109,6 +109,7 @@ public class TestQueryStateInfo
                         DateTime.parse("1991-09-06T06:00-05:30"),
                         Duration.valueOf("8m"),
                         Duration.valueOf("7m"),
+                        Duration.valueOf("34m"),
                         Duration.valueOf("9m"),
                         Duration.valueOf("10m"),
                         Duration.valueOf("11m"),

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -33,6 +33,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.airlift.units.DataSize.succinctBytes;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -93,7 +94,8 @@ public class TestFeaturesConfig
                 .setPreferPartialAggregation(true)
                 .setHistogramGroupImplementation(HistogramGroupImplementation.NEW)
                 .setArrayAggGroupImplementation(ArrayAggGroupImplementation.NEW)
-                .setMaxGroupingSets(2048));
+                .setMaxGroupingSets(2048)
+                .setPreAllocateMemoryThreshold(succinctBytes(0)));
     }
 
     @Test
@@ -152,6 +154,7 @@ public class TestFeaturesConfig
                 .put("optimizer.use-mark-distinct", "false")
                 .put("optimizer.prefer-partial-aggregation", "false")
                 .put("analyzer.max-grouping-sets", "2047")
+                .put("experimental.preallocate-memory-threshold", "5TB")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -206,7 +209,8 @@ public class TestFeaturesConfig
                 .setPreferPartialAggregation(false)
                 .setHistogramGroupImplementation(HistogramGroupImplementation.LEGACY)
                 .setArrayAggGroupImplementation(ArrayAggGroupImplementation.LEGACY)
-                .setMaxGroupingSets(2047);
+                .setMaxGroupingSets(2047)
+                .setPreAllocateMemoryThreshold(DataSize.valueOf("5TB"));
         assertFullMapping(properties, expected);
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryAwareExecution.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryAwareExecution.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.memory.ClusterMemoryManager;
+import com.facebook.presto.memory.LocalMemoryManager;
+import com.facebook.presto.memory.MemoryManagerConfig;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.session.ResourceEstimates;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Key;
+import io.airlift.units.DataSize;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static com.facebook.presto.execution.QueryState.FAILED;
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.execution.QueryState.WAITING_FOR_RESOURCES;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static io.airlift.units.DataSize.succinctBytes;
+
+@Test(singleThreaded = true)
+public class TestMemoryAwareExecution
+{
+    private QueryManager queryManager;
+    private long totalAvailableMemory;
+    private long queryMaxMemoryBytes;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        TestingPrestoServer server = new TestingPrestoServer(
+                true,
+                ImmutableMap.of("experimental.preallocate-memory-threshold", "1B"),
+                null,
+                null,
+                new SqlParserOptions(),
+                ImmutableList.of());
+
+        LocalMemoryManager localMemoryManager = server.getInstance(Key.get(LocalMemoryManager.class));
+        ClusterMemoryManager clusterMemoryManager = server.getInstance(Key.get(ClusterMemoryManager.class));
+        queryManager = server.getQueryManager();
+        queryMaxMemoryBytes = server.getInstance(Key.get(MemoryManagerConfig.class)).getMaxQueryMemory().toBytes();
+
+        // wait for cluster memory to be picked up
+        while (clusterMemoryManager.getClusterMemoryBytes() == 0) {
+            Thread.sleep(1000);
+        }
+        totalAvailableMemory = localMemoryManager.getPool(LocalMemoryManager.GENERAL_POOL).getMaxBytes();
+    }
+
+    @Test
+    public void testWaitingForResources()
+            throws Exception
+    {
+        QueryId normalQuery = queryWithResourceEstimate(new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty()), queryManager);
+        ResourceEstimates estimate = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.of(DataSize.valueOf("20GB")));
+        QueryId highMemoryQuery = queryWithResourceEstimate(estimate, queryManager);
+        assertState(normalQuery, RUNNING);
+        assertState(highMemoryQuery, WAITING_FOR_RESOURCES);
+        queryManager.failQuery(normalQuery, new Exception("Killed"));
+        waitForState(normalQuery, FAILED);
+    }
+
+    @Test
+    public void testPreAllocateTooMuch()
+            throws Exception
+    {
+        DataSize tooMuch = succinctBytes(queryMaxMemoryBytes + 1);
+        ResourceEstimates estimate = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.of(tooMuch));
+        QueryId highMemoryQuery = queryWithResourceEstimate(estimate, queryManager);
+        assertState(highMemoryQuery, FAILED);
+    }
+
+    @Test(invocationCount = 5, invocationTimeOut = 60000)
+    public void testStartWhenPreAllocationClears()
+            throws Exception
+    {
+        // Invoke multiple times to make sure that pre-allocation state resets properly and that there aren't weird data races
+        // TODO: Remove subtraction of 156 * invocationCount * 2 when memory leak in PartitionedOutputBuffer is fixed
+        ResourceEstimates estimate = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.of(succinctBytes(totalAvailableMemory - (156 * 5 * 2))));
+
+        QueryId highMemoryQuery1 = queryWithResourceEstimate(estimate, queryManager);
+        assertState(highMemoryQuery1, RUNNING);
+
+        QueryId highMemoryQuery2 = queryWithResourceEstimate(estimate, queryManager);
+        assertState(highMemoryQuery2, WAITING_FOR_RESOURCES);
+
+        queryManager.failQuery(highMemoryQuery1, new Exception("Killed"));
+        waitForState(highMemoryQuery1, FAILED);
+        assertState(highMemoryQuery2, RUNNING);
+
+        queryManager.failQuery(highMemoryQuery2, new Exception("Killed"));
+        waitForState(highMemoryQuery2, FAILED);
+    }
+
+    private static QueryId queryWithResourceEstimate(ResourceEstimates estimate, QueryManager queryManager)
+            throws ExecutionException, InterruptedException
+    {
+        QueryId queryId = queryManager.createQueryId();
+        queryManager.createQuery(queryId, new TestingSessionContext(testSessionBuilder().setResourceEstimates(estimate).build()), "SELECT 1").get();
+        return queryId;
+    }
+
+    private void assertState(QueryId queryId, QueryState state)
+            throws InterruptedException
+    {
+        assertEquals(waitForState(queryId, state), state);
+    }
+
+    private QueryState waitForState(QueryId queryId, QueryState state)
+            throws InterruptedException
+    {
+        QueryState actualState;
+        do {
+            actualState = queryManager.getQueryInfo(queryId).getState();
+            if (actualState.isDone() || actualState == state) {
+                return actualState;
+            }
+            Thread.sleep(1000);
+        }
+        while (true);
+    }
+}


### PR DESCRIPTION
If peak memory estimates are provided and the
experimental.memory-aware-execution flag is enabled, the coordinator
will not schedule a query for execution unless it can 'pre-allocate'
enough memory for the query to complete. This is currently designed
specifically for the scenario when there are a small number of
extremely memory-intensive queries and the goal is to not have them
trip over each other.