### PR TITLE
Only check column access once

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -688,14 +688,6 @@ class StatementAnalyzer
                     .withRelationType(RelationId.of(node), queryBodyScope.getRelationType())
                     .build();
 
-            // check column access permissions for each table
-            analysis.getTableColumnReferences(session.getIdentity())
-                    .forEach((tableName, columns) ->
-                            accessControl.checkCanSelectFromColumns(session.getRequiredTransactionId(),
-                                    session.getIdentity(),
-                                    tableName,
-                                    ImmutableSet.copyOf(columns)));
-
             analysis.setScope(node, queryScope);
             return queryScope;
         }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7357,6 +7357,7 @@ public abstract class AbstractTestQueries
         assertAccessDenied("SELECT count(name) as c FROM nation where comment > 'abc' GROUP BY regionkey having max(nationkey) > 10", "Cannot select from columns \\[nationkey, regionkey, name, comment\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
         assertAccessDenied("SELECT 1 FROM region, nation where region.regionkey = nation.nationkey", "Cannot select from columns \\[nationkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
         assertAccessDenied("SELECT count(*) FROM nation", "Cannot select from columns \\[\\] in table .*.nation.*", privilege("nation", SELECT_COLUMN));
+        assertAccessDenied("WITH t1 AS (SELECT * FROM nation) SELECT * FROM t1", "Cannot select from columns \\[nationkey, regionkey, name, comment\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
     }
 
     @Test


### PR DESCRIPTION
Only check column access permissions when we're in the outer query scope
so that the check happens only once for all the tables/columns in the
query.