### PR TITLE
Use streaming aggregation for a correlated scalar subquery

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Aggregator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Aggregator.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.operator.aggregation.Accumulator;
+import com.facebook.presto.operator.aggregation.AccumulatorFactory;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+class Aggregator
+{
+    private final Accumulator aggregation;
+    private final AggregationNode.Step step;
+    private final int intermediateChannel;
+
+    Aggregator(AccumulatorFactory accumulatorFactory, AggregationNode.Step step)
+    {
+        if (step.isInputRaw()) {
+            intermediateChannel = -1;
+            aggregation = accumulatorFactory.createAccumulator();
+        }
+        else {
+            checkArgument(accumulatorFactory.getInputChannels().size() == 1, "expected 1 input channel for intermediate aggregation");
+            intermediateChannel = accumulatorFactory.getInputChannels().get(0);
+            aggregation = accumulatorFactory.createIntermediateAccumulator();
+        }
+        this.step = step;
+    }
+
+    public Type getType()
+    {
+        if (step.isOutputPartial()) {
+            return aggregation.getIntermediateType();
+        }
+        else {
+            return aggregation.getFinalType();
+        }
+    }
+
+    public void processPage(Page page)
+    {
+        if (step.isInputRaw()) {
+            aggregation.addInput(page);
+        }
+        else {
+            aggregation.addIntermediate(page.getBlock(intermediateChannel));
+        }
+    }
+
+    public void evaluate(BlockBuilder blockBuilder)
+    {
+        if (step.isOutputPartial()) {
+            aggregation.evaluateIntermediate(blockBuilder);
+        }
+        else {
+            aggregation.evaluateFinal(blockBuilder);
+        }
+    }
+
+    public long getEstimatedSize()
+    {
+        return aggregation.getEstimatedSize();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.operator.aggregation.AccumulatorFactory;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.JoinCompiler;
+import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class StreamingAggregationOperator
+        implements Operator
+{
+    public static class StreamingAggregationOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final List<Type> sourceTypes;
+        private final List<Type> groupByTypes;
+        private final List<Integer> groupByChannels;
+        private final Step step;
+        private final List<AccumulatorFactory> accumulatorFactories;
+        private final JoinCompiler joinCompiler;
+        private boolean closed;
+
+        public StreamingAggregationOperatorFactory(int operatorId, PlanNodeId planNodeId, List<Type> sourceTypes, List<Type> groupByTypes, List<Integer> groupByChannels, Step step, List<AccumulatorFactory> accumulatorFactories, JoinCompiler joinCompiler)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.sourceTypes = ImmutableList.copyOf(requireNonNull(sourceTypes, "sourceTypes is null"));
+            this.groupByTypes = ImmutableList.copyOf(requireNonNull(groupByTypes, "groupByTypes is null"));
+            this.groupByChannels = ImmutableList.copyOf(requireNonNull(groupByChannels, "groupByChannels is null"));
+            this.step = step;
+            this.accumulatorFactories = ImmutableList.copyOf(requireNonNull(accumulatorFactories, "accumulatorFactories is null"));
+            this.joinCompiler = requireNonNull(joinCompiler, "joinCompiler is null");
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, StreamingAggregationOperator.class.getSimpleName());
+            return new StreamingAggregationOperator(operatorContext, sourceTypes, groupByTypes, groupByChannels, step, accumulatorFactories, joinCompiler);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            return new StreamingAggregationOperatorFactory(operatorId, planNodeId, sourceTypes, groupByTypes, groupByChannels, step, accumulatorFactories, joinCompiler);
+        }
+    }
+
+    private final OperatorContext operatorContext;
+    private final LocalMemoryContext systemMemoryContext;
+    private final LocalMemoryContext userMemoryContext;
+    private final List<Type> groupByTypes;
+    private final int[] groupByChannels;
+    private final List<AccumulatorFactory> accumulatorFactories;
+    private final Step step;
+    private final PagesHashStrategy pagesHashStrategy;
+
+    private List<Aggregator> aggregates;
+    private final PageBuilder pageBuilder;
+    private final Deque<Page> outputPages = new LinkedList<>();
+    private Page currentGroup;
+    private boolean finishing;
+
+    public StreamingAggregationOperator(OperatorContext operatorContext, List<Type> sourceTypes, List<Type> groupByTypes, List<Integer> groupByChannels, Step step, List<AccumulatorFactory> accumulatorFactories, JoinCompiler joinCompiler)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        this.userMemoryContext = operatorContext.localUserMemoryContext();
+        this.groupByTypes = ImmutableList.copyOf(requireNonNull(groupByTypes, "groupByTypes is null"));
+        this.groupByChannels = Ints.toArray(requireNonNull(groupByChannels, "groupByChannels is null"));
+        this.accumulatorFactories = requireNonNull(accumulatorFactories, "accumulatorFactories is null");
+        this.step = requireNonNull(step, "step is null");
+
+        this.aggregates = setupAggregates(step, accumulatorFactories);
+        this.pageBuilder = new PageBuilder(toTypes(groupByTypes, aggregates));
+        requireNonNull(joinCompiler, "joinCompiler is null");
+
+        requireNonNull(sourceTypes, "sourceTypes is null");
+        pagesHashStrategy = joinCompiler.compilePagesHashStrategyFactory(sourceTypes, groupByChannels, Optional.empty())
+                .createPagesHashStrategy(
+                        sourceTypes.stream()
+                                .map(type -> ImmutableList.<Block>of())
+                                .collect(toImmutableList()), OptionalInt.empty());
+    }
+
+    private List<Aggregator> setupAggregates(Step step, List<AccumulatorFactory> accumulatorFactories)
+    {
+        ImmutableList.Builder<Aggregator> builder = ImmutableList.builder();
+        for (AccumulatorFactory factory : accumulatorFactories) {
+            builder.add(new Aggregator(factory, step));
+        }
+        return builder.build();
+    }
+
+    private static List<Type> toTypes(List<Type> groupByTypes, List<Aggregator> aggregates)
+    {
+        ImmutableList.Builder<Type> builder = ImmutableList.builder();
+        builder.addAll(groupByTypes);
+        aggregates.stream()
+                .map(Aggregator::getType)
+                .forEach(builder::add);
+        return builder.build();
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finishing && outputPages.isEmpty();
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        checkState(!finishing, "Operator is already finishing");
+        requireNonNull(page, "page is null");
+
+        processInput(page);
+        updateMemoryUsage();
+    }
+
+    private void updateMemoryUsage()
+    {
+        long memorySize = pageBuilder.getRetainedSizeInBytes();
+        for (Page output : outputPages) {
+            memorySize += output.getRetainedSizeInBytes();
+        }
+        for (Aggregator aggregator : aggregates) {
+            memorySize += aggregator.getEstimatedSize();
+        }
+
+        if (currentGroup != null) {
+            memorySize += currentGroup.getRetainedSizeInBytes();
+        }
+
+        if (step.isOutputPartial()) {
+            systemMemoryContext.setBytes(memorySize);
+        }
+        else {
+            userMemoryContext.setBytes(memorySize);
+        }
+    }
+
+    private void processInput(Page page)
+    {
+        requireNonNull(page, "page is null");
+
+        Page groupByPage = extractColumns(page, groupByChannels);
+        if (currentGroup != null) {
+            if (!pagesHashStrategy.rowEqualsRow(0, extractColumns(currentGroup, groupByChannels), 0, groupByPage)) {
+                // page starts with new group, so flush it
+                evaluateAndFlushGroup(currentGroup, 0);
+            }
+            currentGroup = null;
+        }
+
+        int startPosition = 0;
+        while (true) {
+            // may be equal to page.getPositionCount() if the end is not found in this page
+            int nextGroupStart = findNextGroupStart(startPosition, groupByPage);
+            addRowsToAggregates(page, startPosition, nextGroupStart - 1);
+
+            if (nextGroupStart < page.getPositionCount()) {
+                // current group stops somewhere in the middle of the page, so flush it
+                evaluateAndFlushGroup(page, startPosition);
+                startPosition = nextGroupStart;
+            }
+            else {
+                currentGroup = page.getRegion(page.getPositionCount() - 1, 1);
+                return;
+            }
+        }
+    }
+
+    private static Page extractColumns(Page page, int[] channels)
+    {
+        Block[] newBlocks = new Block[channels.length];
+        for (int i = 0; i < channels.length; i++) {
+            newBlocks[i] = page.getBlock(channels[i]);
+        }
+        return new Page(page.getPositionCount(), newBlocks);
+    }
+
+    private void addRowsToAggregates(Page page, int startPosition, int endPosition)
+    {
+        for (Aggregator aggregator : aggregates) {
+            aggregator.processPage(page.getRegion(startPosition, endPosition - startPosition + 1));
+        }
+    }
+
+    private void evaluateAndFlushGroup(Page page, int position)
+    {
+        pageBuilder.declarePosition();
+        for (int i = 0; i < groupByTypes.size(); i++) {
+            Block block = page.getBlock(groupByChannels[i]);
+            Type type = groupByTypes.get(i);
+            type.appendTo(block, position, pageBuilder.getBlockBuilder(i));
+        }
+        int offset = groupByTypes.size();
+        for (int i = 0; i < aggregates.size(); i++) {
+            aggregates.get(i).evaluate(pageBuilder.getBlockBuilder(offset + i));
+        }
+
+        if (pageBuilder.isFull()) {
+            outputPages.add(pageBuilder.build());
+            pageBuilder.reset();
+        }
+
+        aggregates = setupAggregates(step, accumulatorFactories);
+    }
+
+    private int findNextGroupStart(int startPosition, Page page)
+    {
+        for (int i = startPosition + 1; i < page.getPositionCount(); i++) {
+            if (!pagesHashStrategy.rowEqualsRow(startPosition, page, i, page)) {
+                return i;
+            }
+        }
+
+        return page.getPositionCount();
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (!outputPages.isEmpty()) {
+            return outputPages.removeFirst();
+        }
+
+        return null;
+    }
+
+    @Override
+    public void finish()
+    {
+        finishing = true;
+
+        if (currentGroup != null) {
+            evaluateAndFlushGroup(currentGroup, 0);
+            currentGroup = null;
+        }
+
+        if (!pageBuilder.isEmpty()) {
+            outputPages.add(pageBuilder.build());
+            pageBuilder.reset();
+        }
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finishing && outputPages.isEmpty() && currentGroup == null && pageBuilder.isEmpty();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -73,6 +73,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PushProjectionThroughExcha
 import com.facebook.presto.sql.planner.iterative.rule.PushProjectionThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.PushTableWriteThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.PushTopNThroughUnion;
+import com.facebook.presto.sql.planner.iterative.rule.PushUpAssignUniqueIdThroughRemoteExchange;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
@@ -421,6 +422,7 @@ public class PlanOptimizers
                 ImmutableSet.<Rule<?>>builder()
                         .add(new RemoveRedundantIdentityProjections())
                         .addAll(new TransformSpatialPredicates(metadata).rules())
+                        .add(new PushUpAssignUniqueIdThroughRemoteExchange())
                         .add(new InlineProjections())
                         .build()));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -560,6 +560,7 @@ class QueryPlanner
                 subPlan.getRoot(),
                 aggregations,
                 groupingSymbols,
