### PR TITLE
Update jline to 2.14.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -724,7 +724,7 @@
             <dependency>
                 <groupId>jline</groupId>
                 <artifactId>jline</artifactId>
-                <version>2.13</version>
+                <version>2.14.6</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.fusesource.jansi</groupId>

--- a/presto-cli/src/main/java/com/facebook/presto/cli/LineReader.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/LineReader.java
@@ -64,7 +64,7 @@ public class LineReader
     @Override
     public void close()
     {
-        shutdown();
+        super.close();
     }
 
     public boolean interrupted()


### PR DESCRIPTION
On Ubuntu 18.04 the `infocmp` (command that prints terminal capabilities)
outputs the `colors` property in hex format. The jline library up
to 2.14.4 didn't support such representation.

https://github.com/jline/jline2/commit/c1b1676de1803278289af0622ad202f1c7a526ec