### PR TITLE
Fix memory accounting in OrcInputStream

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
@@ -67,7 +67,7 @@ public final class OrcInputStream
         requireNonNull(systemMemoryContext, "systemMemoryContext is null");
         this.bufferMemoryUsage = systemMemoryContext.newLocalMemoryContext();
         this.fixedMemoryUsage = systemMemoryContext.newLocalMemoryContext();
-        this.fixedMemoryUsage.setBytes(sliceInput.length());
+        this.fixedMemoryUsage.setBytes(sliceInput.getRetainedSize());
 
         if (!decompressor.isPresent()) {
             this.current = sliceInput;
@@ -83,7 +83,7 @@ public final class OrcInputStream
     public void close()
     {
         current = null;
-        fixedMemoryUsage.setBytes(compressedSliceInput.length()); // see comments above for fixedMemoryUsage
+        fixedMemoryUsage.setBytes(compressedSliceInput.getRetainedSize()); // see comments above for fixedMemoryUsage
 
         buffer = null;
         bufferMemoryUsage.setBytes(0);


### PR DESCRIPTION
Previously, sliceInput.length() was used as an approximation of the
retained size for memory accounting. However, that value can be
significantly larger than the actual retained size. For example,
for ChunkedSliceInput the length() method returns the total length
of the backing stream instead of the actual buffer size that's
retained. That causes significant over-accounting for the scan operators.

