### PR TITLE
Support multiple ranges in ShardPredicate

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
@@ -229,7 +229,11 @@ public class RaptorMetadata
                 .collect(toCollection(ArrayList::new));
 
         columns.add(hiddenColumn(SHARD_UUID_COLUMN_NAME, SHARD_UUID_COLUMN_TYPE));
-        columns.add(hiddenColumn(BUCKET_NUMBER_COLUMN_NAME, INTEGER));
+
+        if (handle.isBucketed()) {
+            columns.add(hiddenColumn(BUCKET_NUMBER_COLUMN_NAME, INTEGER));
+        }
+
         return new ConnectorTableMetadata(tableName, columns, properties.build());
     }
 
@@ -251,8 +255,10 @@ public class RaptorMetadata
         RaptorColumnHandle uuidColumn = shardUuidColumnHandle(connectorId);
         builder.put(uuidColumn.getColumnName(), uuidColumn);
 
-        RaptorColumnHandle bucketNumberColumn = bucketNumberColumnHandle(connectorId);
-        builder.put(bucketNumberColumn.getColumnName(), bucketNumberColumn);
+        if (raptorTableHandle.isBucketed()) {
+            RaptorColumnHandle bucketNumberColumn = bucketNumberColumnHandle(connectorId);
+            builder.put(bucketNumberColumn.getColumnName(), bucketNumberColumn);
+        }
 
         return builder.build();
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableHandle.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableHandle.java
@@ -70,6 +70,11 @@ public final class RaptorTableHandle
         this.delete = delete;
     }
 
