### PR TITLE
Fix backward-compatibility processing for array with one group field

### DIFF
--- a/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
+++ b/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
@@ -54,7 +54,7 @@ public class ColumnIOConverter
         if (ROW.equals(type.getTypeSignature().getBase())) {
             GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
             List<Type> parameters = type.getTypeParameters();
-            ImmutableList.Builder<Optional<Field>> fileldsBuilder = ImmutableList.builder();
+            ImmutableList.Builder<Optional<Field>> fieldsBuilder = ImmutableList.builder();
             List<TypeSignatureParameter> fields = type.getTypeSignature().getParameters();
             boolean structHasParameters = false;
             for (int i = 0; i < fields.size(); i++) {
@@ -62,10 +62,10 @@ public class ColumnIOConverter
                 String name = namedTypeSignature.getName().get().toLowerCase(Locale.ENGLISH);
                 Optional<Field> field = constructField(parameters.get(i), groupColumnIO.getChild(name));
                 structHasParameters |= field.isPresent();
-                fileldsBuilder.add(field);
+                fieldsBuilder.add(field);
             }
             if (structHasParameters) {
-                return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, fileldsBuilder.build()));
+                return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, fieldsBuilder.build()));
             }
             return Optional.empty();
         }
@@ -73,7 +73,7 @@ public class ColumnIOConverter
             GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
             MapType mapType = (MapType) type;
             GroupColumnIO keyValueColumnIO = getMapKeyValueColumn(groupColumnIO);
-            if (keyValueColumnIO.getChildrenCount() < 2) {
+            if (keyValueColumnIO.getChildrenCount() != 2) {
                 return Optional.empty();
             }
             Optional<Field> keyField = constructField(mapType.getKeyType(), keyValueColumnIO.getChild(0));
@@ -83,7 +83,7 @@ public class ColumnIOConverter
         else if (ARRAY.equals(type.getTypeSignature().getBase())) {
             GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
             List<Type> types = type.getTypeParameters();
-            if (groupColumnIO.getChildrenCount() == 0) {
+            if (groupColumnIO.getChildrenCount() != 1) {
                 return Optional.empty();
             }
             Optional<Field> field = constructField(types.get(0), getArrayElementColumn(groupColumnIO.getChild(0)));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -152,10 +152,10 @@ public class ParquetTester
     {
         ArrayList<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString(objectInspector.getTypeName());
         MessageType schema = SingleLevelArraySchemaConverter.convert(TEST_COLUMN, typeInfos);
-        testRoundTrip(objectInspector, writeValues, readValues, type, Optional.of(schema));
+        testSingleLevelArrayRoundTrip(objectInspector, writeValues, readValues, type, Optional.of(schema));
         if (objectInspector.getTypeName().contains("map<")) {
             schema = SingleLevelArrayMapKeyValuesSchemaConverter.convert(TEST_COLUMN, typeInfos);
-            testRoundTrip(objectInspector, writeValues, readValues, type, Optional.of(schema));
+            testSingleLevelArrayRoundTrip(objectInspector, writeValues, readValues, type, Optional.of(schema));
         }
     }
 
@@ -163,7 +163,8 @@ public class ParquetTester
             throws Exception
     {
         // just the values
-        testRoundTripType(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), Optional.empty());
+        testRoundTripType(singletonList(objectInspector), new Iterable<?>[] {writeValues},
+                new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), Optional.empty(), false);
 
         // all nulls
         assertRoundTrip(singletonList(objectInspector), new Iterable<?>[] {transform(writeValues, constant(null))},
@@ -173,7 +174,7 @@ public class ParquetTester
             MessageType schema = MapKeyValuesSchemaConverter.convert(TEST_COLUMN, typeInfos);
             // just the values
             testRoundTripType(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {
-                    readValues}, TEST_COLUMN, singletonList(type), Optional.of(schema));
+                    readValues}, TEST_COLUMN, singletonList(type), Optional.of(schema), false);
 
             // all nulls
             assertRoundTrip(singletonList(objectInspector), new Iterable<?>[] {transform(writeValues, constant(null))},
@@ -184,34 +185,40 @@ public class ParquetTester
     public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, Optional<MessageType> parquetSchema)
             throws Exception
     {
-        testRoundTrip(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), parquetSchema);
+        testRoundTrip(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), parquetSchema, false);
     }
 
