### PR TITLE
Update PlanPrinter to distinguish between inner and left spatial joins

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -614,7 +614,8 @@ public class PlanPrinter
             node.getFilter().ifPresent(expression -> joinExpressions.add(expression));
 
             if (node.isSpatialJoin()) {
-                print(indent, "- SpatialJoin[%s] => [%s]",
+                print(indent, "- Spatial%s[%s] => [%s]",
+                        node.getType().getJoinLabel(),
                         Joiner.on(" AND ").join(joinExpressions),
                         formatOutputs(node.getOutputSymbols()));
             }


### PR DESCRIPTION
Modified output of `EXPLAIN <query>` to distinguish between inner and left spatial joins. 

`SpatialInnerJoin["st_contains"("st_geometryfromtext", "st_point")] => [st_point:Geometry, st_geometryfromtext:Geometry]`

vs.

`SpatialLeftJoin["st_contains"("st_geometryfromtext", "st_point")] => [st_point:Geometry, st_geometryfromtext:Geometry]`