+    public boolean isBucketed()
+    {
+        return this.distributionId.isPresent();
+    }
+
     @JsonProperty
     public String getConnectorId()
     {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardIterator.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardIterator.java
@@ -70,7 +70,7 @@ final class ShardIterator
     {
         this.merged = merged;
         this.bucketToNode = bucketToNode.orElse(null);
-        ShardPredicate predicate = ShardPredicate.create(effectivePredicate, bucketToNode.isPresent());
+        ShardPredicate predicate = ShardPredicate.create(effectivePredicate);
 
         String sql;
         if (bucketToNode.isPresent()) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
@@ -39,7 +39,6 @@ import static com.facebook.presto.raptor.util.UuidUtil.uuidStringToBytes;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -48,6 +47,7 @@ class ShardPredicate
     private final String predicate;
     private final List<JDBCType> types;
     private final List<Object> values;
+    private static final int MAX_RANGE_COUNT = 100;
 
     private ShardPredicate(String predicate, List<JDBCType> types, List<Object> values)
     {
@@ -108,50 +108,55 @@ class ShardPredicate
                 continue;
             }
 
+            StringJoiner columnPredicate = new StringJoiner(" OR ", "(", ")").setEmptyValue("true");
             Ranges ranges = domain.getValues().getRanges();
 
-            // TODO: support multiple ranges
-            if (ranges.getRangeCount() != 1) {
+            // prevent generating complicated metadata queries
+            if (ranges.getRangeCount() > MAX_RANGE_COUNT) {
                 continue;
             }
-            Range range = getOnlyElement(ranges.getOrderedRanges());
 
-            Object minValue = null;
-            Object maxValue = null;
-            if (range.isSingleValue()) {
-                minValue = range.getSingleValue();
-                maxValue = range.getSingleValue();
-            }
-            else {
-                if (!range.getLow().isLowerUnbounded()) {
-                    minValue = range.getLow().getValue();
+            for (Range range : ranges.getOrderedRanges()) {
+                Object minValue = null;
+                Object maxValue = null;
+                if (range.isSingleValue()) {
+                    minValue = range.getSingleValue();
+                    maxValue = range.getSingleValue();
                 }
-                if (!range.getHigh().isUpperUnbounded()) {
-                    maxValue = range.getHigh().getValue();
+                else {
+                    if (!range.getLow().isLowerUnbounded()) {
+                        minValue = range.getLow().getValue();
+                    }
+                    if (!range.getHigh().isUpperUnbounded()) {
+                        maxValue = range.getHigh().getValue();
+                    }
                 }
-            }
 
-            String min;
-            String max;
-            if (handle.isBucketNumber()) {
-                min = "bucket_number";
-                max = "bucket_number";
-            }
-            else {
-                min = minColumn(handle.getColumnId());
-                max = maxColumn(handle.getColumnId());
-            }
+                String min;
+                String max;
+                if (handle.isBucketNumber()) {
+                    min = "bucket_number";
+                    max = "bucket_number";
+                }
+                else {
+                    min = minColumn(handle.getColumnId());
+                    max = maxColumn(handle.getColumnId());
+                }
 
-            if (minValue != null) {
-                predicate.add(format("(%s >= ? OR %s IS NULL)", max, max));
-                types.add(jdbcType);
-                values.add(minValue);
+                StringJoiner rangePredicate = new StringJoiner(" AND ", "(", ")").setEmptyValue("true");
+                if (minValue != null) {
+                    rangePredicate.add(format("(%s >= ? OR %s IS NULL)", max, max));
+                    types.add(jdbcType);
+                    values.add(minValue);
+                }
+                if (maxValue != null) {
+                    rangePredicate.add(format("(%s <= ? OR %s IS NULL)", min, min));
+                    types.add(jdbcType);
+                    values.add(maxValue);
+                }
+                columnPredicate.add(rangePredicate.toString());
             }
-            if (maxValue != null) {
-                predicate.add(format("(%s <= ? OR %s IS NULL)", min, min));
-                types.add(jdbcType);
-                values.add(maxValue);
-            }
+            predicate.add(columnPredicate.toString());
         }
         return new ShardPredicate(predicate.toString(), types.build(), values.build());
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardPredicate.java
@@ -80,7 +80,7 @@ class ShardPredicate
                 .toString();
     }
 
-    public static ShardPredicate create(TupleDomain<RaptorColumnHandle> tupleDomain, boolean bucketed)
+    public static ShardPredicate create(TupleDomain<RaptorColumnHandle> tupleDomain)
     {
         StringJoiner predicate = new StringJoiner(" AND ").setEmptyValue("true");
         ImmutableList.Builder<JDBCType> types = ImmutableList.builder();
@@ -134,10 +134,6 @@ class ShardPredicate
             String min;
             String max;
             if (handle.isBucketNumber()) {
-                if (!bucketed) {
-                    predicate.add("false");
-                    continue;
-                }
                 min = "bucket_number";
                 max = "bucket_number";
             }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
@@ -155,6 +155,13 @@ public class TestRaptorIntegrationSmokeTest
         assertEquals(actual, IntStream.range(0, 50).boxed().collect(toSet()));
     }
 
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Column '\\$bucket_number' cannot be resolved")
+    public void testNoBucketNumberHiddenColumn()
+    {
+        assertUpdate("CREATE TABLE test_no_bucket_number (test bigint)");
+        computeActual("SELECT DISTINCT \"$bucket_number\" FROM test_no_bucket_number");
+    }
+
     @Test
     public void testShardingByTemporalDateColumn()
     {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
@@ -71,6 +71,7 @@ import static com.facebook.presto.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static com.facebook.presto.spi.predicate.Range.greaterThan;
 import static com.facebook.presto.spi.predicate.Range.greaterThanOrEqual;
 import static com.facebook.presto.spi.predicate.Range.lessThan;
+import static com.facebook.presto.spi.predicate.Range.range;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
@@ -570,10 +571,27 @@ public class TestDatabaseShardManager
         shardAssertion(tableId).range(c6, lessThan(BOOLEAN, true)).expected(shards);
         shardAssertion(tableId).range(c6, lessThan(BOOLEAN, false)).expected(shard1, shard3);
 
-        // TODO: support multiple ranges
+        // Test multiple ranges
         shardAssertion(tableId)
                 .domain(c1, createDomain(lessThan(BIGINT, 0L), greaterThan(BIGINT, 25L)))
-                .expected(shards);
+                .expected();
+
+        shardAssertion(tableId)
+                .domain(c1, createDomain(range(BIGINT, 3L, true, 4L, true), range(BIGINT, 16L, true, 18L, true)))
+                .expected(shard2, shard3);
+
+        shardAssertion(tableId)
+                .domain(c5, createDomain(
+                        range(createVarcharType(10), utf8Slice("gum"), true, utf8Slice("happy"), true),
+                        range(createVarcharType(10), utf8Slice("pear"), true, utf8Slice("wall"), true)))
+                .expected(shard1, shard3);
+
+        shardAssertion(tableId)
+                .domain(c1, createDomain(range(BIGINT, 3L, true, 4L, true), range(BIGINT, 16L, true, 18L, true)))
+                .domain(c5, createDomain(
+                        range(createVarcharType(10), utf8Slice("gum"), true, utf8Slice("happy"), true),
+                        range(createVarcharType(10), utf8Slice("pear"), true, utf8Slice("wall"), true)))
+                .expected(shard3);
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardPredicate.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardPredicate.java
@@ -48,7 +48,7 @@ public class TestShardPredicate
         TupleDomain<RaptorColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
                 shardUuidColumnHandle("test"), singleValue(VARCHAR, utf8Slice(uuid))));
 
-        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain, bucketed);
+        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain);
 
         assertEquals(shardPredicate.getPredicate(), "shard_uuid = ?");
         assertEquals(shardPredicate.getTypes(), ImmutableList.of(VARBINARY));
@@ -64,7 +64,7 @@ public class TestShardPredicate
                 shardUuidColumnHandle("test"),
                 create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(equal(VARCHAR, uuid0), equal(VARCHAR, uuid1))), false)));
 
