### PR TITLE
Improve ORC stripe size estimation

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -108,6 +108,11 @@ public class OrcOutputBuffer
         return compressedOutputStream.size();
     }
 
+    public long estimateOutputDataSize()
+    {
+        return compressedOutputStream.size() + bufferPosition;
+    }
+
     public int writeDataTo(SliceOutput outputStream)
     {
         checkState(bufferPosition == 0, "Buffer must be closed before writeDataTo can be called");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterStats.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterStats.java
@@ -32,8 +32,8 @@ public class OrcWriterStats
     }
 
     private final OrcWriterFlushStats allFlush = new OrcWriterFlushStats("ALL");
-    private final OrcWriterFlushStats maxRowsFlush = new OrcWriterFlushStats(MAX_BYTES.name());
-    private final OrcWriterFlushStats maxBytesFlush = new OrcWriterFlushStats(MAX_ROWS.name());
+    private final OrcWriterFlushStats maxRowsFlush = new OrcWriterFlushStats(MAX_ROWS.name());
+    private final OrcWriterFlushStats maxBytesFlush = new OrcWriterFlushStats(MAX_BYTES.name());
     private final OrcWriterFlushStats dictionaryFullFlush = new OrcWriterFlushStats(DICTIONARY_FULL.name());
     private final OrcWriterFlushStats closedFlush = new OrcWriterFlushStats(CLOSED.name());
     private final AtomicLong writerSizeInBytes = new AtomicLong();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -89,7 +89,7 @@ public class ByteArrayOutputStream
     @Override
     public long getBufferedBytes()
     {
-        return buffer.size();
+        return buffer.estimateOutputDataSize();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -155,7 +155,7 @@ public class ByteOutputStream
     @Override
     public long getBufferedBytes()
     {
-        return buffer.size() + size;
+        return buffer.estimateOutputDataSize() + size;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
@@ -117,7 +117,7 @@ public class DecimalOutputStream
     @Override
     public long getBufferedBytes()
     {
-        return buffer.size();
+        return buffer.estimateOutputDataSize();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
@@ -77,7 +77,7 @@ public class DoubleOutputStream
     @Override
     public long getBufferedBytes()
     {
-        return buffer.size();
+        return buffer.estimateOutputDataSize();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
@@ -77,7 +77,7 @@ public class FloatOutputStream
     @Override
     public long getBufferedBytes()
     {
-        return buffer.size();
+        return buffer.estimateOutputDataSize();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -86,7 +86,7 @@ public class LongOutputStreamDwrf
     @Override
     public long getBufferedBytes()
     {
-        return buffer.size();
+        return buffer.estimateOutputDataSize();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -196,7 +196,7 @@ public class LongOutputStreamV1
     @Override
     public long getBufferedBytes()
     {
-        return buffer.size() + (Long.BYTES * size);
+        return buffer.estimateOutputDataSize() + (Long.BYTES * size);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -755,7 +755,7 @@ public class LongOutputStreamV2
     @Override
     public long getBufferedBytes()
     {
-        return buffer.size() + (Long.BYTES * numLiterals);
+        return buffer.estimateOutputDataSize() + (Long.BYTES * numLiterals);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
@@ -27,6 +27,10 @@ public interface ValueOutputStream<C extends StreamCheckpoint>
 
     StreamDataOutput getStreamDataOutput(int column);
 
+    /**
+     * This method returns the size of the flushed data plus any unflushed data.
+     * If the output is compressed, flush data size is the size after compression.
+     */
     long getBufferedBytes();
 
     long getRetainedBytes();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriter.java
@@ -56,6 +56,10 @@ public interface ColumnWriter
      */
     List<StreamDataOutput> getDataStreams();
 
+    /**
+     * This method returns the size of the flushed data plus any unflushed data.
+     * If the output is compressed, flush data size is the size after compression.
+     */
     long getBufferedBytes();
 
     long getRetainedBytes();


### PR DESCRIPTION
Currently buffered bytes are used to estimate ORC strip size and
deciding flush. This can overestimate stripe size when compression
is enabled.