### PR TITLE
Remove time-based expiration of page function bytecode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -97,7 +97,6 @@ import static io.airlift.bytecode.expression.BytecodeExpressions.newArray;
 import static io.airlift.bytecode.expression.BytecodeExpressions.not;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.HOURS;
 
 public class PageFunctionCompiler
 {
@@ -121,15 +120,10 @@ public class PageFunctionCompiler
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.determinismEvaluator = new DeterminismEvaluator(metadata.getFunctionRegistry());
 
-        // We have observed deoptimization storms that lead to slowness.
-        // We suspect that it is a JVM bug that is related to stale/corrupted profiling data associated
-        // with generated classes, thus the following cache entries are expired after one hour.
-
         if (expressionCacheSize > 0) {
             projectionCache = CacheBuilder.newBuilder()
                     .recordStats()
                     .maximumSize(expressionCacheSize)
-                    .expireAfterWrite(1, HOURS)
                     .build(CacheLoader.from(projection -> compileProjectionInternal(projection, Optional.empty())));
             projectionCacheStats = new CacheStatsMBean(projectionCache);
         }
@@ -142,7 +136,6 @@ public class PageFunctionCompiler
             filterCache = CacheBuilder.newBuilder()
                     .recordStats()
                     .maximumSize(expressionCacheSize)
-                    .expireAfterWrite(1, HOURS)
                     .build(CacheLoader.from(filter -> compileFilterInternal(filter, Optional.empty())));
             filterCacheStats = new CacheStatsMBean(filterCache);
         }


### PR DESCRIPTION
The JVM bug can affect newly generated code, so expiring it
based on time does not help.