### PR TITLE
Add partial distinct for global aggergation without marking

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/CountAggregationBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/CountAggregationBenchmark.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +35,7 @@ import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.mapWithIndex;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class CountAggregationBenchmark
         extends AbstractSimpleOperatorBenchmark
@@ -56,7 +58,8 @@ public class CountAggregationBenchmark
                 Step.SINGLE,
                 ImmutableList.of(new GeneralInternalAccumulatorFactory(countFunction.bind(ImmutableList.of(0), Optional.empty()))),
                 mapWithIndex(ordersTableTypes.stream(), (type, channel) -> new AggregationInputChannel(new Symbol("i" + channel), (int) channel, type))
-                    .collect(toImmutableList()));
+                    .collect(toImmutableList()),
+                new DataSize(16, MEGABYTE));
         return ImmutableList.of(tableScanOperator, aggregationOperator);
     }
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/DoubleSumAggregationBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/DoubleSumAggregationBenchmark.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +36,7 @@ import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.mapWithIndex;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class DoubleSumAggregationBenchmark
         extends AbstractSimpleOperatorBenchmark
@@ -57,7 +59,8 @@ public class DoubleSumAggregationBenchmark
                 Step.SINGLE,
                 ImmutableList.of(new GeneralInternalAccumulatorFactory(doubleSum.bind(ImmutableList.of(0), Optional.empty()))),
                 mapWithIndex(ordersTableTypes.stream(), (type, channel) -> new AggregationInputChannel(new Symbol("i" + channel), (int) channel, type))
-                    .collect(toImmutableList()));
+                    .collect(toImmutableList()),
+                new DataSize(16, MEGABYTE));
         return ImmutableList.of(tableScanOperator, aggregationOperator);
     }
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
@@ -14,9 +14,11 @@
 package com.facebook.presto.benchmark;
 
 import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.AggregationOperator.AggregationInputChannel;
 import com.facebook.presto.operator.AggregationOperator.AggregationOperatorFactory;
 import com.facebook.presto.operator.FilterAndProjectOperator;
 import com.facebook.presto.operator.OperatorFactory;
+import com.facebook.presto.operator.aggregation.GeneralInternalAccumulatorFactory;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.operator.project.InputChannels;
 import com.facebook.presto.operator.project.PageFilter;
@@ -27,6 +29,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.sql.gen.PageFunctionCompiler;
+import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.LocalQueryRunner;
@@ -85,8 +88,8 @@ public class HandTpchQuery6
                 2,
                 new PlanNodeId("test"),
                 Step.SINGLE,
-                ImmutableList.of(
-                        doubleSum.bind(ImmutableList.of(0), Optional.empty())));
+                ImmutableList.of(new GeneralInternalAccumulatorFactory(doubleSum.bind(ImmutableList.of(0), Optional.empty()))),
+                ImmutableList.of(new AggregationInputChannel(new Symbol("input"), 0, DOUBLE)));
 
         return ImmutableList.of(tableScanOperator, tpchQuery6Operator, aggregationOperator);
     }

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.sql.relational.Expressions.field;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class HandTpchQuery6
         extends AbstractSimpleOperatorBenchmark
@@ -89,7 +90,8 @@ public class HandTpchQuery6
                 new PlanNodeId("test"),
                 Step.SINGLE,
                 ImmutableList.of(new GeneralInternalAccumulatorFactory(doubleSum.bind(ImmutableList.of(0), Optional.empty()))),
-                ImmutableList.of(new AggregationInputChannel(new Symbol("input"), 0, DOUBLE)));
+                ImmutableList.of(new AggregationInputChannel(new Symbol("input"), 0, DOUBLE)),
+                new DataSize(16, MEGABYTE));
 
         return ImmutableList.of(tableScanOperator, tpchQuery6Operator, aggregationOperator);
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -29,7 +29,6 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.GrantInfo;
@@ -82,11 +81,7 @@ public class InformationSchemaPageSourceProvider
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         for (Page page : table.getPages()) {
-            Block[] blocks = new Block[channels.size()];
-            for (int index = 0; index < blocks.length; index++) {
-                blocks[index] = page.getBlock(channels.get(index));
-            }
-            pages.add(new Page(page.getPositionCount(), blocks));
+            pages.add(page.selectChannels(channels));
         }
         return new FixedPageSource(pages.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/cost/AggregationStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/AggregationStatsRule.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -59,7 +60,7 @@ public class AggregationStatsRule
                 node.getAggregations()));
     }
 
