### PR TITLE
Remove LocalMemoryContext::transferMemory method

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -267,18 +267,6 @@ public class TaskContext
         return taskMemoryContext.localSystemMemoryContext();
     }
 
-    /**
-     * This method is used to create a new LocalMemoryContext that will be used to keep track of the bytes transferred from
-     * the OperatorContext with the OperatorContext::transferMemoryToTaskContext() method.
-     * Creating a new memory context for this purpose simplifies tracking those bytes.
-     * The caller must close this LocalMemoryContext when done.
-     * @return a new LocalMemoryContext to track the bytes transferred from the OperatorContext to TaskContext
-     */
-    public synchronized LocalMemoryContext createNewTransferredBytesMemoryContext()
-    {
-        return taskMemoryContext.newUserMemoryContext();
-    }
-
     public void moreMemoryAvailable()
     {
         pipelineContexts.forEach(PipelineContext::moreMemoryAvailable);

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/LocalMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/LocalMemoryContext.java
@@ -17,16 +17,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 public interface LocalMemoryContext
 {
-    /**
-     * This method transfers the allocations from this memory context to the "to" memory context,
-     * where parent of this is a descendant of to.parent (there can be multiple AggregatedMemoryContexts between them).
-     * <p>
-     * During the transfer the implementation of this method must not reflect any state changes outside of the contexts
-     * (e.g., by calling the reservation handlers).
-     */
-    @Deprecated
-    void transferMemory(LocalMemoryContext to);
-
     long getBytes();
 
     /**

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/SimpleLocalMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/SimpleLocalMemoryContext.java
@@ -19,7 +19,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-import static com.facebook.presto.memory.context.AbstractAggregatedMemoryContext.addExact;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -77,50 +76,6 @@ public final class SimpleLocalMemoryContext
             return true;
         }
         return false;
-    }
-
-    /**
-     * This method transfers the allocations from this memory context to the "to" memory context,
-     * where parent of this is a descendant of to.parent (there can be multiple AggregatedMemoryContexts between them).
-     * <p>
-     * During the transfer the implementation of this method must not reflect any state changes outside of the contexts
-     * (e.g., by calling the reservation handlers).
-     * <p>
-     * This method currently has a single use ({@code NestedLoopJoinPages}) and any change should be tested carefully due to
-     * its somewhat complex semantics.
-     */
-    @Deprecated
-    @Override
-    public synchronized void transferMemory(LocalMemoryContext to)
-    {
-        checkArgument(to instanceof SimpleLocalMemoryContext, "to must be an instance of SimpleLocalMemoryContext");
-        checkState(!closed, "already closed");
-
-        SimpleLocalMemoryContext target = (SimpleLocalMemoryContext) to;
-        checkMemoryContextState(target);
-
-        AbstractAggregatedMemoryContext parent = parentMemoryContext;
-        while (parent != null && parent != target.parentMemoryContext) {
-            parent.addBytes(-usedBytes);
-            parent = parent.getParent();
-        }
-        target.addBytes(usedBytes);
-        usedBytes = 0;
-    }
-
-    private void checkMemoryContextState(SimpleLocalMemoryContext target)
-    {
-        AbstractAggregatedMemoryContext parent = parentMemoryContext;
-        while (parent != null && parent != target.parentMemoryContext) {
-            parent = parent.getParent();
-        }
-        // if parent is null at this point, we fail as the memory context state is probably corrupt.
-        checkState(parent != null, "memory context state is corrupt");
-    }
-
-    private synchronized void addBytes(long bytes)
-    {
-        usedBytes = addExact(usedBytes, bytes);
     }
 
     @Override

--- a/presto-memory-context/src/test/java/com/facebook/presto/memory/context/TestMemoryContexts.java
+++ b/presto-memory-context/src/test/java/com/facebook/presto/memory/context/TestMemoryContexts.java
@@ -148,34 +148,6 @@ public class TestMemoryContexts
         assertEquals(reservationHandler.getReservation(), maxMemory);
     }
 
-    @Test
-    public void testTransferMemory()
-    {
-        TestMemoryReservationHandler reservationHandler = new TestMemoryReservationHandler(1_000);
-        AggregatedMemoryContext taskContext = newRootAggregatedMemoryContext(reservationHandler, GUARANTEED_MEMORY);
-        LocalMemoryContext taskLocalMemoryContext = taskContext.newLocalMemoryContext();
-        AggregatedMemoryContext pipelineContext = taskContext.newAggregatedMemoryContext();
-        AggregatedMemoryContext driverContext = pipelineContext.newAggregatedMemoryContext();
-        AggregatedMemoryContext operatorContext = driverContext.newAggregatedMemoryContext();
-        LocalMemoryContext operatorLocalMemoryContext = operatorContext.newLocalMemoryContext();
-
-        operatorLocalMemoryContext.setBytes(10);
-        assertEquals(taskContext.getBytes(), 10);
-        assertEquals(pipelineContext.getBytes(), 10);
-        assertEquals(driverContext.getBytes(), 10);
-        assertEquals(operatorContext.getBytes(), 10);
-        assertEquals(taskLocalMemoryContext.getBytes(), 0);
-        assertEquals(reservationHandler.getReservation(), 10);
-
-        operatorLocalMemoryContext.transferMemory(taskLocalMemoryContext);
-        assertEquals(operatorLocalMemoryContext.getBytes(), 0);
-        assertEquals(operatorContext.getBytes(), 0);
-        assertEquals(pipelineContext.getBytes(), 0);
-        assertEquals(driverContext.getBytes(), 0);
-        assertEquals(taskContext.getBytes(), 10);
-        assertEquals(reservationHandler.getReservation(), 10);
-    }
-
     private static class TestMemoryReservationHandler
             implements MemoryReservationHandler
     {


### PR DESCRIPTION
This method was only used by the nested loop join operator. Now that
nested loop join operator doesn't depend on this method it can be
removed.