### PR TITLE
Check column access for view identities

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/LegacyAccessControl.java
@@ -158,11 +158,6 @@ public class LegacyAccessControl
     }
 
     @Override
-    public void checkCanSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
-    {
-    }
-
-    @Override
     public void checkCanInsertIntoTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {
     }
@@ -179,21 +174,6 @@ public class LegacyAccessControl
 
     @Override
     public void checkCanDropView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
-    {
-    }
-
-    @Override
-    public void checkCanSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
-    {
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
-    {
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
     {
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/PartitionsAwareAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/PartitionsAwareAccessControl.java
@@ -119,21 +119,17 @@ public class PartitionsAwareAccessControl
     @Override
     public void checkCanSelectFromColumns(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, Set<String> columnNames)
     {
-        delegate.checkCanSelectFromColumns(transactionHandle, identity, tableName, columnNames);
-    }
-    @Override
-    public void checkCanSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
-    {
         if (isPartitionsSystemTable(tableName)) {
             try {
-                checkCanSelectFromTable(transactionHandle, identity, getSourceTableNameForPartitionsTable(tableName));
+                checkCanSelectFromColumns(transactionHandle, identity, getSourceTableNameForPartitionsTable(tableName), columnNames);
                 return;
             }
             catch (AccessDeniedException e) {
                 denySelectTable(tableName.toString());
             }
         }
-        delegate.checkCanSelectFromTable(transactionHandle, identity, tableName);
+
+        delegate.checkCanSelectFromColumns(transactionHandle, identity, tableName, columnNames);
     }
 
     @Override
@@ -158,24 +154,6 @@ public class PartitionsAwareAccessControl
     public void checkCanDropView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
     {
         delegate.checkCanDropView(transactionHandle, identity, viewName);
-    }
-
-    @Override
-    public void checkCanSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
-    {
-        delegate.checkCanSelectFromView(transactionHandle, identity, viewName);
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
-    {
-        delegate.checkCanCreateViewWithSelectFromTable(transactionHandle, identity, tableName);
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
-    {
-        delegate.checkCanCreateViewWithSelectFromView(transactionHandle, identity, viewName);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
@@ -54,7 +54,6 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameS
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
-import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static java.util.Objects.requireNonNull;
 
@@ -177,14 +176,9 @@ public class SqlStandardAccessControl
     }
 
     @Override
-    public void checkCanSelectFromColumns(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, Set<String> columnNames)
+    public void checkCanSelectFromColumns(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName, Set<String> columnNames)
     {
-        // TODO
-    }
-
-    @Override
-    public void checkCanSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
-    {
+        // TODO: Implement column level access control
         if (!checkTablePermission(transaction, identity, tableName, SELECT)) {
             denySelectTable(tableName.toString());
         }
@@ -223,39 +217,15 @@ public class SqlStandardAccessControl
     }
 
     @Override
-    public void checkCanSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName, Set<String> columnNames)
     {
-        if (!checkTablePermission(transaction, identity, viewName, SELECT)) {
-            denySelectView(viewName.toString());
-        }
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
-    {
+        // TODO implement column level access control
         if (!checkTablePermission(transaction, identity, tableName, SELECT)) {
             denySelectTable(tableName.toString());
         }
-        else if (!getGrantOptionForPrivilege(transaction, identity, Privilege.SELECT, tableName)) {
+        if (!getGrantOptionForPrivilege(transaction, identity, Privilege.SELECT, tableName)) {
             denyCreateViewWithSelect(tableName.toString());
         }
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
-    {
-        if (!checkTablePermission(transaction, identity, viewName, SELECT)) {
-            denySelectView(viewName.toString());
-        }
-        if (!getGrantOptionForPrivilege(transaction, identity, Privilege.SELECT, viewName)) {
-            denyCreateViewWithSelect(viewName.toString());
-        }
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromColumns(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName, Set<String> columnNames)
-    {
-        // TODO
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/SqlStandardAccessControl.java
@@ -224,7 +224,7 @@ public class SqlStandardAccessControl
             denySelectTable(tableName.toString());
         }
         if (!getGrantOptionForPrivilege(transaction, identity, Privilege.SELECT, tableName)) {
-            denyCreateViewWithSelect(tableName.toString());
+            denyCreateViewWithSelect(tableName.toString(), identity);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/security/TestPartitionsAwareAccessControl.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/security/TestPartitionsAwareAccessControl.java
@@ -34,7 +34,7 @@ public class TestPartitionsAwareAccessControl
     {
         for (Method interfaceMethod : interfaceClass.getMethods()) {
             Method implementationMethod = implementationClass.getMethod(interfaceMethod.getName(), interfaceMethod.getParameterTypes());
-            if (interfaceMethod.equals(implementationMethod)) {
+            if (interfaceMethod.equals(implementationMethod) && interfaceMethod.getAnnotation(Deprecated.class) == null) {
                 throw new AssertionError(format(
                         "Method should be overridden in %s: %s",
                         implementationClass,

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.transaction.TransactionId;
+import com.google.common.collect.ImmutableSet;
 
 import java.security.Principal;
 import java.util.Set;
@@ -141,8 +142,13 @@ public interface AccessControl
      * Check if identity is allowed to select from the specified table.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanSelectFromColumns} instead
      */
-    void checkCanSelectFromTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName);
+    @Deprecated
+    default void checkCanSelectFromTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName)
+    {
+        checkCanSelectFromColumns(transactionId, identity, tableName, ImmutableSet.of());
+    }
 
     /**
      * Check if identity is allowed to insert into the specified table.
@@ -176,22 +182,37 @@ public interface AccessControl
      * Check if identity is allowed to select from the specified view.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanSelectFromColumns} instead
      */
-    void checkCanSelectFromView(TransactionId transactionId, Identity identity, QualifiedObjectName viewName);
+    @Deprecated
+    default void checkCanSelectFromView(TransactionId transactionId, Identity identity, QualifiedObjectName viewName)
+    {
+        checkCanSelectFromColumns(transactionId, identity, viewName, ImmutableSet.of());
+    }
 
     /**
      * Check if identity is allowed to create a view that selects from the specified table.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanCreateViewWithSelectFromColumns} instead
      */
-    void checkCanCreateViewWithSelectFromTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName);
+    @Deprecated
+    default void checkCanCreateViewWithSelectFromTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName)
+    {
+        checkCanCreateViewWithSelectFromColumns(transactionId, identity, tableName, ImmutableSet.of());
+    }
 
     /**
      * Check if identity is allowed to create a view that selects from the specified view.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanCreateViewWithSelectFromColumns} instead
      */
-    void checkCanCreateViewWithSelectFromView(TransactionId transactionId, Identity identity, QualifiedObjectName viewName);
+    @Deprecated
+    default void checkCanCreateViewWithSelectFromView(TransactionId transactionId, Identity identity, QualifiedObjectName viewName)
+    {
+        checkCanCreateViewWithSelectFromColumns(transactionId, identity, viewName, ImmutableSet.of());
+    }
 
     /**
      * Check if identity is allowed to create a view that selects from the specified columns.

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -195,6 +195,7 @@ public interface AccessControl
 
     /**
      * Check if identity is allowed to create a view that selects from the specified columns.
+     * If this is implemented, checkCanCreateViewWithSelectFromTable and checkCanCreateViewWithSelectFromView can be pass-through.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
@@ -147,11 +147,6 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
-    public void checkCanSelectFromTable(Identity identity, CatalogSchemaTableName table)
-    {
-    }
-
-    @Override
     public void checkCanInsertIntoTable(Identity identity, CatalogSchemaTableName table)
     {
     }
@@ -172,22 +167,7 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
-    public void checkCanSelectFromView(Identity identity, CatalogSchemaTableName view)
-    {
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromTable(Identity identity, CatalogSchemaTableName table)
-    {
-    }
-
-    @Override
     public void checkCanCreateViewWithSelectFromColumns(Identity identity, CatalogSchemaTableName table, Set<String> columns)
-    {
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromView(Identity identity, CatalogSchemaTableName view)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -194,7 +194,7 @@ public class DenyAllAccessControl
     @Override
     public void checkCanCreateViewWithSelectFromColumns(TransactionId transactionId, Identity identity, QualifiedObjectName tableName, Set<String> columnNames)
     {
-        denyCreateViewWithSelect(tableName.toString());
+        denyCreateViewWithSelect(tableName.toString(), identity);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -42,8 +42,6 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameS
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectColumns;
-import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
-import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetSystemSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetUser;
@@ -152,7 +150,6 @@ public class DenyAllAccessControl
     @Override
     public void checkCanSelectFromTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName)
     {
-        denySelectTable(tableName.toString());
     }
 
     @Override
@@ -182,19 +179,16 @@ public class DenyAllAccessControl
     @Override
     public void checkCanSelectFromView(TransactionId transactionId, Identity identity, QualifiedObjectName viewName)
     {
-        denySelectView(viewName.toString());
     }
 
     @Override
     public void checkCanCreateViewWithSelectFromTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName)
     {
-        denyCreateViewWithSelect(tableName.toString());
     }
 
     @Override
     public void checkCanCreateViewWithSelectFromView(TransactionId transactionId, Identity identity, QualifiedObjectName viewName)
     {
-        denyCreateViewWithSelect(viewName.toString());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
@@ -247,11 +247,6 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkCanSelectFromTable(Identity identity, CatalogSchemaTableName table)
-    {
-    }
-
-    @Override
     public void checkCanInsertIntoTable(Identity identity, CatalogSchemaTableName table)
     {
     }
@@ -268,21 +263,6 @@ public class FileBasedSystemAccessControl
 
     @Override
     public void checkCanDropView(Identity identity, CatalogSchemaTableName view)
-    {
-    }
-
-    @Override
-    public void checkCanSelectFromView(Identity identity, CatalogSchemaTableName view)
-    {
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromTable(Identity identity, CatalogSchemaTableName table)
-    {
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromView(Identity identity, CatalogSchemaTableName view)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
@@ -73,26 +73,7 @@ public class ReadOnlySystemAccessControl
     }
 
     @Override
-    public void checkCanSelectFromTable(Identity identity, CatalogSchemaTableName table)
-    {
-    }
-
-    @Override
-    public void checkCanSelectFromView(Identity identity, CatalogSchemaTableName view)
-    {
-    }
-
-    @Override
     public void checkCanSetCatalogSessionProperty(Identity identity, String catalogName, String propertyName)
-    {
-    }
-    @Override
-    public void checkCanCreateViewWithSelectFromTable(Identity identity, CatalogSchemaTableName table)
-    {
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromView(Identity identity, CatalogSchemaTableName view)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -24,7 +24,6 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupingOperation;
 import com.facebook.presto.sql.tree.Statement;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import java.util.List;
@@ -73,12 +72,13 @@ public class Analyzer
         analyzer.analyze(rewrittenStatement, Optional.empty());
 
         // check column access permissions for each table
-        analysis.getTableColumnReferences(session.getIdentity())
-                .forEach((tableName, columns) ->
-                        accessControl.checkCanSelectFromColumns(session.getRequiredTransactionId(),
-                                session.getIdentity(),
+        analysis.getTableColumnReferences().forEach((accessControlInfo, tableColumnReferences) ->
+                tableColumnReferences.forEach((tableName, columns) ->
+                        accessControlInfo.getAccessControl().checkCanSelectFromColumns(
+                                session.getRequiredTransactionId(),
+                                accessControlInfo.getIdentity(),
                                 tableName,
-                                ImmutableSet.copyOf(columns)));
+                                columns)));
         return analysis;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1559,7 +1559,7 @@ public class ExpressionAnalyzer
         analysis.addFunctionSignatures(resolvedFunctions);
         analysis.addColumnReferences(analyzer.getColumnReferences());
         analysis.addLambdaArgumentReferences(analyzer.getLambdaArgumentReferences());
-        analysis.addTableColumnReferences(session.getIdentity(), analyzer.getTableColumnReferences());
+        analysis.addTableColumnReferences(accessControl, session.getIdentity(), analyzer.getTableColumnReferences());
 
         return new ExpressionAnalysis(
                 expressionTypes,

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -778,7 +778,7 @@ class StatementAnalyzer
             }
 
             QualifiedObjectName name = createQualifiedObjectName(session, table, table.getName());
-            analysis.addEmptyColumnReferencesForTable(session.getIdentity(), name);
+            analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), name);
 
             Optional<ViewDefinition> optionalView = metadata.getView(session, name);
             if (optionalView.isPresent()) {
@@ -2134,7 +2134,8 @@ class StatementAnalyzer
 
                 ExpressionAnalysis expressionAnalysis = ExpressionAnalyzer.analyzeExpression(session,
                         metadata,
-                        accessControl, sqlParser,
+                        accessControl,
+                        sqlParser,
                         orderByScope,
                         analysis,
                         expression);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -391,7 +391,7 @@ class StatementAnalyzer
                     session);
 
             Scope tableScope = analyzer.analyze(table, scope);
-            node.getWhere().ifPresent(where -> analyzer.analyzeWhere(node, tableScope, where));
+            node.getWhere().ifPresent(where -> analyzeWhere(node, tableScope, where));
 
             analysis.setUpdateType("DELETE");
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
@@ -35,6 +35,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColu
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateSchema;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateViewWithSelect;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDeleteTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDropColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyDropSchema;
@@ -291,7 +292,7 @@ public class TestingAccessControlManager
     public void checkCanCreateViewWithSelectFromTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName)
     {
         if (shouldDenyPrivilege(identity.getUser(), tableName.getObjectName(), CREATE_VIEW_WITH_SELECT_TABLE)) {
-            denySelectTable(tableName.toString());
+            denyCreateViewWithSelect(tableName.toString());
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanCreateViewWithSelectFromTable(transactionId, identity, tableName);
@@ -302,7 +303,7 @@ public class TestingAccessControlManager
     public void checkCanCreateViewWithSelectFromView(TransactionId transactionId, Identity identity, QualifiedObjectName viewName)
     {
         if (shouldDenyPrivilege(identity.getUser(), viewName.getObjectName(), CREATE_VIEW_WITH_SELECT_VIEW)) {
-            denySelectView(viewName.toString());
+            denyCreateViewWithSelect(viewName.toString());
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanCreateViewWithSelectFromView(transactionId, identity, viewName);
@@ -313,7 +314,7 @@ public class TestingAccessControlManager
     public void checkCanCreateViewWithSelectFromColumns(TransactionId transactionId, Identity identity, QualifiedObjectName tableName, Set<String> columnNames)
     {
         if (shouldDenyPrivilege(identity.getUser(), tableName.getObjectName(), CREATE_VIEW_WITH_SELECT_COLUMNS)) {
-            denySelectView(tableName.toString());
+            denyCreateViewWithSelect(tableName.toString());
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanCreateViewWithSelectFromColumns(transactionId, identity, tableName, columnNames);

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
@@ -292,7 +292,7 @@ public class TestingAccessControlManager
     public void checkCanCreateViewWithSelectFromTable(TransactionId transactionId, Identity identity, QualifiedObjectName tableName)
     {
         if (shouldDenyPrivilege(identity.getUser(), tableName.getObjectName(), CREATE_VIEW_WITH_SELECT_TABLE)) {
-            denyCreateViewWithSelect(tableName.toString());
+            denyCreateViewWithSelect(tableName.toString(), identity);
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanCreateViewWithSelectFromTable(transactionId, identity, tableName);
@@ -303,7 +303,7 @@ public class TestingAccessControlManager
     public void checkCanCreateViewWithSelectFromView(TransactionId transactionId, Identity identity, QualifiedObjectName viewName)
     {
         if (shouldDenyPrivilege(identity.getUser(), viewName.getObjectName(), CREATE_VIEW_WITH_SELECT_VIEW)) {
-            denyCreateViewWithSelect(viewName.toString());
+            denyCreateViewWithSelect(viewName.toString(), identity);
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanCreateViewWithSelectFromView(transactionId, identity, viewName);
@@ -314,7 +314,7 @@ public class TestingAccessControlManager
     public void checkCanCreateViewWithSelectFromColumns(TransactionId transactionId, Identity identity, QualifiedObjectName tableName, Set<String> columnNames)
     {
         if (shouldDenyPrivilege(identity.getUser(), tableName.getObjectName(), CREATE_VIEW_WITH_SELECT_COLUMNS)) {
-            denyCreateViewWithSelect(tableName.toString());
+            denyCreateViewWithSelect(tableName.toString(), identity);
         }
         if (denyPrivileges.isEmpty()) {
             super.checkCanCreateViewWithSelectFromColumns(transactionId, identity, tableName, columnNames);

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -147,7 +147,7 @@ public class TestAccessControlManager
                 });
     }
 
-    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Access Denied: Cannot select from table schema.table")
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Access Denied: Cannot select from columns \\[\\] in table or view schema.table")
     public void testDenyCatalogAccessControl()
     {
         CatalogManager catalogManager = new CatalogManager();
@@ -271,7 +271,7 @@ public class TestAccessControlManager
                 }
 
                 @Override
-                public void checkCanSelectFromTable(Identity identity, CatalogSchemaTableName table)
+                public void checkCanSelectFromColumns(Identity identity, CatalogSchemaTableName table, Set<String> columns)
                 {
                     if (table.getCatalogName().equals("secured_catalog")) {
                         denySelectTable(table.toString());
@@ -290,12 +290,6 @@ public class TestAccessControlManager
     private static class DenyConnectorAccessControl
             implements ConnectorAccessControl
     {
-        @Override
-        public void checkCanSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
-        {
-            denySelectTable(tableName.toString());
-        }
-
         @Override
         public void checkCanSelectFromColumns(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, Set<String> columnNames)
         {
@@ -376,24 +370,6 @@ public class TestAccessControlManager
 
         @Override
         public void checkCanDropView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void checkCanSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
@@ -82,11 +82,6 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public void checkCanSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
-    {
-    }
-
-    @Override
     public void checkCanInsertIntoTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {
     }
@@ -103,21 +98,6 @@ public class AllowAllAccessControl
 
     @Override
     public void checkCanDropView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
-    {
-    }
-
-    @Override
-    public void checkCanSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
-    {
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
-    {
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
     {
     }
 

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
@@ -191,7 +191,7 @@ public class FileBasedAccessControl
             denySelectTable(tableName.toString());
         }
         if (!checkTablePermission(identity, tableName, GRANT_SELECT)) {
-            denyCreateViewWithSelect(tableName.toString());
+            denyCreateViewWithSelect(tableName.toString(), identity);
         }
     }
 

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
@@ -51,7 +51,6 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameC
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
-import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 
 public class FileBasedAccessControl
         implements ConnectorAccessControl
@@ -146,12 +145,7 @@ public class FileBasedAccessControl
     @Override
     public void checkCanSelectFromColumns(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, Set<String> columnNames)
     {
-        // allow - Column level privileges not yet implemented
-    }
-
-    @Override
-    public void checkCanSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
-    {
+        // TODO: Implement column level permissions
         if (!checkTablePermission(identity, tableName, SELECT)) {
             denySelectTable(tableName.toString());
         }
@@ -190,39 +184,15 @@ public class FileBasedAccessControl
     }
 
     @Override
-    public void checkCanSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
+    public void checkCanCreateViewWithSelectFromColumns(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, Set<String> columnNames)
     {
-        if (!checkTablePermission(identity, viewName, SELECT)) {
-            denySelectView(viewName.toString());
-        }
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
-    {
+        // TODO: implement column level permissions
         if (!checkTablePermission(identity, tableName, SELECT)) {
             denySelectTable(tableName.toString());
         }
         if (!checkTablePermission(identity, tableName, GRANT_SELECT)) {
             denyCreateViewWithSelect(tableName.toString());
         }
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
-    {
-        if (!checkTablePermission(identity, viewName, SELECT)) {
-            denySelectView(viewName.toString());
-        }
-        if (!checkTablePermission(identity, viewName, GRANT_SELECT)) {
-            denyCreateViewWithSelect(viewName.toString());
-        }
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromColumns(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, Set<String> columnNames)
-    {
-        // allow - Column level privileges not yet implemented
     }
 
     @Override

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ReadOnlyAccessControl.java
@@ -102,12 +102,6 @@ public class ReadOnlyAccessControl
     }
 
     @Override
-    public void checkCanSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
-    {
-        // allow
-    }
-
-    @Override
     public void checkCanInsertIntoTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
     {
         denyInsertTable(tableName.toString());
@@ -129,24 +123,6 @@ public class ReadOnlyAccessControl
     public void checkCanDropView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
     {
         denyDropView(viewName.toString());
-    }
-
-    @Override
-    public void checkCanSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
-    {
-        // allow
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName tableName)
-    {
-        // allow
-    }
-
-    @Override
-    public void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transaction, Identity identity, SchemaTableName viewName)
-    {
-        // allow
     }
 
     @Override

--- a/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
@@ -48,23 +48,21 @@ public class TestFileBasedAccessControl
             throws IOException
     {
         ConnectorAccessControl accessControl = createAccessControl("table.json");
-        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("alice"), new SchemaTableName("test", "test"));
-        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("alice"), new SchemaTableName("bobschema", "bobtable"));
+        accessControl.checkCanSelectFromColumns(TRANSACTION_HANDLE, user("alice"), new SchemaTableName("test", "test"), ImmutableSet.of());
+        accessControl.checkCanSelectFromColumns(TRANSACTION_HANDLE, user("alice"), new SchemaTableName("bobschema", "bobtable"), ImmutableSet.of());
         accessControl.checkCanSelectFromColumns(TRANSACTION_HANDLE, user("alice"), new SchemaTableName("bobschema", "bobtable"), ImmutableSet.of("bobcolumn"));
-        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
+        accessControl.checkCanSelectFromColumns(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"), ImmutableSet.of());
         accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
         accessControl.checkCanDeleteFromTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
-        accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("joe"), new SchemaTableName("bobschema", "bobtable"));
-        accessControl.checkCanCreateViewWithSelectFromTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
-        accessControl.checkCanCreateViewWithSelectFromView(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"));
+        accessControl.checkCanSelectFromColumns(TRANSACTION_HANDLE, user("joe"), new SchemaTableName("bobschema", "bobtable"), ImmutableSet.of());
+        accessControl.checkCanCreateViewWithSelectFromColumns(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable"), ImmutableSet.of());
         accessControl.checkCanDropTable(TRANSACTION_HANDLE, user("admin"), new SchemaTableName("bobschema", "bobtable"));
         assertDenied(() -> accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, user("alice"), new SchemaTableName("bobschema", "bobtable")));
         assertDenied(() -> accessControl.checkCanDropTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bobschema", "bobtable")));
         assertDenied(() -> accessControl.checkCanInsertIntoTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("test", "test")));
-        assertDenied(() -> accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("admin"), new SchemaTableName("secret", "secret")));
-        assertDenied(() -> accessControl.checkCanSelectFromTable(TRANSACTION_HANDLE, user("joe"), new SchemaTableName("secret", "secret")));
-        assertDenied(() -> accessControl.checkCanCreateViewWithSelectFromTable(TRANSACTION_HANDLE, user("joe"), new SchemaTableName("bobschema", "bobtable")));
-        assertDenied(() -> accessControl.checkCanCreateViewWithSelectFromView(TRANSACTION_HANDLE, user("joe"), new SchemaTableName("bobschema", "bobtable")));
+        assertDenied(() -> accessControl.checkCanSelectFromColumns(TRANSACTION_HANDLE, user("admin"), new SchemaTableName("secret", "secret"), ImmutableSet.of()));
+        assertDenied(() -> accessControl.checkCanSelectFromColumns(TRANSACTION_HANDLE, user("joe"), new SchemaTableName("secret", "secret"), ImmutableSet.of()));
+        assertDenied(() -> accessControl.checkCanCreateViewWithSelectFromColumns(TRANSACTION_HANDLE, user("joe"), new SchemaTableName("bobschema", "bobtable"), ImmutableSet.of()));
     }
 
     @Test

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSqlStandardAccessControlChecks.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSqlStandardAccessControlChecks.java
@@ -149,7 +149,7 @@ public class TestSqlStandardAccessControlChecks
 
         // Charlie still cannot access view because Bob does not have SELECT WITH GRANT OPTION
         assertThat(() -> charlieExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
-                .failsWithMessage(format("Access Denied: Cannot create view that selects from default.%s", tableName));
+                .failsWithMessage(format("Access Denied: View owner 'bob' cannot create view that selects from default.%s", tableName));
 
         // Give Bob SELECT WITH GRANT OPTION on the underlying table
         aliceExecutor.executeQuery(format("REVOKE SELECT ON %s FROM bob", tableName));

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSqlStandardAccessControlChecks.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSqlStandardAccessControlChecks.java
@@ -144,7 +144,7 @@ public class TestSqlStandardAccessControlChecks
 
         // Verify that Charlie does not have SELECT on the view, then grant access
         assertThat(() -> charlieExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
-                .failsWithMessage(format("Access Denied: Cannot select from view default.%s", viewName));
+                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", viewName));
         bobExecutor.executeQuery(format("GRANT SELECT ON %s TO charlie", viewName));
 
         // Charlie still cannot access view because Bob does not have SELECT WITH GRANT OPTION

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
@@ -283,7 +283,7 @@ public interface ConnectorAccessControl
      */
     default void checkCanCreateViewWithSelectFromColumns(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName, Set<String> columnNames)
     {
-        denyCreateViewWithSelect(tableName.toString());
+        denyCreateViewWithSelect(tableName.toString(), identity);
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorAccessControl.java
@@ -17,7 +17,6 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.Privilege;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
@@ -37,11 +36,10 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameS
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectColumns;
-import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
-import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTablesMetadata;
+import static java.util.Collections.emptySet;
 
 public interface ConnectorAccessControl
 {
@@ -94,7 +92,7 @@ public interface ConnectorAccessControl
      */
     default Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
     {
-        return Collections.emptySet();
+        return emptySet();
     }
 
     /**
@@ -146,7 +144,7 @@ public interface ConnectorAccessControl
      */
     default Set<SchemaTableName> filterTables(ConnectorTransactionHandle transactionHandle, Identity identity, Set<SchemaTableName> tableNames)
     {
-        return Collections.emptySet();
+        return emptySet();
     }
 
     /**
@@ -194,10 +192,12 @@ public interface ConnectorAccessControl
      * Check if identity is allowed to select from the specified table in this catalog.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanSelectFromColumns} instead
      */
+    @Deprecated
     default void checkCanSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
     {
-        denySelectTable(tableName.toString());
+        checkCanSelectFromColumns(transactionHandle, identity, tableName, emptySet());
     }
 
     /**
@@ -244,30 +244,36 @@ public interface ConnectorAccessControl
      * Check if identity is allowed to select from the specified view in this catalog.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanSelectFromColumns} instead
      */
+    @Deprecated
     default void checkCanSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
     {
-        denySelectView(viewName.toString());
+        checkCanSelectFromColumns(transactionHandle, identity, viewName, emptySet());
     }
 
     /**
      * Check if identity is allowed to create the specified view that selects from the specified table in this catalog.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanCreateViewWithSelectFromColumns} instead
      */
+    @Deprecated
     default void checkCanCreateViewWithSelectFromTable(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName tableName)
     {
-        denyCreateViewWithSelect(tableName.toString());
+        checkCanCreateViewWithSelectFromColumns(transactionHandle, identity, tableName, emptySet());
     }
 
     /**
      * Check if identity is allowed to create a view that selects from the specified view in this catalog.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanCreateViewWithSelectFromColumns} instead
      */
+    @Deprecated
     default void checkCanCreateViewWithSelectFromView(ConnectorTransactionHandle transactionHandle, Identity identity, SchemaTableName viewName)
     {
-        denyCreateViewWithSelect(viewName.toString());
+        checkCanCreateViewWithSelectFromColumns(transactionHandle, identity, viewName, emptySet());
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
@@ -199,14 +199,14 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot create view %s%s", viewName, formatExtraInfo(extraInfo)));
     }
 
-    public static void denyCreateViewWithSelect(String sourceName)
+    public static void denyCreateViewWithSelect(String sourceName, Identity identity)
     {
-        denyCreateViewWithSelect(sourceName, null);
+        denyCreateViewWithSelect(sourceName, identity, null);
     }
 
-    public static void denyCreateViewWithSelect(String sourceName, String extraInfo)
+    public static void denyCreateViewWithSelect(String sourceName, Identity identity, String extraInfo)
     {
-        throw new AccessDeniedException(format("Cannot create view that selects from %s%s", sourceName, formatExtraInfo(extraInfo)));
+        throw new AccessDeniedException(format("View owner '%s' cannot create view that selects from %s%s", identity.getUser(), sourceName, formatExtraInfo(extraInfo)));
     }
 
     public static void denyDropView(String viewName)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.SchemaTableName;
 
 import java.security.Principal;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
@@ -39,8 +40,6 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameS
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectColumns;
-import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
-import static com.facebook.presto.spi.security.AccessDeniedException.denySelectView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowSchemas;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowTablesMetadata;
@@ -228,10 +227,12 @@ public interface SystemAccessControl
      * Check if identity is allowed to select from the specified table in a catalog.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanSelectFromColumns} instead
      */
+    @Deprecated
     default void checkCanSelectFromTable(Identity identity, CatalogSchemaTableName table)
     {
-        denySelectTable(table.toString());
+        checkCanSelectFromColumns(identity, table, new HashSet<>());
     }
 
     /**
@@ -278,30 +279,36 @@ public interface SystemAccessControl
      * Check if identity is allowed to select from the specified view in a catalog.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanSelectFromColumns} instead
      */
+    @Deprecated
     default void checkCanSelectFromView(Identity identity, CatalogSchemaTableName view)
     {
-        denySelectView(view.toString());
+        checkCanSelectFromColumns(identity, view, new HashSet<>());
     }
 
     /**
      * Check if identity is allowed to create a view that selects from the specified table in a catalog.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanCreateViewWithSelectFromColumns} instead
      */
+    @Deprecated
     default void checkCanCreateViewWithSelectFromTable(Identity identity, CatalogSchemaTableName table)
     {
-        denyCreateViewWithSelect(table.toString());
+        checkCanCreateViewWithSelectFromColumns(identity, table, new HashSet<>());
     }
 
     /**
      * Check if identity is allowed to create a view that selects from the specified view in a catalog.
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
+     * @deprecated Use {@link #checkCanCreateViewWithSelectFromColumns} instead
      */
+    @Deprecated
     default void checkCanCreateViewWithSelectFromView(Identity identity, CatalogSchemaTableName view)
     {
-        denyCreateViewWithSelect(view.toString());
+        checkCanCreateViewWithSelectFromColumns(identity, view, new HashSet<>());
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -318,7 +318,7 @@ public interface SystemAccessControl
      */
     default void checkCanCreateViewWithSelectFromColumns(Identity identity, CatalogSchemaTableName table, Set<String> columns)
     {
-        denyCreateViewWithSelect(table.toString());
+        denyCreateViewWithSelect(table.toString(), identity);
     }
 
     /**

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -898,7 +898,7 @@ public abstract class AbstractTestDistributedQueries
         // verify selecting from a view over a table requires the view owner to have special view creation privileges for the table
         assertAccessDenied(
                 "SELECT * FROM test_view_access",
-                "Cannot create view that selects from .*.orders.*",
+                "View owner 'test_view_access_owner' cannot create view that selects from .*.orders.*",
                 privilege(viewOwnerSession.getUser(), "orders", CREATE_VIEW_WITH_SELECT_TABLE));
 
         // verify the view owner can select from the view even without special view creation privileges
@@ -930,7 +930,7 @@ public abstract class AbstractTestDistributedQueries
         // verify selecting from a view over a view requires the view owner of the outer view to have special view creation privileges for the inner view
         assertAccessDenied(
                 "SELECT * FROM test_nested_view_access",
-                "Cannot create view that selects from .*.test_view_access.*",
+                "View owner 'test_nested_view_access_owner' cannot create view that selects from .*.test_view_access.*",
                 privilege(nestedViewOwnerSession.getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
 
         // verify selecting from a view over a view does not require the session user to have SELECT privileges for the inner view
@@ -965,7 +965,7 @@ public abstract class AbstractTestDistributedQueries
         // verify selecting from a view over a table requires the view owner to have special view creation privileges for the table
         assertAccessDenied(
                 "SELECT * FROM test_view_access",
-                "Cannot create view that selects from .*.orders.*",
+                "View owner 'test_view_access_owner' cannot create view that selects from .*.orders.*",
                 privilege(viewOwnerSession.getUser(), "orders", CREATE_VIEW_WITH_SELECT_COLUMNS));
 
         // verify the view owner can select from the view even without special view creation privileges
@@ -997,7 +997,7 @@ public abstract class AbstractTestDistributedQueries
         // verify selecting from a view over a view requires the view owner of the outer view to have special view creation privileges for the inner view
         assertAccessDenied(
                 "SELECT * FROM test_nested_view_access",
-                "Cannot create view that selects from .*.test_view_access.*",
+                "View owner 'test_nested_view_access_owner' cannot create view that selects from .*.test_view_access.*",
                 privilege(nestedViewOwnerSession.getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_COLUMNS));
 
         // verify selecting from a view over a view does not require the session user to have SELECT privileges for the inner view

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -589,6 +589,10 @@ public abstract class AbstractTestDistributedQueries
         assertExplainAnalyze("EXPLAIN ANALYZE DELETE FROM analyze_test WHERE TRUE");
         assertQuery("SELECT COUNT(*) from analyze_test", "SELECT 0");
         assertUpdate("DROP TABLE analyze_test");
+
+        // Test DELETE access control
+        assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
+        assertAccessAllowed("DELETE FROM test_delete", privilege("orders", SELECT_COLUMN));
     }
 
     @Test
@@ -873,7 +877,7 @@ public abstract class AbstractTestDistributedQueries
     }
 
     @Test
-    public void testViewAccessControl()
+    public void testTableLevelViewAccessControl()
     {
         skipTestUnless(supportsViews());
 
@@ -892,7 +896,7 @@ public abstract class AbstractTestDistributedQueries
         // verify selecting from a view over a table requires the view owner to have special view creation privileges for the table
         assertAccessDenied(
                 "SELECT * FROM test_view_access",
-                "Cannot select from table .*.orders.*",
+                "Cannot create view that selects from .*.orders.*",
                 privilege(viewOwnerSession.getUser(), "orders", CREATE_VIEW_WITH_SELECT_TABLE));
 
         // verify the view owner can select from the view even without special view creation privileges
@@ -908,6 +912,67 @@ public abstract class AbstractTestDistributedQueries
         assertAccessAllowed(
                 "SELECT * FROM test_view_access",
                 privilege(getSession().getUser(), "orders", SELECT_TABLE));
+
+        Session nestedViewOwnerSession = TestingSession.testSessionBuilder()
+                .setIdentity(new Identity("test_nested_view_access_owner", Optional.empty()))
+                .setCatalog(getSession().getCatalog().get())
+                .setSchema(getSession().getSchema().get())
+                .build();
+
+        // view creation permissions are only checked at query time, not at creation
+        assertAccessAllowed(
+                nestedViewOwnerSession,
+                "CREATE VIEW test_nested_view_access AS SELECT * FROM test_view_access",
+                privilege("test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
+
+        // verify selecting from a view over a view requires the view owner of the outer view to have special view creation privileges for the inner view
+        assertAccessDenied(
+                "SELECT * FROM test_nested_view_access",
+                "Cannot create view that selects from .*.test_view_access.*",
+                privilege(nestedViewOwnerSession.getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
+
+        // verify selecting from a view over a view does not require the session user to have SELECT privileges for the inner view
+        assertAccessAllowed(
+                "SELECT * FROM test_nested_view_access",
+                privilege(getSession().getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
+        assertAccessAllowed(
+                "SELECT * FROM test_nested_view_access",
+                privilege(getSession().getUser(), "test_view_access", SELECT_VIEW));
+
+        assertAccessAllowed(nestedViewOwnerSession, "DROP VIEW test_nested_view_access");
+        assertAccessAllowed(viewOwnerSession, "DROP VIEW test_view_access");
+    }
+
+    @Test
+    public void testColumnLevelViewAccessControl()
+    {
+        skipTestUnless(supportsViews());
+
+        Session viewOwnerSession = TestingSession.testSessionBuilder()
+                .setIdentity(new Identity("test_view_access_owner", Optional.empty()))
+                .setCatalog(getSession().getCatalog().get())
+                .setSchema(getSession().getSchema().get())
+                .build();
+
+        // view creation permissions are only checked at query time, not at creation
+        assertAccessAllowed(
+                viewOwnerSession,
+                "CREATE VIEW test_view_access AS SELECT * FROM orders",
+                privilege("orders", CREATE_VIEW_WITH_SELECT_COLUMNS));
+
+        // verify selecting from a view over a table requires the view owner to have special view creation privileges for the table
+        assertAccessDenied(
+                "SELECT * FROM test_view_access",
+                "Cannot create view that selects from .*.orders.*",
+                privilege(viewOwnerSession.getUser(), "orders", CREATE_VIEW_WITH_SELECT_COLUMNS));
+
+        // verify the view owner can select from the view even without special view creation privileges
+        assertAccessAllowed(
+                viewOwnerSession,
+                "SELECT * FROM test_view_access",
+                privilege(viewOwnerSession.getUser(), "orders", CREATE_VIEW_WITH_SELECT_COLUMNS));
+
+        // verify selecting from a view over a table does not require the session user to have SELECT privileges on the underlying table
         assertAccessAllowed(
                 "SELECT * FROM test_view_access",
                 privilege(getSession().getUser(), "orders", CREATE_VIEW_WITH_SELECT_COLUMNS));
@@ -925,21 +990,21 @@ public abstract class AbstractTestDistributedQueries
         assertAccessAllowed(
                 nestedViewOwnerSession,
                 "CREATE VIEW test_nested_view_access AS SELECT * FROM test_view_access",
-                privilege("test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
+                privilege("test_view_access", CREATE_VIEW_WITH_SELECT_COLUMNS));
 
         // verify selecting from a view over a view requires the view owner of the outer view to have special view creation privileges for the inner view
         assertAccessDenied(
                 "SELECT * FROM test_nested_view_access",
-                "Cannot select from view .*.test_view_access.*",
-                privilege(nestedViewOwnerSession.getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
+                "Cannot create view that selects from .*.test_view_access.*",
+                privilege(nestedViewOwnerSession.getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_COLUMNS));
 
         // verify selecting from a view over a view does not require the session user to have SELECT privileges for the inner view
         assertAccessAllowed(
                 "SELECT * FROM test_nested_view_access",
-                privilege(getSession().getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_VIEW));
+                privilege(getSession().getUser(), "test_view_access", CREATE_VIEW_WITH_SELECT_COLUMNS));
         assertAccessAllowed(
                 "SELECT * FROM test_nested_view_access",
-                privilege(getSession().getUser(), "test_view_access", SELECT_VIEW));
+                privilege(getSession().getUser(), "test_view_access", SELECT_COLUMN));
 
         assertAccessAllowed(nestedViewOwnerSession, "DROP VIEW test_nested_view_access");
         assertAccessAllowed(viewOwnerSession, "DROP VIEW test_view_access");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -592,6 +592,8 @@ public abstract class AbstractTestDistributedQueries
 
         // Test DELETE access control
         assertUpdate("CREATE TABLE test_delete AS SELECT * FROM orders", "SELECT count(*) FROM orders");
+        assertAccessDenied("DELETE FROM test_delete where orderkey < 12", "Cannot select from columns \\[orderkey\\] in table or view .*.test_delete.*", privilege("orderkey", SELECT_COLUMN));
+        assertAccessAllowed("DELETE FROM test_delete where orderkey < 12", privilege("orderdate", SELECT_COLUMN));
         assertAccessAllowed("DELETE FROM test_delete", privilege("orders", SELECT_COLUMN));
     }
 


### PR DESCRIPTION
Check column access for view identities.  The check was being skipped
when we moved column access checks to the Analyzer. With this change,
createViewWithSelectFromColumns can replace
createViewWithSelectFromTable/View