### PR TITLE
Implement approx_distinct under the annotation framework

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.block.BlockSerdeUtil;
-import com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregations;
+import com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregation;
 import com.facebook.presto.operator.aggregation.ApproximateDoublePercentileAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateDoublePercentileArrayAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateLongPercentileAggregations;
@@ -30,6 +30,7 @@ import com.facebook.presto.operator.aggregation.BooleanOrAggregation;
 import com.facebook.presto.operator.aggregation.CentralMomentsAggregation;
 import com.facebook.presto.operator.aggregation.CountAggregation;
 import com.facebook.presto.operator.aggregation.CountIfAggregation;
+import com.facebook.presto.operator.aggregation.DefaultApproximateCountDistinctAggregation;
 import com.facebook.presto.operator.aggregation.DoubleCorrelationAggregation;
 import com.facebook.presto.operator.aggregation.DoubleCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
@@ -410,6 +411,8 @@ public class FunctionRegistry
                 .window(NthValueFunction.class)
                 .window(LagFunction.class)
                 .window(LeadFunction.class)
+                .aggregate(ApproximateCountDistinctAggregation.class)
+                .aggregate(DefaultApproximateCountDistinctAggregation.class)
                 .aggregates(CountAggregation.class)
                 .aggregates(VarianceAggregation.class)
                 .aggregates(CentralMomentsAggregation.class)
@@ -433,7 +436,6 @@ public class FunctionRegistry
                 .aggregates(IntervalYearToMonthAverageAggregation.class)
                 .aggregates(GeometricMeanAggregations.class)
                 .aggregates(RealGeometricMeanAggregations.class)
-                .aggregates(ApproximateCountDistinctAggregations.class)
                 .aggregates(MergeHyperLogLogAggregation.class)
                 .aggregates(ApproximateSetAggregation.class)
                 .aggregates(DoubleHistogramAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
@@ -97,9 +97,10 @@ public class AggregationFromAnnotationsParser
             Method combineFunction = getCombineFunction(aggregationDefinition, stateClass);
             Optional<Method> aggregationStateSerializerFactory = getAggregationStateSerializerFactory(aggregationDefinition, stateClass);
             Method outputFunction = getOnlyElement(getOutputFunctions(aggregationDefinition, stateClass));
-            Method inputFunction = getOnlyElement(getInputFunctions(aggregationDefinition, stateClass));
-            AggregationImplementation implementation = parseImplementation(aggregationDefinition, header, stateClass, inputFunction, outputFunction, combineFunction, aggregationStateSerializerFactory);
-            implementationsBuilder.addImplementation(implementation);
+            for (Method inputFunction : getInputFunctions(aggregationDefinition, stateClass)) {
+                AggregationImplementation implementation = parseImplementation(aggregationDefinition, header, stateClass, inputFunction, outputFunction, combineFunction, aggregationStateSerializerFactory);
+                implementationsBuilder.addImplementation(implementation);
+            }
         }
 
         ParametricImplementationsGroup<AggregationImplementation> implementations = implementationsBuilder.build();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregation.java
@@ -19,80 +19,91 @@ import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.AggregationState;
 import com.facebook.presto.spi.function.CombineFunction;
 import com.facebook.presto.spi.function.InputFunction;
-import com.facebook.presto.spi.function.LiteralParameters;
+import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.OutputFunction;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.Slice;
 import io.airlift.stats.cardinality.HyperLogLog;
 
+import java.lang.invoke.MethodHandle;
+
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.util.Failures.checkCondition;
+import static com.facebook.presto.util.Failures.internalError;
 
 @AggregationFunction("approx_distinct")