+                ImmutableList.of(),
                 AggregationNode.Step.SINGLE,
                 Optional.empty(),
                 groupIdSymbol);
@@ -770,6 +771,7 @@ class QueryPlanner
                             subPlan.getRoot(),
                             ImmutableMap.of(),
                             ImmutableList.of(subPlan.getRoot().getOutputSymbols()),
+                            ImmutableList.of(),
                             AggregationNode.Step.SINGLE,
                             Optional.empty(),
                             Optional.empty()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -813,6 +813,7 @@ class RelationPlanner
                 node,
                 ImmutableMap.of(),
                 ImmutableList.of(node.getOutputSymbols()),
+                ImmutableList.of(),
                 AggregationNode.Step.SINGLE,
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
@@ -117,6 +117,7 @@ public class AddIntermediateAggregations
                     source,
                     inputsAsOutputs(aggregation.getAggregations()),
                     aggregation.getGroupingSets(),
+                    aggregation.getPreGroupedSymbols(),
                     AggregationNode.Step.INTERMEDIATE,
                     aggregation.getHashSymbol(),
                     aggregation.getGroupIdSymbol());
@@ -159,6 +160,7 @@ public class AddIntermediateAggregations
                 gatheringExchange,
                 outputsAsInputs(aggregation.getAggregations()),
                 aggregation.getGroupingSets(),
+                aggregation.getPreGroupedSymbols(),
                 AggregationNode.Step.INTERMEDIATE,
                 aggregation.getHashSymbol(),
                 aggregation.getGroupIdSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -171,6 +171,7 @@ public class ExpressionRewriteRuleSet
                         aggregationNode.getSource(),
                         aggregations.build(),
                         aggregationNode.getGroupingSets(),
+                        aggregationNode.getPreGroupedSymbols(),
                         aggregationNode.getStep(),
                         aggregationNode.getHashSymbol(),
                         aggregationNode.getGroupIdSymbol()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -110,6 +111,7 @@ public class ImplementFilteredAggregations
                                 newAssignments.build()),
                         aggregations.build(),
                         aggregation.getGroupingSets(),
+                        ImmutableList.of(),
                         aggregation.getStep(),
                         aggregation.getHashSymbol(),
                         aggregation.getGroupIdSymbol()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
@@ -171,6 +171,7 @@ public class MultipleDistinctAggregationToMarkDistinct
                         subPlan,
                         newAggregations,
                         parent.getGroupingSets(),
+                        ImmutableList.of(),
                         parent.getStep(),
                         parent.getHashSymbol(),
                         parent.getGroupIdSymbol()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationColumns.java
@@ -54,6 +54,7 @@ public class PruneAggregationColumns
                         aggregationNode.getSource(),
                         prunedAggregations,
                         aggregationNode.getGroupingSets(),
+                        aggregationNode.getPreGroupedSymbols(),
                         aggregationNode.getStep(),
                         aggregationNode.getHashSymbol(),
                         aggregationNode.getGroupIdSymbol()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
@@ -78,6 +78,6 @@ public class PruneOrderByInAggregation
         if (!anyRewritten) {
             return Result.empty();
         }
