### PR TITLE
Add support for assign unique id node and filter in our join stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/AssignUniqueIdStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/AssignUniqueIdStatsRule.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.Patterns;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+
+public class AssignUniqueIdStatsRule
+        implements ComposableStatsCalculator.Rule<AssignUniqueId>
+{
+    private static final Pattern<AssignUniqueId> PATTERN = Patterns.assignUniqueId();
+
+    @Override
+    public Pattern<AssignUniqueId> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<PlanNodeStatsEstimate> calculate(AssignUniqueId assignUniqueId, StatsProvider statsProvider, Lookup lookup, Session session, Map<Symbol, Type> types)
+    {
+        PlanNodeStatsEstimate sourceStats = statsProvider.getStats(assignUniqueId.getSource());
+        return Optional.of(PlanNodeStatsEstimate.buildFrom(sourceStats)
+                .addSymbolStatistics(assignUniqueId.getIdColumn(), SymbolStatsEstimate.builder()
+                        .setDistinctValuesCount(sourceStats.getOutputRowCount())
+                        .setNullsFraction(0.0)
+                        .setAverageRowSize(BIGINT.getFixedSize())
+                        .build())
+                .build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
@@ -35,6 +36,7 @@ import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
@@ -117,6 +119,12 @@ public class CostCalculatorUsingExchanges
         public PlanNodeCostEstimate visitGroupReference(GroupReference node, Void context)
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PlanNodeCostEstimate visitAssignUniqueId(AssignUniqueId node, Void context)
+        {
+            return cpuCost(getStats(node).getOutputSizeInBytes(ImmutableList.of(node.getIdColumn())));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -23,6 +23,7 @@ import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.connector.system.SystemConnectorModule;
 import com.facebook.presto.cost.AggregationStatsRule;
+import com.facebook.presto.cost.AssignUniqueIdStatsRule;
 import com.facebook.presto.cost.CoefficientBasedStatsCalculator;
 import com.facebook.presto.cost.ComposableStatsCalculator;
 import com.facebook.presto.cost.ComposableStatsCalculator.Rule;
@@ -533,6 +534,7 @@ public class ServerMainModule
         rules.add(new JoinStatsRule(filterStatsCalculator, normalizer));
         rules.add(new AggregationStatsRule(normalizer));
         rules.add(new UnionStatsRule(normalizer));
+        rules.add(new AssignUniqueIdStatsRule());
         rules.add(new SemiJoinStatsRule());
 
         return new ComposableStatsCalculator(rules.build());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -30,6 +30,11 @@ public class Patterns
 {
     private Patterns() {}
 
+    public static Pattern<AssignUniqueId> assignUniqueId()
+    {
+        return typeOf(AssignUniqueId.class);
+    }
+
     public static Pattern<AggregationNode> aggregation()
     {
         return typeOf(AggregationNode.class);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -232,6 +232,16 @@ public class TestTpchLocalStats
                         .verifyExactColumnStatistics("ps_suppkey")
                         .verifyColumnStatistics("l_suppkey", absoluteError(6.0))
                         .verifyColumnStatistics("l_orderkey", absoluteError(6.0)));
+
+        // simple non-equi join
+        statisticsAssertion.check("SELECT * FROM partsupp LEFT JOIN lineitem ON ps_partkey = l_partkey AND ps_suppkey < l_suppkey",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(4.0))
+                        .verifyExactColumnStatistics("ps_partkey")
+                        .verifyColumnStatistics("l_partkey", relativeError(0.10))
+                        .verifyExactColumnStatistics("ps_suppkey")
+                        .verifyColumnStatistics("l_suppkey", relativeError(1.0))
+                        .verifyColumnStatistics("l_orderkey", relativeError(0.10)));
     }
 
     @Test
@@ -277,6 +287,16 @@ public class TestTpchLocalStats
                         .verifyExactColumnStatistics("ps_suppkey")
                         .verifyColumnStatistics("l_suppkey", absoluteError(6.0))
                         .verifyColumnStatistics("l_orderkey", absoluteError(6.0)));
+
+        // simple non-equi join
+        statisticsAssertion.check("SELECT * FROM lineitem RIGHT JOIN partsupp ON ps_partkey = l_partkey AND ps_suppkey < l_suppkey",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(4.0))
+                        .verifyExactColumnStatistics("ps_partkey")
+                        .verifyColumnStatistics("l_partkey", relativeError(0.10))
+                        .verifyExactColumnStatistics("ps_suppkey")
+                        .verifyColumnStatistics("l_suppkey", relativeError(1.0))
+                        .verifyColumnStatistics("l_orderkey", relativeError(0.10)));
     }
 
     @Test