-public final class ApproximateCountDistinctAggregations
+public final class ApproximateCountDistinctAggregation
 {
-    private static final double DEFAULT_STANDARD_ERROR = 0.023;
     private static final double LOWEST_MAX_STANDARD_ERROR = 0.0040625;
     private static final double HIGHEST_MAX_STANDARD_ERROR = 0.26000;
 
-    private ApproximateCountDistinctAggregations() {}
+    private ApproximateCountDistinctAggregation() {}
 
     @InputFunction
-    public static void input(@AggregationState HyperLogLogState state, @SqlType(StandardTypes.BIGINT) long value)
-    {
-        input(state, value, DEFAULT_STANDARD_ERROR);
-    }
-
-    @InputFunction
-    public static void input(@AggregationState HyperLogLogState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.DOUBLE) double maxStandardError)
+    @TypeParameter("T")
+    public static void input(
+            @OperatorDependency(operator = XX_HASH_64, returnType = StandardTypes.BIGINT, argumentTypes = {"T"}) MethodHandle methodHandle,
+            @AggregationState HyperLogLogState state,
+            @SqlType("T") long value,
+            @SqlType(StandardTypes.DOUBLE) double maxStandardError)
     {
         HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
         state.addMemoryUsage(-hll.estimatedInMemorySize());
-        hll.add(value);
+        long hash;
+        try {
+            hash = (long) methodHandle.invokeExact(value);
+        }
+        catch (Throwable t) {
+            throw internalError(t);
+        }
+        hll.addHash(hash);
         state.addMemoryUsage(hll.estimatedInMemorySize());
     }
 
     @InputFunction
