### PR TITLE
Define all parameters in single place

### DIFF
--- a/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
@@ -28,6 +28,9 @@ pushd $PROJECT_ROOT
 set +e
 ./mvnw -pl presto-hive-hadoop2 test -P test-hive-hadoop2-s3 \
   -DHADOOP_USER_NAME=hive \
+  -Dhive.hadoop2.metastoreHost=localhost \
+  -Dhive.hadoop2.metastorePort=9083 \
+  -Dhive.hadoop2.databaseName=default \
   -Dhive.hadoop2.s3.awsAccessKey=${AWS_ACCESS_KEY_ID} \
   -Dhive.hadoop2.s3.awsSecretKey=${AWS_SECRET_ACCESS_KEY} \
   -Dhive.hadoop2.s3.writableBucket=${S3_BUCKET}

--- a/presto-hive-hadoop2/bin/run_hive_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_tests.sh
@@ -25,6 +25,9 @@ set +e
 ./mvnw -pl presto-hive-hadoop2 test -P test-hive-hadoop2 \
   -Dhive.hadoop2.timeZone=UTC \
   -DHADOOP_USER_NAME=hive \
+  -Dhive.hadoop2.metastoreHost=localhost \
+  -Dhive.hadoop2.metastorePort=9083 \
+  -Dhive.hadoop2.databaseName=default \
   -Dhive.hadoop2.metastoreHost=hadoop-master \
   -Dhive.hadoop2.timeZone=Asia/Kathmandu \
   -Dhive.metastore.thrift.client.socks-proxy=${PROXY}:1180 \

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -125,11 +125,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <groups>hive</groups>
-                            <systemProperties>
-                                <hive.hadoop2.metastoreHost>localhost</hive.hadoop2.metastoreHost>
-                                <hive.hadoop2.metastorePort>9083</hive.hadoop2.metastorePort>
-                                <hive.hadoop2.databaseName>default</hive.hadoop2.databaseName>
-                            </systemProperties>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -144,11 +139,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <groups>hive-s3</groups>
-                            <systemProperties>
-                                <hive.hadoop2.metastoreHost>localhost</hive.hadoop2.metastoreHost>
-                                <hive.hadoop2.metastorePort>9083</hive.hadoop2.metastorePort>
-                                <hive.hadoop2.databaseName>default</hive.hadoop2.databaseName>
-                            </systemProperties>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Define all parameters in single place

It is easier when parameters are set in single place.
Also pom.xml is not the best place to set default values for parameters,
because test can called from IDE and then defaults are not set. When
parameters are set in script then it is easier to manually copy them to IDE.