-    public static PlanNodeStatsEstimate groupBy(PlanNodeStatsEstimate sourceStats, Collection<Symbol> groupBySymbols, Map<Symbol, Aggregation> aggregations)
+    public static PlanNodeStatsEstimate groupBy(PlanNodeStatsEstimate sourceStats, Collection<Symbol> groupBySymbols, List<Aggregation> aggregations)
     {
         PlanNodeStatsEstimate.Builder result = PlanNodeStatsEstimate.builder();
         for (Symbol groupBySymbol : groupBySymbols) {
@@ -80,8 +81,8 @@ public class AggregationStatsRule
         }
         result.setOutputRowCount(min(rowsCount, sourceStats.getOutputRowCount()));
 
-        for (Map.Entry<Symbol, Aggregation> aggregationEntry : aggregations.entrySet()) {
-            result.addSymbolStatistics(aggregationEntry.getKey(), estimateAggregationStats(aggregationEntry.getValue(), sourceStats));
+        for (Aggregation aggregation : aggregations) {
+            result.addSymbolStatistics(aggregation.getOutputSymbol(), estimateAggregationStats(aggregation, sourceStats));
         }
 
         return result.build();

--- a/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -176,7 +177,16 @@ public class AggregationOperator
         }
 
         state = State.FINISHED;
-        return pageBuilder.build();
+
+        Page page = pageBuilder.build();
+
+        // prepend the row type block for partial outputs
+        if (partial) {
+            BlockBuilder blockBuilder = TINYINT.createBlockBuilder(null, 1);
+            TINYINT.writeLong(blockBuilder, 1);
+            page = page.prependColumn(blockBuilder.build());
+        }
+        return page;
     }
 
     private static class Aggregator

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DistinctInternalAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DistinctInternalAccumulatorFactory.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.operator.MarkDistinctHash;
+import com.facebook.presto.operator.UpdateMemory;
+import com.facebook.presto.operator.Work;
+import com.facebook.presto.operator.project.SelectedPositions;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.ByteArrayBlock;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.JoinCompiler;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.IntStream.range;
+
+public class DistinctInternalAccumulatorFactory
+        implements InternalAccumulatorFactory
+{
+    private final AccumulatorFactory accumulatorFactory;
+    private final List<Type> argumentTypes;
+    private final Type finalType;
+    private final List<Integer> argumentChannels;
+    private final Optional<Integer> maskChannel;
+    private final Session session;
+
+    private final JoinCompiler joinCompiler;
+
+    public DistinctInternalAccumulatorFactory(
+            AccumulatorFactory accumulatorFactory,
+            List<Type> argumentTypes,
+            List<Integer> argumentChannels,
+            Optional<Integer> maskChannel,
+            Session session,
+            JoinCompiler joinCompiler)
+    {
+        this.accumulatorFactory = requireNonNull(accumulatorFactory, "accumulatorFactory is null");
+        this.argumentTypes = ImmutableList.copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
+        this.argumentChannels = ImmutableList.copyOf(requireNonNull(argumentChannels, "argumentChannels is null"));
+        this.finalType = accumulatorFactory.createAccumulator().getFinalType();
+        this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
+        this.session = requireNonNull(session, "session is null");
+        this.joinCompiler = requireNonNull(joinCompiler, "joinCompiler is null");
+        verify(accumulatorFactory.getInputChannels().size() == argumentTypes.size());
+    }
+
+    @Override
+    public Type getIntermediateType()
+    {
+        return BOOLEAN;
+    }
+
+    @Override
+    public Type getFinalType()
+    {
+        return finalType;
+    }
+
+    @Override
+    public boolean isDistinct()
+    {
+        return true;
+    }
+
+    @Override
+    public InternalSingleAccumulator createSingleAccumulator()
+    {
+        return new DistinctInternalFinalAccumulator(accumulatorFactory.createAccumulator(), argumentTypes, argumentChannels, maskChannel, session, joinCompiler);
+    }
+
+    @Override
+    public InternalPartialAccumulator createPartialAccumulator()
+    {
+        return new DistinctInternalPartialAccumulator(argumentTypes, argumentChannels, maskChannel, session, joinCompiler);
+    }
+
+    @Override
+    public InternalIntermediateAccumulator createIntermediateAccumulator()
+    {
+        return new DistinctInternalPartialAccumulator(argumentTypes, argumentChannels, maskChannel, session, joinCompiler);
+    }
+
+    @Override
+    public InternalFinalAccumulator createFinalAccumulator()
+    {
+        return new DistinctInternalFinalAccumulator(accumulatorFactory.createAccumulator(), argumentTypes, argumentChannels, maskChannel, session, joinCompiler);
+    }
+
+    public static class DistinctInternalPartialAccumulator
+            implements InternalPartialAccumulator, InternalIntermediateAccumulator
+    {
+        private final MarkDistinctHash hash;
+        private final List<Integer> argumentChannels;
+        private final Optional<Integer> maskChannel;
+
+        public DistinctInternalPartialAccumulator(
+                List<Type> argumentTypes,
+                List<Integer> argumentChannels,
+                Optional<Integer> maskChannel,
+                Session session,
+                JoinCompiler joinCompiler)
+        {
+            this.argumentChannels = ImmutableList.copyOf(requireNonNull(argumentChannels, "argumentChannels is null"));
+            this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
+
+            hash = new MarkDistinctHash(session, argumentTypes, range(0, argumentTypes.size()).toArray(), Optional.empty(), joinCompiler, UpdateMemory.NOOP);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return hash.getEstimatedSize();
+        }
+
+        @Override
+        public Type getIntermediateType()
+        {
+            return BOOLEAN;
+        }
+
+        @Override
+        public boolean isDistinct()
+        {
+            return true;
+        }
+
+        @Override
+        public Optional<Block> addInput(Page page)
+        {
+            // 1. mask input to based on mask channel
+            SelectedPositions selectedPositions = maskChannel
+                    .map(page::getBlock)
+                    .map(DistinctInternalAccumulatorFactory::booleanBlockToSelectedPositions)
+                    .orElse(SelectedPositions.positionsRange(0, page.getPositionCount()));
+            if (selectedPositions.isEmpty()) {
+                return Optional.empty();
+            }
+            Page masked = selectedPositions.selectPositions(page);
+
+            // 2. determine which of the selected positions are distinct
+            Page hashChannels = new Page(masked.getPositionCount(), argumentChannels.stream().map(masked::getBlock).toArray(Block[]::new));
+            Work<Block> work = hash.markDistinctRows(hashChannels);
+            checkState(work.process());
+            Block distinctSelectedPositions = work.getResult();
+
+            // 3. return boolean block of the distinct positions
+            return buildDistinctSelectedPositionsMask(page.getPositionCount(), selectedPositions, distinctSelectedPositions);
+        }
+
+        @Override
+        public void addIntermediate(Block block)
+        {
+            for (int position = 0; position < block.getPositionCount(); position++) {
+                verify(block.isNull(position), "Distinct accumulator does not have intermediate results");
+            }
+        }
+
+        @Override
+        public void evaluateIntermediate(BlockBuilder blockBuilder)
+        {
+            blockBuilder.appendNull();
+        }
+    }
+
+    public static class DistinctInternalFinalAccumulator
+            implements InternalFinalAccumulator, InternalSingleAccumulator
+    {
+        private final Accumulator accumulator;
+        private final MarkDistinctHash hash;
+        private final List<Integer> argumentChannels;
+        private final Optional<Integer> maskChannel;
+
+        public DistinctInternalFinalAccumulator(
+                Accumulator accumulator,
+                List<Type> argumentTypes,
+                List<Integer> argumentChannels,
+                Optional<Integer> maskChannel,
+                Session session,
+                JoinCompiler joinCompiler)
+        {
+            this.accumulator = requireNonNull(accumulator, "accumulator is null");
+            this.argumentChannels = ImmutableList.copyOf(requireNonNull(argumentChannels, "argumentChannels is null"));
+            this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
+
+            hash = new MarkDistinctHash(session, argumentTypes, range(0, argumentTypes.size()).toArray(), Optional.empty(), joinCompiler, UpdateMemory.NOOP);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return hash.getEstimatedSize() + accumulator.getEstimatedSize();
+        }
+
+        @Override
+        public Type getIntermediateType()
+        {
+            return BOOLEAN;
+        }
+
+        @Override
+        public Type getFinalType()
+        {
+            return accumulator.getFinalType();
+        }
+
+        @Override
+        public boolean isDistinct()
+        {
+            return true;
+        }
+
+        @Override
+        public void addInput(Page page)
+        {
+            // 1. mask input rows based on mask channel
+            SelectedPositions selectedPositions = maskChannel
+                    .map(page::getBlock)
+                    .map(DistinctInternalAccumulatorFactory::booleanBlockToSelectedPositions)
+                    .orElse(SelectedPositions.positionsRange(0, page.getPositionCount()));
+            Page masked = selectedPositions.selectPositions(page);
+            if (masked.getPositionCount() == 0) {
+                return;
+            }
+
+            // 2. determine which of the selected positions are distinct
+            Page hashChannels = masked.selectChannels(argumentChannels);
+            Work<Block> work = hash.markDistinctRows(hashChannels);
+            checkState(work.process());
+            Block distinctSelectedPositions = work.getResult();
+
+            // 3. add distinct positions to the accumulator
+            Page distinct = filter(masked, distinctSelectedPositions);
+            if (distinct.getPositionCount() == 0) {
+                return;
+            }
+            accumulator.addInput(distinct);
+        }
+
+        private static Page filter(Page page, Block mask)
+        {
+            int[] ids = new int[mask.getPositionCount()];
+            int next = 0;
+            for (int i = 0; i < page.getPositionCount(); ++i) {
+                if (BOOLEAN.getBoolean(mask, i)) {
+                    ids[next++] = i;
+                }
+            }
+
+            return page.getPositions(ids, 0, next);
+        }
+
+        @Override
+        public void addIntermediate(Block block)
+        {
+            for (int position = 0; position < block.getPositionCount(); position++) {
+                verify(block.isNull(position), "Distinct accumulator does not have intermediate results");
+            }
+        }
+
+        @Override
+        public void evaluateFinal(BlockBuilder blockBuilder)
+        {
+            accumulator.evaluateFinal(blockBuilder);
+        }
+    }
+
+    private static SelectedPositions booleanBlockToSelectedPositions(Block mask)
+    {
+        int[] ids = new int[mask.getPositionCount()];
+        int next = 0;
+        for (int i = 0; i < mask.getPositionCount(); ++i) {
+            if (BOOLEAN.getBoolean(mask, i)) {
+                ids[next++] = i;
+            }
+        }
+
+        return SelectedPositions.positionsList(ids, 0, next);
+    }
+
+    private static Optional<Block> buildDistinctSelectedPositionsMask(int inputPositionCount, SelectedPositions selectedPositions, Block distinctSelectedPositions)
+    {
+        boolean hasDistinct = false;
+        byte[] distinct = new byte[inputPositionCount];
+        for (int filteredPosition = 0; filteredPosition < distinctSelectedPositions.getPositionCount(); filteredPosition++) {
+            if (BOOLEAN.getBoolean(distinctSelectedPositions, filteredPosition)) {
+                int originalPosition = selectedPositions.getSelectedPosition(filteredPosition);
+                verify(originalPosition < inputPositionCount);
+                hasDistinct = true;
+                distinct[originalPosition] = 1;
+            }
+        }
+
+        return hasDistinct ? Optional.of(new ByteArrayBlock(distinct.length, new boolean[distinct.length], distinct)) : Optional.empty();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GeneralInternalAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GeneralInternalAccumulatorFactory.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class GeneralInternalAccumulatorFactory
+        implements InternalAccumulatorFactory
+{
+    private final AccumulatorFactory accumulatorFactory;
+    private final Type intermediateType;
+    private final Type finalType;
+
+    public GeneralInternalAccumulatorFactory(AccumulatorFactory accumulatorFactory)
+    {
+        this.accumulatorFactory = requireNonNull(accumulatorFactory, "accumulatorFactory is null");
+        Accumulator accumulator = accumulatorFactory.createAccumulator();
+        this.intermediateType = accumulator.getIntermediateType();
+        this.finalType = accumulator.getFinalType();
+    }
+
+    @Override
+    public Type getIntermediateType()
+    {
+        return intermediateType;
+    }
+
+    @Override
+    public Type getFinalType()
+    {
+        return finalType;
+    }
+
+    @Override
+    public boolean isDistinct()
+    {
+        return false;
+    }
+
+    @Override
+    public InternalSingleAccumulator createSingleAccumulator()
+    {
+        return new GeneralInternalAccumulator(accumulatorFactory.createAccumulator());
+    }
+
+    @Override
+    public InternalPartialAccumulator createPartialAccumulator()
+    {
+        return new GeneralInternalIntermediateAccumulator(accumulatorFactory.createAccumulator());
+    }
+
+    @Override
+    public InternalIntermediateAccumulator createIntermediateAccumulator()
+    {
+        return new GeneralInternalIntermediateAccumulator(accumulatorFactory.createIntermediateAccumulator());
+    }
+
+    @Override
+    public InternalFinalAccumulator createFinalAccumulator()
+    {
+        return new GeneralInternalAccumulator(accumulatorFactory.createIntermediateAccumulator());
+    }
+
+    public static class GeneralInternalAccumulator
+            implements InternalSingleAccumulator, InternalFinalAccumulator
+    {
+        private final Accumulator accumulator;
+
+        public GeneralInternalAccumulator(Accumulator accumulator)
+        {
+            this.accumulator = requireNonNull(accumulator, "accumulator is null");
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return accumulator.getEstimatedSize();
+        }
+
+        @Override
+        public Type getIntermediateType()
+        {
+            return accumulator.getIntermediateType();
+        }
+
+        @Override
+        public Type getFinalType()
+        {
+            return accumulator.getFinalType();
+        }
+
+        @Override
+        public boolean isDistinct()
+        {
+            return false;
+        }
+
+        @Override
+        public void addInput(Page page)
+        {
+            accumulator.addInput(page);
+        }
+
+        @Override
+        public void addIntermediate(Block block)
+        {
+            accumulator.addIntermediate(block);
+        }
+
+        @Override
+        public void evaluateFinal(BlockBuilder blockBuilder)
+        {
+            accumulator.evaluateFinal(blockBuilder);
+        }
+    }
+
+    public static class GeneralInternalIntermediateAccumulator
+            implements InternalPartialAccumulator, InternalIntermediateAccumulator
+    {
+        private final Accumulator accumulator;
+
+        public GeneralInternalIntermediateAccumulator(Accumulator accumulator)
+        {
+            this.accumulator = requireNonNull(accumulator, "accumulator is null");
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return accumulator.getEstimatedSize();
+        }
+
+        @Override
+        public Type getIntermediateType()
+        {
+            return accumulator.getIntermediateType();
+        }
+
+        @Override
+        public boolean isDistinct()
+        {
+            return false;
+        }
+
+        @Override
+        public Optional<Block> addInput(Page page)
+        {
+            accumulator.addInput(page);
+            return Optional.empty();
+        }
+
+        @Override
+        public void addIntermediate(Block block)
+        {
+            accumulator.addIntermediate(block);
+        }
+
+        @Override
+        public void evaluateIntermediate(BlockBuilder blockBuilder)
+        {
+            accumulator.evaluateIntermediate(blockBuilder);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GeneralInternalAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GeneralInternalAccumulatorFactory.java
@@ -178,5 +178,10 @@ public class GeneralInternalAccumulatorFactory
         {
             accumulator.evaluateIntermediate(blockBuilder);
         }
+
+        @Override
+        public void flush()
+        {
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/InternalAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/InternalAccumulatorFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.Optional;
+
+public interface InternalAccumulatorFactory
+{
+    Type getIntermediateType();
+
+    Type getFinalType();
+
+    boolean isDistinct();
+
+    InternalSingleAccumulator createSingleAccumulator();
+
+    InternalPartialAccumulator createPartialAccumulator();
+
+    InternalIntermediateAccumulator createIntermediateAccumulator();
+
+    InternalFinalAccumulator createFinalAccumulator();
+
+    interface InternalSingleAccumulator
+    {
+        long getEstimatedSize();
+
+        Type getFinalType();
+
+        boolean isDistinct();
+
+        void addInput(Page page);
+
+        void evaluateFinal(BlockBuilder blockBuilder);
+    }
+
+    interface InternalPartialAccumulator
+    {
+        long getEstimatedSize();
+
+        Type getIntermediateType();
+
+        boolean isDistinct();
+
+        Optional<Block> addInput(Page page);
+
+        void evaluateIntermediate(BlockBuilder blockBuilder);
+    }
+
+    interface InternalIntermediateAccumulator
+    {
+        long getEstimatedSize();
+
+        Type getIntermediateType();
+
+        boolean isDistinct();
+
+        Optional<Block> addInput(Page page);
+
+        void addIntermediate(Block block);
+
+        void evaluateIntermediate(BlockBuilder blockBuilder);
+    }
+
+    interface InternalFinalAccumulator
+    {
+        long getEstimatedSize();
+
+        Type getIntermediateType();
+
+        Type getFinalType();
+
+        boolean isDistinct();
+
+        void addInput(Page page);
+
+        void addIntermediate(Block block);
+
+        void evaluateFinal(BlockBuilder blockBuilder);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/InternalAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/InternalAccumulatorFactory.java
@@ -60,6 +60,8 @@ public interface InternalAccumulatorFactory
         Optional<Block> addInput(Page page);
 
         void evaluateIntermediate(BlockBuilder blockBuilder);
+
+        void flush();
     }
 
     interface InternalIntermediateAccumulator
@@ -75,6 +77,8 @@ public interface InternalAccumulatorFactory
         void addIntermediate(Block block);
 
         void evaluateIntermediate(BlockBuilder blockBuilder);
+
+        void flush();
     }
 
     interface InternalFinalAccumulator

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
@@ -89,7 +89,7 @@ public class ExpressionExtractor
         @Override
         public Void visitAggregation(AggregationNode node, ImmutableList.Builder<Expression> context)
         {
-            node.getAggregations().values()
+            node.getAggregations()
                     .forEach(aggregation -> context.add(aggregation.getCall()));
             return super.visitAggregation(node, context);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2373,7 +2373,13 @@ public class LocalExecutionPlanner
                     .map(symbol -> new AggregationInputChannel(symbol, source.getLayout().get(symbol), source.getTypes().get(source.getLayout().get(symbol))))
                     .collect(toImmutableList());
 
-            OperatorFactory operatorFactory = new AggregationOperatorFactory(context.getNextOperatorId(), node.getId(), node.getStep(), accumulatorFactories, inputChannels);
+            OperatorFactory operatorFactory = new AggregationOperatorFactory(
+                    context.getNextOperatorId(),
+                    node.getId(),
+                    node.getStep(),
+                    accumulatorFactories,
+                    inputChannels,
+                    maxPartialAggregationMemorySize);
 
             return new PhysicalOperation(operatorFactory, makeLayout(node), context, source);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2300,11 +2300,9 @@ public class LocalExecutionPlanner
             int outputChannel = 0;
             ImmutableMap.Builder<Symbol, Integer> outputMappings = ImmutableMap.builder();
             List<AccumulatorFactory> accumulatorFactories = new ArrayList<>();
-            for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
-                Symbol symbol = entry.getKey();
-                Aggregation aggregation = entry.getValue();
+            for (Aggregation aggregation : node.getAggregations()) {
                 accumulatorFactories.add(buildAccumulatorFactory(source, aggregation));
-                outputMappings.put(symbol, outputChannel); // one aggregation per channel
+                outputMappings.put(aggregation.getOutputSymbol(), outputChannel); // one aggregation per channel
                 outputChannel++;
             }
 
@@ -2324,12 +2322,9 @@ public class LocalExecutionPlanner
 
             List<Symbol> aggregationOutputSymbols = new ArrayList<>();
             List<AccumulatorFactory> accumulatorFactories = new ArrayList<>();
-            for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
-                Symbol symbol = entry.getKey();
-                Aggregation aggregation = entry.getValue();
-
+            for (Aggregation aggregation : node.getAggregations()) {
                 accumulatorFactories.add(buildAccumulatorFactory(source, aggregation));
-                aggregationOutputSymbols.add(symbol);
+                aggregationOutputSymbols.add(aggregation.getOutputSymbol());
             }
 
             ImmutableList.Builder<Integer> globalAggregationGroupIds = ImmutableList.builder();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -551,7 +551,7 @@ class QueryPlanner
             }
             aggregationTranslations.put(parametersReplaced, newSymbol);
 
-            aggregationsBuilder.put(newSymbol, new Aggregation((FunctionCall) rewritten, analysis.getFunctionSignature(aggregate), Optional.empty()));
+            aggregationsBuilder.put(newSymbol, new Aggregation(newSymbol, (FunctionCall) rewritten, analysis.getFunctionSignature(aggregate), Optional.empty()));
         }
         Map<Symbol, Aggregation> aggregations = aggregationsBuilder.build();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -535,7 +535,7 @@ class QueryPlanner
         aggregationTranslations.copyMappingsFrom(groupingTranslations);
 
         // 2.d. Rewrite aggregates
-        ImmutableMap.Builder<Symbol, Aggregation> aggregationsBuilder = ImmutableMap.builder();
+        ImmutableList.Builder<Aggregation> aggregationsBuilder = ImmutableList.builder();
         boolean needPostProjectionCoercion = false;
         for (FunctionCall aggregate : analysis.getAggregates(node)) {
             Expression parametersReplaced = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters(), analysis), aggregate);
@@ -551,9 +551,9 @@ class QueryPlanner
             }
             aggregationTranslations.put(parametersReplaced, newSymbol);
 
-            aggregationsBuilder.put(newSymbol, new Aggregation(newSymbol, (FunctionCall) rewritten, analysis.getFunctionSignature(aggregate), Optional.empty()));
+            aggregationsBuilder.add(new Aggregation(newSymbol, (FunctionCall) rewritten, analysis.getFunctionSignature(aggregate), Optional.empty()));
         }
-        Map<Symbol, Aggregation> aggregations = aggregationsBuilder.build();
+        List<Aggregation> aggregations = aggregationsBuilder.build();
 
         AggregationNode aggregationNode = new AggregationNode(
                 idAllocator.getNextId(),
@@ -768,7 +768,7 @@ class QueryPlanner
                     new AggregationNode(
                             idAllocator.getNextId(),
                             subPlan.getRoot(),
-                            ImmutableMap.of(),
+                            ImmutableList.of(),
                             ImmutableList.of(subPlan.getRoot().getOutputSymbols()),
                             AggregationNode.Step.SINGLE,
                             Optional.empty(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -562,7 +562,8 @@ class QueryPlanner
                 groupingSymbols,
                 AggregationNode.Step.SINGLE,
                 Optional.empty(),
-                groupIdSymbol);
+                groupIdSymbol,
+                Optional.empty());
 
         subPlan = new PlanBuilder(aggregationTranslations, aggregationNode, analysis.getParameters());
 
@@ -771,6 +772,7 @@ class QueryPlanner
                             ImmutableList.of(),
                             ImmutableList.of(subPlan.getRoot().getOutputSymbols()),
                             AggregationNode.Step.SINGLE,
+                            Optional.empty(),
                             Optional.empty(),
                             Optional.empty()));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -811,7 +811,7 @@ class RelationPlanner
     {
         return new AggregationNode(idAllocator.getNextId(),
                 node,
-                ImmutableMap.of(),
+                ImmutableList.of(),
                 ImmutableList.of(node.getOutputSymbols()),
                 AggregationNode.Step.SINGLE,
                 Optional.empty(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -815,6 +815,7 @@ class RelationPlanner
                 ImmutableList.of(node.getOutputSymbols()),
                 AggregationNode.Step.SINGLE,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/AddIntermediateAggregations.java
@@ -21,7 +21,6 @@ import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.planner.SymbolsExtractor;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
@@ -199,7 +198,7 @@ public class AddIntermediateAggregations
         ImmutableList.Builder<AggregationNode.Aggregation> builder = ImmutableList.builder();
         for (Aggregation aggregation : assignments) {
             // Should only have one input symbol
-            Symbol input = getOnlyElement(SymbolsExtractor.extractAll(aggregation.getCall()));
+            Symbol input = getOnlyElement(aggregation.getInputSymbols());
             builder.add(new Aggregation(
                     input,
                     aggregation.getCall(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -167,7 +167,8 @@ public class ExpressionRewriteRuleSet
                         aggregationNode.getGroupingSets(),
                         aggregationNode.getStep(),
                         aggregationNode.getHashSymbol(),
-                        aggregationNode.getGroupIdSymbol()));
+                        aggregationNode.getGroupIdSymbol(),
+                        aggregationNode.getRowTypeSymbol()));
             }
             return Result.empty();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -15,7 +15,6 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
-import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
@@ -29,11 +28,9 @@ import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -154,13 +151,10 @@ public class ExpressionRewriteRuleSet
         public Result apply(AggregationNode aggregationNode, Captures captures, Context context)
         {
             boolean anyRewritten = false;
-            ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
-            for (Map.Entry<Symbol, Aggregation> entry : aggregationNode.getAggregations().entrySet()) {
-                Aggregation aggregation = entry.getValue();
+            ImmutableList.Builder<Aggregation> aggregations = ImmutableList.builder();
+            for (Aggregation aggregation : aggregationNode.getAggregations()) {
                 FunctionCall call = (FunctionCall) rewriter.rewrite(aggregation.getCall(), context);
-                aggregations.put(
-                        entry.getKey(),
-                        new Aggregation(entry.getValue().getOutputSymbol(), call, aggregation.getSignature(), aggregation.getMask()));
+                aggregations.add(new Aggregation(aggregation.getOutputSymbol(), call, aggregation.getSignature(), aggregation.getMask()));
                 if (!aggregation.getCall().equals(call)) {
                     anyRewritten = true;
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -160,7 +160,7 @@ public class ExpressionRewriteRuleSet
                 FunctionCall call = (FunctionCall) rewriter.rewrite(aggregation.getCall(), context);
                 aggregations.put(
                         entry.getKey(),
-                        new Aggregation(call, aggregation.getSignature(), aggregation.getMask()));
+                        new Aggregation(entry.getValue().getOutputSymbol(), call, aggregation.getSignature(), aggregation.getMask()));
                 if (!aggregation.getCall().equals(call)) {
                     anyRewritten = true;
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
@@ -109,6 +109,7 @@ public class ImplementFilteredAggregations
                         aggregationNode.getGroupingSets(),
                         aggregationNode.getStep(),
                         aggregationNode.getHashSymbol(),
-                        aggregationNode.getGroupIdSymbol()));
+                        aggregationNode.getGroupIdSymbol(),
+                        aggregationNode.getRowTypeSymbol()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
@@ -93,6 +93,7 @@ public class ImplementFilteredAggregations
                 mask = Optional.of(symbol);
             }
             aggregations.put(output, new Aggregation(
+                    output,
                     new FunctionCall(call.getName(), call.getWindow(), Optional.empty(), call.getOrderBy(), call.isDistinct(), call.getArguments()),
                     entry.getValue().getSignature(),
                     mask));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
@@ -150,6 +150,7 @@ public class MultipleDistinctAggregationToMarkDistinct
                 // remove the distinct flag and set the distinct marker
                 newAggregations.put(entry.getKey(),
                         new Aggregation(
+                                entry.getValue().getOutputSymbol(),
                                 new FunctionCall(
                                         call.getName(),
                                         call.getWindow(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
@@ -171,6 +171,7 @@ public class MultipleDistinctAggregationToMarkDistinct
                         parent.getGroupingSets(),
                         parent.getStep(),
                         parent.getHashSymbol(),
-                        parent.getGroupIdSymbol()));
+                        parent.getGroupIdSymbol(),
+                        parent.getRowTypeSymbol()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationColumns.java
@@ -57,6 +57,7 @@ public class PruneAggregationColumns
                         aggregationNode.getGroupingSets(),
                         aggregationNode.getStep(),
                         aggregationNode.getHashSymbol(),
-                        aggregationNode.getGroupIdSymbol()));
+                        aggregationNode.getGroupIdSymbol(),
+                        aggregationNode.getRowTypeSymbol()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationColumns.java
@@ -16,14 +16,15 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
 import com.facebook.presto.sql.planner.plan.PlanNode;
-import com.google.common.collect.Maps;
 
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class PruneAggregationColumns
         extends ProjectOffPushDownRule<AggregationNode>
@@ -39,9 +40,9 @@ public class PruneAggregationColumns
             AggregationNode aggregationNode,
             Set<Symbol> referencedOutputs)
     {
-        Map<Symbol, AggregationNode.Aggregation> prunedAggregations = Maps.filterKeys(
-                aggregationNode.getAggregations(),
-                referencedOutputs::contains);
+        List<Aggregation> prunedAggregations = aggregationNode.getAggregations().stream()
+                .filter(aggregation -> referencedOutputs.contains(aggregation.getOutputSymbol()))
+                .collect(toImmutableList());
 
         if (prunedAggregations.size() == aggregationNode.getAggregations().size()) {
             return Optional.empty();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
@@ -45,7 +45,7 @@ public class PruneAggregationSourceColumns
         Set<Symbol> requiredInputs = Streams.concat(
                 aggregationNode.getGroupingKeys().stream(),
                 aggregationNode.getHashSymbol().map(Stream::of).orElse(Stream.empty()),
-                aggregationNode.getAggregations().values().stream()
+                aggregationNode.getAggregations().stream()
                         .flatMap(PruneAggregationSourceColumns::getAggregationInputs))
                 .collect(toImmutableSet());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneCountAggregationOverScalar.java
@@ -16,7 +16,6 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
@@ -24,11 +23,8 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.google.common.collect.ImmutableList;
 
-import java.util.Map;
-
 import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A count over a subquery can be reduced to a VALUES(1) provided
@@ -51,17 +47,14 @@ public class PruneCountAggregationOverScalar
         if (!parent.hasDefaultOutput() || parent.getOutputSymbols().size() != 1) {
             return Result.empty();
         }
-        Map<Symbol, AggregationNode.Aggregation> assignments = parent.getAggregations();
-        for (Map.Entry<Symbol, AggregationNode.Aggregation> entry : assignments.entrySet()) {
-            AggregationNode.Aggregation aggregation = entry.getValue();
-            requireNonNull(aggregation, "aggregation is null");
+        for (AggregationNode.Aggregation aggregation : parent.getAggregations()) {
             Signature signature = aggregation.getSignature();
             FunctionCall functionCall = aggregation.getCall();
             if (!"count".equals(signature.getName()) || !functionCall.getArguments().isEmpty()) {
                 return Result.empty();
             }
         }
-        if (!assignments.isEmpty() && isScalar(parent.getSource(), context.getLookup())) {
+        if (!parent.getAggregations().isEmpty() && isScalar(parent.getSource(), context.getLookup())) {
             return Result.ofPlanNode(new ValuesNode(parent.getId(), parent.getOutputSymbols(), ImmutableList.of(ImmutableList.of(new LongLiteral("1")))));
         }
         return Result.empty();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
@@ -74,6 +74,14 @@ public class PruneOrderByInAggregation
         if (!anyRewritten) {
             return Result.empty();
         }
-        return Result.ofPlanNode(new AggregationNode(node.getId(), node.getSource(), aggregations.build(), node.getGroupingSets(), node.getStep(), node.getHashSymbol(), node.getGroupIdSymbol()));
+        return Result.ofPlanNode(new AggregationNode(
+                node.getId(),
+                node.getSource(),
+                aggregations.build(),
+                node.getGroupingSets(),
+                node.getStep(),
+                node.getHashSymbol(),
+                node.getGroupIdSymbol(),
+                node.getRowTypeSymbol()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
@@ -71,7 +71,7 @@ public class PruneOrderByInAggregation
                         aggregation.getCall().getArguments(),
                         aggregation.getCall().getFilter());
 
-                aggregations.put(entry.getKey(), new Aggregation(rewritten, aggregation.getSignature(), aggregation.getMask()));
+                aggregations.put(entry.getKey(), new Aggregation(entry.getValue().getOutputSymbol(), rewritten, aggregation.getSignature(), aggregation.getMask()));
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -271,11 +271,13 @@ public class PushAggregationThroughOuterJoin
         for (Map.Entry<Symbol, AggregationNode.Aggregation> entry : referenceAggregation.getAggregations().entrySet()) {
             Symbol aggregationSymbol = entry.getKey();
             AggregationNode.Aggregation aggregation = entry.getValue();
+            FunctionCall overNullCall = (FunctionCall) inlineSymbols(sourcesSymbolMapping, aggregation.getCall());
+            Symbol overNullSymbol = symbolAllocator.newSymbol(overNullCall, symbolAllocator.getTypes().get(aggregationSymbol));
             AggregationNode.Aggregation overNullAggregation = new AggregationNode.Aggregation(
-                    (FunctionCall) inlineSymbols(sourcesSymbolMapping, aggregation.getCall()),
+                    overNullSymbol,
+                    overNullCall,
                     aggregation.getSignature(),
                     aggregation.getMask().map(x -> Symbol.from(sourcesSymbolMapping.get(x))));
-            Symbol overNullSymbol = symbolAllocator.newSymbol(overNullAggregation.getCall(), symbolAllocator.getTypes().get(aggregationSymbol));
             aggregationsOverNullBuilder.put(overNullSymbol, overNullAggregation);
             aggregationsSymbolMappingBuilder.put(aggregationSymbol, overNullSymbol);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -134,7 +134,8 @@ public class PushAggregationThroughOuterJoin
                 ImmutableList.of(groupingKeys),
                 aggregation.getStep(),
                 aggregation.getHashSymbol(),
-                aggregation.getGroupIdSymbol());
+                aggregation.getGroupIdSymbol(),
+                aggregation.getRowTypeSymbol());
 
         JoinNode rewrittenJoin;
         if (join.getType() == JoinNode.Type.LEFT) {
@@ -299,6 +300,7 @@ public class PushAggregationThroughOuterJoin
                 aggregationsOverNullBuilder.build(),
                 ImmutableList.of(ImmutableList.of()),
                 AggregationNode.Step.SINGLE,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
         return new MappedAggregationInfo(aggregationOverNullRow, aggregationsSymbolMapping);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -216,7 +216,7 @@ public class PushPartialAggregationThroughExchange
             }
             finalAggregations.add(new AggregationNode.Aggregation(
                     originalAggregation.getOutputSymbol(),
-                    new FunctionCall(QualifiedName.of(signature.getName()), finalAggregationArguments),
+                    new FunctionCall(QualifiedName.of(signature.getName()), originalAggregation.getCall().isDistinct(), finalAggregationArguments),
                     signature,
                     finalAggregationMask));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.preferPartialAggregation;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.FINAL;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.SINGLE;
@@ -214,7 +215,8 @@ public class PushPartialAggregationThroughExchange
                 node.getGroupingSets(),
                 PARTIAL,
                 node.getHashSymbol(),
-                node.getGroupIdSymbol());
+                node.getGroupIdSymbol(),
+                Optional.of(context.getSymbolAllocator().newSymbol("rowType", TINYINT)));
 
         return new AggregationNode(
                 node.getId(),
@@ -223,6 +225,7 @@ public class PushPartialAggregationThroughExchange
                 node.getGroupingSets(),
                 FINAL,
                 node.getHashSymbol(),
-                node.getGroupIdSymbol());
+                node.getGroupIdSymbol(),
+                Optional.empty());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -200,11 +200,12 @@ public class PushPartialAggregationThroughExchange
             Symbol intermediateSymbol = context.getSymbolAllocator().newSymbol(signature.getName(), function.getIntermediateType());
 
             checkState(!originalAggregation.getCall().getOrderBy().isPresent(), "Aggregate with ORDER BY does not support partial aggregation");
-            intermediateAggregation.put(intermediateSymbol, new AggregationNode.Aggregation(originalAggregation.getCall(), signature, originalAggregation.getMask()));
+            intermediateAggregation.put(intermediateSymbol, new AggregationNode.Aggregation(intermediateSymbol, originalAggregation.getCall(), signature, originalAggregation.getMask()));
 
             // rewrite final aggregation in terms of intermediate function
             finalAggregation.put(entry.getKey(),
                     new AggregationNode.Aggregation(
+                            entry.getValue().getOutputSymbol(),
                             new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.of(intermediateSymbol.toSymbolReference())),
                             signature,
                             Optional.empty()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Streams;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -95,9 +94,9 @@ public class PushPartialAggregationThroughJoin
         return Result.empty();
     }
 
-    private boolean allAggregationsOn(Map<Symbol, AggregationNode.Aggregation> aggregations, List<Symbol> symbols)
+    private boolean allAggregationsOn(List<AggregationNode.Aggregation> aggregations, List<Symbol> symbols)
     {
-        Set<Symbol> inputs = extractUnique(aggregations.values().stream().map(AggregationNode.Aggregation::getCall).collect(toImmutableList()));
+        Set<Symbol> inputs = extractUnique(aggregations.stream().map(AggregationNode.Aggregation::getCall).collect(toImmutableList()));
         return symbols.containsAll(inputs);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -159,7 +159,8 @@ public class PushPartialAggregationThroughJoin
                 ImmutableList.of(groupingSet),
                 aggregation.getStep(),
                 aggregation.getHashSymbol(),
-                aggregation.getGroupIdSymbol());
+                aggregation.getGroupIdSymbol(),
+                aggregation.getRowTypeSymbol());
     }
 
     private PlanNode pushPartialToJoin(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -28,19 +28,18 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.isPushAggregationThroughJoin;
-import static com.facebook.presto.sql.planner.SymbolsExtractor.extractUnique;
 import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.intersection;
 
@@ -96,7 +95,10 @@ public class PushPartialAggregationThroughJoin
 
     private boolean allAggregationsOn(List<AggregationNode.Aggregation> aggregations, List<Symbol> symbols)
     {
-        Set<Symbol> inputs = extractUnique(aggregations.stream().map(AggregationNode.Aggregation::getCall).collect(toImmutableList()));
+        Set<Symbol> inputs = aggregations.stream()
+                .map(AggregationNode.Aggregation::getInputSymbols)
+                .flatMap(Collection::stream)
+                .collect(toImmutableSet());
         return symbols.containsAll(inputs);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -86,7 +86,8 @@ public class SimplifyCountOverConstant
                 parent.getGroupingSets(),
                 parent.getStep(),
                 parent.getHashSymbol(),
-                parent.getGroupIdSymbol()));
+                parent.getGroupIdSymbol(),
+                parent.getRowTypeSymbol()));
     }
 
     private static boolean isCountOverConstant(AggregationNode.Aggregation aggregation, Assignments inputs)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -71,6 +71,7 @@ public class SimplifyCountOverConstant
             if (isCountOverConstant(aggregation, child.getAssignments())) {
                 changed = true;
                 aggregations.put(symbol, new AggregationNode.Aggregation(
+                        entry.getValue().getOutputSymbol(),
                         new FunctionCall(QualifiedName.of("count"), ImmutableList.of()),
                         new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT)),
                         aggregation.getMask()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
@@ -132,6 +132,7 @@ public class SingleDistinctAggregationToGroupBy
                                         .build()),
                                 SINGLE,
                                 Optional.empty(),