-    public static void input(@AggregationState HyperLogLogState state, @SqlType(StandardTypes.DOUBLE) double value)
-    {
-        input(state, value, DEFAULT_STANDARD_ERROR);
-    }
-
-    @InputFunction
-    public static void input(@AggregationState HyperLogLogState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double maxStandardError)
-    {
-        input(state, Double.doubleToLongBits(value), maxStandardError);
-    }
-
-    @InputFunction
-    @LiteralParameters("x")
-    public static void input(@AggregationState HyperLogLogState state, @SqlType("varchar(x)") Slice value)
-    {
-        input(state, value, DEFAULT_STANDARD_ERROR);
-    }
-
-    @InputFunction
-    @LiteralParameters("x")
-    public static void input(@AggregationState HyperLogLogState state, @SqlType("varchar(x)") Slice value, @SqlType(StandardTypes.DOUBLE) double maxStandardError)
-    {
-        inputBinary(state, value, maxStandardError);
-    }
-
-    @InputFunction
-    public static void inputBinary(@AggregationState HyperLogLogState state, @SqlType(StandardTypes.VARBINARY) Slice value)
-    {
-        inputBinary(state, value, DEFAULT_STANDARD_ERROR);
-    }
-
-    @InputFunction
-    public static void inputBinary(@AggregationState HyperLogLogState state, @SqlType(StandardTypes.VARBINARY) Slice value, @SqlType(StandardTypes.DOUBLE) double maxStandardError)
+    @TypeParameter("T")
+    public static void input(
+            @OperatorDependency(operator = XX_HASH_64, returnType = StandardTypes.BIGINT, argumentTypes = {"T"}) MethodHandle methodHandle,
+            @AggregationState HyperLogLogState state,
+            @SqlType("T") double value,
+            @SqlType(StandardTypes.DOUBLE) double maxStandardError)
     {
         HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
         state.addMemoryUsage(-hll.estimatedInMemorySize());
-        hll.add(value);
+        long hash;
+        try {
+            hash = (long) methodHandle.invokeExact(value);
+        }
+        catch (Throwable t) {
+            throw internalError(t);
+        }
+        hll.addHash(hash);
+        state.addMemoryUsage(hll.estimatedInMemorySize());
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(
+            @OperatorDependency(operator = XX_HASH_64, returnType = StandardTypes.BIGINT, argumentTypes = {"T"}) MethodHandle methodHandle,
+            @AggregationState HyperLogLogState state,
+            @SqlType("T") Slice value,
+            @SqlType(StandardTypes.DOUBLE) double maxStandardError)
+    {
+        HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
+        state.addMemoryUsage(-hll.estimatedInMemorySize());
+        long hash;
+        try {
+            hash = (long) methodHandle.invokeExact(value);
+        }
+        catch (Throwable t) {
+            throw internalError(t);
+        }
+        hll.addHash(hash);
         state.addMemoryUsage(hll.estimatedInMemorySize());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.HyperLogLogState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OperatorDependency;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.type.StandardTypes;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
+
+@AggregationFunction("approx_distinct")
+public final class DefaultApproximateCountDistinctAggregation
+{
+    private static final double DEFAULT_STANDARD_ERROR = 0.023;
+
+    private DefaultApproximateCountDistinctAggregation() {}
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(
+            @OperatorDependency(operator = XX_HASH_64, returnType = StandardTypes.BIGINT, argumentTypes = {"T"}) MethodHandle methodHandle,
+            @AggregationState HyperLogLogState state,
+            @SqlType("T") long value)
+    {
+        ApproximateCountDistinctAggregation.input(methodHandle, state, value, DEFAULT_STANDARD_ERROR);
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(
+            @OperatorDependency(operator = XX_HASH_64, returnType = StandardTypes.BIGINT, argumentTypes = {"T"}) MethodHandle methodHandle,
+            @AggregationState HyperLogLogState state,
+            @SqlType("T") double value)
+    {
+        ApproximateCountDistinctAggregation.input(methodHandle, state, value, DEFAULT_STANDARD_ERROR);
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(
+            @OperatorDependency(operator = XX_HASH_64, returnType = StandardTypes.BIGINT, argumentTypes = {"T"}) MethodHandle methodHandle,
+            @AggregationState HyperLogLogState state,
+            @SqlType("T") Slice value)
+    {
+        ApproximateCountDistinctAggregation.input(methodHandle, state, value, DEFAULT_STANDARD_ERROR);
+    }
+
+    @CombineFunction
+    public static void combineState(@AggregationState HyperLogLogState state, @AggregationState HyperLogLogState otherState)
+    {
+        ApproximateCountDistinctAggregation.combineState(state, otherState);
+    }
+
+    @OutputFunction(StandardTypes.BIGINT)
+    public static void evaluateFinal(@AggregationState HyperLogLogState state, BlockBuilder out)
+    {
+        ApproximateCountDistinctAggregation.evaluateFinal(state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/BigintOperators.java
@@ -24,6 +24,7 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -44,6 +45,7 @@ import static com.facebook.presto.spi.function.OperatorType.NEGATION;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SATURATED_FLOOR_CAST;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.toIntExact;
@@ -288,5 +290,12 @@ public final class BigintOperators
             return false;
         }
         return notEqual(left, right);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        return XxHash64.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DoubleOperators.java
@@ -25,6 +25,7 @@ import com.google.common.math.DoubleMath;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -45,6 +46,7 @@ import static com.facebook.presto.spi.function.OperatorType.NEGATION;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SATURATED_FLOOR_CAST;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Double.doubleToLongBits;
@@ -314,5 +316,12 @@ public final class DoubleOperators
             return false;
         }
         return notEqual(left, right);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        return XxHash64.hash(Double.doubleToLongBits(value));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/VarbinaryOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarbinaryOperators.java
@@ -29,6 +29,7 @@ import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 
 public final class VarbinaryOperators
 {
@@ -92,7 +93,7 @@ public final class VarbinaryOperators
         // This needs to match the hash function for VARBINARY blocks
         // (i.e. AstractVariableWidthBlock.hash(...))
         // TODO: we need to get rid of hash from Block and rely on HASH_CODE operators only
-        return XxHash64.hash(value);
+        return xxHash64(value);
     }
 
     @ScalarOperator(IS_DISTINCT_FROM)
@@ -110,5 +111,12 @@ public final class VarbinaryOperators
             return false;
         }
         return notEqual(left, right);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.VARBINARY) Slice value)
+    {
+        return XxHash64.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
@@ -33,6 +33,7 @@ import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static java.lang.String.format;
 
 public final class VarcharOperators
@@ -249,5 +250,13 @@ public final class VarcharOperators
             return false;
         }
         return notEqual(left, right);
+    }
+
+    @LiteralParameters("x")
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType("varchar(x)") Slice slice)
+    {
+        return XxHash64.hash(slice);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctAggregations.java
@@ -16,7 +16,7 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.spi.PrestoException;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregations.standardErrorToBuckets;
+import static com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregation.standardErrorToBuckets;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/math_functions/checkMathFunctionsRegistered.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/math_functions/checkMathFunctionsRegistered.result
@@ -2,10 +2,8 @@
  abs | bigint | bigint | scalar | true | absolute value |
  abs | double | double | scalar | true | absolute value |
  acos | double | double | scalar | true | arc cosine |
- approx_distinct | bigint | bigint | aggregate | true | |
- approx_distinct | bigint | bigint, double | aggregate | true | |
- approx_distinct | bigint | double | aggregate | true | |
- approx_distinct | bigint | double, double | aggregate | true | |
+ approx_distinct | bigint | T | aggregate | true | |
+ approx_distinct | bigint | T, double | aggregate | true | |
  approx_percentile | bigint | bigint, bigint, double | aggregate | true | |
  approx_percentile | bigint | bigint, double | aggregate | true | |
  approx_percentile | double | double, bigint, double | aggregate | true | |

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/OperatorType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/OperatorType.java
@@ -32,7 +32,8 @@ public enum OperatorType
     SUBSCRIPT("[]"),
     HASH_CODE("HASH CODE"),
     SATURATED_FLOOR_CAST("SATURATED FLOOR CAST"),
-    IS_DISTINCT_FROM("IS DISTINCT FROM");
+    IS_DISTINCT_FROM("IS DISTINCT FROM"),
+    XX_HASH_64("XX HASH 64");
 
     private final String operator;
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -660,14 +660,14 @@ public abstract class AbstractTestAggregations
     @Test
     public void testApproximateCountDistinct()
     {
-        assertQuery("SELECT approx_distinct(custkey) FROM orders", "SELECT 996");
-        assertQuery("SELECT approx_distinct(custkey, 0.023) FROM orders", "SELECT 996");
-        assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE)) FROM orders", "SELECT 1031");
-        assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE), 0.023) FROM orders", "SELECT 1031");
-        assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR)) FROM orders", "SELECT 1011");
-        assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR), 0.023) FROM orders", "SELECT 1011");
-        assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR))) FROM orders", "SELECT 1011");
-        assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR)), 0.023) FROM orders", "SELECT 1011");
+        assertQuery("SELECT approx_distinct(custkey) FROM orders", "SELECT 990");
+        assertQuery("SELECT approx_distinct(custkey, 0.023) FROM orders", "SELECT 990");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE)) FROM orders", "SELECT 1014");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE), 0.023) FROM orders", "SELECT 1014");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR)) FROM orders", "SELECT 1036");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR), 0.023) FROM orders", "SELECT 1036");
+        assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR))) FROM orders", "SELECT 1036");
+        assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR)), 0.023) FROM orders", "SELECT 1036");
     }
 
     @Test
