### PR TITLE
Fix LocalFileRecordCursor timestamp parser

### DIFF
--- a/presto-local-file/pom.xml
+++ b/presto-local-file/pom.xml
@@ -48,11 +48,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>


### PR DESCRIPTION
If the JVM default timezone is UTC then HTTP request log timestamp
will not be parseable by the LocalFileRecordCursor (e.g.,
2017-12-21T00:12:27Z and 2017-12-21T00:12:27.000Z).

This change uses the same formatter as in [HttpLogLayout](https://github.com/airlift/airlift/blob/8231839017159b70029dda31fababdc672348c55/http-server/src/main/java/io/airlift/http/server/HttpLogLayout.java#L13).

Fixes #9601.

Given the log (the last two timestamps are not parseable with the current code):
```
2018-05-24T23:59:59.006-07:00	2401:db00:21:7095:face:0:2d:0	GET	/v1/statement/20180525_065921_13647_iwv5x/32	null	null	200	0	54	1002	null
2017-12-21T00:12:27Z	2401:db00:21:7095:face:0:2d:0	GET	/v1/statement/20180525_065921_13647_iwv5x/32	null	null	200	0	54	1002	null
2017-12-21T00:12:27.000Z	2401:db00:21:7095:face:0:2d:0	GET	/v1/statement/20180525_065921_13647_iwv5x/32	null	null	200	0	54	1002	null
```

We get:

```
 select * from localfile.logs.http_request_log;
 server_address |        timestamp        |        client_address         | method |                 request_uri                  | user | agent | response_code | request_size | res
----------------+-------------------------+-------------------------------+--------+----------------------------------------------+------+-------+---------------+--------------+----
 127.0.0.1:8080 | 2018-05-24 23:59:59.006 | 2401:db00:21:7095:face:0:2d:0 | GET    | /v1/statement/20180525_065921_13647_iwv5x/32 | NULL | NULL  |           200 |            0 |
 127.0.0.1:8080 | 2017-12-21 00:12:27.000 | 2401:db00:21:7095:face:0:2d:0 | GET    | /v1/statement/20180525_065921_13647_iwv5x/32 | NULL | NULL  |           200 |            0 |
 127.0.0.1:8080 | 2017-12-21 00:12:27.000 | 2401:db00:21:7095:face:0:2d:0 | GET    | /v1/statement/20180525_065921_13647_iwv5x/32 | NULL | NULL  |           200 |            0 |
(3 rows)
```