### PR TITLE
Add support for a global total memory limit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
+++ b/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
@@ -24,9 +24,14 @@ public class ExceededMemoryLimitException
 {
     private final DataSize maxMemory;
 
-    public static ExceededMemoryLimitException exceededGlobalLimit(DataSize maxMemory)
+    public static ExceededMemoryLimitException exceededGlobalUserLimit(DataSize maxMemory)
     {
-        return new ExceededMemoryLimitException(maxMemory, format("Query exceeded max memory size of %s", maxMemory));
+        return new ExceededMemoryLimitException(maxMemory, format("Query exceeded max user memory size of %s", maxMemory));
+    }
+
+    public static ExceededMemoryLimitException exceededGlobalTotalLimit(DataSize maxMemory)
+    {
+        return new ExceededMemoryLimitException(maxMemory, format("Query exceeded max total memory size of %s", maxMemory));
     }
 
     public static ExceededMemoryLimitException exceededLocalUserMemoryLimit(DataSize maxMemory)

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -51,6 +51,7 @@ public final class SystemSessionProperties
     public static final String TASK_CONCURRENCY = "task_concurrency";
     public static final String TASK_SHARE_INDEX_LOADING = "task_share_index_loading";
     public static final String QUERY_MAX_MEMORY = "query_max_memory";
+    public static final String QUERY_MAX_TOTAL_MEMORY = "query_max_total_memory";
     public static final String QUERY_MAX_EXECUTION_TIME = "query_max_execution_time";
     public static final String QUERY_MAX_RUN_TIME = "query_max_run_time";
     public static final String RESOURCE_OVERCOMMIT = "resource_overcommit";
@@ -223,6 +224,15 @@ public final class SystemSessionProperties
                         VARCHAR,
                         DataSize.class,
                         memoryManagerConfig.getMaxQueryMemory(),
+                        true,
+                        value -> DataSize.valueOf((String) value),
+                        DataSize::toString),
+                new PropertyMetadata<>(
+                        QUERY_MAX_TOTAL_MEMORY,
+                        "Maximum amount of distributed total memory a query can use",
+                        VARCHAR,
+                        DataSize.class,
+                        memoryManagerConfig.getMaxQueryTotalMemory(),
                         true,
                         value -> DataSize.valueOf((String) value),
                         DataSize::toString),
