### PR TITLE
Remove hardcoded query max memory in TestingPrestoServer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -189,10 +189,6 @@ public class TestingPrestoServer
                 .put("task.max-worker-threads", "4")
                 .put("exchange.client-threads", "4");
 
-        if (!properties.containsKey("query.max-memory-per-node")) {
-            serverProperties.put("query.max-memory-per-node", "512MB");
-        }
-
         if (coordinator) {
             // TODO: enable failure detector
             serverProperties.put("failure-detector.enabled", "false");


### PR DESCRIPTION
With the removal of the sytem pool and the introduction of the new query
total memory limit, this hardcoded value may cause failures depending
on the JVM heap size used for testing.

This change was introduced in https://github.com/prestodb/presto/commit/cc65c4b626d311bced1344172091fc4a539827fd. I have run the tests in another test PR (https://github.com/prestodb/presto/pull/10693, [build](https://travis-ci.org/prestodb/presto/builds/382920031)) and they all look good, so it seems that we don't need this hardcoded config anymore. 