### PR TITLE
Fixed silent clamping for double to long cast

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -217,7 +217,12 @@ public final class DoubleOperators
     @SqlType(StandardTypes.BIGINT)
     public static long castToLong(@SqlType(StandardTypes.DOUBLE) double value)
     {
-        return (long) MathFunctions.round(value);
+        try {
+            return toIntExact((long) MathFunctions.round(value));
+        }
+        catch (ArithmeticException e) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for big integer: " + value, e);
+        }
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -221,7 +221,7 @@ public final class DoubleOperators
             return toIntExact((long) MathFunctions.round(value));
         }
         catch (ArithmeticException e) {
-            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for big integer: " + value, e);
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for bigint: " + value, e);
         }
     }
 


### PR DESCRIPTION
Casting to long now fails the same way as cast to int. 