-        return Result.ofPlanNode(new AggregationNode(node.getId(), node.getSource(), aggregations.build(), node.getGroupingSets(), node.getStep(), node.getHashSymbol(), node.getGroupIdSymbol()));
+        return Result.ofPlanNode(new AggregationNode(node.getId(), node.getSource(), aggregations.build(), node.getGroupingSets(), node.getPreGroupedSymbols(), node.getStep(), node.getHashSymbol(), node.getGroupIdSymbol()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -129,6 +129,7 @@ public class PushAggregationThroughOuterJoin
                 getInnerTable(join),
                 aggregation.getAggregations(),
                 ImmutableList.of(groupingKeys),
+                ImmutableList.of(),
                 aggregation.getStep(),
                 aggregation.getHashSymbol(),
                 aggregation.getGroupIdSymbol());
@@ -287,6 +288,7 @@ public class PushAggregationThroughOuterJoin
                 nullRow,
                 aggregationsOverNullBuilder.build(),
                 ImmutableList.of(ImmutableList.of()),
+                ImmutableList.of(),
                 AggregationNode.Step.SINGLE,
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -67,6 +67,7 @@ public class PushPartialAggregationThroughExchange
     private static final Capture<ExchangeNode> EXCHANGE_NODE = Capture.newCapture();
 
     private static final Pattern<AggregationNode> PATTERN = aggregation()
+            .matching(node -> !node.isStreamable())
             .with(source().matching(exchange().capturedAs(EXCHANGE_NODE)));
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -215,6 +215,7 @@ public class PushPartialAggregationThroughExchange
                 node.getSource(),
                 intermediateAggregation,
                 node.getGroupingSets(),
+                ImmutableList.of(),
                 PARTIAL,
                 node.getHashSymbol(),
                 node.getGroupIdSymbol());
@@ -224,6 +225,7 @@ public class PushPartialAggregationThroughExchange
                 partial,
                 finalAggregation,
                 node.getGroupingSets(),
