### PR TITLE
 Lower initial number of entries in PageBuilder constructor

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/SortBuffer.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/SortBuffer.java
@@ -30,6 +30,7 @@ import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static java.lang.Math.addExact;
 import static java.util.Objects.requireNonNull;
 
@@ -43,6 +44,7 @@ public class SortBuffer
     private final List<SortOrder> sortOrders;
     private final PageSorter pageSorter;
     private final List<Page> pages = new ArrayList<>();
+    private final PageBuilder pageBuilder;
 
     private long usedMemoryBytes;
     private int rowCount;
@@ -60,6 +62,7 @@ public class SortBuffer
         this.sortFields = ImmutableList.copyOf(requireNonNull(sortFields, "sortFields is null"));
         this.sortOrders = ImmutableList.copyOf(requireNonNull(sortOrders, "sortOrders is null"));
         this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
+        this.pageBuilder = new PageBuilder(types);
     }
 
     public long getRetainedBytes()
@@ -110,7 +113,7 @@ public class SortBuffer
             positionIndex[i] = pageSorter.decodePositionIndex(addresses[i]);
         }
 
-        PageBuilder pageBuilder = new PageBuilder(types);
+        verify(pageBuilder.isEmpty());
 
         for (int i = 0; i < pageIndex.length; i++) {
             Page page = pages.get(pageIndex[i]);

--- a/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
@@ -164,7 +164,9 @@ public class AggregationOperator
         // project results into output blocks
         List<Type> types = aggregates.stream().map(Aggregator::getType).collect(toImmutableList());
 
-        PageBuilder pageBuilder = new PageBuilder(types);
+        // output page will only be constructed once,
+        // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
+        PageBuilder pageBuilder = new PageBuilder(1, types);
 
         pageBuilder.declarePosition();
         for (int i = 0; i < aggregates.size(); i++) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/DeleteOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DeleteOperator.java
@@ -154,7 +154,9 @@ public class DeleteOperator
 
         Collection<Slice> fragments = getFutureValue(finishFuture);
 
-        PageBuilder page = new PageBuilder(TYPES);
+        // output page will only be constructed once,
+        // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
+        PageBuilder page = new PageBuilder(fragments.size() + 1, TYPES);
         BlockBuilder rowsBuilder = page.getBlockBuilder(0);
         BlockBuilder fragmentBuilder = page.getBlockBuilder(1);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -506,7 +506,9 @@ public class HashAggregationOperator
                 .map(AccumulatorFactory::createAccumulator)
                 .collect(Collectors.toList());
 
-        PageBuilder output = new PageBuilder(types);
+        // global aggregation output page will only be constructed once,
+        // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
+        PageBuilder output = new PageBuilder(globalAggregationGroupIds.size(), types);
 
         for (int groupId : globalAggregationGroupIds) {
             output.declarePosition();

--- a/presto-main/src/main/java/com/facebook/presto/operator/MetadataDeleteOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MetadataDeleteOperator.java
@@ -134,7 +134,9 @@ public class MetadataDeleteOperator
 
         OptionalLong rowsDeletedCount = metadata.metadataDelete(session, tableHandle, tableLayout);
 
-        PageBuilder page = new PageBuilder(TYPES);
+        // output page will only be constructed once,
+        // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
+        PageBuilder page = new PageBuilder(1, TYPES);
         BlockBuilder rowsBuilder = page.getBlockBuilder(0);
         page.declarePosition();
         if (rowsDeletedCount.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableFinishOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableFinishOperator.java
@@ -148,7 +148,9 @@ public class TableFinishOperator
 
         outputMetadata = tableFinisher.finishTable(fragmentBuilder.build());
 
-        PageBuilder page = new PageBuilder(TYPES);
+        // output page will only be constructed once,
+        // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
+        PageBuilder page = new PageBuilder(1, TYPES);
         page.declarePosition();
         BIGINT.writeLong(page.getBlockBuilder(0), rowCount);
         return page.build();

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
@@ -219,7 +219,9 @@ public class TableWriterOperator
         committed = true;
         updateWrittenBytes();
 
-        PageBuilder page = new PageBuilder(TYPES);
+        // output page will only be constructed once,
+        // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
+        PageBuilder page = new PageBuilder(fragments.size() + 1, TYPES);
         BlockBuilder rowsBuilder = page.getBlockBuilder(0);
         BlockBuilder fragmentBuilder = page.getBlockBuilder(1);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshotBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSnapshotBuilder.java
@@ -32,6 +32,7 @@ import java.util.OptionalInt;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class IndexSnapshotBuilder
@@ -52,6 +53,8 @@ public class IndexSnapshotBuilder
 
     private final List<Page> pages = new ArrayList<>();
     private long memoryInBytes;
+
+    private PageBuilder missingKeysPageBuilder;
 
     public IndexSnapshotBuilder(List<Type> outputTypes,
             List<Integer> keyOutputChannels,
@@ -90,6 +93,8 @@ public class IndexSnapshotBuilder
         this.outputPagesIndex = pagesIndexFactory.newPagesIndex(outputTypes, expectedPositions);
         this.missingKeysIndex = pagesIndexFactory.newPagesIndex(missingKeysTypes.build(), expectedPositions);
         this.missingKeys = missingKeysIndex.createLookupSourceSupplier(session, this.missingKeysChannels).get();
+
+        this.missingKeysPageBuilder = new PageBuilder(missingKeysIndex.getTypes());
     }
 
     public List<Type> getOutputTypes()
@@ -129,7 +134,7 @@ public class IndexSnapshotBuilder
         LookupSource lookupSource = outputPagesIndex.createLookupSourceSupplier(session, keyOutputChannels, keyOutputHashChannel, Optional.empty(), Optional.empty(), ImmutableList.of()).get();
 
         // Build a page containing the keys that produced no output rows, so in future requests can skip these keys
-        PageBuilder missingKeysPageBuilder = new PageBuilder(missingKeysIndex.getTypes());
+        verify(missingKeysPageBuilder.isEmpty());
         UnloadedIndexKeyRecordCursor indexKeysRecordCursor = indexKeysRecordSet.cursor();
         while (indexKeysRecordCursor.advanceNextPosition()) {
             Page page = indexKeysRecordCursor.getPage();
@@ -144,6 +149,9 @@ public class IndexSnapshotBuilder
             }
         }
         Page missingKeysPage = missingKeysPageBuilder.build();
+        if (!missingKeysPageBuilder.isEmpty()) {
+            missingKeysPageBuilder.reset();
+        }
 
         memoryInBytes += missingKeysPage.getSizeInBytes();
         if (isMemoryExceeded()) {
@@ -151,7 +159,7 @@ public class IndexSnapshotBuilder
         }
 
         // only update missing keys if we have new missing keys
-        if (!missingKeysPageBuilder.isEmpty()) {
+        if (missingKeysPage.getPositionCount() != 0) {
             missingKeysIndex.addPage(missingKeysPage);
             missingKeys = missingKeysIndex.createLookupSourceSupplier(session, missingKeysChannels).get();
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
@@ -28,7 +28,11 @@ import static java.util.Objects.requireNonNull;
 
 public class PageBuilder
 {
-    private static final int DEFAULT_INITIAL_EXPECTED_ENTRIES = 1024;
+    // We choose default initial size to be 8 for PageBuilder and BlockBuilder
+    // so the underlying data is larger than the object overhead, and the size is power of 2.
+    //
+    // This could be any other small number.
+    private static final int DEFAULT_INITIAL_EXPECTED_ENTRIES = 8;
 
     private final BlockBuilder[] blockBuilders;
     private final List<Type> types;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
@@ -35,6 +35,16 @@ public class PageBuilder
     private PageBuilderStatus pageBuilderStatus;
     private int declaredPositions;
 
+    /**
+     * Create a PageBuilder with given types.
+     * <p>
+     * A PageBuilder instance created with this constructor has no estimation about bytes per entry,
+     * therefore it can resize frequently while appending new rows.
+     * <p>
+     * This constructor should only be used to get the initial PageBuilder.
+     * Once the PageBuilder is full use reset() or createPageBuilderLike() to create a new
+     * PageBuilder instance with its size estimated based on previous data.
+     */
     public PageBuilder(List<? extends Type> types)
     {
         this(DEFAULT_INITIAL_EXPECTED_ENTRIES, types);


### PR DESCRIPTION
PageBuilder constructor has no estimation about bytes per entry.
With the previous default initial expected entries set to 1024,
one could construct PageBuilder consumes too much memory when
the number of columns is huge, which is problematic.

As an concrete example, in PartitionedOutputOperator, the initial
memory holding by `pageBuilders` in constructor will be

```
partitionCount * columnCount * DEFAULT_INITIAL_EXPECTED_ENTRIES
    * sum(columnExpectedBytesPerEntry)
```

With hundreds of partitions and thousands of columns, a single
PartitionedOutputOperator can hold multiple GBs memory.

With PageBuilder constructor only being used to create
"seed" PageBuilder, a more conservative DEFAULT_INITIAL_EXPECTED_ENTRIES
can be used to avoid such issues. The penalty of resizing will only
affect the first PageBuilder.