-    public void testRoundTrip(List<ObjectInspector> objectInspectors, Iterable<?>[] writeValues, Iterable<?>[] readValues, List<String> columnNames, List<Type> columnTypes, Optional<MessageType> parquetSchema)
+    public void testSingleLevelArrayRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, Type type, Optional<MessageType> parquetSchema)
+            throws Exception
+    {
+        testRoundTrip(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), parquetSchema, true);
+    }
+
+    public void testRoundTrip(List<ObjectInspector> objectInspectors, Iterable<?>[] writeValues, Iterable<?>[] readValues, List<String> columnNames, List<Type> columnTypes, Optional<MessageType> parquetSchema, boolean singleLevelArray)
             throws Exception
     {
         // just the values
-        testRoundTripType(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema);
+        testRoundTripType(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema, singleLevelArray);
 
         // all nulls
-        assertRoundTrip(objectInspectors, transformToNulls(writeValues), transformToNulls(readValues), columnNames, columnTypes, parquetSchema);
+        assertRoundTrip(objectInspectors, transformToNulls(writeValues), transformToNulls(readValues), columnNames, columnTypes, parquetSchema, singleLevelArray);
     }
 
     private void testRoundTripType(List<ObjectInspector> objectInspectors, Iterable<?>[] writeValues, Iterable<?>[] readValues,
-            List<String> columnNames, List<Type> columnTypes, Optional<MessageType> parquetSchema)
+            List<String> columnNames, List<Type> columnTypes, Optional<MessageType> parquetSchema, boolean singleLevelArray)
             throws Exception
     {
         // forward order
-        assertRoundTrip(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema);
+        assertRoundTrip(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema, singleLevelArray);
 
         // reverse order
-        assertRoundTrip(objectInspectors, reverse(writeValues), reverse(readValues), columnNames, columnTypes, parquetSchema);
+        assertRoundTrip(objectInspectors, reverse(writeValues), reverse(readValues), columnNames, columnTypes, parquetSchema, singleLevelArray);
 
         // forward order with nulls
-        assertRoundTrip(objectInspectors, insertNullEvery(5, writeValues), insertNullEvery(5, readValues), columnNames, columnTypes, parquetSchema);
+        assertRoundTrip(objectInspectors, insertNullEvery(5, writeValues), insertNullEvery(5, readValues), columnNames, columnTypes, parquetSchema, singleLevelArray);
 
         // reverse order with nulls
-        assertRoundTrip(objectInspectors, insertNullEvery(5, reverse(writeValues)), insertNullEvery(5, reverse(readValues)), columnNames, columnTypes, parquetSchema);
+        assertRoundTrip(objectInspectors, insertNullEvery(5, reverse(writeValues)), insertNullEvery(5, reverse(readValues)), columnNames, columnTypes, parquetSchema, singleLevelArray);
     }
 
     void assertRoundTrip(List<ObjectInspector> objectInspectors,
@@ -220,6 +227,18 @@ public class ParquetTester
             List<String> columnNames,
             List<Type> columnTypes,
             Optional<MessageType> parquetSchema)
+            throws Exception
+    {
+        assertRoundTrip(objectInspectors, writeValues, readValues, columnNames, columnTypes, parquetSchema, false);
+    }
+
+    void assertRoundTrip(List<ObjectInspector> objectInspectors,
+            Iterable<?>[] writeValues,
+            Iterable<?>[] readValues,
+            List<String> columnNames,
+            List<Type> columnTypes,
+            Optional<MessageType> parquetSchema,
+            boolean singleLevelArray)
             throws Exception
     {
         for (WriterVersion version : versions) {
@@ -236,7 +255,8 @@ public class ParquetTester
                             createTableProperties(columnNames, objectInspectors),
                             getStandardStructObjectInspector(columnNames, objectInspectors),
                             getIterators(writeValues),
-                            parquetSchema);
+                            parquetSchema,
+                            singleLevelArray);
                     assertFileContents(
                             tempFile.getFile(),
                             getIterators(readValues),
@@ -383,10 +403,11 @@ public class ParquetTester
             Properties tableProperties,
             SettableStructObjectInspector objectInspector,
             Iterator<?>[] valuesByField,
-            Optional<MessageType> parquetSchema)
+            Optional<MessageType> parquetSchema,
+            boolean singleLevelArray)
             throws Exception
     {
-        RecordWriter recordWriter = new TestMapredParquetOutputFormat(parquetSchema)
+        RecordWriter recordWriter = new TestMapredParquetOutputFormat(parquetSchema, singleLevelArray)
                 .getHiveRecordWriter(
                         jobConf,
                         new Path(outputFile.toURI()),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArraySchemaConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/SingleLevelArraySchemaConverter.java
@@ -162,7 +162,7 @@ public class SingleLevelArraySchemaConverter
     private static GroupType convertArrayType(final String name, final ListTypeInfo typeInfo, final Repetition repetition)
     {
         final TypeInfo subType = typeInfo.getListElementTypeInfo();
-        return listWrapper(name, OriginalType.LIST, convertType("array_element", subType, Repetition.REPEATED), repetition);
+        return listWrapper(name, OriginalType.LIST, convertType("array", subType, Repetition.REPEATED), repetition);
     }
 
     // An optional group containing multiple elements

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriteSupport.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriteSupport.java
@@ -31,6 +31,12 @@ class TestDataWritableWriteSupport
 {
     private TestDataWritableWriter writer;
     private MessageType schema;
+    private boolean singleLevelArray;
+
+    public TestDataWritableWriteSupport(boolean singleLevelArray)
+    {
+        this.singleLevelArray = singleLevelArray;
+    }
 
     @Override
     public WriteContext init(final Configuration configuration)
@@ -42,7 +48,7 @@ class TestDataWritableWriteSupport
     @Override
     public void prepareForWrite(final RecordConsumer recordConsumer)
     {
-        writer = new TestDataWritableWriter(recordConsumer, schema);
+        writer = new TestDataWritableWriter(recordConsumer, schema, singleLevelArray);
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestMapredParquetOutputFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestMapredParquetOutputFormat.java
@@ -41,9 +41,9 @@ public class TestMapredParquetOutputFormat
 {
     private final Optional<MessageType> schema;
 
-    public TestMapredParquetOutputFormat(Optional<MessageType> schema)
+    public TestMapredParquetOutputFormat(Optional<MessageType> schema, boolean singleLevelArray)
     {
-        super(new ParquetOutputFormat<>(new TestDataWritableWriteSupport()));
+        super(new ParquetOutputFormat<>(new TestDataWritableWriteSupport(singleLevelArray)));
         this.schema = requireNonNull(schema, "schema is null");
     }
 


### PR DESCRIPTION
According to Parquet spec:
If the repeated field is a group with one field and is named either array
or uses the LIST-annotated group's name with _tuple appended
then the repeated type is the element type and elements are required.

https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists