### PR TITLE
Display some message in UI when server unreachable

### DIFF
--- a/presto-main/src/main/resources/webapp/assets/cluster-hud.js
+++ b/presto-main/src/main/resources/webapp/assets/cluster-hud.js
@@ -43,6 +43,7 @@ let ClusterHUD = React.createClass({
             lastCpuTime: null,
 
             initialized: false,
+            serverUnreachable: false,
         };
     },
     resetTimer: function() {
@@ -91,12 +92,14 @@ let ClusterHUD = React.createClass({
                 lastCpuTime: clusterState.totalCpuTimeSecs,
 
                 initialized: true,
+                serverUnreachable: false,
 
                 lastRefresh: Date.now()
             });
             this.resetTimer();
         }.bind(this))
         .error(function() {
+            this.setState({ ...this.state, serverUnreachable: true });
             this.resetTimer();
         }.bind(this));
     },
@@ -127,6 +130,12 @@ let ClusterHUD = React.createClass({
         $('[data-toggle="tooltip"]').tooltip();
     },
     render: function() {
+        if (this.state.serverUnreachable) {
+            return (<div className="row error-message">
+                <h4 className="font-white">Server cannot be reached</h4>
+            </div>);
+        }
+
         return (<div className="row">
             <div className="col-xs-12">
                 <div className="row">


### PR DESCRIPTION
When server becomes unreachable (or user fails to authenticate), display
"Server cannot be reached" in the UI.

-----------
Before:

- red dot is easy to overlook and people don't immediately know what it means

![image](https://user-images.githubusercontent.com/144328/40409593-ae9215a0-5e6b-11e8-8828-4fb5d7aaece9.png)

-----------
After:

- besides the red dot, there is message in the place where user are expected to see server status

![image](https://user-images.githubusercontent.com/144328/40409699-f949dd30-5e6b-11e8-8c48-8e1c8d3f74a8.png)
