### PR TITLE
Speedup TestHiveFileBasedSecurity

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileBasedSecurity.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileBasedSecurity.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -25,7 +26,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
-import static io.airlift.tpch.TpchTable.getTables;
+import static io.airlift.tpch.TpchTable.NATION;
 
 public class TestHiveFileBasedSecurity
 {
@@ -36,27 +37,28 @@ public class TestHiveFileBasedSecurity
             throws Exception
     {
         String path = this.getClass().getResource("security.json").getPath();
-        queryRunner = createQueryRunner(getTables(), ImmutableMap.of(), "file", ImmutableMap.of("security.config-file", path));
+        queryRunner = createQueryRunner(ImmutableList.of(NATION), ImmutableMap.of(), "file", ImmutableMap.of("security.config-file", path));
     }
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test
     public void testAdminCanRead()
     {
         Session admin = getSession("user");
-        queryRunner.execute(admin, "SELECT * FROM orders");
+        queryRunner.execute(admin, "SELECT * FROM nation");
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Access Denied: Cannot select from table tpch.orders.*")
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Access Denied: Cannot select from table tpch.nation.*")
     public void testNonAdminCannotRead()
     {
         Session bob = getSession("bob");
-        queryRunner.execute(bob, "SELECT * FROM orders");
+        queryRunner.execute(bob, "SELECT * FROM nation");
     }
 
     private Session getSession(String user)


### PR DESCRIPTION
Instead of creating the entire TPCH table set it is enough to create
one small table, such as nation.

After closing a query executor reference must be nullified to prevent
memory leaks.

cc @arhimondr 