+                                Optional.empty(),
                                 Optional.empty()),
                         // remove DISTINCT flag from function calls
                         aggregation.getAggregations().stream()
@@ -140,7 +141,8 @@ public class SingleDistinctAggregationToGroupBy
                         aggregation.getGroupingSets(),
                         aggregation.getStep(),
                         aggregation.getHashSymbol(),
-                        aggregation.getGroupIdSymbol()));
+                        aggregation.getGroupIdSymbol(),
+                        aggregation.getRowTypeSymbol()));
     }
 
     private static AggregationNode.Aggregation removeDistinct(AggregationNode.Aggregation aggregation)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
@@ -156,6 +156,7 @@ public class SingleDistinctAggregationToGroupBy
 
         FunctionCall call = aggregation.getCall();
         return new AggregationNode.Aggregation(
+                aggregation.getOutputSymbol(),
                 new FunctionCall(
                         call.getName(),
                         call.getWindow(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -205,6 +205,7 @@ public class TransformCorrelatedInPredicateToJoin
                 ImmutableList.of(probeSide.getOutputSymbols()),
                 AggregationNode.Step.SINGLE,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         // TODO since we care only about "some count > 0", we could have specialized node instead of leftOuterJoin that does the job without materializing join results

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -200,8 +200,8 @@ public class TransformCorrelatedInPredicateToJoin
                 idAllocator.getNextId(),
                 leftOuterJoin,
                 ImmutableMap.<Symbol, AggregationNode.Aggregation>builder()
-                        .put(countMatchesSymbol, countWithFilter(matchCondition))
-                        .put(countNullMatchesSymbol, countWithFilter(nullMatchCondition))
+                        .put(countMatchesSymbol, countWithFilter(countMatchesSymbol, matchCondition))
+                        .put(countNullMatchesSymbol, countWithFilter(countNullMatchesSymbol, nullMatchCondition))
                         .build(),
                 ImmutableList.of(probeSide.getOutputSymbols()),
                 AggregationNode.Step.SINGLE,
@@ -241,7 +241,7 @@ public class TransformCorrelatedInPredicateToJoin
                 Optional.empty());
     }
 
-    private static AggregationNode.Aggregation countWithFilter(Expression condition)
+    private static AggregationNode.Aggregation countWithFilter(Symbol outputSymbol, Expression condition)
     {
         FunctionCall countCall = new FunctionCall(
                 QualifiedName.of("count"),
@@ -252,6 +252,7 @@ public class TransformCorrelatedInPredicateToJoin
                 ImmutableList.<Expression>of()); /* arguments */
 
         return new AggregationNode.Aggregation(
+                outputSymbol,
                 countCall,
                 new Signature("count", FunctionKind.AGGREGATE, BIGINT.getTypeSignature()),
                 Optional.<Symbol>empty()); /* mask */

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -51,7 +51,6 @@ import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.util.AstUtils;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nullable;
@@ -199,9 +198,9 @@ public class TransformCorrelatedInPredicateToJoin
         AggregationNode aggregation = new AggregationNode(
                 idAllocator.getNextId(),
                 leftOuterJoin,
-                ImmutableMap.<Symbol, AggregationNode.Aggregation>builder()
-                        .put(countMatchesSymbol, countWithFilter(countMatchesSymbol, matchCondition))
-                        .put(countNullMatchesSymbol, countWithFilter(countNullMatchesSymbol, nullMatchCondition))
+                ImmutableList.<AggregationNode.Aggregation>builder()
+                        .add(countWithFilter(countMatchesSymbol, matchCondition))
+                        .add(countWithFilter(countNullMatchesSymbol, nullMatchCondition))
                         .build(),
                 ImmutableList.of(probeSide.getOutputSymbols()),
                 AggregationNode.Step.SINGLE,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
@@ -161,7 +161,7 @@ public class TransformExistsApplyToLateralNode
                         new AggregationNode(
                                 context.getIdAllocator().getNextId(),
                                 parent.getSubquery(),
-                                ImmutableMap.of(count, new Aggregation(COUNT_CALL, countSignature, Optional.empty())),
+                                ImmutableMap.of(count, new Aggregation(count, COUNT_CALL, countSignature, Optional.empty())),
                                 ImmutableList.of(ImmutableList.of()),
                                 AggregationNode.Step.SINGLE,
                                 Optional.empty(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
@@ -38,7 +38,6 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.Optional;
 
@@ -161,7 +160,7 @@ public class TransformExistsApplyToLateralNode
                         new AggregationNode(
                                 context.getIdAllocator().getNextId(),
                                 parent.getSubquery(),
-                                ImmutableMap.of(count, new Aggregation(count, COUNT_CALL, countSignature, Optional.empty())),
+                                ImmutableList.of(new Aggregation(count, COUNT_CALL, countSignature, Optional.empty())),
                                 ImmutableList.of(ImmutableList.of()),
                                 AggregationNode.Step.SINGLE,
                                 Optional.empty(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
@@ -164,6 +164,7 @@ public class TransformExistsApplyToLateralNode
                                 ImmutableList.of(ImmutableList.of()),
                                 AggregationNode.Step.SINGLE,
                                 Optional.empty(),
+                                Optional.empty(),
                                 Optional.empty()),
                         Assignments.of(exists, new ComparisonExpression(GREATER_THAN, count.toSymbolReference(), new Cast(new LongLiteral("0"), BIGINT.toString())))),
                 parent.getCorrelation(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -178,7 +178,8 @@ public class HashGenerationOptimizer
                             node.getGroupingSets(),
                             node.getStep(),
                             hashSymbol,
-                            node.getGroupIdSymbol()),
+                            node.getGroupIdSymbol(),
+                            node.getRowTypeSymbol()),
                     hashSymbol.isPresent() ? ImmutableMap.of(groupByHash.get(), hashSymbol.get()) : ImmutableMap.of());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -243,6 +243,7 @@ public class ImplementIntersectAndExceptAsUnion
                     ImmutableList.of(originalColumns),
                     Step.SINGLE,
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -233,6 +233,7 @@ public class ImplementIntersectAndExceptAsUnion
             for (int i = 0; i < markers.size(); i++) {
                 Symbol output = aggregationOutputs.get(i);
                 aggregations.put(output, new Aggregation(
+                        output,
                         new FunctionCall(QualifiedName.of("count"), ImmutableList.of(markers.get(i).toSymbolReference())),
                         COUNT_AGGREGATION,
                         Optional.empty()));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -104,7 +104,7 @@ public class MetadataQueryOptimizer
         public PlanNode visitAggregation(AggregationNode node, RewriteContext<Void> context)
         {
             // supported functions are only MIN/MAX/APPROX_DISTINCT or distinct aggregates
-            for (Aggregation aggregation : node.getAggregations().values()) {
+            for (Aggregation aggregation : node.getAggregations()) {
                 if (!ALLOWED_FUNCTIONS.contains(aggregation.getCall().getName().toString()) && !aggregation.getCall().isDistinct()) {
                     return context.defaultRewrite(node);
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -153,6 +153,7 @@ public class OptimizeMixedDistinctAggregations
                 FunctionCall functionCall = entry.getValue().getCall();
                 if (entry.getValue().getMask().isPresent()) {
                     aggregations.put(entry.getKey(), new Aggregation(
+                            entry.getValue().getOutputSymbol(),
                             new FunctionCall(
                                     functionCall.getName(),
                                     functionCall.getWindow(),
@@ -166,6 +167,7 @@ public class OptimizeMixedDistinctAggregations
                     Symbol argument = aggregateInfo.getNewNonDistinctAggregateSymbols().get(entry.getKey());
                     QualifiedName functionName = QualifiedName.of("arbitrary");
                     aggregations.put(entry.getKey(), new Aggregation(
+                            entry.getValue().getOutputSymbol(),
                             new FunctionCall(functionName, functionCall.getWindow(), false, ImmutableList.of(argument.toSymbolReference())),
                             getFunctionSignature(functionName, argument),
                             Optional.empty()));
@@ -412,7 +414,7 @@ public class OptimizeMixedDistinctAggregations
                             functionCall = new FunctionCall(functionCall.getName(), functionCall.getWindow(), false, arguments.build());
                         }
                     }
-                    aggregations.put(newSymbol, new Aggregation(functionCall, entry.getValue().getSignature(), Optional.empty()));
+                    aggregations.put(newSymbol, new Aggregation(newSymbol, functionCall, entry.getValue().getSignature(), Optional.empty()));
                 }
             }
             return new AggregationNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -181,7 +181,8 @@ public class OptimizeMixedDistinctAggregations
                     node.getGroupingSets(),
                     node.getStep(),
                     Optional.empty(),
-                    node.getGroupIdSymbol());
+                    node.getGroupIdSymbol(),
+                    node.getRowTypeSymbol());
         }
 
         @Override
@@ -424,6 +425,7 @@ public class OptimizeMixedDistinctAggregations
                     ImmutableList.of(ImmutableList.copyOf(groupByKeys)),
                     SINGLE,
                     originalNode.getHashSymbol(),
+                    Optional.empty(),
                     Optional.empty());
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -174,6 +174,7 @@ public class PlanNodeDecorrelator
                             .build()),
                     AggregationNode.Step.SINGLE,
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty());
 
             return Optional.of(new DecorrelationResult(
@@ -233,7 +234,8 @@ public class PlanNodeDecorrelator
                     newGroupingSets.build(),
                     decorrelatedAggregation.getStep(),
                     decorrelatedAggregation.getHashSymbol(),
-                    decorrelatedAggregation.getGroupIdSymbol());
+                    decorrelatedAggregation.getGroupIdSymbol(),
+                    decorrelatedAggregation.getRowTypeSymbol());
 
             boolean atMostSingleRow = newAggregation.getGroupingSets().size() == 1
                     && constantSymbols.containsAll(newAggregation.getGroupingKeys());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -31,7 +31,6 @@ import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -169,7 +168,7 @@ public class PlanNodeDecorrelator
             AggregationNode aggregationNode = new AggregationNode(
                     idAllocator.getNextId(),
                     decorrelatedChildNode,
-                    ImmutableMap.of(),
+                    ImmutableList.of(),
                     ImmutableList.of(ImmutableList.<Symbol>builder()
                             .addAll(decorrelatedChildNode.getOutputSymbols())
                             .build()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -1008,7 +1008,8 @@ public class PredicatePushDown
                         node.getGroupingSets(),
                         node.getStep(),
                         node.getHashSymbol(),
-                        node.getGroupIdSymbol());
+                        node.getGroupIdSymbol(),
+                        node.getRowTypeSymbol());
             }
             if (!postAggregationConjuncts.isEmpty()) {
                 output = new FilterNode(idAllocator.getNextId(), output, combineConjuncts(postAggregationConjuncts));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -303,15 +303,12 @@ public class PruneUnreferencedOutputs
                 expectedInputs.add(node.getHashSymbol().get());
             }
 
-            ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
-            for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
-                Symbol symbol = entry.getKey();
-
-                if (context.get().contains(symbol)) {
-                    Aggregation aggregation = entry.getValue();
+            ImmutableList.Builder<Aggregation> aggregations = ImmutableList.builder();
+            for (Aggregation aggregation : node.getAggregations()) {
+                if (context.get().contains(aggregation.getOutputSymbol())) {
                     expectedInputs.addAll(SymbolsExtractor.extractUnique(aggregation.getCall()));
                     aggregation.getMask().ifPresent(expectedInputs::add);
-                    aggregations.put(symbol, aggregation);
+                    aggregations.add(aggregation);
                 }
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -319,7 +319,8 @@ public class PruneUnreferencedOutputs
                     node.getGroupingSets(),
                     node.getStep(),
                     node.getHashSymbol(),
-                    node.getGroupIdSymbol());
+                    node.getGroupIdSymbol(),
+                    node.getRowTypeSymbol());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -306,8 +306,7 @@ public class PruneUnreferencedOutputs
             ImmutableList.Builder<Aggregation> aggregations = ImmutableList.builder();
             for (Aggregation aggregation : node.getAggregations()) {
                 if (context.get().contains(aggregation.getOutputSymbol())) {
-                    expectedInputs.addAll(SymbolsExtractor.extractUnique(aggregation.getCall()));
-                    aggregation.getMask().ifPresent(expectedInputs::add);
+                    expectedInputs.addAll(aggregation.getInputSymbols());
                     aggregations.add(aggregation);
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -197,6 +197,7 @@ public class ScalarAggregationToJoinRewriter
                 ImmutableList.of(groupBySymbols),
                 scalarAggregation.getStep(),
                 scalarAggregation.getHashSymbol(),
-                Optional.empty()));
+                Optional.empty(),
+                scalarAggregation.getRowTypeSymbol()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -178,6 +178,7 @@ public class ScalarAggregationToJoinRewriter
                 List<TypeSignature> scalarAggregationSourceTypeSignatures = ImmutableList.of(
                         symbolAllocator.getTypes().get(nonNullableAggregationSourceSymbol).getTypeSignature());
                 aggregations.put(symbol, new Aggregation(
+                        symbol,
                         new FunctionCall(
                                 COUNT,
                                 ImmutableList.of(nonNullableAggregationSourceSymbol.toSymbolReference())),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SetFlatteningOptimizer.java
@@ -134,7 +134,8 @@ public class SetFlatteningOptimizer
                     node.getGroupingSets(),
                     node.getStep(),
                     node.getHashSymbol(),
-                    node.getGroupIdSymbol());
+                    node.getGroupIdSymbol(),
+                    node.getRowTypeSymbol());
         }
 
         private static boolean isDistinctOperator(AggregationNode node)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -101,7 +101,8 @@ public class SymbolMapper
                 groupingSets,
                 node.getStep(),
                 node.getHashSymbol().map(this::map),
