### PR TITLE
Fix rpm dependency

### DIFF
--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -97,6 +97,9 @@
                                 <dependency>
                                     <name>/usr/sbin/groupadd</name>
                                 </dependency>
+                                <dependency>
+                                    <name>/usr/bin/uuidgen</name>
+                                </dependency>
                             </dependencies>
 
                             <links>


### PR DESCRIPTION
The rpm install script uses `uuidgen` to generate `node.id`.