+                ImmutableList.of(),
                 FINAL,
                 node.getHashSymbol(),
                 node.getGroupIdSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -56,6 +56,11 @@ public class PushPartialAggregationThroughJoin
 
     private static boolean isSupportedAggregationNode(AggregationNode aggregationNode)
     {
+        // Don't split streaming aggregations
+        if (aggregationNode.isStreamable()) {
+            return false;
+        }
+
         if (aggregationNode.getHashSymbol().isPresent()) {
             // TODO: add support for hash symbol in aggregation node
             return false;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -156,6 +156,7 @@ public class PushPartialAggregationThroughJoin
                 source,
                 aggregation.getAggregations(),
                 ImmutableList.of(groupingSet),
+                ImmutableList.of(),
                 aggregation.getStep(),
                 aggregation.getHashSymbol(),
                 aggregation.getGroupIdSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushUpAssignUniqueIdThroughRemoteExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushUpAssignUniqueIdThroughRemoteExchange.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.PartitioningScheme;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static com.facebook.presto.sql.planner.plan.Patterns.assignUniqueId;
+import static com.facebook.presto.sql.planner.plan.Patterns.exchange;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+/**
+ * Pushes AssignUniqueId node up through the remote exchange to avoid
+ * loosing partitioned_on(unique) and grouped(unique) stream properties.
+ */
+public final class PushUpAssignUniqueIdThroughRemoteExchange
+        implements Rule<ExchangeNode>
+{
+    private static final Capture<AssignUniqueId> ASSIGN_UNIQUE_ID = newCapture();
+    private static final Pattern<ExchangeNode> PATTERN = exchange()
+            .matching(exchange -> exchange.getScope() == REMOTE)
+            .with(source().matching(assignUniqueId().capturedAs(ASSIGN_UNIQUE_ID)));
+
+    @Override
+    public Pattern<ExchangeNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(ExchangeNode node, Captures captures, Context context)
+    {
+        AssignUniqueId assignUniqueId = captures.get(ASSIGN_UNIQUE_ID);
+        PartitioningScheme partitioningScheme = node.getPartitioningScheme();
+        if (partitioningScheme.getPartitioning().getColumns().contains(assignUniqueId.getIdColumn())) {
+            // The column produced by the AssignUniqueId is used in the partitioning scheme of the exchange.
+            // Hence, AssignUniqueId node has to stay below the exchange node.
+            return Result.empty();
+        }
+
+        return Result.ofPlanNode(new AssignUniqueId(
+                assignUniqueId.getId(),
+                new ExchangeNode(
+                        node.getId(),
+                        node.getType(),
+                        node.getScope(),
+                        new PartitioningScheme(
+                                partitioningScheme.getPartitioning(),
+                                removeSymbol(partitioningScheme.getOutputLayout(), assignUniqueId.getIdColumn()),
+                                partitioningScheme.getHashColumn(),
+                                partitioningScheme.isReplicateNullsAndAny(),
+                                partitioningScheme.getBucketToPartition()),
+                        ImmutableList.of(assignUniqueId.getSource()),
+                        ImmutableList.of(removeSymbol(getOnlyElement(node.getInputs()), assignUniqueId.getIdColumn()))),
+                assignUniqueId.getIdColumn()));
+    }
+
+    private static List<Symbol> removeSymbol(List<Symbol> symbols, Symbol symbolToRemove)
+    {
+        return symbols.stream()
+                .filter(symbol -> !symbolToRemove.equals(symbol))
+                .collect(toImmutableList());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -86,6 +86,7 @@ public class SimplifyCountOverConstant
                 child,
                 aggregations,
                 parent.getGroupingSets(),
+                ImmutableList.of(),
                 parent.getStep(),
                 parent.getHashSymbol(),
                 parent.getGroupIdSymbol()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Collections.emptyList;
 
 /**
  * Implements distinct aggregations with similar inputs by transforming plans of the following shape:
@@ -135,6 +136,7 @@ public class SingleDistinctAggregationToGroupBy
                                         .addAll(aggregation.getGroupingKeys())
                                         .addAll(symbols)
                                         .build()),
+                                ImmutableList.of(),
                                 SINGLE,
                                 Optional.empty(),
                                 Optional.empty()),
@@ -145,6 +147,7 @@ public class SingleDistinctAggregationToGroupBy
                                         Map.Entry::getKey,
                                         e -> removeDistinct(e.getValue()))),
                         aggregation.getGroupingSets(),
+                        emptyList(),
                         aggregation.getStep(),
                         aggregation.getHashSymbol(),
                         aggregation.getGroupIdSymbol()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -204,6 +204,7 @@ public class TransformCorrelatedInPredicateToJoin
                         .put(countNullMatchesSymbol, countWithFilter(nullMatchCondition))
                         .build(),
                 ImmutableList.of(probeSide.getOutputSymbols()),
+                ImmutableList.of(),
                 AggregationNode.Step.SINGLE,
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
@@ -163,6 +163,7 @@ public class TransformExistsApplyToLateralNode
                                 parent.getSubquery(),
                                 ImmutableMap.of(count, new Aggregation(COUNT_CALL, countSignature, Optional.empty())),
                                 ImmutableList.of(ImmutableList.of()),
+                                ImmutableList.of(),
                                 AggregationNode.Step.SINGLE,
                                 Optional.empty(),
                                 Optional.empty()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -176,6 +176,7 @@ public class HashGenerationOptimizer
                             child.getNode(),
                             node.getAggregations(),
                             node.getGroupingSets(),
+                            node.getPreGroupedSymbols(),
                             node.getStep(),
                             hashSymbol,
                             node.getGroupIdSymbol()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -160,7 +160,7 @@ public class HashGenerationOptimizer
         public PlanWithProperties visitAggregation(AggregationNode node, HashComputationSet parentPreference)
         {
             Optional<HashComputation> groupByHash = Optional.empty();
-            if (!canSkipHashGeneration(node.getGroupingKeys())) {
+            if (!node.isStreamable() && !canSkipHashGeneration(node.getGroupingKeys())) {
                 groupByHash = computeHash(node.getGroupingKeys());
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -670,7 +670,16 @@ public class HashGenerationOptimizer
 
             boolean preferenceSatisfied;
             if (pruneExtraHashSymbols) {
-                preferenceSatisfied = result.getHashSymbols().keySet().equals(requiredHashes.getHashes());
+                // Make sure that
+                // (1) result has all required hashes
+                // (2) any extra hashes are preferred hashes (e.g. no pruning is needed)
+                Set<HashComputation> resultHashes = result.getHashSymbols().keySet();
+                Set<HashComputation> requiredAndPreferredHashes = ImmutableSet.<HashComputation>builder()
+                        .addAll(requiredHashes.getHashes())
+                        .addAll(preferredHashes.getHashes())
+                        .build();
+                preferenceSatisfied = resultHashes.containsAll(requiredHashes.getHashes())
+                    && requiredAndPreferredHashes.containsAll(resultHashes);
             }
             else {
                 preferenceSatisfied = result.getHashSymbols().keySet().containsAll(requiredHashes.getHashes());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -242,6 +242,7 @@ public class ImplementIntersectAndExceptAsUnion
                     sourceNode,
                     aggregations.build(),
                     ImmutableList.of(originalColumns),
+                    ImmutableList.of(),
                     Step.SINGLE,
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LocalProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LocalProperties.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.collect.Iterators.peekingIterator;
 
-final class LocalProperties
+public final class LocalProperties
 {
     private LocalProperties()
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -177,6 +177,7 @@ public class OptimizeMixedDistinctAggregations
                     source,
                     aggregations.build(),
                     node.getGroupingSets(),
+                    ImmutableList.of(),
                     node.getStep(),
                     Optional.empty(),
                     node.getGroupIdSymbol());
@@ -420,6 +421,7 @@ public class OptimizeMixedDistinctAggregations
                     groupIdNode,
                     aggregations.build(),
                     ImmutableList.of(ImmutableList.copyOf(groupByKeys)),
+                    ImmutableList.of(),
                     SINGLE,
                     originalNode.getHashSymbol(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -173,6 +173,7 @@ public class PlanNodeDecorrelator
                     ImmutableList.of(ImmutableList.<Symbol>builder()
                             .addAll(decorrelatedChildNode.getOutputSymbols())
                             .build()),
+                    ImmutableList.of(),
                     AggregationNode.Step.SINGLE,
                     Optional.empty(),
                     Optional.empty());
@@ -232,6 +233,7 @@ public class PlanNodeDecorrelator
                     decorrelatedAggregation.getSource(),
                     decorrelatedAggregation.getAggregations(),
                     newGroupingSets.build(),
+                    ImmutableList.of(),
                     decorrelatedAggregation.getStep(),
                     decorrelatedAggregation.getHashSymbol(),
                     decorrelatedAggregation.getGroupIdSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -1006,6 +1006,7 @@ public class PredicatePushDown
                         rewrittenSource,
                         node.getAggregations(),
                         node.getGroupingSets(),
+                        ImmutableList.of(),
                         node.getStep(),
                         node.getHashSymbol(),
                         node.getGroupIdSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -383,6 +383,16 @@ public class PropertyDerivations
                     constants.putAll(probeProperties.getConstants());
                     constants.putAll(buildProperties.getConstants());
 
+                    if (node.isCrossJoin()) {
+                        // Cross join preserves only constants from probe and build sides.
+                        // Cross join doesn't preserve sorting or grouping local properties on either side.
+                        return ActualProperties.builder()
+                                .global(probeProperties)
+                                .local(ImmutableList.of())
+                                .constants(constants)
+                                .build();
+                    }
+
                     return ActualProperties.builderFrom(probeProperties)
                             .constants(constants)
                             .unordered(unordered)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -321,6 +321,7 @@ public class PruneUnreferencedOutputs
                     source,
                     aggregations.build(),
                     node.getGroupingSets(),
+                    ImmutableList.of(),
                     node.getStep(),
                     node.getHashSymbol(),
                     node.getGroupIdSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -197,6 +197,7 @@ public class ScalarAggregationToJoinRewriter
                 leftOuterJoin,
                 aggregations.build(),
                 ImmutableList.of(groupBySymbols),
+                ImmutableList.of(),
                 scalarAggregation.getStep(),
                 scalarAggregation.getHashSymbol(),
                 Optional.empty()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
@@ -132,6 +132,7 @@ public class SetFlatteningOptimizer
                     rewrittenNode,
                     node.getAggregations(),
                     node.getGroupingSets(),
+                    ImmutableList.of(),
                     node.getStep(),
                     node.getHashSymbol(),
                     node.getGroupIdSymbol());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -429,7 +429,15 @@ public final class StreamPropertyDerivations
         @Override
         public StreamProperties visitAssignUniqueId(AssignUniqueId node, List<StreamProperties> inputProperties)
         {
-            return Iterables.getOnlyElement(inputProperties);
+            StreamProperties properties = Iterables.getOnlyElement(inputProperties);
+            if (properties.getPartitioningColumns().isPresent()) {
+                // preserve input (possibly preferred) partitioning
+                return properties;
+            }
+
+            return new StreamProperties(properties.getDistribution(),
+                    Optional.of(ImmutableList.of(node.getIdColumn())),
+                    properties.isOrdered());
         }
 
         //

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -177,10 +177,8 @@ public final class StreamPropertyDerivations
                             .translate(column -> PropertyDerivations.filterOrRewrite(node.getOutputSymbols(), node.getCriteria(), column))
                             .unordered(unordered);
                 case LEFT:
-                    // the left can contain nulls in any stream so we can't say anything about the
-                    // partitioning but the other properties of the left will be maintained.
                     return leftProperties
-                            .withUnspecifiedPartitioning()
+                            .translate(column -> PropertyDerivations.filterIfMissing(node.getOutputSymbols(), column))
                             .unordered(unordered);
                 case RIGHT:
                     // since this is a right join, none of the matched output rows will contain nulls

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -101,6 +101,7 @@ public class SymbolMapper
                 source,
                 aggregations.build(),
                 groupingSets,
+                ImmutableList.of(),
                 node.getStep(),
                 node.getHashSymbol().map(this::map),
                 node.getGroupIdSymbol().map(this::map));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
@@ -161,6 +161,7 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
                                     functionRegistry.resolveFunction(COUNT, fromTypeSignatures(outputColumnTypeSignature)),
                                     Optional.empty())),
                     ImmutableList.of(ImmutableList.of()),
+                    ImmutableList.of(),
                     AggregationNode.Step.SINGLE,
                     Optional.empty(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import javax.annotation.concurrent.Immutable;
@@ -233,6 +232,11 @@ public class AggregationNode
         //
         // 2. aggregations that must produce default output and are not decomposable, we can not distribute them.
         return (hasEmptyGroupingSet() && !hasNonEmptyGroupingSet()) || (hasDefaultOutput() && !isDecomposable(functionRegistry));
+    }
+
+    public boolean isStreamable()
+    {
+        return !preGroupedSymbols.isEmpty() && groupingSets.size() == 1 && !Iterables.getOnlyElement(groupingSets).isEmpty();
     }
 
     public enum Step

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -723,6 +723,9 @@ public class PlanPrinter
             if (node.getStep() != AggregationNode.Step.SINGLE) {
                 type = format("(%s)", node.getStep().toString());
             }
+            if (node.isStreamable()) {
+                type = format("%s(STREAMING)", type);
+            }
             String key = "";
             if (!node.getGroupingKeys().isEmpty()) {
                 key = node.getGroupingKeys().toString();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanSanityChecker.java
@@ -53,7 +53,8 @@ public final class PlanSanityChecker
                         new NoIdentifierLeftChecker(),
                         new VerifyOnlyOneOutputNode(),
                         new VerifyNoFilteredAggregations(),
-                        new ValidateAggregationsWithDefaultValues(forceSingleNode))
+                        new ValidateAggregationsWithDefaultValues(forceSingleNode),
+                        new ValidateStreamingAggregations())
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingAggregations.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.GroupingProperty;
+import com.facebook.presto.spi.LocalProperty;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.optimizations.LocalProperties;
+import com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.PlanVisitor;
+import com.facebook.presto.sql.planner.sanity.PlanSanityChecker.Checker;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.derivePropertiesRecursively;
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Verifies that input of streaming aggregations is grouped on the grouping keys
+ */
+public class ValidateStreamingAggregations
+        implements Checker
+{
+    @Override
+    public void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
+    {
+        planNode.accept(new Visitor(session, metadata, sqlParser, types), null);
+    }
+
+    private static final class Visitor
+            extends PlanVisitor<Void, Void>
+    {
+        private final Session sesstion;
+        private final Metadata metadata;
+        private final SqlParser sqlParser;
+        private final Map<Symbol, Type> types;
+
+        private Visitor(Session sesstion, Metadata metadata, SqlParser sqlParser, Map<Symbol, Type> types)
+        {
+            this.sesstion = sesstion;
+            this.metadata = metadata;
+            this.sqlParser = sqlParser;
+            this.types = types;
+        }
+
+        @Override
+        protected Void visitPlan(PlanNode node, Void context)
+        {
+            node.getSources().forEach(source -> source.accept(this, context));
+            return null;
+        }
+
+        @Override
+        public Void visitAggregation(AggregationNode node, Void context)
+        {
+            if (node.getPreGroupedSymbols().isEmpty()) {
+                return null;
+            }
+
+            StreamProperties properties = derivePropertiesRecursively(node.getSource(), metadata, sesstion, types, sqlParser);
+
+            List<LocalProperty<Symbol>> desiredProperties = ImmutableList.of(new GroupingProperty<>(node.getPreGroupedSymbols()));
+            Iterator<Optional<LocalProperty<Symbol>>> matchIterator = LocalProperties.match(properties.getLocalProperties(), desiredProperties).iterator();
+            Optional<LocalProperty<Symbol>> unsatisfiedRequirement = Iterators.getOnlyElement(matchIterator);
+            checkArgument(!unsatisfiedRequirement.isPresent(), "Streaming aggregation with input not grouped on the grouping keys");
+            return null;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -366,6 +366,7 @@ public class TestCostCalculator
                 source,
                 ImmutableMap.of(new Symbol("count"), aggregation),
                 ImmutableList.of(source.getOutputSymbols()),
+                ImmutableList.of(),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndStreamingAggregationOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndStreamingAggregationOperators.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.HashAggregationOperator.HashAggregationOperatorFactory;
+import com.facebook.presto.operator.StreamingAggregationOperator.StreamingAggregationOperatorFactory;
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spiller.SpillerFactory;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.gen.JoinCompiler;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.testing.TestingTaskContext;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.block.BlockAssertions.createLongSequenceBlock;
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.operator.BenchmarkHashAndStreamingAggregationOperators.Context.ROWS_PER_PAGE;
+import static com.facebook.presto.operator.BenchmarkHashAndStreamingAggregationOperators.Context.TOTAL_PAGES;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.airlift.units.DataSize.succinctBytes;
+import static java.lang.String.format;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+import static org.testng.Assert.assertEquals;
+
+@State(Thread)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(3)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10, time = 2, timeUnit = SECONDS)
+public class BenchmarkHashAndStreamingAggregationOperators
+{
+    private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+
+    private static final InternalAggregationFunction LONG_SUM = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("sum", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature()));
+    private static final InternalAggregationFunction COUNT = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("count", AGGREGATE, BIGINT.getTypeSignature()));
+
+    @State(Thread)
+    public static class Context
+    {
+        public static final int TOTAL_PAGES = 140;
+        public static final int ROWS_PER_PAGE = 10_000;
+
+        @Param({"1", "10", "1000"})
+        public int rowsPerGroup;
+
+        @Param({"streaming", "hash"})
+        public String operatorType;
+
+        private ExecutorService executor;
+        private ScheduledExecutorService scheduledExecutor;
+        private OperatorFactory operatorFactory;
+        private List<Page> pages;
+
+        @Setup
+        public void setup()
+        {
+            executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
+            scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+
+            int groupsPerPage = ROWS_PER_PAGE / rowsPerGroup;
+
+            boolean hashAggregation = operatorType.equalsIgnoreCase("hash");
+
+            RowPagesBuilder pagesBuilder = RowPagesBuilder.rowPagesBuilder(hashAggregation, ImmutableList.of(0), VARCHAR, BIGINT);
+            for (int i = 0; i < TOTAL_PAGES; i++) {
+                BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, ROWS_PER_PAGE);
+                for (int j = 0; j < groupsPerPage; j++) {
+                    String groupKey = format("%s", i * groupsPerPage + j);
+                    repeatToStringBlock(groupKey, rowsPerGroup, blockBuilder);
+                }
+                pagesBuilder.addBlocksPage(blockBuilder.build(), createLongSequenceBlock(0, ROWS_PER_PAGE));
+            }
+
+            pages = pagesBuilder.build();
+
+            if (hashAggregation) {
+                operatorFactory = createHashAggregationOperatorFactory(pagesBuilder.getHashChannel());
+            }
+            else {
+                operatorFactory = createStreamingAggregationOperatorFactory();
+            }
+        }
+
+        private OperatorFactory createStreamingAggregationOperatorFactory()
+        {
+            return new StreamingAggregationOperatorFactory(
+                    0,
+                    new PlanNodeId("test"),
+                    ImmutableList.of(VARCHAR),
+                    ImmutableList.of(VARCHAR),
+                    ImmutableList.of(0),
+                    AggregationNode.Step.SINGLE,
+                    ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty()),
+                            LONG_SUM.bind(ImmutableList.of(1), Optional.empty())),
+                    new JoinCompiler(MetadataManager.createTestMetadataManager(), new FeaturesConfig()));
+        }
+
+        private OperatorFactory createHashAggregationOperatorFactory(Optional<Integer> hashChannel)
+        {
+            JoinCompiler joinCompiler = new JoinCompiler(MetadataManager.createTestMetadataManager(), new FeaturesConfig());
+            SpillerFactory spillerFactory = (types, localSpillContext, aggregatedMemoryContext) -> null;
+
+            return new HashAggregationOperatorFactory(
+                    0,
+                    new PlanNodeId("test"),
+                    ImmutableList.of(VARCHAR),
+                    ImmutableList.of(0),
+                    ImmutableList.of(),
+                    AggregationNode.Step.SINGLE,
+                    false,
+                    ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty()),
+                            LONG_SUM.bind(ImmutableList.of(1), Optional.empty())),
+                    hashChannel,
+                    Optional.empty(),
+                    100_000,
+                    new DataSize(16, MEGABYTE),
+                    false,
+                    succinctBytes(8),
+                    succinctBytes(Integer.MAX_VALUE),
+                    spillerFactory,
+                    joinCompiler);
+        }
+
+        private static void repeatToStringBlock(String value, int count, BlockBuilder blockBuilder)
+        {
+            for (int i = 0; i < count; i++) {
+                VARCHAR.writeString(blockBuilder, value);
+            }
+        }
+
+        public TaskContext createTaskContext()
+        {
+            return TestingTaskContext.createTaskContext(executor, scheduledExecutor, TEST_SESSION, new DataSize(2, GIGABYTE));
+        }
+
+        public OperatorFactory getOperatorFactory()
+        {
+            return operatorFactory;
+        }
+
+        public List<Page> getPages()
+        {
+            return pages;
+        }
+    }
+
+    @Benchmark
+    public List<Page> benchmark(Context context)
+    {
+        DriverContext driverContext = context.createTaskContext().addPipelineContext(0, true, true).addDriverContext();
+        Operator operator = context.getOperatorFactory().createOperator(driverContext);
+
+        Iterator<Page> input = context.getPages().iterator();
+        ImmutableList.Builder<Page> outputPages = ImmutableList.builder();
+
+        boolean finishing = false;
+        for (int loops = 0; !operator.isFinished() && loops < 1_000_000; loops++) {
+            if (operator.needsInput()) {
+                if (input.hasNext()) {
+                    Page inputPage = input.next();
+                    operator.addInput(inputPage);
+                }
+                else if (!finishing) {
+                    operator.finish();
+                    finishing = true;
+                }
+            }
+
+            Page outputPage = operator.getOutput();
+            if (outputPage != null) {
+                outputPages.add(outputPage);
+            }
+        }
+
+        return outputPages.build();
+    }
+
+    @Test
+    public void verifyStreaming()
+    {
+        verify(1, "streaming");
+        verify(10, "streaming");
+        verify(1000, "streaming");
+    }
+
+    @Test
+    public void verifyHash()
+    {
+        verify(1, "hash");
+        verify(10, "hash");
+        verify(1000, "hash");
+    }
+
+    private void verify(int rowsPerGroup, String operatorType)
+    {
+        Context context = new Context();
+        context.operatorType = operatorType;
+        context.rowsPerGroup = rowsPerGroup;
+        context.setup();
+
+        assertEquals(TOTAL_PAGES, context.getPages().size());
+        for (int i = 0; i < TOTAL_PAGES; i++) {
+            assertEquals(ROWS_PER_PAGE, context.getPages().get(i).getPositionCount());
+        }
+
+        List<Page> outputPages = benchmark(context);
+        assertEquals(TOTAL_PAGES * ROWS_PER_PAGE / rowsPerGroup, outputPages.stream().mapToInt(Page::getPositionCount).sum());
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkHashAndStreamingAggregationOperators.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestStreamingAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestStreamingAggregationOperator.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.StreamingAggregationOperator.StreamingAggregationOperatorFactory;
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.gen.JoinCompiler;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.testing.MaterializedResult;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.lang.String.format;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+
+@Test(singleThreaded = true)
+public class TestStreamingAggregationOperator
+{
+    private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+
+    private static final InternalAggregationFunction LONG_SUM = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("sum", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature()));
+    private static final InternalAggregationFunction COUNT = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+            new Signature("count", AGGREGATE, BIGINT.getTypeSignature()));
+
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduledExecutor;
+    private DriverContext driverContext;
+    private StreamingAggregationOperatorFactory operatorFactory;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+
+        driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
+                .addPipelineContext(0, true, true)
+                .addDriverContext();
+
+        operatorFactory = new StreamingAggregationOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                ImmutableList.of(BOOLEAN, VARCHAR, BIGINT),
+                ImmutableList.of(VARCHAR),
+                ImmutableList.of(1),
+                AggregationNode.Step.SINGLE,
+                ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty()),
+                        LONG_SUM.bind(ImmutableList.of(2), Optional.empty())),
+                new JoinCompiler(MetadataManager.createTestMetadataManager(), new FeaturesConfig()));
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Test
+    public void test()
+    {
+        RowPagesBuilder rowPagesBuilder = RowPagesBuilder.rowPagesBuilder(BOOLEAN, VARCHAR, BIGINT);
+        List<Page> input = rowPagesBuilder
+                .addSequencePage(3, 0, 0, 1)
+                .row(true, "3", 4)
+                .row(false, "3", 5)
+                .pageBreak()
+                .row(true, "3", 6)
+                .row(false, "4", 7)
+                .row(true, "4", 8)
+                .row(false, "4", 9)
+                .row(true, "4", 10)
+                .pageBreak()
+                .row(false, "5", 11)
+                .row(true, "5", 12)
+                .row(false, "5", 13)
+                .row(true, "5", 14)
+                .row(false, "5", 15)
+                .pageBreak()
+                .addSequencePage(3, 0, 6, 16)
+                .build();
+
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, BIGINT, BIGINT)
+                .row("0", 1L, 1L)
+                .row("1", 1L, 2L)
+                .row("2", 1L, 3L)
+                .row("3", 3L, 15L)
+                .row("4", 4L, 34L)
+                .row("5", 5L, 65L)
+                .row("6", 1L, 16L)
+                .row("7", 1L, 17L)
+                .row("8", 1L, 18L)
+                .build();
+
+        assertOperatorEquals(operatorFactory, driverContext, input, expected);
+    }
+
+    @Test
+    public void testEmptyInput()
+    {
+        RowPagesBuilder rowPagesBuilder = RowPagesBuilder.rowPagesBuilder(BOOLEAN, VARCHAR, BIGINT);
+        List<Page> input = rowPagesBuilder.build();
+
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, BIGINT, BIGINT).build();
+        assertOperatorEquals(operatorFactory, driverContext, input, expected);
+    }
+
+    @Test
+    public void testSinglePage()
+    {
+        RowPagesBuilder rowPagesBuilder = RowPagesBuilder.rowPagesBuilder(BOOLEAN, VARCHAR, BIGINT);
+        List<Page> input = rowPagesBuilder
+                .row(false, "a", 5)
+                .build();
+
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, BIGINT, BIGINT)
+                .row("a", 1L, 5L)
+                .build();
+        assertOperatorEquals(operatorFactory, driverContext, input, expected);
+    }
+
+    @Test
+    public void testUniqueGroupingValues()
+    {
+        RowPagesBuilder rowPagesBuilder = RowPagesBuilder.rowPagesBuilder(BOOLEAN, VARCHAR, BIGINT);
+        List<Page> input = rowPagesBuilder
+                .addSequencePage(10, 0, 0, 0)
+                .addSequencePage(10, 0, 10, 10)
+                .build();
+
+        MaterializedResult.Builder builder = resultBuilder(driverContext.getSession(), VARCHAR, BIGINT, BIGINT);
+        for (int i = 0; i < 20; i++) {
+            builder.row(format("%s", i), 1L, Long.valueOf(i));
+        }
+
+        assertOperatorEquals(operatorFactory, driverContext, input, builder.build());
+    }
+
+    @Test
+    public void testSingleGroupingValue()
+    {
+        RowPagesBuilder rowPagesBuilder = RowPagesBuilder.rowPagesBuilder(BOOLEAN, VARCHAR, BIGINT);
+        List<Page> input = rowPagesBuilder
+                .row(true, "a", 1)
+                .row(false, "a", 2)
+                .row(true, "a", 3)
+                .row(false, "a", 4)
+                .row(true, "a", 5)
+                .pageBreak()
+                .row(false, "a", 6)
+                .row(true, "a", 7)
+                .row(false, "a", 8)
+                .pageBreak()
+                .pageBreak()
+                .row(true, "a", 9)
+                .row(false, "a", 10)
+                .build();
+
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, BIGINT, BIGINT)
+                .row("a", 10L, 55L)
+                .build();
+        assertOperatorEquals(operatorFactory, driverContext, input, expected);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -158,6 +158,7 @@ public class TestEffectivePredicateExtractor
                         C, new Aggregation(fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty()),
                         D, new Aggregation(fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty())),
                 ImmutableList.of(ImmutableList.of(A, B, C)),
