### PR TITLE
Added support for SliceOutput as a key in ReferenceCountMap

### DIFF
--- a/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
@@ -16,6 +16,7 @@ package com.facebook.presto.array;
 import com.facebook.presto.spi.block.Block;
 import io.airlift.slice.SizeOf;
 import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -86,6 +87,9 @@ public final class ReferenceCountMap
         }
         else if (key instanceof Slice) {
             extraIdentity = (int) ((Slice) key).getRetainedSize();
+        }
+        else if (key instanceof SliceOutput) {
+            extraIdentity = (int) ((SliceOutput) key).getRetainedSize();
         }
         else if (key.getClass().isArray()) {
             extraIdentity = getLength(key);


### PR DESCRIPTION
This PR adds support for having SliceOutput as a key in `ReferenceCountMap` so that we can track the objects created in `VariableWidthBlockBuilder`.

Other workaround is by modifying the VariableWidthBlockBuilder
```

    @Override
    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
    {
        consumer.accept(sliceOutput.getUnderlyingSlice(), sliceOutput.getRetainedSize());
        consumer.accept(offsets, sizeOf(offsets));
        consumer.accept(valueIsNull, sizeOf(valueIsNull));
        consumer.accept(this, (long) INSTANCE_SIZE);
    }
```