### PR TITLE
Avoid repeated BlockBuilder construction in ArrayDistinctFunction

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayDistinctFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayDistinctFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.operator.aggregation.TypedSet;
+import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.Description;
@@ -21,6 +22,7 @@ import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
@@ -30,11 +32,17 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 @Description("Remove duplicate values from the given array")
 public final class ArrayDistinctFunction
 {
-    private ArrayDistinctFunction() {}
+    private final PageBuilder pageBuilder;
+
+    @TypeParameter("E")
+    public ArrayDistinctFunction(@TypeParameter("E") Type elementType)
+    {
+        pageBuilder = new PageBuilder(ImmutableList.of(elementType));
+    }
 
     @TypeParameter("E")
     @SqlType("array(E)")
-    public static Block distinct(@TypeParameter("E") Type type, @SqlType("array(E)") Block array)
+    public Block distinct(@TypeParameter("E") Type type, @SqlType("array(E)") Block array)
     {
         if (array.getPositionCount() < 2) {
             return array;
@@ -50,19 +58,28 @@ public final class ArrayDistinctFunction
         }
 
         TypedSet typedSet = new TypedSet(type, array.getPositionCount(), "array_distinct");
-        BlockBuilder distinctElementBlockBuilder = type.createBlockBuilder(null, array.getPositionCount());
+        int distinctCount = 0;
+
+        if (pageBuilder.isFull()) {
+            pageBuilder.reset();
+        }
+
+        BlockBuilder distinctElementBlockBuilder = pageBuilder.getBlockBuilder(0);
         for (int i = 0; i < array.getPositionCount(); i++) {
             if (!typedSet.contains(array, i)) {
                 typedSet.add(array, i);
+                distinctCount++;
                 type.appendTo(array, i, distinctElementBlockBuilder);
             }
         }
 
-        return distinctElementBlockBuilder.build();
+        pageBuilder.declarePositions(distinctCount);
+
+        return distinctElementBlockBuilder.getRegion(distinctElementBlockBuilder.getPositionCount() - distinctCount, distinctCount);
     }
 
     @SqlType("array(bigint)")
-    public static Block bigintDistinct(@SqlType("array(bigint)") Block array)
+    public Block bigintDistinct(@SqlType("array(bigint)") Block array)
     {
         if (array.getPositionCount() == 0) {
             return array;
@@ -70,22 +87,32 @@ public final class ArrayDistinctFunction
 
         boolean containsNull = false;
         LongSet set = new LongOpenHashSet(array.getPositionCount());
-        BlockBuilder distinctElementBlockBuilder = BIGINT.createBlockBuilder(null, array.getPositionCount());
+        int distinctCount = 0;
+
+        if (pageBuilder.isFull()) {
+            pageBuilder.reset();
+        }
+
+        BlockBuilder distinctElementBlockBuilder = pageBuilder.getBlockBuilder(0);
         for (int i = 0; i < array.getPositionCount(); i++) {
             if (array.isNull(i)) {
                 if (!containsNull) {
                     containsNull = true;
                     distinctElementBlockBuilder.appendNull();
+                    distinctCount++;
                 }
                 continue;
             }
-
             long value = BIGINT.getLong(array, i);
-            if (set.add(value)) {
-                BIGINT.writeLong(distinctElementBlockBuilder, value);
+            if (!set.contains(value)) {
+                set.add(value);
+                distinctCount++;
+                BIGINT.appendTo(array, i, distinctElementBlockBuilder);
             }
         }
 
-        return distinctElementBlockBuilder.build();
+        pageBuilder.declarePositions(distinctCount);
+
+        return distinctElementBlockBuilder.getRegion(distinctElementBlockBuilder.getPositionCount() - distinctCount, distinctCount);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -946,6 +946,7 @@ public class TestArrayOperators
 
         // Test for BIGINT-optimized implementation
         assertFunction("ARRAY_DISTINCT(ARRAY [CAST(5 AS BIGINT), NULL, CAST(12 AS BIGINT), NULL])", new ArrayType(BIGINT), asList(5L, null, 12L));
+        assertFunction("ARRAY_DISTINCT(ARRAY [CAST(100 AS BIGINT), NULL, CAST(100 AS BIGINT), NULL, 0, -2, 0])", new ArrayType(BIGINT), asList(100L, null, 0L, -2L));
 
         assertFunction(
                 "ARRAY_DISTINCT(ARRAY [2.3, 2.3, 2.2])",
@@ -955,6 +956,11 @@ public class TestArrayOperators
                 "ARRAY_DISTINCT(ARRAY [2.330, 1.900, 2.330])",
                 new ArrayType(createDecimalType(4, 3)),
                 ImmutableList.of(decimal("2.330"), decimal("1.900")));
+
+        assertCachedInstanceHasBoundedRetainedSize("ARRAY_DISTINCT(ARRAY[2, 3, 4, 1, 2])");
+        assertCachedInstanceHasBoundedRetainedSize("ARRAY_DISTINCT(ARRAY[CAST(5 AS BIGINT), NULL, CAST(12 AS BIGINT), NULL])");
+        assertCachedInstanceHasBoundedRetainedSize("ARRAY_DISTINCT(ARRAY[true, true, false, true, false])");
+        assertCachedInstanceHasBoundedRetainedSize("ARRAY_DISTINCT(ARRAY['cat', 'dog', 'dog', 'coffee', 'apple'])");
     }
 
     @Test


### PR DESCRIPTION
Use same mechanism as ArrayShuffleFunction to avoid repeated BlockBuilder construction in ArrayDistinctFunction