### PR TITLE
Set default soft memory limit to Long.MAX_VALUE

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -86,7 +86,7 @@ public class InternalResourceGroup
     // Configuration
     // =============
     @GuardedBy("root")
-    private long softMemoryLimitBytes;
+    private long softMemoryLimitBytes = Long.MAX_VALUE;
     @GuardedBy("root")
     private int softConcurrencyLimit;
     @GuardedBy("root")


### PR DESCRIPTION
This fixes #10383, where deployments using the legacy resource group
configuration manager were unable to run more than a single query that
used memory concurrently.