@@ -509,6 +519,11 @@ public final class SystemSessionProperties
     public static DataSize getQueryMaxMemory(Session session)
     {
         return session.getSystemProperty(QUERY_MAX_MEMORY, DataSize.class);
+    }
+
+    public static DataSize getQueryMaxTotalMemory(Session session)
+    {
+        return session.getSystemProperty(QUERY_MAX_TOTAL_MEMORY, DataSize.class);
     }
 
     public static Duration getQueryMaxRunTime(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryManagerConfig.java
@@ -23,6 +23,7 @@ import io.airlift.units.MinDuration;
 import javax.validation.constraints.NotNull;
 
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.succinctBytes;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 @DefunctConfig({
@@ -30,7 +31,10 @@ import static java.util.concurrent.TimeUnit.MINUTES;
         "query.low-memory-killer.enabled"})
 public class MemoryManagerConfig
 {
+    // enforced against user memory allocations
     private DataSize maxQueryMemory = new DataSize(20, GIGABYTE);
+    // enforced against user + system memory allocations (default is maxQueryMemory * 2)
+    private DataSize maxQueryTotalMemory;
     private String lowMemoryKillerPolicy = LowMemoryKillerPolicy.NONE;
     private Duration killOnOutOfMemoryDelay = new Duration(5, MINUTES);
 
@@ -71,6 +75,22 @@ public class MemoryManagerConfig
     public MemoryManagerConfig setMaxQueryMemory(DataSize maxQueryMemory)
     {
         this.maxQueryMemory = maxQueryMemory;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getMaxQueryTotalMemory()
+    {
+        if (maxQueryTotalMemory == null) {
+            return succinctBytes(maxQueryMemory.toBytes() * 2);
+        }
+        return maxQueryTotalMemory;
+    }
+
+    @Config("query.max-total-memory")
+    public MemoryManagerConfig setMaxQueryTotalMemory(DataSize maxQueryTotalMemory)
+    {
+        this.maxQueryTotalMemory = maxQueryTotalMemory;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryManagerConfig.java
@@ -37,7 +37,8 @@ public class TestMemoryManagerConfig
         assertRecordedDefaults(ConfigAssertions.recordDefaults(MemoryManagerConfig.class)
                 .setLowMemoryKillerPolicy(NONE)
                 .setKillOnOutOfMemoryDelay(new Duration(5, MINUTES))
-                .setMaxQueryMemory(new DataSize(20, GIGABYTE)));
+                .setMaxQueryMemory(new DataSize(20, GIGABYTE))
+                .setMaxQueryTotalMemory(new DataSize(40, GIGABYTE)));
     }
 
     @Test
@@ -47,12 +48,14 @@ public class TestMemoryManagerConfig
                 .put("query.low-memory-killer.policy", "total-reservation-on-blocked-nodes")
                 .put("query.low-memory-killer.delay", "20s")
                 .put("query.max-memory", "2GB")
+                .put("query.max-total-memory", "3GB")
                 .build();
 
         MemoryManagerConfig expected = new MemoryManagerConfig()
                 .setLowMemoryKillerPolicy(TOTAL_RESERVATION_ON_BLOCKED_NODES)
                 .setKillOnOutOfMemoryDelay(new Duration(20, SECONDS))
-                .setMaxQueryMemory(new DataSize(2, GIGABYTE));
+                .setMaxQueryMemory(new DataSize(2, GIGABYTE))
+                .setMaxQueryTotalMemory(new DataSize(3, GIGABYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -25,6 +25,7 @@ import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -285,13 +286,34 @@ public class TestMemoryManager
                 .anyMatch(task -> task.getBlockedReasons().contains(WAITING_FOR_MEMORY));
     }
 
-    @Test(timeOut = 60_000, expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Query exceeded max memory size of 1kB.*")
-    public void testQueryMemoryLimit()
+    @DataProvider(name = "legacy_system_pool_enabled")
+    public Object[][] legacySystemPoolEnabled()
+    {
+        return new Object[][] {{true}, {false}};
+    }
+
+    @Test(timeOut = 60_000, dataProvider = "legacy_system_pool_enabled", expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Query exceeded max user memory size of 1kB.*")
+    public void testQueryUserMemoryLimit(boolean systemPoolEnabled)
             throws Exception
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("task.max-partial-aggregation-memory", "1B")
                 .put("query.max-memory", "1kB")
+                .put("query.max-total-memory", "1GB")
+                .put("deprecated.legacy-system-pool-enabled", String.valueOf(systemPoolEnabled))
+                .build();
+        try (QueryRunner queryRunner = createQueryRunner(SESSION, properties)) {
+            queryRunner.execute(SESSION, "SELECT COUNT(*), repeat(orderstatus, 1000) FROM orders GROUP BY 2");
+        }
+    }
+
+    @Test(timeOut = 60_000, expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Query exceeded max total memory size of 2kB.*")
+    public void testQueryTotalMemoryLimit()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("query.max-memory", "1kB")
+                .put("query.max-total-memory", "2kB")
                 .build();
         try (QueryRunner queryRunner = createQueryRunner(SESSION, properties)) {
             queryRunner.execute(SESSION, "SELECT COUNT(*), repeat(orderstatus, 1000) FROM orders GROUP BY 2");


### PR DESCRIPTION
Since the  local total memory limit is only enforced when the system pool is disabled, to be consistent with that we also enforce the global total memory limit only when the system pool is disabled.