### PR TITLE
Allow nulls to be appended in zip_with

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -212,8 +212,9 @@ Array Functions
 .. function:: zip_with(array<T>, array<U>, function<T,U,R>) -> array<R>
 
     Merges the two given arrays, element-wise, into a single array using ``function``.
-    Both arrays must be the same length. ::
+    If one array is shorter, `NULL`s are appended at the end to match the length of the longer array, before applying ``function``::
 
         SELECT zip_with(ARRAY[1, 3, 5], ARRAY['a', 'b', 'c'], (x, y) -> (y, x)); -- [ROW('a', 1), ROW('b', 3), ROW('c', 5)]
         SELECT zip_with(ARRAY[1, 2], ARRAY[3, 4], (x, y) -> x + y); -- [4, 6]
         SELECT zip_with(ARRAY['a', 'b', 'c'], ARRAY['d', 'e', 'f'], (x, y) -> concat(x, y)); -- ['ad', 'be', 'cf']
+        SELECT zip_with(ARRAY['a'], ARRAY['d', null, 'f'], (x, y) -> coalesce(x, y)); -- ['a', null, 'f']

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestZipWithFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestZipWithFunction.java
@@ -76,9 +76,18 @@ public class TestZipWithFunction
     @Test
     public void testDifferentLength()
     {
-        assertInvalidFunction("zip_with(ARRAY[1], ARRAY['a', 'b'], (x, y) -> (y, x))", "Arrays must have the same length");
-        assertInvalidFunction("zip_with(ARRAY[NULL, 2], ARRAY['a'], (x, y) -> (y, x))", "Arrays must have the same length");
-        assertInvalidFunction("zip_with(ARRAY[1, NULL], ARRAY[NULL, 2, 1], (x, y) -> x + y)", "Arrays must have the same length");
+        assertFunction(
+                "zip_with(ARRAY[1], ARRAY['a', 'bc'], (x, y) -> (y, x))",
+                new ArrayType(RowType.anonymous(ImmutableList.of(createVarcharType(2), INTEGER))),
+                ImmutableList.of(ImmutableList.of("a", 1), asList("bc", null)));
+        assertFunction(
+                "zip_with(ARRAY[NULL, 2], ARRAY['a'], (x, y) -> (y, x))",
+                new ArrayType(RowType.anonymous(ImmutableList.of(createVarcharType(1), INTEGER))),
+                ImmutableList.of(asList("a", null), asList(null, 2)));
+        assertFunction(
+                "zip_with(ARRAY[NULL, NULL], ARRAY[NULL, 2, 1], (x, y) -> x + y)",
+                new ArrayType(INTEGER),
+                asList(null, null, null));
     }
 
     @Test


### PR DESCRIPTION
This simplifies the query when zip arrays with different lengths.

In the current syntax, there is no way to distinguish between an appended `NULL` and an actual `NULL` in the lambda function. If this is required in future use cases, we'll be able to support it by implementing a `zip_with` that takes in a ternary lambda expression.