### PR TITLE
Add support for NullValueBlock

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -96,6 +97,9 @@ public abstract class AbstractTestBlock
         Field[] fields = block.getClass().getDeclaredFields();
         try {
             for (Field field : fields) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
                 Class<?> type = field.getType();
                 if (type.isPrimitive()) {
                     continue;

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
@@ -15,10 +15,17 @@ package com.facebook.presto.block;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.ByteArrayBlockBuilder;
+import com.facebook.presto.spi.block.IntArrayBlockBuilder;
+import com.facebook.presto.spi.block.LongArrayBlockBuilder;
+import com.facebook.presto.spi.block.RunLengthBlockEncoding;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.block.ShortArrayBlockBuilder;
 import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 public class TestRunLengthEncodedBlock
         extends AbstractTestBlock
@@ -52,5 +59,44 @@ public class TestRunLengthEncodedBlock
     private static BlockBuilder createBlockBuilder()
     {
         return new VariableWidthBlockBuilder(null, 1, 1);
+    }
+
+    @Test
+    public void testBuildingFromLongArrayBlockBuilder()
+    {
+        LongArrayBlockBuilder blockBuilder = new LongArrayBlockBuilder(null, 100);
+        populateNullValues(blockBuilder, 100);
+        assertEquals(blockBuilder.build().getEncodingName(), RunLengthBlockEncoding.NAME);
+    }
+
+    @Test
+    public void testBuildingFromIntArrayBlockBuilder()
+    {
+        IntArrayBlockBuilder blockBuilder = new IntArrayBlockBuilder(null, 100);
+        populateNullValues(blockBuilder, 100);
+        assertEquals(blockBuilder.build().getEncodingName(), RunLengthBlockEncoding.NAME);
+    }
+
+    @Test
+    public void testBuildingFromShortArrayBlockBuilder()
+    {
+        ShortArrayBlockBuilder blockBuilder = new ShortArrayBlockBuilder(null, 100);
+        populateNullValues(blockBuilder, 100);
+        assertEquals(blockBuilder.build().getEncodingName(), RunLengthBlockEncoding.NAME);
+    }
+
+    @Test
+    public void testBuildingFromByteArrayBlockBuilder()
+    {
+        ByteArrayBlockBuilder blockBuilder = new ByteArrayBlockBuilder(null, 100);
+        populateNullValues(blockBuilder, 100);
+        assertEquals(blockBuilder.build().getEncodingName(), RunLengthBlockEncoding.NAME);
+    }
+
+    private void populateNullValues(BlockBuilder blockBuilder, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            blockBuilder.appendNull();
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
@@ -67,10 +67,11 @@ public class TestPagesSerde
         // empty page
         Page page = new Page(builder.build());
         int pageSize = serializedSize(ImmutableList.of(BIGINT), page);
-        assertEquals(pageSize, 35); // page overhead
+        assertEquals(pageSize, 47); // page overhead ideally 35 but since a 0 sized block will be a RLEBlock we have an overhead of 12
 
         // page with one value
         BIGINT.writeLong(builder, 123);
+        pageSize = 35; // Now we have moved to the normal block implementation so the page size overhead is 35
         page = new Page(builder.build());
         int firstValueSize = serializedSize(ImmutableList.of(BIGINT), page) - pageSize;
         assertEquals(firstValueSize, 9); // value size + value overhead

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
@@ -102,10 +102,7 @@ public abstract class AbstractTestAggregationFunction
         }
         Block[] blocks = new Block[parameterTypes.size()];
         for (int i = 0; i < parameterTypes.size(); i++) {
-            Block nullValueBlock = parameterTypes.get(0).createBlockBuilder(null, 1)
-                    .appendNull()
-                    .build();
-            blocks[i] = new RunLengthEncodedBlock(nullValueBlock, 10);
+            blocks[i] = RunLengthEncodedBlock.create(parameterTypes.get(0), null, 10);
         }
 
         testAggregation(getExpectedValueIncludingNulls(0, 0, 10), blocks);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
@@ -368,11 +368,7 @@ public final class AggregationTestUtils
 
     private static RunLengthEncodedBlock createNullRLEBlock(int positionCount)
     {
-        Block value = BOOLEAN.createBlockBuilder(null, 1)
-                .appendNull()
-                .build();
-
-        return new RunLengthEncodedBlock(value, positionCount);
+        return (RunLengthEncodedBlock) RunLengthEncodedBlock.create(BOOLEAN, null, positionCount);
     }
 
     public static Object getGroupValue(GroupedAccumulator groupedAggregation, int groupId)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -34,6 +34,9 @@ public class RunLengthEncodedBlock
     public static Block create(Type type, Object value, int positionCount)
     {
         Block block = Utils.nativeValueToBlock(type, value);
+        if (block instanceof RunLengthEncodedBlock) {
+            block = ((RunLengthEncodedBlock) block).getValue();
+        }
         return new RunLengthEncodedBlock(block, positionCount);
     }
 
@@ -47,16 +50,17 @@ public class RunLengthEncodedBlock
             throw new IllegalArgumentException(format("Expected value to contain a single position but has %s positions", value.getPositionCount()));
         }
 
-        // value can not be a RunLengthEncodedBlock because this could cause stack overflow in some of the methods
         if (value instanceof RunLengthEncodedBlock) {
-            throw new IllegalArgumentException(format("Value can not be an instance of a %s", getClass().getName()));
+            this.value = ((RunLengthEncodedBlock) value).getValue();
+        }
+        else {
+            this.value = value;
         }
 
         if (positionCount < 0) {
             throw new IllegalArgumentException("positionCount is negative");
         }
 
-        this.value = value;
         this.positionCount = positionCount;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -139,84 +139,98 @@ public class RunLengthEncodedBlock
     @Override
     public int getSliceLength(int position)
     {
+        checkReadablePosition(position);
         return value.getSliceLength(0);
     }
 
     @Override
     public byte getByte(int position, int offset)
     {
+        checkReadablePosition(position);
         return value.getByte(0, offset);
     }
 
     @Override
     public short getShort(int position, int offset)
     {
+        checkReadablePosition(position);
         return value.getShort(0, offset);
     }
 
     @Override
     public int getInt(int position, int offset)
     {
+        checkReadablePosition(position);
         return value.getInt(0, offset);
     }
 
     @Override
     public long getLong(int position, int offset)
     {
+        checkReadablePosition(position);
         return value.getLong(0, offset);
     }
 
     @Override
     public Slice getSlice(int position, int offset, int length)
     {
+        checkReadablePosition(position);
         return value.getSlice(0, offset, length);
     }
 
     @Override
     public <T> T getObject(int position, Class<T> clazz)
     {
+        checkReadablePosition(position);
         return value.getObject(0, clazz);
     }
 
     @Override
     public boolean bytesEqual(int position, int offset, Slice otherSlice, int otherOffset, int length)
     {
+        checkReadablePosition(position);
         return value.bytesEqual(0, offset, otherSlice, otherOffset, length);
     }
 
     @Override
     public int bytesCompare(int position, int offset, int length, Slice otherSlice, int otherOffset, int otherLength)
     {
+        checkReadablePosition(position);
         return value.bytesCompare(0, offset, length, otherSlice, otherOffset, otherLength);
     }
 
     @Override
     public void writeBytesTo(int position, int offset, int length, BlockBuilder blockBuilder)
     {
+        checkReadablePosition(position);
         value.writeBytesTo(0, offset, length, blockBuilder);
     }
 
     @Override
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
+        checkReadablePosition(position);
         value.writePositionTo(0, blockBuilder);
     }
 
     @Override
     public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
+        checkReadablePosition(position);
         return value.equals(0, offset, otherBlock, otherPosition, otherOffset, length);
     }
 
     @Override
     public long hash(int position, int offset, int length)
     {
+        checkReadablePosition(position);
         return value.hash(0, offset, length);
     }
 
     @Override
     public int compareTo(int leftPosition, int leftOffset, int leftLength, Block rightBlock, int rightPosition, int rightOffset, int rightLength)
     {
+        checkReadablePosition(leftPosition);
         return value.compareTo(0, leftOffset, leftLength, rightBlock, rightPosition, rightOffset, rightLength);
     }
 


### PR DESCRIPTION
We have created a NullValueBlock which effectively represents a block in which **all the entries are null**. If we have a LongArrayBlock of size 7168 in which all the entries are null, we have a long array of same size which we don't require.  When such type of blocks are replaced with a NullValueBlock (which maintains only the positionCount) we can reduce the memory consumed by those blocks. Serialization/DeSerialization of the NullValueblocks are also simple as we use only the positionCount. In future we can also add tweak the project and filter operators when working on the NullValueBlocks(Similar to RunLengthEncodedBlock and DictionaryBlock).