### PR TITLE
Hover tooltip in Live Plan for tablescan and filter nodes

### DIFF
--- a/presto-main/src/main/resources/webapp/assets/plan.js
+++ b/presto-main/src/main/resources/webapp/assets/plan.js
@@ -51,9 +51,15 @@ function flattenNode(stages, nodeInfo, result)
     const sources = allSources[0];
     const remoteSources = allSources[1];
 
+    var tableName = '';
+    if (nodeInfo.hasOwnProperty('table')) {
+        tableName = nodeInfo.table.connectorHandle.schemaTableName.schema + '.' + nodeInfo.table.connectorHandle.schemaTableName.table;
+    }
+
     result.set(nodeInfo.id, {
         id: nodeInfo.id,
         type: nodeInfo['@type'],
+        tableName: tableName,
         sources: sources.map(function(node) { return node.id }),
         remoteSources: remoteSources,
         stats: {}
@@ -188,7 +194,7 @@ let LivePlan = React.createClass({
         stage.nodes.forEach(node => {
             const nodeId = "node-" + node.id;
 
-            graph.setNode(nodeId, {label: node.type, style: 'fill: #fff'});
+            graph.setNode(nodeId, {label: this.getNodeLabelSvg(node.type, node.tableName), labelType: 'svg', style: 'fill: #fff'});
             graph.setParent(nodeId, clusterId);
 
             node.sources.forEach(source => {
@@ -203,6 +209,19 @@ let LivePlan = React.createClass({
                 });
             }
         });
+    },
+    getNodeLabelSvg: function(label, tooltip) {
+        var svg_label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        var tspan = document.createElementNS('http://www.w3.org/2000/svg','tspan');
+        tspan.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+        tspan.setAttribute('dy', '1em');
+        tspan.setAttribute('x', '1');
+        tspan.textContent = label;
+        var title = document.createElementNS('http://www.w3.org/2000/svg','title');
+        title.textContent = tooltip;
+        svg_label.appendChild(tspan);
+        svg_label.appendChild(title);
+        return svg_label;
     },
     updateD3Graph: function() {
         if (!this.state.query) {

--- a/presto-main/src/main/resources/webapp/assets/plan.js
+++ b/presto-main/src/main/resources/webapp/assets/plan.js
@@ -50,21 +50,7 @@ function flattenNode(stages, nodeInfo, result)
     const allSources = computeSources(nodeInfo);
     const sources = allSources[0];
     const remoteSources = allSources[1];
-
-    var extraInfo = '';
-    switch(nodeInfo['@type']) {
-        case 'tablescan':
-            if (nodeInfo.hasOwnProperty('table')) {
-                // TODO: Check handle.schemaTableName.schema. If not defined, try handle.schemaName. Similarly with the table name.
-                extraInfo = nodeInfo.table.connectorHandle.schemaTableName.schema + '.' + nodeInfo.table.connectorHandle.schemaTableName.table;
-            }
-            break;
-        case 'filter':
-            if (nodeInfo.hasOwnProperty('predicate')) {
-                extraInfo = nodeInfo.predicate;
-            }
-            break;
-    }
+    const extraInfo = computeExtraInfo(nodeInfo);
 
     result.set(nodeInfo.id, {
         id: nodeInfo.id,
@@ -221,21 +207,14 @@ let LivePlan = React.createClass({
         });
     },
     getNodeLabelSvg: function(node) {
-        var svg_label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-        var tspan = document.createElementNS('http://www.w3.org/2000/svg','tspan');
-        tspan.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
-        tspan.setAttribute('dy', '1em');
-        tspan.setAttribute('x', '1');
-        tspan.textContent = node.type;
-        svg_label.appendChild(tspan);
+        var svgLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
 
+        svgLabel.appendChild(buildSvgElement('tspan', node.type));
         if (node.extraInfo !== '') {
-            var title = document.createElementNS('http://www.w3.org/2000/svg','title');
-            title.textContent = node.extraInfo;
-            svg_label.appendChild(title);
+            svgLabel.appendChild(buildSvgElement('title', node.extraInfo));
         }
 
-        return svg_label;
+        return svgLabel;
     },
     updateD3Graph: function() {
         if (!this.state.query) {

--- a/presto-main/src/main/resources/webapp/assets/plan.js
+++ b/presto-main/src/main/resources/webapp/assets/plan.js
@@ -51,18 +51,28 @@ function flattenNode(stages, nodeInfo, result)
     const sources = allSources[0];
     const remoteSources = allSources[1];
 
-    var tableName = '';
-    if (nodeInfo.hasOwnProperty('table')) {
-        tableName = nodeInfo.table.connectorHandle.schemaTableName.schema + '.' + nodeInfo.table.connectorHandle.schemaTableName.table;
+    var extraInfo = '';
+    switch(nodeInfo['@type']) {
+        case 'tablescan':
+            if (nodeInfo.hasOwnProperty('table')) {
+                // TODO: Check handle.schemaTableName.schema. If not defined, try handle.schemaName. Similarly with the table name.
+                extraInfo = nodeInfo.table.connectorHandle.schemaTableName.schema + '.' + nodeInfo.table.connectorHandle.schemaTableName.table;
+            }
+            break;
+        case 'filter':
+            if (nodeInfo.hasOwnProperty('predicate')) {
+                extraInfo = nodeInfo.predicate;
+            }
+            break;
     }
 
     result.set(nodeInfo.id, {
         id: nodeInfo.id,
         type: nodeInfo['@type'],
-        tableName: tableName,
         sources: sources.map(function(node) { return node.id }),
         remoteSources: remoteSources,
-        stats: {}
+        stats: {},
+        extraInfo: extraInfo
     });
 
     sources.forEach(function(child) {
@@ -194,7 +204,7 @@ let LivePlan = React.createClass({
         stage.nodes.forEach(node => {
             const nodeId = "node-" + node.id;
 
-            graph.setNode(nodeId, {label: this.getNodeLabelSvg(node.type, node.tableName), labelType: 'svg', style: 'fill: #fff'});
+            graph.setNode(nodeId, {label: this.getNodeLabelSvg(node), labelType: 'svg', style: 'fill: #fff'});
             graph.setParent(nodeId, clusterId);
 
             node.sources.forEach(source => {
@@ -210,17 +220,21 @@ let LivePlan = React.createClass({
             }
         });
     },
-    getNodeLabelSvg: function(label, tooltip) {
+    getNodeLabelSvg: function(node) {
         var svg_label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
         var tspan = document.createElementNS('http://www.w3.org/2000/svg','tspan');
         tspan.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
         tspan.setAttribute('dy', '1em');
         tspan.setAttribute('x', '1');
-        tspan.textContent = label;
-        var title = document.createElementNS('http://www.w3.org/2000/svg','title');
-        title.textContent = tooltip;
+        tspan.textContent = node.type;
         svg_label.appendChild(tspan);
-        svg_label.appendChild(title);
+
+        if (node.extraInfo !== '') {
+            var title = document.createElementNS('http://www.w3.org/2000/svg','title');
+            title.textContent = node.extraInfo;
+            svg_label.appendChild(title);
+        }
+
         return svg_label;
     },
     updateD3Graph: function() {

--- a/presto-main/src/main/resources/webapp/assets/plan.js
+++ b/presto-main/src/main/resources/webapp/assets/plan.js
@@ -51,6 +51,7 @@ function flattenNode(stages, nodeInfo, result)
     const sources = allSources[0];
     const remoteSources = allSources[1];
     const extraInfo = computeExtraInfo(nodeInfo);
+    const tableName = computeTableName(nodeInfo);
 
     result.set(nodeInfo.id, {
         id: nodeInfo.id,
@@ -58,7 +59,8 @@ function flattenNode(stages, nodeInfo, result)
         sources: sources.map(function(node) { return node.id }),
         remoteSources: remoteSources,
         stats: {},
-        extraInfo: extraInfo
+        extraInfo: extraInfo,
+        tableName: tableName
     });
 
     sources.forEach(function(child) {
@@ -208,8 +210,16 @@ let LivePlan = React.createClass({
     },
     getNodeLabelSvg: function(node) {
         var svgLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        svgLabel.setAttribute("y", "1em");
 
         svgLabel.appendChild(buildSvgElement('tspan', node.type));
+
+        if (node.tableName !== '') {
+            var tableName = buildSvgElement('tspan', "↳ " + node.tableName);
+            tableName.setAttribute("dy", "1.2em");
+            svgLabel.appendChild(tableName);
+        }
+
         if (node.extraInfo !== '') {
             svgLabel.appendChild(buildSvgElement('title', node.extraInfo));
         }

--- a/presto-main/src/main/resources/webapp/assets/utils.js
+++ b/presto-main/src/main/resources/webapp/assets/utils.js
@@ -261,6 +261,30 @@ function computeSources(nodeInfo)
     return [sources, remoteSources];
 }
 
+function computeExtraInfo(nodeInfo) {
+    var extraInfo = '';
+
+    switch(nodeInfo['@type']) {
+        case 'tablescan':
+            if (nodeInfo.hasOwnProperty('table')) {
+                const connectorHandle = nodeInfo.table.connectorHandle;
+
+                if (connectorHandle.hasOwnProperty('schemaTableName')) {
+                    extraInfo = connectorHandle.schemaTableName.schema + '.' + connectorHandle.schemaTableName.table;
+                } else if (connectorHandle.hasOwnProperty('schemaName') || connectorHandle.hasOwnProperty('tableName')) {
+                    extraInfo = connectorHandle.schemaName + '.' + connectorHandle.tableName;
+                }
+            }
+            break;
+        case 'filter':
+            if (nodeInfo.hasOwnProperty('predicate')) {
+                extraInfo = nodeInfo.predicate;
+            }
+            break;
+    }
+    return extraInfo;
+}
+
 // Utility functions
 // =================
 
@@ -553,4 +577,11 @@ function removeQueryId(id) {
         return id.substring(pos + 1);
     }
     return id;
+}
+
+function buildSvgElement(qualifiedName, textContent) {
+    var svgElement = document.createElementNS('http://www.w3.org/2000/svg', qualifiedName);
+    svgElement.setAttribute('dy', '1em');
+    svgElement.textContent = textContent;
+    return svgElement;
 }

--- a/presto-main/src/main/resources/webapp/assets/utils.js
+++ b/presto-main/src/main/resources/webapp/assets/utils.js
@@ -261,21 +261,25 @@ function computeSources(nodeInfo)
     return [sources, remoteSources];
 }
 
+function computeTableName(nodeInfo) {
+    var tableName = '';
+
+    if (nodeInfo['@type'] === 'tablescan' && nodeInfo.hasOwnProperty('table')) {
+        const connectorHandle = nodeInfo.table.connectorHandle;
+
+        if (connectorHandle.hasOwnProperty('schemaTableName')) {
+            tableName = connectorHandle.schemaTableName.schema + '.' + connectorHandle.schemaTableName.table;
+        } else if (connectorHandle.hasOwnProperty('schemaName') || connectorHandle.hasOwnProperty('tableName')) {
+            tableName = connectorHandle.schemaName + '.' + connectorHandle.tableName;
+        }
+    }
+    return tableName;
+}
+
 function computeExtraInfo(nodeInfo) {
     var extraInfo = '';
 
     switch(nodeInfo['@type']) {
-        case 'tablescan':
-            if (nodeInfo.hasOwnProperty('table')) {
-                const connectorHandle = nodeInfo.table.connectorHandle;
-
-                if (connectorHandle.hasOwnProperty('schemaTableName')) {
-                    extraInfo = connectorHandle.schemaTableName.schema + '.' + connectorHandle.schemaTableName.table;
-                } else if (connectorHandle.hasOwnProperty('schemaName') || connectorHandle.hasOwnProperty('tableName')) {
-                    extraInfo = connectorHandle.schemaName + '.' + connectorHandle.tableName;
-                }
-            }
-            break;
         case 'filter':
             if (nodeInfo.hasOwnProperty('predicate')) {
                 extraInfo = nodeInfo.predicate;
@@ -581,7 +585,7 @@ function removeQueryId(id) {
 
 function buildSvgElement(qualifiedName, textContent) {
     var svgElement = document.createElementNS('http://www.w3.org/2000/svg', qualifiedName);
-    svgElement.setAttribute('dy', '1em');
+    svgElement.setAttribute("x", "1");
     svgElement.textContent = textContent;
     return svgElement;
 }


### PR DESCRIPTION
Addresses: https://github.com/prestodb/presto/issues/9602

Exposes a tooltip for `tablescan` nodes to display the table name. Also exposes a tooltip for `filter` nodes to show the predicate.

Test query [tested with Hive and MySQL]:
```sql
select * 
from system.runtime.tasks a 
inner join system.runtime.tasks b 
    on a.task_id = b.task_id 
where a.state <> 'FINISHED';
```

<img width="684" alt="screen shot 2018-06-15 at 2 02 27 pm" src="https://user-images.githubusercontent.com/33286085/41482870-ed05b756-70a4-11e8-88bf-b8e9cb0d8803.png">

<img width="310" alt="screen shot 2018-06-15 at 2 10 48 pm" src="https://user-images.githubusercontent.com/33286085/41483163-069eff78-70a6-11e8-8a6c-291c21d57305.png">
