### PR TITLE
Fix sending challenge for multiple authenticators

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
@@ -96,7 +96,7 @@ public class AuthenticationFilter
         skipRequestBody(request);
 
         for (String value : authenticateHeaders) {
-            response.setHeader(WWW_AUTHENTICATE, value);
+            response.addHeader(WWW_AUTHENTICATE, value);
         }
 
         if (messages.isEmpty()) {


### PR DESCRIPTION
When using multiple authentication methods such as PASSWORD and JWT,
the WWW-Authenticate challenge was only sent for the last method
rather than all of them. This breaks authentication for clients
that do not pre-authenticate requests.