### PR TITLE
Support LazyBlock in ColumnarArray/Map/Row

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/block/TestColumnarArray.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestColumnarArray.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.ColumnarArray;
 import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -70,6 +71,7 @@ public class TestColumnarArray
         assertColumnarArray(block, expectedValues);
         assertDictionaryBlock(block, expectedValues);
         assertRunLengthEncodedBlock(block, expectedValues);
+        assertLazyBlock(block, expectedValues);
 
         int offset = 1;
         int length = expectedValues.length - 2;
@@ -81,6 +83,7 @@ public class TestColumnarArray
         assertColumnarArray(blockRegion, expectedValuesRegion);
         assertDictionaryBlock(blockRegion, expectedValuesRegion);
         assertRunLengthEncodedBlock(blockRegion, expectedValuesRegion);
+        assertLazyBlock(block, expectedValues);
     }
 
     private static <T> void assertDictionaryBlock(Block block, T[] expectedValues)
@@ -102,6 +105,14 @@ public class TestColumnarArray
             assertBlock(runLengthEncodedBlock, expectedDictionaryValues);
             assertColumnarArray(runLengthEncodedBlock, expectedDictionaryValues);
         }
+    }
+
+    private static <T> void assertLazyBlock(Block block, T[] expectedValues)
+    {
+        LazyBlock lazyBlock = new LazyBlock(block.getPositionCount(), inputLazyBlock -> inputLazyBlock.setBlock(block));
+
+        assertBlock(lazyBlock, expectedValues);
+        assertColumnarArray(lazyBlock, expectedValues);
     }
 
     private static <T> void assertColumnarArray(Block block, T[] expectedValues)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestColumnarMap.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestColumnarMap.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.ColumnarMap;
 import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.MapBlockBuilder;
 import com.facebook.presto.spi.block.MethodHandleUtil;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
@@ -78,6 +79,7 @@ public class TestColumnarMap
         assertColumnarMap(block, expectedValues);
         assertDictionaryBlock(block, expectedValues);
         assertRunLengthEncodedBlock(block, expectedValues);
+        assertLazyBlock(block, expectedValues);
 
         int offset = 1;
         int length = expectedValues.length - 2;
@@ -89,6 +91,7 @@ public class TestColumnarMap
         assertColumnarMap(blockRegion, expectedValuesRegion);
         assertDictionaryBlock(blockRegion, expectedValuesRegion);
         assertRunLengthEncodedBlock(blockRegion, expectedValuesRegion);
+        assertLazyBlock(block, expectedValues);
     }
 
     private static void assertDictionaryBlock(Block block, Slice[][][] expectedValues)
@@ -110,6 +113,14 @@ public class TestColumnarMap
             assertBlock(runLengthEncodedBlock, expectedDictionaryValues);
             assertColumnarMap(runLengthEncodedBlock, expectedDictionaryValues);
         }
+    }
+
+    private static void assertLazyBlock(Block block, Slice[][][] expectedValues)
+    {
+        LazyBlock lazyBlock = new LazyBlock(block.getPositionCount(), inputLazyBlock -> inputLazyBlock.setBlock(block));
+
+        assertBlock(lazyBlock, expectedValues);
+        assertColumnarMap(lazyBlock, expectedValues);
     }
 
     private static void assertColumnarMap(Block block, Slice[][][] expectedValues)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestColumnarRow.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestColumnarRow.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.ColumnarRow;
 import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.RowBlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import io.airlift.slice.Slice;
@@ -73,6 +74,7 @@ public class TestColumnarRow
         assertColumnarRow(block, expectedValues);
         assertDictionaryBlock(block, expectedValues);
         assertRunLengthEncodedBlock(block, expectedValues);
+        assertLazyBlock(block, expectedValues);
 
         int offset = 1;
         int length = expectedValues.length - 2;
@@ -84,6 +86,7 @@ public class TestColumnarRow
         assertColumnarRow(blockRegion, expectedValuesRegion);
         assertDictionaryBlock(blockRegion, expectedValuesRegion);
         assertRunLengthEncodedBlock(blockRegion, expectedValuesRegion);
+        assertLazyBlock(blockRegion, expectedValuesRegion);
     }
 
     private static <T> void assertDictionaryBlock(Block block, T[] expectedValues)
@@ -94,6 +97,14 @@ public class TestColumnarRow
         assertBlock(dictionaryBlock, expectedDictionaryValues);
         assertColumnarRow(dictionaryBlock, expectedDictionaryValues);
         assertRunLengthEncodedBlock(dictionaryBlock, expectedDictionaryValues);
+    }
+
+    private static <T> void assertLazyBlock(Block block, T[] expectedValues)
+    {
+        LazyBlock lazyBlock = new LazyBlock(block.getPositionCount(), inputLazyBlock -> inputLazyBlock.setBlock(block));
+
+        assertBlock(lazyBlock, expectedValues);
+        assertColumnarRow(lazyBlock, expectedValues);
     }
 
     private static <T> void assertRunLengthEncodedBlock(Block block, T[] expectedValues)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarArray.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarArray.java
@@ -32,6 +32,13 @@ public class ColumnarArray
         if (block instanceof RunLengthEncodedBlock) {
             return toColumnarArray((RunLengthEncodedBlock) block);
         }
+        if (block instanceof LazyBlock) {
+            LazyBlock lazyBlock = (LazyBlock) block;
+            if (!lazyBlock.isLoaded()) {
+                throw new IllegalArgumentException("LazyBlock is expected to be loaded");
+            }
+            return toColumnarArray(lazyBlock.getBlock());
+        }
 
         if (!(block instanceof AbstractArrayBlock)) {
             throw new IllegalArgumentException("Invalid array block: " + block.getClass().getName());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarMap.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarMap.java
@@ -33,6 +33,13 @@ public class ColumnarMap
         if (block instanceof RunLengthEncodedBlock) {
             return toColumnarMap((RunLengthEncodedBlock) block);
         }
+        if (block instanceof LazyBlock) {
+            LazyBlock lazyBlock = (LazyBlock) block;
+            if (!lazyBlock.isLoaded()) {
+                throw new IllegalArgumentException("LazyBlock is expected to be loaded");
+            }
+            return toColumnarMap(lazyBlock.getBlock());
+        }
 
         if (!(block instanceof AbstractMapBlock)) {
             throw new IllegalArgumentException("Invalid map block: " + block.getClass().getName());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
@@ -30,6 +30,13 @@ public final class ColumnarRow
         if (block instanceof RunLengthEncodedBlock) {
             return toColumnarRow((RunLengthEncodedBlock) block);
         }
+        if (block instanceof LazyBlock) {
+            LazyBlock lazyBlock = (LazyBlock) block;
+            if (!lazyBlock.isLoaded()) {
+                throw new IllegalArgumentException("LazyBlock is expected to be loaded");
+            }
+            return toColumnarRow(lazyBlock.getBlock());
+        }
 
         if (!(block instanceof AbstractRowBlock)) {
             throw new IllegalArgumentException("Invalid row block: " + block.getClass().getName());


### PR DESCRIPTION
LazyBlock will be passed to the OrcWriter if the TableWriterOperator
is directly next to the TableScanOperator.

In the future, we should make operators not producing LazyBlocks
by explicitly unwrap them.