+                ImmutableList.of(),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
                 Optional.empty());
@@ -181,6 +182,7 @@ public class TestEffectivePredicateExtractor
                 filter(baseTableScan, FALSE_LITERAL),
                 ImmutableMap.of(),
                 ImmutableList.of(ImmutableList.of()),
+                ImmutableList.of(),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -196,6 +196,7 @@ public class TestTypeValidator
                                 false),
                         Optional.empty())),
                 ImmutableList.of(ImmutableList.of(columnA, columnB)),
+                ImmutableList.of(),
                 SINGLE,
                 Optional.empty(),
                 Optional.empty());
@@ -253,6 +254,7 @@ public class TestTypeValidator
                                 false),
                         Optional.empty())),
                 ImmutableList.of(ImmutableList.of(columnA, columnB)),
+                ImmutableList.of(),
                 SINGLE,
                 Optional.empty(),
                 Optional.empty());
@@ -280,6 +282,7 @@ public class TestTypeValidator
                                 false),
                         Optional.empty())),
                 ImmutableList.of(ImmutableList.of(columnA, columnB)),
+                ImmutableList.of(),
                 SINGLE,
                 Optional.empty(),
                 Optional.empty());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
@@ -96,6 +96,10 @@ public class AggregationMatcher
             return NO_MATCH;
         }
 