@@ -675,8 +675,8 @@ public abstract class AbstractTestAggregations
     {
         MaterializedResult actual = computeActual("SELECT orderstatus, approx_distinct(custkey) FROM orders GROUP BY orderstatus");
         MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
-                .row("O", 995L)
-                .row("F", 993L)
+                .row("O", 990L)
+                .row("F", 990L)
                 .row("P", 303L)
                 .build();
 
@@ -688,8 +688,8 @@ public abstract class AbstractTestAggregations
     {
         MaterializedResult actual = computeActual("SELECT orderstatus, approx_distinct(custkey, 0.023) FROM orders GROUP BY orderstatus");
         MaterializedResult expected = resultBuilder(getSession(), actual.getTypes())
-                .row("O", 995L)
-                .row("F", 993L)
+                .row("O", 990L)
+                .row("F", 990L)
                 .row("P", 303L)
                 .build();
 


### PR DESCRIPTION
This is part of the work to support `approx_distinct` for all data types. The goal is that any type that implements the `XX HASH 64` operator can have its `approx_distinct` implementation via the parametric implementation of `approx_distinct`.

What we have done:
(1) support a single aggregation function to have multiple `input` function implementations. 
(2) convert existing implementation of `approx_distinct` into the annotation framework. 

What's next (separate PR):
(1) implement `XX_HASH_64` operators for other data types