-                node.getGroupIdSymbol().map(this::map));
+                node.getGroupIdSymbol().map(this::map),
+                node.getRowTypeSymbol().map(this::map));
     }
 
     public TopNNode map(TopNNode node, PlanNode source, PlanNodeId newNodeId)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -86,7 +86,9 @@ public class SymbolMapper
             Symbol symbol = entry.getKey();
             Aggregation aggregation = entry.getValue();
 
-            aggregations.put(map(symbol), new Aggregation(
+            Symbol outputSymbol = map(symbol);
+            aggregations.put(outputSymbol, new Aggregation(
+                    outputSymbol,
                     (FunctionCall) map(aggregation.getCall()),
                     aggregation.getSignature(),
                     aggregation.getMask().map(this::map)));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -81,14 +81,10 @@ public class SymbolMapper
 
     private AggregationNode map(AggregationNode node, PlanNode source, PlanNodeId newNodeId)
     {
-        ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
-        for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
-            Symbol symbol = entry.getKey();
-            Aggregation aggregation = entry.getValue();
-
-            Symbol outputSymbol = map(symbol);
-            aggregations.put(outputSymbol, new Aggregation(
-                    outputSymbol,
+        ImmutableList.Builder<Aggregation> aggregations = ImmutableList.builder();
+        for (Aggregation aggregation : node.getAggregations()) {
+            aggregations.add(new Aggregation(
+                    map(aggregation.getOutputSymbol()),
                     (FunctionCall) map(aggregation.getCall()),
                     aggregation.getSignature(),
                     aggregation.getMask().map(this::map)));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
@@ -166,6 +166,7 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
                     ImmutableList.of(ImmutableList.of()),
                     AggregationNode.Step.SINGLE,
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty());
 
             PlanNode lateralJoinNode = new LateralJoinNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
@@ -45,7 +45,6 @@ import com.facebook.presto.sql.tree.SearchedCaseExpression;
 import com.facebook.presto.sql.tree.SimpleCaseExpression;
 import com.facebook.presto.sql.tree.WhenClause;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -143,23 +142,23 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
             subqueryPlan = new AggregationNode(
                     idAllocator.getNextId(),
                     subqueryPlan,
-                    ImmutableMap.of(
-                            minValue, new Aggregation(
+                    ImmutableList.of(
+                            new Aggregation(
                                     minValue,
                                     new FunctionCall(MIN, outputColumnReferences),
                                     functionRegistry.resolveFunction(MIN, fromTypeSignatures(outputColumnTypeSignature)),
                                     Optional.empty()),
-                            maxValue, new Aggregation(
+                            new Aggregation(
                                     maxValue,
                                     new FunctionCall(MAX, outputColumnReferences),
                                     functionRegistry.resolveFunction(MAX, fromTypeSignatures(outputColumnTypeSignature)),
                                     Optional.empty()),
-                            countAllValue, new Aggregation(
+                            new Aggregation(
                                     countAllValue,
                                     new FunctionCall(COUNT, emptyList()),
                                     functionRegistry.resolveFunction(COUNT, emptyList()),
                                     Optional.empty()),
-                            countNonNullValue, new Aggregation(
+                            new Aggregation(
                                     countNonNullValue,
                                     new FunctionCall(COUNT, outputColumnReferences),
                                     functionRegistry.resolveFunction(COUNT, fromTypeSignatures(outputColumnTypeSignature)),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
@@ -145,18 +145,22 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
                     subqueryPlan,
                     ImmutableMap.of(
                             minValue, new Aggregation(
+                                    minValue,
                                     new FunctionCall(MIN, outputColumnReferences),
                                     functionRegistry.resolveFunction(MIN, fromTypeSignatures(outputColumnTypeSignature)),
                                     Optional.empty()),
                             maxValue, new Aggregation(
+                                    maxValue,
                                     new FunctionCall(MAX, outputColumnReferences),
                                     functionRegistry.resolveFunction(MAX, fromTypeSignatures(outputColumnTypeSignature)),
                                     Optional.empty()),
                             countAllValue, new Aggregation(
+                                    countAllValue,
                                     new FunctionCall(COUNT, emptyList()),
                                     functionRegistry.resolveFunction(COUNT, emptyList()),
                                     Optional.empty()),
                             countNonNullValue, new Aggregation(
+                                    countNonNullValue,
                                     new FunctionCall(COUNT, outputColumnReferences),
                                     functionRegistry.resolveFunction(COUNT, fromTypeSignatures(outputColumnTypeSignature)),
                                     Optional.empty())),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
@@ -253,7 +253,7 @@ public final class AggregationNode
                 .map(functionRegistry::getAggregateFunctionImplementation)
                 .allMatch(InternalAggregationFunction::isDecomposable);
 
-        return !hasOrderBy && !hasDistinct && decomposableFunctions;
+        return !hasOrderBy && decomposableFunctions && (!hasNonEmptyGroupingSet() || !hasDistinct);
     }
 
     public boolean hasSingleNodeExecutionPreference(FunctionRegistry functionRegistry)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -732,12 +732,12 @@ public class PlanPrinter
             printPlanNodesStatsAndCost(indent + 2, node);
             printStats(indent + 2, node.getId());
 
-            for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
-                if (entry.getValue().getMask().isPresent()) {
-                    print(indent + 2, "%s := %s (mask = %s)", entry.getKey(), entry.getValue().getCall(), entry.getValue().getMask().get());
+            for (Aggregation aggregation : node.getAggregations()) {
+                if (aggregation.getMask().isPresent()) {
+                    print(indent + 2, "%s := %s (mask = %s)", aggregation.getOutputSymbol(), aggregation.getCall(), aggregation.getMask().get());
                 }
                 else {
-                    print(indent + 2, "%s := %s", entry.getKey(), entry.getValue().getCall());
+                    print(indent + 2, "%s := %s", aggregation.getOutputSymbol(), aggregation.getCall());
                 }
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
@@ -166,17 +166,17 @@ public final class TypeValidator
             verifyTypeSignature(symbol, expectedType.getTypeSignature(), actualType.getTypeSignature());
         }
 
-        private void checkFunctionSignature(Map<Symbol, Aggregation> aggregations)
+        private void checkFunctionSignature(List<Aggregation> aggregations)
         {
-            for (Map.Entry<Symbol, Aggregation> entry : aggregations.entrySet()) {
-                checkSignature(entry.getKey(), entry.getValue().getSignature());
+            for (Aggregation aggregation : aggregations) {
+                checkSignature(aggregation.getOutputSymbol(), aggregation.getSignature());
             }
         }
 
-        private void checkFunctionCall(Map<Symbol, Aggregation> aggregations)
+        private void checkFunctionCall(List<Aggregation> aggregations)
         {
-            for (Map.Entry<Symbol, Aggregation> entry : aggregations.entrySet()) {
-                checkCall(entry.getKey(), entry.getValue().getCall());
+            for (Aggregation aggregation : aggregations) {
+                checkCall(aggregation.getOutputSymbol(), aggregation.getCall());
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -117,7 +117,7 @@ public final class ValidateDependenciesChecker
             Set<Symbol> inputs = createInputs(source, boundSymbols);
             checkDependencies(inputs, node.getGroupingKeys(), "Invalid node. Grouping key symbols (%s) not in source plan output (%s)", node.getGroupingKeys(), node.getSource().getOutputSymbols());
 
-            for (Aggregation aggregation : node.getAggregations().values()) {
+            for (Aggregation aggregation : node.getAggregations()) {
                 Set<Symbol> dependencies = SymbolsExtractor.extractUnique(aggregation.getCall());
                 checkDependencies(inputs, dependencies, "Invalid node. Aggregation dependencies (%s) not in source plan output (%s)", dependencies, node.getSource().getOutputSymbols());
                 aggregation.getMask().ifPresent(mask -> {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -118,7 +118,7 @@ public final class ValidateDependenciesChecker
             checkDependencies(inputs, node.getGroupingKeys(), "Invalid node. Grouping key symbols (%s) not in source plan output (%s)", node.getGroupingKeys(), node.getSource().getOutputSymbols());
 
             for (Aggregation aggregation : node.getAggregations()) {
-                Set<Symbol> dependencies = SymbolsExtractor.extractUnique(aggregation.getCall());
+                Set<Symbol> dependencies = aggregation.getInputSymbols();
                 checkDependencies(inputs, dependencies, "Invalid node. Aggregation dependencies (%s) not in source plan output (%s)", dependencies, node.getSource().getOutputSymbols());
                 aggregation.getMask().ifPresent(mask -> {
                     checkDependencies(inputs, ImmutableSet.of(mask), "Invalid node. Aggregation mask symbol (%s) not in source plan output (%s)", mask, node.getSource().getOutputSymbols());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoFilteredAggregations.java
@@ -35,7 +35,7 @@ public final class VerifyNoFilteredAggregations
                 .where(AggregationNode.class::isInstance)
                 .<AggregationNode>findAll()
                 .stream()
-                .flatMap(node -> node.getAggregations().values().stream())
+                .flatMap(node -> node.getAggregations().stream())
                 .filter(aggregation -> aggregation.getCall().getFilter().isPresent())
                 .forEach(ignored -> {
                     throw new IllegalStateException("Generated plan contains unimplemented filtered aggregations");

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -326,12 +326,12 @@ public final class GraphvizPrinter
         public Void visitAggregation(AggregationNode node, Void context)
         {
             StringBuilder builder = new StringBuilder();
-            for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
-                if (entry.getValue().getMask().isPresent()) {
-                    builder.append(format("%s := %s (mask = %s)\\n", entry.getKey(), entry.getValue().getCall(), entry.getValue().getMask().get()));
+            for (Aggregation aggregation : node.getAggregations()) {
+                if (aggregation.getMask().isPresent()) {
+                    builder.append(format("%s := %s (mask = %s)\\n", aggregation.getOutputSymbol(), aggregation.getCall(), aggregation.getMask().get()));
                 }
                 else {
-                    builder.append(format("%s := %s\\n", entry.getKey(), entry.getValue().getCall()));
+                    builder.append(format("%s := %s\\n", aggregation.getOutputSymbol(), aggregation.getCall()));
                 }
             }
             printNode(node, format("Aggregate[%s]", node.getStep()), builder.toString(), NODE_COLORS.get(NodeType.AGGREGATE));

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -369,6 +369,7 @@ public class TestCostCalculator
                 ImmutableList.of(source.getOutputSymbols()),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -357,6 +357,7 @@ public class TestCostCalculator
     private AggregationNode aggregation(String id, PlanNode source)
     {
         AggregationNode.Aggregation aggregation = new AggregationNode.Aggregation(
+                new Symbol("count"),
                 new FunctionCall(QualifiedName.of("count"), ImmutableList.of()),
                 new Signature("count", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT)),
                 Optional.empty());
@@ -364,7 +365,7 @@ public class TestCostCalculator
         return new AggregationNode(
                 new PlanNodeId(id),
                 source,
-                ImmutableMap.of(new Symbol("count"), aggregation),
+                ImmutableMap.of(aggregation.getOutputSymbol(), aggregation),
                 ImmutableList.of(source.getOutputSymbols()),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -365,7 +365,7 @@ public class TestCostCalculator
         return new AggregationNode(
                 new PlanNodeId(id),
                 source,
-                ImmutableMap.of(aggregation.getOutputSymbol(), aggregation),
+                ImmutableList.of(aggregation),
                 ImmutableList.of(source.getOutputSymbols()),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
@@ -13,24 +13,31 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.RowPagesBuilder;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.AggregationOperator.AggregationInputChannel;
 import com.facebook.presto.operator.AggregationOperator.AggregationOperatorFactory;
+import com.facebook.presto.operator.aggregation.DistinctInternalAccumulatorFactory;
 import com.facebook.presto.operator.aggregation.GeneralInternalAccumulatorFactory;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.TestingTaskContext;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -38,6 +45,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.block.BlockAssertions.assertBlockEquals;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -46,14 +54,21 @@ import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
-import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.mapWithIndex;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.testing.Assertions.assertLessThan;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.airlift.units.DataSize.succinctBytes;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
-@Test(singleThreaded = true)
+@Test
 public class TestAggregationOperator
 {
     private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
@@ -71,17 +86,13 @@ public class TestAggregationOperator
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
-    private DriverContext driverContext;
+    private final JoinCompiler joinCompiler = new JoinCompiler(MetadataManager.createTestMetadataManager(), new FeaturesConfig());
 
     @BeforeMethod
     public void setUp()
     {
         executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
-
-        driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
-                .addPipelineContext(0, true, true)
-                .addDriverContext();
     }
 
     @AfterMethod
@@ -119,12 +130,100 @@ public class TestAggregationOperator
                         new GeneralInternalAccumulatorFactory(DOUBLE_SUM.bind(ImmutableList.of(5), Optional.empty())),
                         new GeneralInternalAccumulatorFactory(maxVarcharColumn.bind(ImmutableList.of(6), Optional.empty()))),
                 mapWithIndex(inputTypes.stream(), (type, channel) -> new AggregationInputChannel(new Symbol("i" + channel), (int) channel, type))
-                    .collect(toImmutableList()));
+                    .collect(toImmutableList()),
+                new DataSize(16, MEGABYTE));
 
+        DriverContext driverContext = createDriverContext(Integer.MAX_VALUE);
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, BIGINT, DOUBLE, VARCHAR, BIGINT, BIGINT, REAL, DOUBLE, VARCHAR)
                 .row(100L, 4950L, 49.5, "399", 100L, 54950L, 44950.0f, 54950.0, "599")
                 .build();
 
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
+    }
+
+    @Test
+    public void testMultiplePartialFlushes()
+            throws Exception
+    {
+        RowPagesBuilder rowPagesBuilder = rowPagesBuilder(BIGINT);
+        List<Page> input = rowPagesBuilder
+                .addSequencePage(500, 0)
+                .addSequencePage(500, 500)
+                .addSequencePage(500, 1000)
+                .addSequencePage(500, 1500)
+                .addSequencePage(500, 2000)
+                .addSequencePage(500, 2500)
+                .build();
+
+        DataSize maxPartialMemory = new DataSize(100, KILOBYTE);
+        AggregationOperatorFactory operatorFactory = new AggregationOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                Step.PARTIAL,
+                ImmutableList.of(new DistinctInternalAccumulatorFactory(
+                        COUNT.bind(ImmutableList.of(0), Optional.empty()),
+                        ImmutableList.of(BIGINT),
+                        ImmutableList.of(0),
+                        Optional.empty(),
+                        TEST_SESSION,
+                        joinCompiler)),
+                ImmutableList.of(new AggregationInputChannel(new Symbol("x"), 0, BIGINT)),
+                maxPartialMemory);
+
+        DriverContext driverContext = createDriverContext(1024);
+
+        try (Operator operator = operatorFactory.createOperator(driverContext)) {
+            Iterator<Page> inputIterator = input.iterator();
+
+            // Fill up the aggregation
+            long lastMemoryUsage = driverContext.getSystemMemoryUsage();
+            assertLessThan(lastMemoryUsage, maxPartialMemory.toBytes());
+            boolean memoryIncreased = false;
+            boolean memoryDecreased = false;
+            while (inputIterator.hasNext()) {
+                Page inputPage = inputIterator.next();
+                operator.addInput(inputPage);
+
+                long currentMemoryUsage = driverContext.getSystemMemoryUsage();
+                // memory should always be less than the max
+                assertLessThan(currentMemoryUsage, maxPartialMemory.toBytes());
+                if (currentMemoryUsage > lastMemoryUsage) {
+                    memoryIncreased = true;
+                }
+                if (currentMemoryUsage < lastMemoryUsage) {
+                    memoryDecreased = true;
+                }
+                lastMemoryUsage = currentMemoryUsage;
+
+                // all values are unique, so output should be the same size as input
+                Page output = operator.getOutput();
+                assertBlockEquals(BIGINT, output.getBlock(2), inputPage.getBlock(0));
+                assertEquals(output.getBlock(0).getPositionCount(), inputPage.getPositionCount());
+            }
+            // we expect memory to increase and then decrease at least once
+            assertTrue(memoryIncreased);
+            assertTrue(memoryDecreased);
+
+            // finish the operator
+            operator.finish();
+            // there should be one output page
+            Page output = operator.getOutput();
+            assertNotNull(output);
+            assertTrue(operator.isFinished());
+            assertFalse(operator.needsInput());
+
+            // there should be one output position and it should be null
+            assertEquals(output.getPositionCount(), 1);
+            assertTrue(output.getBlock(1).isNull(0));
+        }
+    }
+
+    private DriverContext createDriverContext(long memoryLimit)
+    {
+        return TestingTaskContext.builder(executor, scheduledExecutor, TEST_SESSION)
+                .setMemoryPoolSize(succinctBytes(memoryLimit))
+                .build()
+                .addPipelineContext(0, true, true)
+                .addDriverContext();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -155,8 +155,8 @@ public class TestEffectivePredicateExtractor
                                 greaterThan(AE, bigintLiteral(2)),
                                 equals(EE, FE))),
                 ImmutableMap.of(
-                        C, new Aggregation(fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty()),
-                        D, new Aggregation(fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty())),
+                        C, new Aggregation(C, fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty()),
+                        D, new Aggregation(D, fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty())),
                 ImmutableList.of(ImmutableList.of(A, B, C)),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -154,9 +154,9 @@ public class TestEffectivePredicateExtractor
                                 lessThan(CE, DE),
                                 greaterThan(AE, bigintLiteral(2)),
                                 equals(EE, FE))),
-                ImmutableMap.of(
-                        C, new Aggregation(C, fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty()),
-                        D, new Aggregation(D, fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty())),
+                ImmutableList.of(
+                        new Aggregation(C, fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty()),
+                        new Aggregation(D, fakeFunction(), fakeFunctionHandle("test", AGGREGATE), Optional.empty())),
                 ImmutableList.of(ImmutableList.of(A, B, C)),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
@@ -179,7 +179,7 @@ public class TestEffectivePredicateExtractor
         PlanNode node = new AggregationNode(
                 newId(),
                 filter(baseTableScan, FALSE_LITERAL),
-                ImmutableMap.of(),
+                ImmutableList.of(),
                 ImmutableList.of(ImmutableList.of()),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -160,6 +160,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.of(ImmutableList.of(A, B, C)),
                 AggregationNode.Step.FINAL,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         Expression effectivePredicate = effectivePredicateExtractor.extract(node);
@@ -182,6 +183,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.of(),
                 ImmutableList.of(ImmutableList.of()),
                 AggregationNode.Step.FINAL,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -199,6 +199,7 @@ public class TestTypeValidator
                 ImmutableList.of(ImmutableList.of(columnA, columnB)),
                 SINGLE,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         assertTypesValid(node);
@@ -257,6 +258,7 @@ public class TestTypeValidator
                 ImmutableList.of(ImmutableList.of(columnA, columnB)),
                 SINGLE,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         assertTypesValid(node);
@@ -284,6 +286,7 @@ public class TestTypeValidator
                         Optional.empty())),
                 ImmutableList.of(ImmutableList.of(columnA, columnB)),
                 SINGLE,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -185,6 +185,7 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 ImmutableMap.of(aggregationSymbol, new Aggregation(
+                        aggregationSymbol,
                         new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())),
                         new Signature(
                                 "sum",
@@ -242,6 +243,7 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 ImmutableMap.of(aggregationSymbol, new Aggregation(
+                        aggregationSymbol,
                         new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference())),
                         new Signature(
                                 "sum",
@@ -269,6 +271,7 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 ImmutableMap.of(aggregationSymbol, new Aggregation(
+                        aggregationSymbol,
                         new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())),
                         new Signature(
                                 "sum",

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -184,7 +184,7 @@ public class TestTypeValidator
         PlanNode node = new AggregationNode(
                 newId(),
                 baseTableScan,
-                ImmutableMap.of(aggregationSymbol, new Aggregation(
+                ImmutableList.of(new Aggregation(
                         aggregationSymbol,
                         new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())),
                         new Signature(
@@ -242,7 +242,7 @@ public class TestTypeValidator
         PlanNode node = new AggregationNode(
                 newId(),
                 baseTableScan,
-                ImmutableMap.of(aggregationSymbol, new Aggregation(
+                ImmutableList.of(new Aggregation(
                         aggregationSymbol,
                         new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnA.toSymbolReference())),
                         new Signature(
@@ -270,7 +270,7 @@ public class TestTypeValidator
         PlanNode node = new AggregationNode(
                 newId(),
                 baseTableScan,
-                ImmutableMap.of(aggregationSymbol, new Aggregation(
+                ImmutableList.of(new Aggregation(
                         aggregationSymbol,
                         new FunctionCall(QualifiedName.of("sum"), ImmutableList.of(columnC.toSymbolReference())),
                         new Signature(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationFunctionMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationFunctionMatcher.java
@@ -21,7 +21,6 @@ import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.tree.FunctionCall;
 
-import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -48,10 +47,10 @@ public class AggregationFunctionMatcher
         AggregationNode aggregationNode = (AggregationNode) node;
 
         FunctionCall expectedCall = callMaker.getExpectedValue(symbolAliases);
-        for (Map.Entry<Symbol, Aggregation> assignment : aggregationNode.getAggregations().entrySet()) {
-            if (expectedCall.equals(assignment.getValue().getCall())) {
+        for (Aggregation aggregation : aggregationNode.getAggregations()) {
+            if (expectedCall.equals(aggregation.getCall())) {
                 checkState(!result.isPresent(), "Ambiguous function calls in %s", aggregationNode);
-                result = Optional.of(assignment.getKey());
+                result = Optional.of(aggregation.getOutputSymbol());
             }
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
@@ -18,6 +18,7 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 
@@ -70,10 +71,9 @@ public class AggregationMatcher
         }
 
         List<Symbol> aggregationsWithMask = aggregationNode.getAggregations()
-                .entrySet()
                 .stream()
-                .filter(entry -> entry.getValue().getCall().isDistinct())
-                .map(entry -> entry.getKey())
+                .filter(aggregation -> aggregation.getCall().isDistinct())
+                .map(Aggregation::getOutputSymbol)
                 .collect(Collectors.toList());
 
         if (aggregationsWithMask.size() != masks.keySet().size()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -233,8 +233,8 @@ public class PlanBuilder
     public class AggregationBuilder
     {
         private PlanNode source;
-        private Map<Symbol, Aggregation> assignments = new HashMap<>();
-        private List<List<Symbol>> groupingSets = new ArrayList<>();
+        private final List<Aggregation> aggregations = new ArrayList<>();
+        private final List<List<Symbol>> groupingSets = new ArrayList<>();
         private Step step = Step.SINGLE;
         private Optional<Symbol> hashSymbol = Optional.empty();
         private Optional<Symbol> groupIdSymbol = Optional.empty();
@@ -260,12 +260,12 @@ public class PlanBuilder
             checkArgument(expression instanceof FunctionCall);
             FunctionCall aggregation = (FunctionCall) expression;
             Signature signature = metadata.getFunctionRegistry().resolveFunction(aggregation.getName(), TypeSignatureProvider.fromTypes(inputTypes));
-            return addAggregation(output, new Aggregation(output, aggregation, signature, mask));
+            return addAggregation(new Aggregation(output, aggregation, signature, mask));
         }
 
-        public AggregationBuilder addAggregation(Symbol output, Aggregation aggregation)
+        public AggregationBuilder addAggregation(Aggregation aggregation)
         {
-            assignments.put(output, aggregation);
+            aggregations.add(aggregation);
             return this;
         }
 
@@ -316,7 +316,7 @@ public class PlanBuilder
             return new AggregationNode(
                     idAllocator.getNextId(),
                     source,
-                    assignments,
+                    aggregations,
                     groupingSets,
                     step,
                     hashSymbol,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -238,6 +238,7 @@ public class PlanBuilder
         private Step step = Step.SINGLE;
         private Optional<Symbol> hashSymbol = Optional.empty();
         private Optional<Symbol> groupIdSymbol = Optional.empty();
+        private Optional<Symbol> rowTypeSymbol = Optional.empty();
 
         public AggregationBuilder source(PlanNode source)
         {
@@ -310,6 +311,12 @@ public class PlanBuilder
             return this;
         }
 
+        public AggregationBuilder rowTypeSymbol(Symbol rowTypeSymbol)
+        {
+            this.rowTypeSymbol = Optional.of(rowTypeSymbol);
+            return this;
+        }
+
         protected AggregationNode build()
         {
             checkState(!groupingSets.isEmpty(), "No grouping sets defined; use globalGrouping/addGroupingSet/addEmptyGroupingSet method");
@@ -320,7 +327,8 @@ public class PlanBuilder
                     groupingSets,
                     step,
                     hashSymbol,
-                    groupIdSymbol);
+                    groupIdSymbol,
+                    rowTypeSymbol);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -260,7 +260,7 @@ public class PlanBuilder
             checkArgument(expression instanceof FunctionCall);
             FunctionCall aggregation = (FunctionCall) expression;
             Signature signature = metadata.getFunctionRegistry().resolveFunction(aggregation.getName(), TypeSignatureProvider.fromTypes(inputTypes));
-            return addAggregation(output, new Aggregation(aggregation, signature, mask));
+            return addAggregation(output, new Aggregation(output, aggregation, signature, mask));
         }
 
         public AggregationBuilder addAggregation(Symbol output, Aggregation aggregation)

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
@@ -37,29 +37,29 @@ public class TestFilteredAggregations
     public void testGroupAll()
     {
         assertions.assertQuery(
-                "SELECT count(DISTINCT x) FILTER (WHERE x > 1) " +
+                "SELECT sum(DISTINCT x) FILTER (WHERE x > 1) " +
                         "FROM (VALUES 1, 1, 1, 2, 3, 3) t(x)",
-                "VALUES BIGINT '2'");
+                "VALUES BIGINT '5'");
 
         assertions.assertQuery(
-                "SELECT count(DISTINCT x) FILTER (WHERE x > 1), sum(DISTINCT x) " +
+                "SELECT sum(DISTINCT x) FILTER (WHERE x > 1), sum(DISTINCT x) " +
                         "FROM (VALUES 1, 1, 1, 2, 3, 3) t(x)",
-                "VALUES (BIGINT '2', BIGINT '6')");
+                "VALUES (BIGINT '5', BIGINT '6')");
 
         assertions.assertQuery(
-                "SELECT count(DISTINCT x) FILTER (WHERE x > 1), sum(DISTINCT y) FILTER (WHERE x < 3)" +
+                "SELECT sum(DISTINCT x) FILTER (WHERE x > 1), sum(DISTINCT y) FILTER (WHERE x < 3)" +
                         "FROM (VALUES " +
                         "(1, 10)," +
                         "(1, 20)," +
                         "(1, 20)," +
                         "(2, 20)," +
                         "(3, 30)) t(x, y)",
-                "VALUES (BIGINT '2', BIGINT '30')");
+                "VALUES (BIGINT '5', BIGINT '30')");
 
         assertions.assertQuery(
-                "SELECT count(x) FILTER (WHERE x > 1), sum(DISTINCT x) " +
+                "SELECT sum(x) FILTER (WHERE x > 1), sum(DISTINCT x) " +
                         "FROM (VALUES 1, 2, 3, 3) t(x)",
-                "VALUES (BIGINT '3', BIGINT '6')");
+                "VALUES (BIGINT '8', BIGINT '6')");
     }
 
     @Test

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryPagesStore.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryPagesStore.java
@@ -15,7 +15,6 @@ package com.facebook.presto.plugin.memory;
 
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.block.Block;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -133,13 +132,7 @@ public class MemoryPagesStore
 
     private static Page getColumns(Page page, List<Integer> columnIndexes)
     {
-        Block[] outputBlocks = new Block[columnIndexes.size()];
-
-        for (int i = 0; i < columnIndexes.size(); i++) {
-            outputBlocks[i] = page.getBlock(columnIndexes.get(i));
-        }
-
-        return new Page(page.getPositionCount(), outputBlocks);
+        return page.selectChannels(columnIndexes);
     }
 
     private static final class TableData

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
@@ -288,6 +288,11 @@ public class Page
         return new Page(positionCount, result);
     }
 
+    public Page selectChannels(List<Integer> channels)
+    {
+        return new Page(positionCount, channels.stream().map(channel -> blocks[channel]).toArray(Block[]::new));
+    }
+
     private void updateRetainedSize()
     {
         long retainedSizeInBytes = INSTANCE_SIZE + sizeOf(blocks);


### PR DESCRIPTION
This addresses item 2 from issue #10305 

This is for non group-by aggregations only.  Basically, we have two way to execute agg(distinct x) today.  One is you redistribute the table on `x` and mark which rows are distinct for `x` on N machines, and after all aggregations have marked stuff distinct, we can do a partial on N machines.  Alternatively, we can simply move all rows to one machine, and only do the distinct and all work on one machine.  With the mark distinct strategy you can do huge distincts, but it is super expensive, because you have to redistribute the table for each distinct aggregation.  The single strategy removes the redistributions, but can be high latency because all of work is one on one machine in one thread, and you only get single machine's memory (not distribute memory) for the distinct set.

This change, reduces the latency of the single aggregation by doing a partial mark distinct on each node, so you get N machines doing the marking. And, you get partials for the non-distinct aggregations.  You still have the problem where the final distinct set does not fit in single machine's memory.