+        if (!aggregationNode.getPreGroupedSymbols().isEmpty()) {
+            return NO_MATCH;
+        }
+
         return match();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
@@ -38,13 +38,15 @@ public class AggregationMatcher
 {
     private final Map<Symbol, Symbol> masks;
     private final List<List<String>> groupingSets;
+    private final List<String> preGroupedSymbols;
     private final Optional<Symbol> groupId;
     private final Step step;
 
-    public AggregationMatcher(List<List<String>> groupingSets, Map<Symbol, Symbol> masks, Optional<Symbol> groupId, Step step)
+    public AggregationMatcher(List<List<String>> groupingSets, List<String> preGroupedSymbols, Map<Symbol, Symbol> masks, Optional<Symbol> groupId, Step step)
     {
         this.masks = masks;
         this.groupingSets = groupingSets;
+        this.preGroupedSymbols = preGroupedSymbols;
         this.groupId = groupId;
         this.step = step;
     }
@@ -96,7 +98,7 @@ public class AggregationMatcher
             return NO_MATCH;
         }
 
-        if (!aggregationNode.getPreGroupedSymbols().isEmpty()) {
+        if (!matches(preGroupedSymbols, aggregationNode.getPreGroupedSymbols(), symbolAliases)) {
             return NO_MATCH;
         }
 
@@ -126,6 +128,7 @@ public class AggregationMatcher
     {
         return toStringHelper(this)
                 .add("groupingSets", groupingSets)
+                .add("preGroupedSymbols", preGroupedSymbols)
                 .add("masks", masks)
                 .add("groudId", groupId)
                 .add("step", step)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationStepMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationStepMatcher.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.google.common.base.Preconditions.checkState;
+
+public class AggregationStepMatcher
+        implements Matcher
+{
+    private final Step step;
+
+    public AggregationStepMatcher(Step step)
+    {
+        this.step = step;
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof AggregationNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+        AggregationNode aggregationNode = (AggregationNode) node;
+
+        if (aggregationNode.getStep() != step) {
+            return NO_MATCH;
+        }
+        return match();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.sql.planner.LogicalPlanner;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
@@ -90,6 +91,11 @@ public class BasePlanTest
     {
         closeAllRuntimeException(queryRunner);
         queryRunner = null;
+    }
+
+    public ConnectorId getCurrentConnectorId()
+    {
+        return queryRunner.inTransaction(transactionSession -> queryRunner.getMetadata().getCatalogHandle(transactionSession, transactionSession.getCatalog().get())).get();
     }
 
     protected LocalQueryRunner getQueryRunner()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/JoinMatcher.java
@@ -106,6 +106,7 @@ final class JoinMatcher
     {
         return toStringHelper(this)
                 .omitNullValues()
+                .add("type", joinType)
                 .add("equiCriteria", equiCriteria)
                 .add("filter", filter.orElse(null))
                 .add("distributionType", distributionType.orElse(null))

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -218,7 +218,19 @@ public final class PlanMatchPattern
             Step step,
             PlanMatchPattern source)
     {
-        PlanMatchPattern result = node(AggregationNode.class, source).with(new AggregationMatcher(groupingSets, masks, groupId, step));
+        return aggregation(groupingSets, aggregations, ImmutableList.of(), masks, groupId, step, source);
+    }
+
+    public static PlanMatchPattern aggregation(
+            List<List<String>> groupingSets,
+            Map<Optional<String>, ExpectedValueProvider<FunctionCall>> aggregations,
+            List<String> preGroupedSymbols,
+            Map<Symbol, Symbol> masks,
+            Optional<Symbol> groupId,
+            Step step,
+            PlanMatchPattern source)
+    {
+        PlanMatchPattern result = node(AggregationNode.class, source).with(new AggregationMatcher(groupingSets, preGroupedSymbols, masks, groupId, step));
         aggregations.entrySet().forEach(
                 aggregation -> result.withAlias(aggregation.getKey(), new AggregationFunctionMatcher(aggregation.getValue())));
         return result;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -318,6 +318,7 @@ public class PlanBuilder
                     source,
                     assignments,
                     groupingSets,
+                    ImmutableList.of(),
                     step,
                     hashSymbol,
                     groupIdSymbol);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateAggregationsWithDefaultValues.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateAggregationsWithDefaultValues.java
@@ -59,8 +59,7 @@ public class TestValidateAggregationsWithDefaultValues
     {
         metadata = getQueryRunner().getMetadata();
         builder = new PlanBuilder(new PlanNodeIdAllocator(), metadata);
-        ConnectorId connectorId = getQueryRunner()
-                .inTransaction(session -> metadata.getCatalogHandle(session, session.getCatalog().get())).get();
+        ConnectorId connectorId = getCurrentConnectorId();
         TableHandle nationTableHandle = new TableHandle(
                 connectorId,
                 new TpchTableHandle(connectorId.toString(), "nation", 1.0));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingAggregations.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.metadata.TableLayoutHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
+import com.facebook.presto.tpch.TpchTableLayoutHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
+
+public class TestValidateStreamingAggregations
+        extends BasePlanTest
+{
+    private Metadata metadata;
+    private SqlParser sqlParser;
+    private PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+    private TableHandle nationTableHandle;
+    private TableLayoutHandle nationTableLayoutHandle;
+
+    @BeforeClass
+    public void setup()
+    {
+        metadata = getQueryRunner().getMetadata();
+        sqlParser = getQueryRunner().getSqlParser();
+
+        ConnectorId connectorId = getCurrentConnectorId();
+        nationTableHandle = new TableHandle(
+                connectorId,
+                new TpchTableHandle(connectorId.toString(), "nation", 1.0));
+
+        nationTableLayoutHandle = new TableLayoutHandle(connectorId,
+                TestingTransactionHandle.create(),
+                new TpchTableLayoutHandle((TpchTableHandle) nationTableHandle.getConnectorHandle(), TupleDomain.all()));
+    }
+
+    @Test
+    public void testValidateSuccessful()
+    {
+        validatePlan(
+                p -> p.aggregation(
+                        a -> a.step(SINGLE)
+                                .addGroupingSet(p.symbol("nationkey"))
+                                .source(
+                                        p.tableScan(
+                                                nationTableHandle,
+                                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
+                                                ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)),
+                                                Optional.of(nationTableLayoutHandle)))));
+
+        validatePlan(
+                p -> p.aggregation(
+                        a -> a.step(SINGLE)
+                                .addGroupingSet(p.symbol("unique"), p.symbol("nationkey"))
+                                .preGroupedSymbols(p.symbol("unique"), p.symbol("nationkey"))
+                                .source(
+                                        p.assignUniqueId(p.symbol("unique"),
+                                                p.tableScan(
+                                                        nationTableHandle,
+                                                        ImmutableList.of(p.symbol("nationkey", BIGINT)),
+                                                        ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)),
+                                                        Optional.of(nationTableLayoutHandle))))));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Streaming aggregation with input not grouped on the grouping keys")
+    public void testValidateFailed()
+    {
+        validatePlan(
+                p -> p.aggregation(
+                        a -> a.step(SINGLE)
+                                .addGroupingSet(p.symbol("nationkey"))
+                                .preGroupedSymbols(p.symbol("nationkey"))
+                                .source(
+                                        p.tableScan(
+                                                nationTableHandle,
+                                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
+                                                ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)),
+                                                Optional.of(nationTableLayoutHandle)))));
+    }
+
+    private void validatePlan(Function<PlanBuilder, PlanNode> planProvider)
+    {
+        PlanBuilder builder = new PlanBuilder(idAllocator, metadata);
+        PlanNode planNode = planProvider.apply(builder);
+        Map<Symbol, Type> types = builder.getSymbols();
+
+        getQueryRunner().inTransaction(session -> {
+            // metadata.getCatalogHandle() registers the catalog for the transaction
+            session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
+            new ValidateStreamingAggregations().validate(planNode, session, metadata, sqlParser, types);
+            return null;
+        });
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
@@ -26,6 +26,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.function.Consumer;
+
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
@@ -34,6 +36,8 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functi
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.FINAL;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.PARTIAL;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
 import static org.testng.Assert.assertEquals;
@@ -201,40 +205,45 @@ public class TestSubqueries
                                 anyTree(
                                         node(ValuesNode.class)),
                                 anyTree(
-                                        // FINAL
-                                        aggregation(ImmutableMap.of(),
+                                        aggregation(ImmutableMap.of(), FINAL,
                                                 exchange(LOCAL, REPARTITION,
-                                                        // PARTIAL
-                                                        aggregation(ImmutableMap.of(),
+                                                        aggregation(ImmutableMap.of(), PARTIAL,
                                                                 anyTree(source))))))),
                 plan -> assertEquals(countFinalAggregationNodes(plan), extraAggregation ? 2 : 1));
     }
 
     private void assertExistsRewrittenToAggregationAboveJoin(@Language("SQL") String actual, @Language("SQL") String expected, boolean extraAggregation)
     {
+        Consumer<Plan> singleStreamingAggregationValidator = plan -> assertEquals(countSingleStreamingAggregations(plan), 1);
+        Consumer<Plan> finalAggregationValidator = plan -> assertEquals(countFinalAggregationNodes(plan), extraAggregation ? 1 : 0);
+
         assertions.assertQueryAndPlan(actual, expected,
                 anyTree(
-                        // FINAL
-                        aggregation(ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("COUNT_PARTIAL"))),
-                                exchange(LOCAL, REPARTITION,
-                                        // PARTIAL
-                                        aggregation(ImmutableMap.of("COUNT_PARTIAL", functionCall("count", ImmutableList.of("NON_NULL"))),
-                                                anyTree(
-                                                        node(JoinNode.class,
-                                                                anyTree(
-                                                                        node(ValuesNode.class)),
-                                                                anyTree(
-                                                                        node(ProjectNode.class,
-                                                                                anyTree(
-                                                                                        node(ValuesNode.class)))
-                                                                                .withAlias("NON_NULL", expression("true"))))))))),
-                plan -> assertEquals(countFinalAggregationNodes(plan), extraAggregation ? 2 : 1));
+                        aggregation(
+                                ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("NON_NULL"))),
+                                SINGLE,
+                                node(JoinNode.class,
+                                        anyTree(
+                                                node(ValuesNode.class)),
+                                        anyTree(
+                                                node(ProjectNode.class,
+                                                        anyTree(
+                                                                node(ValuesNode.class)))
+                                                        .withAlias("NON_NULL", expression("true")))))),
+                singleStreamingAggregationValidator.andThen(finalAggregationValidator));
     }
 
     private static int countFinalAggregationNodes(Plan plan)
     {
         return searchFrom(plan.getRoot())
                 .where(node -> node instanceof AggregationNode && ((AggregationNode) node).getStep() == FINAL)
+                .count();
+    }
+
+    private static int countSingleStreamingAggregations(Plan plan)
+    {
+        return searchFrom(plan.getRoot())
+                .where(node -> node instanceof AggregationNode && ((AggregationNode) node).getStep() == SINGLE && ((AggregationNode) node).isStreamable())
                 .count();
     }
 }


### PR DESCRIPTION
Optimize aggregation in a correlated scalar subquery to remove unnecessary local exchange and partial aggregation and enable streaming mode.

Correlated subquery like

`select name, (select max(name) from region where regionkey = nation.regionkey) from nation;`

is rewritten to a left join with an aggregation over synthetic row ID column generated by AssignUniqueId node:

```
- Aggregation (unique, probe.*)
  - LeftJoin
     - AssignUniqueId (unique)
        - probe
     - build
```

Since "unique" column is unique, the aggregation input is partitioned on grouping keys and therefore aggregation can be executed in a single step without any exchanges. Furthermore, since the output of the join is grouped on "unique" column, the aggregation doesn't need to accumulate all of the input in memory before emitting results. It can generate results every time the value of the "unique" column changes. 

This PR implements streaming support in `HashAggregationOperator`, updates `StreamPropertyDerivations` and `PropertyDerivations` to set `paritioned_on(unique)` and `grouped(unique)` properties for the output of the `AssignUniqueId` node, and uses these properties in `AddLocalExchanges` to enable streaming aggregation.

Fixes #8171 