-        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain, bucketed);
+        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain);
 
         assertEquals(shardPredicate.getPredicate(), "shard_uuid = ? OR shard_uuid = ?");
         assertEquals(shardPredicate.getTypes(), ImmutableList.of(VARBINARY, VARBINARY));
@@ -80,7 +80,7 @@ public class TestShardPredicate
                 shardUuidColumnHandle("test"),
                 create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(equal(VARCHAR, uuid0), equal(VARCHAR, uuid1))), false)));
 
-        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain, bucketed);
+        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain);
 
         assertEquals(shardPredicate.getPredicate(), "true");
     }
@@ -93,7 +93,7 @@ public class TestShardPredicate
                 shardUuidColumnHandle("test"),
                 create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(greaterThanOrEqual(VARCHAR, uuid0))), false)));
 
-        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain, bucketed);
+        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain);
         assertEquals(shardPredicate.getPredicate(), "true");
     }
 
@@ -104,18 +104,7 @@ public class TestShardPredicate
                 bucketNumberColumnHandle("test"),
                 create(SortedRangeSet.copyOf(INTEGER, ImmutableList.of(equal(INTEGER, 1L))), false)));
 
-        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain, true);
+        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain);
         assertEquals(shardPredicate.getPredicate(), "(bucket_number >= ? OR bucket_number IS NULL) AND (bucket_number <= ? OR bucket_number IS NULL)");
-    }
-
-    @Test
-    public void testBucketNumberForNonBucketed()
-    {
-        TupleDomain<RaptorColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
-                bucketNumberColumnHandle("test"),
-                create(SortedRangeSet.copyOf(INTEGER, ImmutableList.of(equal(INTEGER, 1L))), false)));
-
-        ShardPredicate shardPredicate = ShardPredicate.create(tupleDomain, false);
-        assertEquals(shardPredicate.getPredicate(), "false");
     }
 }


### PR DESCRIPTION
Construct a SQL filter clause for column domain that has multiple ranges. For a domain of `col1[[1, 3], [4, 6]], col2[[2, 5], [7, 8]]` ,the constructed predicates should look like:
```
...
(
    (c1_max >= ? OR c1_max IS NULL) AND (c1_min <= ? OR c1_min IS NULL) 
    OR 
    (c1_max >= ? OR c1_max IS NULL) AND (c1_min <= ? OR c1_min IS NULL)
) 
AND 
(
    (bucket_number >= ? OR bucket_number IS NULL) AND (bucket_number <= ? OR bucket_number IS NULL) 
    OR 
    (bucket_number >= ? OR bucket_number IS NULL) AND (bucket_number <= ? OR bucket_number IS NULL)
)
```