@@ -317,6 +337,16 @@ public class TestTpchLocalStats
                         .verifyColumnStatistics("ps_suppkey", absoluteError(6.0))
                         .verifyColumnStatistics("l_suppkey", absoluteError(6.0))
                         .verifyColumnStatistics("l_orderkey", absoluteError(6.0)));
+
+        // simple non-equi join
+        statisticsAssertion.check("SELECT * FROM lineitem FULL JOIN partsupp ON ps_partkey = l_partkey AND ps_suppkey < l_suppkey",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(4.0))
+                        .verifyColumnStatistics("ps_partkey", relativeError(0.10))
+                        .verifyColumnStatistics("l_partkey", relativeError(0.10))
+                        .verifyColumnStatistics("ps_suppkey", relativeError(0.10))
+                        .verifyColumnStatistics("l_suppkey", relativeError(1.0))
+                        .verifyColumnStatistics("l_orderkey", relativeError(0.10)));
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -503,4 +503,12 @@ public class TestTpchLocalStats
                 // of values are filtered out.
                 checks -> checks.estimate(OUTPUT_ROW_COUNT, relativeError(0.0, 1.0)));
     }
+
+    @Test
+    public void testCorrelatedSubquery()
+    {
+        statisticsAssertion.check("SELECT (SELECT count(*) FROM nation n1 WHERE n1.n_nationkey = n2.n_nationkey AND n1.n_regionkey > n2.n_regionkey) FROM nation n2",
+                checks -> checks
+                        .estimate(OUTPUT_ROW_COUNT, relativeError(0.5)));
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -193,38 +193,38 @@ public class TestTpchLocalStats
     public void testLeftJoinStats()
     {
         // non equi predicates
-        statisticsAssertion.check("SELECT * FROM supplier left join nation on true",
+        statisticsAssertion.check("SELECT * FROM supplier LEFT JOIN nation ON true",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
                         .verifyExactColumnStatistics("s_nationkey")
                         .verifyExactColumnStatistics("n_nationkey")
                         .verifyExactColumnStatistics("s_suppkey"));
-        statisticsAssertion.check("SELECT * FROM supplier left join nation on false",
+        statisticsAssertion.check("SELECT * FROM supplier LEFT JOIN nation ON false",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
                         .verifyExactColumnStatistics("s_nationkey")
                         .verifyExactColumnStatistics("s_suppkey"));
         // simple equi join
-        statisticsAssertion.check("SELECT * FROM supplier left join nation on s_nationkey = n_nationkey",
+        statisticsAssertion.check("SELECT * FROM supplier LEFT JOIN nation ON s_nationkey = n_nationkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
                         .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
                         .verifyColumnStatistics("n_nationkey", absoluteError(0.40))
                         .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
-        statisticsAssertion.check("SELECT * FROM supplier left join nation on s_nationkey = n_nationkey AND n_nationkey <= 12",
+        statisticsAssertion.check("SELECT * FROM supplier LEFT JOIN nation ON s_nationkey = n_nationkey AND n_nationkey <= 12",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
                         .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
                         .verifyColumnStatistics("n_nationkey", relativeError(0.40))
                         .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
-        statisticsAssertion.check("SELECT * FROM (SELECT * FROM supplier WHERE s_nationkey <= 12) left join nation on s_nationkey = n_nationkey",
+        statisticsAssertion.check("SELECT * FROM (SELECT * FROM supplier WHERE s_nationkey <= 12) LEFT JOIN nation ON s_nationkey = n_nationkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
                         .verifyColumnStatistics("s_nationkey", absoluteError(2.0))
                         .verifyColumnStatistics("n_nationkey", absoluteError(2.0)));
 
         // join with two keys
-        statisticsAssertion.check("SELECT * FROM partsupp left join lineitem on ps_partkey = l_partkey AND ps_suppkey = l_suppkey",
+        statisticsAssertion.check("SELECT * FROM partsupp LEFT JOIN lineitem ON ps_partkey = l_partkey AND ps_suppkey = l_suppkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(4.0))
                         .verifyExactColumnStatistics("ps_partkey")
@@ -248,38 +248,38 @@ public class TestTpchLocalStats
     public void testRightJoinStats()
     {
         // non equi predicates
-        statisticsAssertion.check("SELECT * FROM nation right join supplier on true",
+        statisticsAssertion.check("SELECT * FROM nation RIGHT JOIN supplier ON true",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
                         .verifyExactColumnStatistics("s_nationkey")
                         .verifyExactColumnStatistics("n_nationkey")
                         .verifyExactColumnStatistics("s_suppkey"));
-        statisticsAssertion.check("SELECT * FROM nation right join supplier on false",
+        statisticsAssertion.check("SELECT * FROM nation RIGHT JOIN supplier ON false",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
                         .verifyExactColumnStatistics("s_nationkey")
                         .verifyExactColumnStatistics("s_suppkey"));
         // simple equi join
-        statisticsAssertion.check("SELECT * FROM nation right join supplier on s_nationkey = n_nationkey",
+        statisticsAssertion.check("SELECT * FROM nation RIGHT JOIN supplier ON s_nationkey = n_nationkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
                         .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
                         .verifyColumnStatistics("n_nationkey", absoluteError(0.40))
                         .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
-        statisticsAssertion.check("SELECT * FROM nation right join supplier on s_nationkey = n_nationkey AND n_nationkey <= 12",
+        statisticsAssertion.check("SELECT * FROM nation RIGHT JOIN supplier ON s_nationkey = n_nationkey AND n_nationkey <= 12",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
                         .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
                         .verifyColumnStatistics("n_nationkey", relativeError(0.40))
                         .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
-        statisticsAssertion.check("SELECT * FROM nation right JOIN (SELECT * FROM supplier WHERE s_nationkey <= 12) on s_nationkey = n_nationkey",
+        statisticsAssertion.check("SELECT * FROM nation RIGHT JOIN (SELECT * FROM supplier WHERE s_nationkey <= 12) ON s_nationkey = n_nationkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
                         .verifyColumnStatistics("s_nationkey", absoluteError(2.0))
                         .verifyColumnStatistics("n_nationkey", absoluteError(2.0)));
 
         // join with two keys
-        statisticsAssertion.check("SELECT * FROM lineitem right join partsupp on ps_partkey = l_partkey AND ps_suppkey = l_suppkey",
+        statisticsAssertion.check("SELECT * FROM lineitem RIGHT JOIN partsupp ON ps_partkey = l_partkey AND ps_suppkey = l_suppkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(4.0))
                         .verifyExactColumnStatistics("ps_partkey")
@@ -303,33 +303,33 @@ public class TestTpchLocalStats
     public void testFullJoinStats()
     {
         // non equi predicates
-        statisticsAssertion.check("SELECT * FROM supplier full join nation on true",
+        statisticsAssertion.check("SELECT * FROM supplier FULL JOIN nation ON true",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, defaultTolerance())
                         .verifyExactColumnStatistics("s_nationkey")
                         .verifyExactColumnStatistics("n_nationkey")
                         .verifyExactColumnStatistics("s_suppkey"));
         // simple equi join
-        statisticsAssertion.check("SELECT * FROM nation full join supplier on s_nationkey = n_nationkey",
+        statisticsAssertion.check("SELECT * FROM nation FULL JOIN supplier ON s_nationkey = n_nationkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
                         .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
                         .verifyColumnStatistics("n_nationkey", absoluteError(0.40))
                         .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
-        statisticsAssertion.check("SELECT * FROM (SELECT * FROM nation WHERE n_nationkey <= 12) full join supplier on s_nationkey = n_nationkey",
+        statisticsAssertion.check("SELECT * FROM (SELECT * FROM nation WHERE n_nationkey <= 12) FULL JOIN supplier ON s_nationkey = n_nationkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
                         .verifyColumnStatistics("s_nationkey", absoluteError(0.40))
                         .verifyColumnStatistics("n_nationkey", relativeError(0.40))
                         .verifyColumnStatistics("s_suppkey", absoluteError(0.40)));
-        statisticsAssertion.check("SELECT * FROM nation full join (SELECT * FROM supplier WHERE s_nationkey <= 12) on s_nationkey = n_nationkey",
+        statisticsAssertion.check("SELECT * FROM nation FULL JOIN (SELECT * FROM supplier WHERE s_nationkey <= 12) ON s_nationkey = n_nationkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(0.70))
                         .verifyColumnStatistics("s_nationkey", relativeError(0.40))
                         .verifyColumnStatistics("n_nationkey", relativeError(0.40)));
 
         // join with two keys
-        statisticsAssertion.check("SELECT * FROM lineitem full join partsupp on ps_partkey = l_partkey AND ps_suppkey = l_suppkey",
+        statisticsAssertion.check("SELECT * FROM lineitem FULL JOIN partsupp ON ps_partkey = l_partkey AND ps_suppkey = l_suppkey",
                 checks -> checks
                         .estimate(OUTPUT_ROW_COUNT, relativeError(4.0))
                         .verifyColumnStatistics("ps_partkey", absoluteError(6.0))


### PR DESCRIPTION
Q21 before:
```
- LeftJoin[("orderkey" = "orderkey_10") AND ("suppkey_12" <> "suppkey_0")][$hashvalue_204, $hashv
        Distribution: REPLICATED
        Cost: {rows: 2450757425 (228.24GB), cpu: 2391276411339.29, memory: 255027000671.95, netwo
    - Project[] => [orderkey:bigint, suppkey_0:bigint, commitdate:date, receiptdate:date, name:va
            Cost: {rows: 296052124 (27.57GB), cpu: 1276596897180.48, memory: 15027412311.95, netw
            $hashvalue_204 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderkey
        - AssignUniqueId => [orderkey:bigint, suppkey_0:bigint, commitdate:date, receiptdate:date
                Cost: {rows: 296052124 (24.81GB), cpu: 1246991684800.55, memory: 15027412311.95,
            - Project[] => [orderkey:bigint, suppkey_0:bigint, commitdate:date, receiptdate:date,
                    Cost: {rows: 296052124 (22.06GB), cpu: 1244623267810.15, memory: 15027412311.
                - InnerJoin[("orderkey" = "orderkey_3")][$hashvalue_201, $hashvalue_202] => [orde
                        Distribution: REPLICATED
                        Cost: {rows: 296052124 (24.81GB), cpu: 1220939097906.21, memory: 15027412
                        ...
    - LocalExchange[HASH][$hashvalue_205] ("orderkey_10") => suppkey_12:bigint, orderkey_10:bigin
            Cost: {rows: 5999989709 (223.52GB), cpu: 599998970900.00, memory: 0.00, network: 0.00
        - ScanProject[table = hive:tpch_sf1000_orc:lineitem, originalConstraint = true] => [suppk
                Cost: {rows: 5999989709 (111.76GB), cpu: 119999794180.00, memory: 0.00, network:
                non_null_188 := true
                $hashvalue_206 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orde
                LAYOUT: tpch_sf1000_orc.lineitem
                suppkey_12 := HiveColumnHandle{name=suppkey, hiveType=bigint, hiveColumnIndex=2,
```
after:
```
- RightJoin[("orderkey_10" = "orderkey") AND ("suppkey_12" <> "suppkey_0")][$hashvalue_195, $hash
        Distribution: PARTITIONED
        Cost: {rows: 2450757425 (228.24GB), cpu: 2181375456974.36, memory: 44879335499.45, networ
    - ScanProject[table = hive:tpch_sf1000_orc:lineitem, originalConstraint = true] => [suppkey_1
            Cost: {rows: 5999989709 (111.76GB), cpu: 119999794180.00, memory: 0.00, network: 0.00
            non_null_188 := true
            $hashvalue_195 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orderkey
            LAYOUT: tpch_sf1000_orc.lineitem
            suppkey_12 := HiveColumnHandle{name=suppkey, hiveType=bigint, hiveColumnIndex=2, colu
            orderkey_10 := HiveColumnHandle{name=orderkey, hiveType=bigint, hiveColumnIndex=0, co
    - LocalExchange[HASH][$hashvalue_196] ("orderkey") => orderkey:bigint, suppkey_0:bigint, comm
            Cost: {rows: 296052124 (27.57GB), cpu: 1306695531175.55, memory: 15274123119.52, netw
        - Project[] => [orderkey:bigint, suppkey_0:bigint, commitdate:date, receiptdate:date, nam
                Cost: {rows: 296052124 (27.57GB), cpu: 1277090318795.61, memory: 15274123119.52,
                $hashvalue_206 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("orde
            - AssignUniqueId => [orderkey:bigint, suppkey_0:bigint, commitdate:date, receiptdate:
                    Cost: {rows: 296052124 (24.81GB), cpu: 1247485106415.68, memory: 15274123119.
                - Project[] => [orderkey:bigint, suppkey_0:bigint, commitdate:date, receiptdate:d
                        Cost: {rows: 296052124 (22.06GB), cpu: 1245116689425.29, memory: 15274123
                    - InnerJoin[("orderkey" = "orderkey_3")][$hashvalue_203, $hashvalue_204] => [
                            Distribution: PARTITIONED
                            Cost: {rows: 296052124 (24.81GB), cpu: 1221432519521.34, memory: 1527
                        - Project[] => [orderkey:bigint, suppkey_0:bigint, commitdate:date, recei
                                Cost: {rows: 296052124 (22.06GB), cpu: 1066103658475.45, memory:
                                $hashvalue_203 := "combine_hash"(BIGINT '0', COALESCE("$operator$
```

Basically outer join sides were not flipped.