### PR TITLE
Fix New Parquet Reader reading array<struct<type:string>>

### DIFF
--- a/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
+++ b/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
@@ -52,6 +52,13 @@ public class ColumnIOConverter
         int repetitionLevel = columnIO.getRepetitionLevel();
         int definitionLevel = columnIO.getDefinitionLevel();
         if (ROW.equals(type.getTypeSignature().getBase())) {
+            if (columnIO instanceof PrimitiveColumnIO) {
+                // single element struct
+                PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;
+                RichColumnDescriptor column = new RichColumnDescriptor(primitiveColumnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType());
+                Optional<Field> field = Optional.of(new PrimitiveField(type.getTypeParameters().get(0), repetitionLevel, definitionLevel, required, column, primitiveColumnIO.getId()));
+                return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(field)));
+            }
             GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
             List<Type> parameters = type.getTypeParameters();
             ImmutableList.Builder<Optional<Field>> fileldsBuilder = ImmutableList.builder();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -186,6 +186,19 @@ public abstract class AbstractTestParquetReader
     }
 
     @Test
+    public void testArrayOfStructOfSingleElement()
+            throws Exception
+    {
+        Iterable<List> structs = createNullableTestStructs(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<List>> values = createTestArrays(structs);
+        List<String> structFieldNames = asList("stringField");
+        Type structType = RowType.from(asList(field("stringField", VARCHAR)));
+        tester.testRoundTrip(
+                getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, asList(javaStringObjectInspector))),
+                values, values, new ArrayType(structType));
+    }
+
+    @Test
     public void testCustomSchemaArrayOfStucts()
             throws Exception
     {


### PR DESCRIPTION
Hi @dain @electrum @nezihyigitbasi @kgalieva 
found a bug when running New Parquet reader for our production traffic (seems like the only bug)

when reading array<struct<type:string>>, columnIO is primitive for the inside struct

With this fix, all of our highly nested Parquet queries are good