### PR TITLE
Hive column statistics small refactorings

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1443,6 +1443,8 @@ public class HiveMetadata
     @Override
     public Optional<ConnectorNewTableLayout> getNewTableLayout(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
+        validatePartitionColumns(tableMetadata);
+        validateBucketColumns(tableMetadata);
         Optional<HiveBucketProperty> bucketProperty = getBucketProperty(tableMetadata.getProperties());
         if (!bucketProperty.isPresent()) {
             return Optional.empty();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
@@ -145,7 +145,8 @@ public class HiveTableProperties
     @SuppressWarnings("unchecked")
     public static List<String> getPartitionedBy(Map<String, Object> tableProperties)
     {
-        return (List<String>) tableProperties.get(PARTITIONED_BY_PROPERTY);
+        List<String> partitionedBy = (List<String>) tableProperties.get(PARTITIONED_BY_PROPERTY);
+        return partitionedBy == null ? ImmutableList.of() : ImmutableList.copyOf(partitionedBy);
     }
 
     public static Optional<HiveBucketProperty> getBucketProperty(Map<String, Object> tableProperties)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -22,7 +22,9 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.SetMultimap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
@@ -41,7 +43,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.hive.HiveUtil.toPartitionValues;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -49,13 +50,15 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.cache.CacheLoader.asyncReloading;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
 import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Streams.stream;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 /**
  * Hive Metastore Cache
@@ -69,8 +72,8 @@ public class CachingHiveMetastore
     private final LoadingCache<String, List<String>> databaseNamesCache;
     private final LoadingCache<HiveTableName, Optional<Table>> tableCache;
     private final LoadingCache<String, Optional<List<String>>> tableNamesCache;
-    private final LoadingCache<TableColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> tableColumnStatisticsCache;
-    private final LoadingCache<PartitionColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> partitionColumnStatisticsCache;
+    private final LoadingCache<HiveTableName, Map<String, HiveColumnStatistics>> tableColumnStatisticsCache;
+    private final LoadingCache<HivePartitionName, Map<String, HiveColumnStatistics>> partitionColumnStatisticsCache;
     private final LoadingCache<String, Optional<List<String>>> viewNamesCache;
     private final LoadingCache<HivePartitionName, Optional<Partition>> partitionCache;
     private final LoadingCache<PartitionFilter, Optional<List<String>>> partitionFilterCache;
@@ -124,32 +127,26 @@ public class CachingHiveMetastore
                 .build(asyncReloading(CacheLoader.from(this::loadAllTables), executor));
 
         tableColumnStatisticsCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
-                .build(asyncReloading(new CacheLoader<TableColumnStatisticsCacheKey, Optional<HiveColumnStatistics>>()
+                .build(asyncReloading(new CacheLoader<HiveTableName, Map<String, HiveColumnStatistics>>()
                 {
                     @Override
-                    public Optional<HiveColumnStatistics> load(TableColumnStatisticsCacheKey key)
+                    public Map<String, HiveColumnStatistics> load(HiveTableName key)
                     {
-                        return loadAll(ImmutableList.of(key)).get(key);
-                    }
-
-                    @Override
-                    public Map<TableColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> loadAll(Iterable<? extends TableColumnStatisticsCacheKey> keys)
-                    {
-                        return loadColumnStatistics(keys);
+                        return loadTableColumnStatistics(key);
                     }
                 }, executor));
 
         partitionColumnStatisticsCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
-                .build(asyncReloading(new CacheLoader<PartitionColumnStatisticsCacheKey, Optional<HiveColumnStatistics>>()
+                .build(asyncReloading(new CacheLoader<HivePartitionName, Map<String, HiveColumnStatistics>>()
                 {
                     @Override
-                    public Optional<HiveColumnStatistics> load(PartitionColumnStatisticsCacheKey key)
+                    public Map<String, HiveColumnStatistics> load(HivePartitionName key)
                     {
-                        return loadAll(ImmutableList.of(key)).get(key);
+                        return loadPartitionColumnStatistics(key);
                     }
 
                     @Override
-                    public Map<PartitionColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> loadAll(Iterable<? extends PartitionColumnStatisticsCacheKey> keys)
+                    public Map<HivePartitionName, Map<String, HiveColumnStatistics>> loadAll(Iterable<? extends HivePartitionName> keys)
                     {
                         return loadPartitionColumnStatistics(keys);
                     }
@@ -261,100 +258,58 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public Optional<Map<String, HiveColumnStatistics>> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
+    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName)
     {
-        Map<TableColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> cacheValues =
-                getAll(tableColumnStatisticsCache, columnNames.stream()
-                        .map(columnName -> new TableColumnStatisticsCacheKey(databaseName, tableName, columnName))
-                        .collect(toList()));
-
-        return Optional.of(
-                ImmutableMap.copyOf(
-                        cacheValues.entrySet().stream()
-                                .filter(entry -> entry.getValue().isPresent())
-                                .collect(toMap(
-                                        entry -> entry.getKey().getColumnName(),
-                                        entry -> entry.getValue().get()))));
+        return get(tableColumnStatisticsCache, new HiveTableName(databaseName, tableName));
     }
 
-    private Map<TableColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> loadColumnStatistics(Iterable<? extends TableColumnStatisticsCacheKey> keys)
+    private Map<String, HiveColumnStatistics> loadTableColumnStatistics(HiveTableName hiveTableName)
     {
-        if (Iterables.isEmpty(keys)) {
-            return ImmutableMap.of();
-        }
-
-        HiveTableName hiveTableName = stream(keys).findFirst().get().getHiveTableName();
-        checkArgument(stream(keys).allMatch(key -> key.getHiveTableName().equals(hiveTableName)), "all keys must relate to same hive table");
-
-        Set<String> columnNames = stream(keys).map(TableColumnStatisticsCacheKey::getColumnName).collect(Collectors.toSet());
-
-        Optional<Map<String, HiveColumnStatistics>> columnStatistics = delegate.getTableColumnStatistics(hiveTableName.getDatabaseName(), hiveTableName.getTableName(), columnNames);
-
-        ImmutableMap.Builder<TableColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> resultMap = ImmutableMap.builder();
-        for (TableColumnStatisticsCacheKey key : keys) {
-            if (!columnStatistics.isPresent() || !columnStatistics.get().containsKey(key.getColumnName())) {
-                resultMap.put(key, Optional.empty());
-            }
-            else {
-                resultMap.put(key, Optional.of(columnStatistics.get().get(key.getColumnName())));
-            }
-        }
-        return resultMap.build();
+        return delegate.getTableColumnStatistics(hiveTableName.getDatabaseName(), hiveTableName.getTableName());
     }
 
     @Override
-    public Optional<Map<String, Map<String, HiveColumnStatistics>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
+    public Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames)
     {
-        List<PartitionColumnStatisticsCacheKey> cacheKeys = partitionNames.stream()
-                .flatMap(
-                        partitionName -> columnNames.stream().map(
-                                columnName -> new PartitionColumnStatisticsCacheKey(databaseName, tableName, partitionName, columnName)))
-                .collect(toList());
-        Map<PartitionColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> cacheValues = getAll(partitionColumnStatisticsCache, cacheKeys);
-
-        ImmutableMap.Builder<String, Map<String, HiveColumnStatistics>> partitionsMap = ImmutableMap.builder();
-        for (String partitionName : partitionNames) {
-            ImmutableMap.Builder<String, HiveColumnStatistics> columnsMap = ImmutableMap.builder();
-            for (String columnName : columnNames) {
-                Optional<HiveColumnStatistics> cacheValue = cacheValues.get(new PartitionColumnStatisticsCacheKey(databaseName, tableName, partitionName, columnName));
-                if (cacheValue.isPresent()) {
-                    columnsMap.put(columnName, cacheValue.get());
-                }
-            }
-            partitionsMap.put(partitionName, columnsMap.build());
-        }
-        return Optional.of(partitionsMap.build());
+        List<HivePartitionName> partitions = partitionNames.stream()
+                .map(partitionName -> HivePartitionName.partition(databaseName, tableName, partitionName))
+                .collect(toImmutableList());
+        Map<HivePartitionName, Map<String, HiveColumnStatistics>> statistics = getAll(partitionColumnStatisticsCache, partitions);
+        return statistics.entrySet()
+                .stream()
+                .filter(entry -> !entry.getValue().isEmpty())
+                .collect(toImmutableMap(entry -> entry.getKey().getPartitionName(), Entry::getValue));
     }
 
-    private Map<PartitionColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> loadPartitionColumnStatistics(Iterable<? extends PartitionColumnStatisticsCacheKey> keys)
+    private Map<String, HiveColumnStatistics> loadPartitionColumnStatistics(HivePartitionName partition)
     {
-        if (Iterables.isEmpty(keys)) {
-            return ImmutableMap.of();
-        }
-        PartitionColumnStatisticsCacheKey firstKey = Iterables.getFirst(keys, null);
-        HiveTableName hiveTableName = firstKey.getHivePartitionName().getHiveTableName();
-        checkArgument(stream(keys).allMatch(key -> key.getHivePartitionName().getHiveTableName().equals(hiveTableName)), "all keys must relate to same hive table");
-        Set<String> partitionNames = stream(keys).map(key -> key.getHivePartitionName().getPartitionName()).collect(Collectors.toSet());
-        Set<String> columnNames = stream(keys).map(PartitionColumnStatisticsCacheKey::getColumnName).collect(Collectors.toSet());
+        Map<String, Map<String, HiveColumnStatistics>> columnStatistics = delegate.getPartitionColumnStatistics(
+                partition.getHiveTableName().getDatabaseName(),
+                partition.getHiveTableName().getTableName(),
+                ImmutableSet.of(partition.getPartitionName()));
+        return columnStatistics.getOrDefault(partition.getPartitionName(), ImmutableMap.of());
+    }
 
-        Optional<Map<String, Map<String, HiveColumnStatistics>>> columnStatistics = delegate.getPartitionColumnStatistics(
-                hiveTableName.getDatabaseName(),
-                hiveTableName.getTableName(),
-                partitionNames,
-                columnNames);
-
-        ImmutableMap.Builder<PartitionColumnStatisticsCacheKey, Optional<HiveColumnStatistics>> resultMap = ImmutableMap.builder();
-        for (PartitionColumnStatisticsCacheKey key : keys) {
-            if (columnStatistics.isPresent()
-                    && columnStatistics.get().containsKey(key.getHivePartitionName().getPartitionName())
-                    && columnStatistics.get().get(key.getHivePartitionName().getPartitionName()).containsKey(key.getColumnName())) {
-                resultMap.put(key, Optional.of(columnStatistics.get().get(key.getHivePartitionName().getPartitionName()).get(key.getColumnName())));
+    private Map<HivePartitionName, Map<String, HiveColumnStatistics>> loadPartitionColumnStatistics(Iterable<? extends HivePartitionName> keys)
+    {
+        SetMultimap<HiveTableName, HivePartitionName> tablePartitions = stream(keys)
+                .collect(toImmutableSetMultimap(HivePartitionName::getHiveTableName, key -> key));
+        ImmutableMap.Builder<HivePartitionName, Map<String, HiveColumnStatistics>> result = ImmutableMap.builder();
+        tablePartitions.keySet().forEach(table -> {
+            Set<String> partitionNames = tablePartitions.get(table).stream()
+                    .map(HivePartitionName::getPartitionName)
+                    .collect(toImmutableSet());
+            Map<String, Map<String, HiveColumnStatistics>> partitionStatistics = delegate.getPartitionColumnStatistics(table.getDatabaseName(), table.getTableName(), partitionNames);
+            for (String partitionName : partitionNames) {
+                if (partitionStatistics.containsKey(partitionName)) {
+                    result.put(HivePartitionName.partition(table, partitionName), partitionStatistics.get(partitionName));
+                }
+                else {
+                    result.put(HivePartitionName.partition(table, partitionName), ImmutableMap.of());
+                }
             }
-            else {
-                resultMap.put(key, Optional.empty());
-            }
-        }
-        return resultMap.build();
+        });
+        return result.build();
     }
 
     @Override
@@ -969,95 +924,6 @@ public class CachingHiveMetastore
                     .add("table", table)
                     .add("database", database)
                     .toString();
-        }
-    }
-
-    private static final class TableColumnStatisticsCacheKey
-    {
-        private final HiveTableName hiveTableName;
-        private final String columnName;
-
-        public TableColumnStatisticsCacheKey(String databaseName, String tableName, String columnName)
-        {
-            this.hiveTableName = HiveTableName.table(
-                    requireNonNull(databaseName, "databaseName is null"),
-                    requireNonNull(tableName, "tableName can not be null"));
-            this.columnName = requireNonNull(columnName, "columnName can not be null");
-        }
-
-        public HiveTableName getHiveTableName()
-        {
-            return hiveTableName;
-        }
-
-        public String getColumnName()
-        {
-            return columnName;
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            TableColumnStatisticsCacheKey that = (TableColumnStatisticsCacheKey) o;
-            return Objects.equals(hiveTableName, that.hiveTableName) &&
-                    Objects.equals(columnName, that.columnName);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(hiveTableName, columnName);
-        }
-    }
-
-    private static final class PartitionColumnStatisticsCacheKey
-    {
-        private final HivePartitionName hivePartitionName;
-        private final String columnName;
-
-        public PartitionColumnStatisticsCacheKey(String databaseName, String tableName, String partitionName, String columnName)
-        {
-            this.hivePartitionName = HivePartitionName.partition(
-                    requireNonNull(databaseName, "databaseName is null"),
-                    requireNonNull(tableName, "tableName can not be null"),
-                    requireNonNull(partitionName, "partitionName can not be null"));
-            this.columnName = requireNonNull(columnName, "columnName can not be null");
-        }
-
-        public HivePartitionName getHivePartitionName()
-        {
-            return hivePartitionName;
-        }
-
-        public String getColumnName()
-        {
-            return columnName;
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            PartitionColumnStatisticsCacheKey that = (PartitionColumnStatisticsCacheKey) o;
-            return Objects.equals(hivePartitionName, that.hivePartitionName) &&
-                    Objects.equals(columnName, that.columnName);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(hivePartitionName, columnName);
         }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -29,9 +29,9 @@ public interface ExtendedHiveMetastore
 
     Optional<Table> getTable(String databaseName, String tableName);
 
-    Optional<Map<String, HiveColumnStatistics>> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames);
+    Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName);
 
-    Optional<Map<String, Map<String, HiveColumnStatistics>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames);
+    Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames);
 
     Optional<List<String>> getAllTables(String databaseName);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveColumnStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveColumnStatistics.java
@@ -18,10 +18,10 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
 
-public class HiveColumnStatistics<T>
+public class HiveColumnStatistics
 {
-    private final Optional<T> lowValue;
-    private final Optional<T> highValue;
+    private final Optional<?> lowValue;
+    private final Optional<?> highValue;
     private final OptionalLong maxColumnLength;
     private final OptionalDouble averageColumnLength;
     private final OptionalLong trueCount;
@@ -30,8 +30,8 @@ public class HiveColumnStatistics<T>
     private final OptionalLong distinctValuesCount;
 
     public HiveColumnStatistics(
-            Optional<T> lowValue,
-            Optional<T> highValue,
+            Optional<?> lowValue,
+            Optional<?> highValue,
             OptionalLong maxColumnLength,
             OptionalDouble averageColumnLength,
             OptionalLong trueCount,
@@ -49,12 +49,12 @@ public class HiveColumnStatistics<T>
         this.distinctValuesCount = distinctValuesCount;
     }
 
-    public Optional<T> getLowValue()
+    public Optional<?> getLowValue()
     {
         return lowValue;
     }
 
-    public Optional<T> getHighValue()
+    public Optional<?> getHighValue()
     {
         return highValue;
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -270,15 +270,15 @@ public class FileHiveMetastore
     }
 
     @Override
-    public Optional<Map<String, HiveColumnStatistics>> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
+    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName)
     {
-        return Optional.of(ImmutableMap.of());
+        return ImmutableMap.of();
     }
 
     @Override
-    public Optional<Map<String, Map<String, HiveColumnStatistics>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
+    public Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames)
     {
-        return Optional.of(ImmutableMap.of());
+        return ImmutableMap.of();
     }
 
     private Table getRequiredTable(String databaseName, String tableName)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -217,15 +217,15 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public Optional<Map<String, HiveColumnStatistics>> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
+    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName)
     {
-        return Optional.of(ImmutableMap.of());
+        return ImmutableMap.of();
     }
 
     @Override
-    public Optional<Map<String, Map<String, HiveColumnStatistics>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
+    public Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames)
     {
-        return Optional.of(ImmutableMap.of());
+        return ImmutableMap.of();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -72,9 +72,9 @@ public interface HiveMetastore
 
     Optional<Table> getTable(String databaseName, String tableName);
 
-    Optional<Set<ColumnStatisticsObj>> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames);
+    Set<ColumnStatisticsObj> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames);
 
-    Optional<Map<String, Set<ColumnStatisticsObj>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames);
+    Map<String, Set<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames);
 
     Set<String> getRoles(String user);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
@@ -71,7 +71,7 @@ public interface HiveMetastoreClient
     List<ColumnStatisticsObj> getTableColumnStatistics(String databaseName, String tableName, List<String> columnNames)
             throws TException;
 
-    Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, List<String> columnNames, List<String> partitionValues)
+    Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, List<String> partitionNames, List<String> columnNames)
             throws TException;
 
     List<String> getPartitionNames(String databaseName, String tableName)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -253,7 +253,7 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public Optional<Map<String, Set<ColumnStatisticsObj>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionValues, Set<String> columnNames)
+    public Optional<Map<String, Set<ColumnStatisticsObj>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
     {
         try {
             return retry()
@@ -261,7 +261,7 @@ public class ThriftHiveMetastore
                     .stopOnIllegalExceptions()
                     .run("getPartitionColumnStatistics", stats.getGetPartitionColumnStatistics().wrap(() -> {
                         try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
-                            Map<String, List<ColumnStatisticsObj>> partitionColumnStatistics = client.getPartitionColumnStatistics(databaseName, tableName, ImmutableList.copyOf(columnNames), ImmutableList.copyOf(partitionValues));
+                            Map<String, List<ColumnStatisticsObj>> partitionColumnStatistics = client.getPartitionColumnStatistics(databaseName, tableName, ImmutableList.copyOf(partitionNames), ImmutableList.copyOf(columnNames));
                             return Optional.of(partitionColumnStatistics.entrySet()
                                     .stream()
                                     .collect(toMap(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.apache.hadoop.hive.metastore.TableType;
@@ -54,6 +55,7 @@ import javax.inject.Inject;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -70,12 +72,12 @@ import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.hadoop.hive.metastore.api.HiveObjectType.DATABASE;
 import static org.apache.hadoop.hive.metastore.api.HiveObjectType.TABLE;
@@ -229,7 +231,7 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public Optional<Set<ColumnStatisticsObj>> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
+    public Set<ColumnStatisticsObj> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
     {
         try {
             return retry()
@@ -237,12 +239,12 @@ public class ThriftHiveMetastore
                     .stopOnIllegalExceptions()
                     .run("getTableColumnStatistics", stats.getGetTableColumnStatistics().wrap(() -> {
                         try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
-                            return Optional.of(ImmutableSet.copyOf(client.getTableColumnStatistics(databaseName, tableName, ImmutableList.copyOf(columnNames))));
+                            return ImmutableSet.copyOf(client.getTableColumnStatistics(databaseName, tableName, ImmutableList.copyOf(columnNames)));
                         }
                     }));
         }
         catch (NoSuchObjectException e) {
-            return Optional.empty();
+            return ImmutableSet.of();
         }
         catch (TException e) {
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
@@ -253,7 +255,7 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public Optional<Map<String, Set<ColumnStatisticsObj>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
+    public Map<String, Set<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
     {
         try {
             return retry()
@@ -262,16 +264,14 @@ public class ThriftHiveMetastore
                     .run("getPartitionColumnStatistics", stats.getGetPartitionColumnStatistics().wrap(() -> {
                         try (HiveMetastoreClient client = clientProvider.createMetastoreClient()) {
                             Map<String, List<ColumnStatisticsObj>> partitionColumnStatistics = client.getPartitionColumnStatistics(databaseName, tableName, ImmutableList.copyOf(partitionNames), ImmutableList.copyOf(columnNames));
-                            return Optional.of(partitionColumnStatistics.entrySet()
+                            return partitionColumnStatistics.entrySet()
                                     .stream()
-                                    .collect(toMap(
-                                            Map.Entry::getKey,
-                                            entry -> ImmutableSet.copyOf(entry.getValue()))));
+                                    .collect(toImmutableMap(Entry::getKey, entry -> ImmutableSet.copyOf(entry.getValue())));
                         }
                     }));
         }
         catch (NoSuchObjectException e) {
-            return Optional.empty();
+            return ImmutableMap.of();
         }
         catch (TException e) {
             throw new PrestoException(HIVE_METASTORE_ERROR, e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -147,10 +147,10 @@ public class ThriftHiveMetastoreClient
     }
 
     @Override
-    public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, List<String> columnNames, List<String> partitionValues)
+    public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, List<String> partitionNames, List<String> columnNames)
             throws TException
     {
-        PartitionsStatsRequest partitionsStatsRequest = new PartitionsStatsRequest(databaseName, tableName, columnNames, partitionValues);
+        PartitionsStatsRequest partitionsStatsRequest = new PartitionsStatsRequest(databaseName, tableName, columnNames, partitionNames);
         return client.get_partitions_statistics_req(partitionsStatsRequest).getPartStats();
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -281,8 +281,7 @@ public final class ThriftMetastoreUtil
                     booleanStatsData.isSetNumTrues() ? OptionalLong.of(booleanStatsData.getNumTrues()) : OptionalLong.empty(),
                     booleanStatsData.isSetNumFalses() ? OptionalLong.of(booleanStatsData.getNumFalses()) : OptionalLong.empty(),
                     booleanStatsData.isSetNumNulls() ? OptionalLong.of(booleanStatsData.getNumNulls()) : OptionalLong.empty(),
-                    booleanStatsData.isSetNumFalses() && booleanStatsData.isSetNumTrues() ?
-                            OptionalLong.of((booleanStatsData.getNumFalses() > 0 ? 1 : 0) + (booleanStatsData.getNumTrues() > 0 ? 1 : 0)) : OptionalLong.empty());
+                    OptionalLong.empty());
         }
         else if (columnStatistics.getStatsData().isSetDateStats()) {
             DateColumnStatsData dateStatsData = columnStatistics.getStatsData().getDateStats();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -237,7 +237,7 @@ public final class ThriftMetastoreUtil
     {
         if (columnStatistics.getStatsData().isSetLongStats()) {
             LongColumnStatsData longStatsData = columnStatistics.getStatsData().getLongStats();
-            return new HiveColumnStatistics<>(
+            return new HiveColumnStatistics(
                     longStatsData.isSetLowValue() ? Optional.of(longStatsData.getLowValue()) : Optional.empty(),
                     longStatsData.isSetHighValue() ? Optional.of(longStatsData.getHighValue()) : Optional.empty(),
                     OptionalLong.empty(),
@@ -249,7 +249,7 @@ public final class ThriftMetastoreUtil
         }
         else if (columnStatistics.getStatsData().isSetDoubleStats()) {
             DoubleColumnStatsData doubleStatsData = columnStatistics.getStatsData().getDoubleStats();
-            return new HiveColumnStatistics<>(
+            return new HiveColumnStatistics(
                     doubleStatsData.isSetLowValue() ? Optional.of(doubleStatsData.getLowValue()) : Optional.empty(),
                     doubleStatsData.isSetHighValue() ? Optional.of(doubleStatsData.getHighValue()) : Optional.empty(),
                     OptionalLong.empty(),
@@ -261,7 +261,7 @@ public final class ThriftMetastoreUtil
         }
         else if (columnStatistics.getStatsData().isSetDecimalStats()) {
             DecimalColumnStatsData decimalStatsData = columnStatistics.getStatsData().getDecimalStats();
-            return new HiveColumnStatistics<>(
+            return new HiveColumnStatistics(
                     decimalStatsData.isSetLowValue() ? fromMetastoreDecimal(decimalStatsData.getLowValue()) : Optional.empty(),
                     decimalStatsData.isSetHighValue() ? fromMetastoreDecimal(decimalStatsData.getHighValue()) : Optional.empty(),
                     OptionalLong.empty(),
@@ -273,7 +273,7 @@ public final class ThriftMetastoreUtil
         }
         else if (columnStatistics.getStatsData().isSetBooleanStats()) {
             BooleanColumnStatsData booleanStatsData = columnStatistics.getStatsData().getBooleanStats();
-            return new HiveColumnStatistics<>(
+            return new HiveColumnStatistics(
                     Optional.empty(),
                     Optional.empty(),
                     OptionalLong.empty(),
@@ -286,7 +286,7 @@ public final class ThriftMetastoreUtil
         }
         else if (columnStatistics.getStatsData().isSetDateStats()) {
             DateColumnStatsData dateStatsData = columnStatistics.getStatsData().getDateStats();
-            return new HiveColumnStatistics<>(
+            return new HiveColumnStatistics(
                     dateStatsData.isSetLowValue() ? fromMetastoreDate(dateStatsData.getLowValue()) : Optional.empty(),
                     dateStatsData.isSetHighValue() ? fromMetastoreDate(dateStatsData.getHighValue()) : Optional.empty(),
                     OptionalLong.empty(),
@@ -298,7 +298,7 @@ public final class ThriftMetastoreUtil
         }
         else if (columnStatistics.getStatsData().isSetStringStats()) {
             StringColumnStatsData stringStatsData = columnStatistics.getStatsData().getStringStats();
-            return new HiveColumnStatistics<>(
+            return new HiveColumnStatistics(
                     Optional.empty(),
                     Optional.empty(),
                     stringStatsData.isSetMaxColLen() ? OptionalLong.of(stringStatsData.getMaxColLen()) : OptionalLong.empty(),
@@ -310,7 +310,7 @@ public final class ThriftMetastoreUtil
         }
         else if (columnStatistics.getStatsData().isSetBinaryStats()) {
             BinaryColumnStatsData binaryStatsData = columnStatistics.getStatsData().getBinaryStats();
-            return new HiveColumnStatistics<>(
+            return new HiveColumnStatistics(
                     Optional.empty(),
                     Optional.empty(),
                     binaryStatsData.isSetMaxColLen() ? OptionalLong.of(binaryStatsData.getMaxColLen()) : OptionalLong.empty(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
@@ -261,6 +261,12 @@ public class MetastoreHiveStatisticsProvider
                     if (columnStatistics.getDistinctValuesCount().isPresent()) {
                         return OptionalDouble.of(columnStatistics.getDistinctValuesCount().getAsLong());
                     }
+                    else if (columnStatistics.getFalseCount().isPresent() && columnStatistics.getTrueCount().isPresent() && columnStatistics.getNullsCount().isPresent()) {
+                        long falseCount = columnStatistics.getFalseCount().getAsLong();
+                        long trueCount = columnStatistics.getTrueCount().getAsLong();
+                        long nullCount = columnStatistics.getNullsCount().getAsLong();
+                        return OptionalDouble.of((falseCount > 0 ? 1 : 0) + (trueCount > 0 ? 1 : 0) + (nullCount > 0 ? 1 : 0));
+                    }
                     else {
                         return OptionalDouble.empty();
                     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTimeZone;
 
 import java.math.BigDecimal;
@@ -46,16 +47,13 @@ import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
 import java.util.PrimitiveIterator;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 
 import static com.facebook.presto.hive.HiveSessionProperties.isStatisticsEnabled;
@@ -70,11 +68,9 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 
 public class MetastoreHiveStatisticsProvider
         implements HiveStatisticsProvider
@@ -240,7 +236,7 @@ public class MetastoreHiveStatisticsProvider
                 .map(stats -> stats.getBasicStatistics().getRowCount())
                 .filter(OptionalLong::isPresent)
                 .map(OptionalLong::getAsLong)
-                .collect(toList());
+                .collect(toImmutableList());
 
         long knownPartitionRowCountsSum = knownPartitionRowCounts.stream().mapToLong(a -> a).sum();
         long partitionsWithStatsCount = knownPartitionRowCounts.size();
@@ -382,32 +378,23 @@ public class MetastoreHiveStatisticsProvider
         }
 
         if (unpartitioned) {
-            return ImmutableMap.of(HivePartition.UNPARTITIONED_ID, getTableStatistics(tableHandle.getSchemaTableName(), tableColumns.keySet()));
+            return ImmutableMap.of(HivePartition.UNPARTITIONED_ID, getTableStatistics(tableHandle.getSchemaTableName()));
         }
         else {
-            return getPartitionsStatistics(tableHandle.getSchemaTableName(), hivePartitions, listNonPartitioningColumns(tableColumns));
+            return getPartitionsStatistics(tableHandle.getSchemaTableName(), hivePartitions);
         }
     }
 
-    private static Set<String> listNonPartitioningColumns(Map<String, ColumnHandle> tableColumns)
-    {
-        return tableColumns.entrySet().stream()
-                .filter(entry -> !((HiveColumnHandle) entry.getValue()).isPartitionKey())
-                .map(Map.Entry::getKey)
-                .collect(toImmutableSet());
-    }
-
-    private Map<String, PartitionStatistics> getPartitionsStatistics(SchemaTableName schemaTableName, List<HivePartition> hivePartitions, Set<String> tableColumns)
+    private Map<String, PartitionStatistics> getPartitionsStatistics(SchemaTableName schemaTableName, List<HivePartition> hivePartitions)
     {
         String databaseName = schemaTableName.getSchemaName();
         String tableName = schemaTableName.getTableName();
 
         ImmutableMap.Builder<String, PartitionStatistics> resultMap = ImmutableMap.builder();
 
-        List<String> partitionNames = hivePartitions.stream().map(HivePartition::getPartitionId).collect(Collectors.toList());
+        List<String> partitionNames = hivePartitions.stream().map(HivePartition::getPartitionId).collect(toImmutableList());
         Map<String, Map<String, HiveColumnStatistics>> partitionColumnStatisticsMap =
-                metastore.getPartitionColumnStatistics(databaseName, tableName, new HashSet<>(partitionNames), tableColumns)
-                        .orElse(ImmutableMap.of());
+                metastore.getPartitionColumnStatistics(databaseName, tableName, ImmutableSet.copyOf(partitionNames));
 
         Map<String, Optional<Partition>> partitionsByNames = metastore.getPartitionsByNames(databaseName, tableName, partitionNames);
         for (String partitionName : partitionNames) {
@@ -421,14 +408,14 @@ public class MetastoreHiveStatisticsProvider
         return resultMap.build();
     }
 
-    private PartitionStatistics getTableStatistics(SchemaTableName schemaTableName, Set<String> tableColumns)
+    private PartitionStatistics getTableStatistics(SchemaTableName schemaTableName)
     {
         String databaseName = schemaTableName.getSchemaName();
         String tableName = schemaTableName.getTableName();
         Table table = metastore.getTable(databaseName, tableName)
                 .orElseThrow(() -> new IllegalArgumentException(format("Could not get metadata for table %s.%s", databaseName, tableName)));
 
-        Map<String, HiveColumnStatistics> tableColumnStatistics = metastore.getTableColumnStatistics(databaseName, tableName, tableColumns).orElse(ImmutableMap.of());
+        Map<String, HiveColumnStatistics> tableColumnStatistics = metastore.getTableColumnStatistics(databaseName, tableName);
 
         return readStatisticsFromParameters(table.getParameters(), tableColumnStatistics);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -749,7 +749,7 @@ public class TestHiveIntegrationSmokeTest
             fail();
         }
         catch (Exception e) {
-            assertEquals(e.getMessage(), "INSERT must write all distribution columns: [custkey, custkey3]");
+            assertEquals(e.getMessage(), "Bucketing columns [custkey3] not present in schema");
         }
 
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
@@ -441,18 +441,18 @@ public class InMemoryHiveMetastore
     }
 
     @Override
-    public synchronized Optional<Set<ColumnStatisticsObj>> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
+    public synchronized Set<ColumnStatisticsObj> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
     {
         SchemaTableName schemaTableName = new SchemaTableName(databaseName, tableName);
         if (!columnStatistics.containsKey(schemaTableName)) {
-            return Optional.empty();
+            return ImmutableSet.of();
         }
 
         Map<String, ColumnStatisticsObj> columnStatisticsMap = columnStatistics.get(schemaTableName);
-        return Optional.of(columnNames.stream()
+        return columnNames.stream()
                 .filter(columnStatisticsMap::containsKey)
                 .map(columnStatisticsMap::get)
-                .collect(toImmutableSet()));
+                .collect(toImmutableSet());
     }
 
     public synchronized void setColumnStatistics(String databaseName, String tableName, String columnName, ColumnStatisticsObj columnStatisticsObj)
@@ -463,7 +463,7 @@ public class InMemoryHiveMetastore
     }
 
     @Override
-    public synchronized Optional<Map<String, Set<ColumnStatisticsObj>>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
+    public synchronized Map<String, Set<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
     {
         ImmutableMap.Builder<String, Set<ColumnStatisticsObj>> result = ImmutableMap.builder();
         for (String partitionName : partitionNames) {
@@ -480,7 +480,7 @@ public class InMemoryHiveMetastore
                             .map(columnStatistics::get)
                             .collect(toImmutableSet()));
         }
-        return Optional.of(result.build());
+        return result.build();
     }
 
     public synchronized void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, String columnName, ColumnStatisticsObj columnStatisticsObj)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
@@ -137,7 +137,7 @@ public class MockHiveMetastoreClient
     }
 
     @Override
-    public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, List<String> columnNames, List<String> partitionValues)
+    public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, List<String> partitionNames, List<String> columnNames)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestThriftMetastoreUtil.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestThriftMetastoreUtil.java
@@ -161,7 +161,7 @@ public class TestThriftMetastoreUtil
         assertEquals(actual.getTrueCount(), OptionalLong.of(100));
         assertEquals(actual.getFalseCount(), OptionalLong.of(10));
         assertEquals(actual.getNullsCount(), OptionalLong.of(0));
-        assertEquals(actual.getDistinctValuesCount(), OptionalLong.of(2));
+        assertEquals(actual.getDistinctValuesCount(), OptionalLong.empty());
     }
 
     @Test

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2419,6 +2419,7 @@ public class LocalExecutionPlanner
     private static Function<Page, Page> enforceLayoutProcessor(List<Symbol> expectedLayout, Map<Symbol, Integer> inputLayout)
     {
         int[] channels = expectedLayout.stream()
+                .peek(symbol -> checkArgument(inputLayout.containsKey(symbol), "channel not found for symbol: %s", symbol))
                 .mapToInt(inputLayout::get)
                 .toArray();
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -396,7 +396,7 @@ public class TestHiveTableStatistics
                 row("c_string", null, 1.0, 1.0, null, null, null),
                 row("c_varchar", null, 1.0, 1.0, null, null, null),
                 row("c_char", null, 1.0, 1.0, null, null, null),
-                row("c_boolean", null, 0.0, 1.0, null, null, null),
+                row("c_boolean", null, 1.0, 1.0, null, null, null),
                 row("c_binary", null, null, 1.0, null, null, null),
                 row(null, null, null, null, 1.0, null, null));
     }


### PR DESCRIPTION
These refactorings are the pre-requisite for the #10456 

Along with tiny trivial refactorings there are few bigger ones:

- Do not store NDV for Boolean in HiveColumnStatistics. Since there is no NDV statistic stored in the Metastore for the `boolean` type, we compute NDV based on (`false`, `true` and `null`) counts statistics. `HiveColumnStatistics` is rather a simple storage class. So, it must hold the exact representation of the statistics stored in the Metastore. The NDV computation must be done in the `MetastoreHiveStatisticsProvider.java`, where all the other translations take place. As part of this refactoring the way we process null is changed, to be consistent with the rest of the statistics (see #10674). 
- Remove optional from the Metastore statistics interfaces. `Optional.empty()` and `Optional.of(ImmutableMap.of())` is basically the same. It introduces a lot of confusion of when to return an empty map, and when to return an empty optional.
- Remove column granularity from the `getStatistics*` metastore methods. Currently we never query statistics for a subset of columns. It is not supported by the `ConnectorMetadata` interface. So this code just complicates the interfaces, and increases the amount of memory used by the statistics cache.