### PR TITLE
Close and let GC QueryRunners in tests

### DIFF
--- a/presto-atop/src/test/java/com/facebook/presto/atop/TestAtopHang.java
+++ b/presto-atop/src/test/java/com/facebook/presto/atop/TestAtopHang.java
@@ -50,6 +50,7 @@ public class TestAtopHang
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test(timeOut = 60_000)

--- a/presto-atop/src/test/java/com/facebook/presto/atop/TestAtopSecurity.java
+++ b/presto-atop/src/test/java/com/facebook/presto/atop/TestAtopSecurity.java
@@ -42,6 +42,7 @@ public class TestAtopSecurity
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/presto-atop/src/test/java/com/facebook/presto/atop/TestAtopSmoke.java
+++ b/presto-atop/src/test/java/com/facebook/presto/atop/TestAtopSmoke.java
@@ -41,6 +41,7 @@ public class TestAtopSmoke
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlConsecutiveJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlConsecutiveJoinBenchmark.java
@@ -44,8 +44,8 @@ public class SqlConsecutiveJoinBenchmark
 
     public static void main(String[] args)
     {
-        LocalQueryRunner queryRunner = createLocalQueryRunner(ImmutableMap.of("reorder_joins", "false"));
-        new SqlConsecutiveJoinBenchmark(queryRunner).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
-        queryRunner.close();
+        try (LocalQueryRunner queryRunner = createLocalQueryRunner(ImmutableMap.of("reorder_joins", "false"))) {
+            new SqlConsecutiveJoinBenchmark(queryRunner).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        }
     }
 }

--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkDecimalAggregation.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkDecimalAggregation.java
@@ -22,6 +22,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -56,7 +57,7 @@ public class BenchmarkDecimalAggregation
         @Param({"double", "decimal(14,2)", "decimal(30,10)"})
         private String type;
 
-        private final MemoryLocalQueryRunner queryRunner = new MemoryLocalQueryRunner();
+        private MemoryLocalQueryRunner queryRunner;
 
         public final MemoryLocalQueryRunner getQueryRunner()
         {
@@ -66,9 +67,17 @@ public class BenchmarkDecimalAggregation
         @Setup
         public void setUp()
         {
+            queryRunner = new MemoryLocalQueryRunner();
             queryRunner.execute(format(
                     "CREATE TABLE memory.default.orders AS SELECT orderstatus, cast(totalprice as %s) totalprice FROM tpch.sf1.orders",
                     type));
+        }
+
+        @TearDown
+        public void tearDown()
+        {
+            queryRunner.close();
+            queryRunner = null;
         }
     }
 

--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkInequalityJoin.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkInequalityJoin.java
@@ -24,6 +24,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -97,6 +98,13 @@ public class BenchmarkInequalityJoin
                             "FROM tpch.tiny.lineitem",
                     buckets,
                     filterOutCoefficient));
+        }
+
+        @TearDown
+        public void tearDown()
+        {
+            queryRunner.close();
+            queryRunner = null;
         }
     }
 

--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkSpatialJoin.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkSpatialJoin.java
@@ -97,6 +97,13 @@ public class BenchmarkSpatialJoin
         {
             queryRunner.dropTable("memory.default.points");
         }
+
+        @TearDown
+        public void tearDown()
+        {
+            queryRunner.close();
+            queryRunner = null;
+        }
     }
 
     @Benchmark

--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
@@ -57,11 +57,12 @@ public class TestBlackHoleSmoke
         queryRunner = createQueryRunner();
     }
 
-    @AfterTest
+    @AfterTest(alwaysRun = true)
     public void tearDown()
     {
         assertThatNoBlackHoleTableIsCreated();
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestManySegments.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestManySegments.java
@@ -81,6 +81,7 @@ public class TestManySegments
             throws Exception
     {
         embeddedKafka.close();
+        embeddedKafka = null;
     }
 
     @BeforeMethod
@@ -99,6 +100,7 @@ public class TestManySegments
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestMinimalFunctionality.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestMinimalFunctionality.java
@@ -67,6 +67,7 @@ public class TestMinimalFunctionality
             throws Exception
     {
         embeddedKafka.close();
+        embeddedKafka = null;
     }
 
     @BeforeMethod
@@ -86,10 +87,11 @@ public class TestMinimalFunctionality
                         .build());
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     private void createMessages(String topicName, int count)

--- a/presto-main/src/test/java/com/facebook/presto/cost/BaseStatsCalculatorTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/BaseStatsCalculatorTest.java
@@ -26,7 +26,7 @@ public abstract class BaseStatsCalculatorTest
         tester = new StatsCalculatorTester();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDown()
     {
         tester.close();

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -47,10 +47,10 @@ import io.airlift.slice.Slices;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
@@ -154,7 +154,7 @@ public class TestExpressionCompiler
     private FunctionAssertions functionAssertions;
     private List<ListenableFuture<?>> futures;
 
-    @BeforeSuite
+    @BeforeClass
     public void setupClass()
     {
         Logging.initialize();
@@ -167,7 +167,7 @@ public class TestExpressionCompiler
         functionAssertions = new FunctionAssertions();
     }
 
-    @AfterSuite
+    @AfterClass(alwaysRun = true)
     public void tearDownClass()
     {
         if (executor != null) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestIterativeOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestIterativeOptimizer.java
@@ -63,6 +63,7 @@ public class TestIterativeOptimizer
     {
         if (queryRunner != null) {
             queryRunner.close();
+            queryRunner = null;
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/QueryAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/QueryAssertions.java
@@ -115,6 +115,7 @@ class QueryAssertions
         }
     }
 
+    @Override
     public void close()
     {
         runner.close();

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestDistinctAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestDistinctAggregations.java
@@ -31,6 +31,7 @@ public class TestDistinctAggregations
     public void teardown()
     {
         assertions.close();
+        assertions = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
@@ -31,6 +31,7 @@ public class TestFilteredAggregations
     public void teardown()
     {
         assertions.close();
+        assertions = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestGrouping.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestGrouping.java
@@ -31,6 +31,7 @@ public class TestGrouping
     public void teardown()
     {
         assertions.close();
+        assertions = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestJoinUsing.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestJoinUsing.java
@@ -31,6 +31,7 @@ public class TestJoinUsing
     public void teardown()
     {
         assertions.close();
+        assertions = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestLegacyJoinUsing.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestLegacyJoinUsing.java
@@ -36,6 +36,7 @@ public class TestLegacyJoinUsing
     public void teardown()
     {
         assertions.close();
+        assertions = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestOrderedAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestOrderedAggregation.java
@@ -31,6 +31,7 @@ public class TestOrderedAggregation
     public void teardown()
     {
         assertions.close();
+        assertions = null;
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
@@ -54,6 +54,7 @@ public class TestSubqueries
     public void teardown()
     {
         assertions.close();
+        assertions = null;
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/security/TestRaptorFileBasedSecurity.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/security/TestRaptorFileBasedSecurity.java
@@ -46,6 +46,7 @@ public class TestRaptorFileBasedSecurity
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/security/TestRaptorReadOnlySecurity.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/security/TestRaptorReadOnlySecurity.java
@@ -36,6 +36,7 @@ public class TestRaptorReadOnlySecurity
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Access Denied: Cannot create .*")

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestMinimalFunctionality.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestMinimalFunctionality.java
@@ -65,6 +65,7 @@ public class TestMinimalFunctionality
     public void stopRedis()
     {
         embeddedRedis.close();
+        embeddedRedis = null;
     }
 
     @BeforeMethod
@@ -81,10 +82,11 @@ public class TestMinimalFunctionality
                         .build());
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     private void populateData(int count)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
@@ -80,6 +80,7 @@ public class TestEventListener
     private void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     private MaterializedResult runQueryAndWaitForEvents(@Language("SQL") String sql, int numEventsExpected)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -79,9 +79,8 @@ public class TestQueuesDb
     @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
-        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-        queryManager.getAllQueryInfo().forEach(queryInfo -> queryManager.cancelQuery(queryInfo.getQueryId()));
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test(timeOut = 60_000)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyQueryContext.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyQueryContext.java
@@ -47,6 +47,7 @@ public class TestLegacyQueryContext
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test(timeOut = 60_000L)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -76,6 +76,7 @@ public class TestMetadataManager
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -51,6 +51,7 @@ public class TestQueryManager
     public void tearDown()
     {
         queryRunner.close();
+        queryRunner = null;
     }
 
     @Test(timeOut = 60_000L)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -38,7 +38,6 @@ import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 public class TestTpchLocalStats
 {
-    private LocalQueryRunner queryRunner;
     private StatisticsAssertion statisticsAssertion;
 
     @BeforeClass
@@ -49,7 +48,7 @@ public class TestTpchLocalStats
                 .setSchema(TINY_SCHEMA_NAME)
                 .build();
 
-        queryRunner = new LocalQueryRunner(defaultSession);
+        LocalQueryRunner queryRunner = new LocalQueryRunner(defaultSession);
         queryRunner.createCatalog(
                 "tpch",
                 new TpchConnectorFactory(1),
@@ -60,11 +59,8 @@ public class TestTpchLocalStats
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
+        statisticsAssertion.close();
         statisticsAssertion = null;
-        if (queryRunner != null) {
-            queryRunner.close();
-            queryRunner = null;
-        }
     }
 
     @Test

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/statistics/TestTpcdsLocalStats.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/statistics/TestTpcdsLocalStats.java
@@ -32,7 +32,6 @@ import static java.util.Collections.emptyMap;
 
 public class TestTpcdsLocalStats
 {
-    private LocalQueryRunner queryRunner;
     private StatisticsAssertion statisticsAssertion;
 
     @BeforeClass
@@ -43,7 +42,7 @@ public class TestTpcdsLocalStats
                 .setSchema("sf1")
                 .build();
 
-        queryRunner = new LocalQueryRunner(defaultSession);
+        LocalQueryRunner queryRunner = new LocalQueryRunner(defaultSession);
         queryRunner.createCatalog("tpcds", new TpcdsConnectorFactory(), emptyMap());
         statisticsAssertion = new StatisticsAssertion(queryRunner);
     }
@@ -51,11 +50,8 @@ public class TestTpcdsLocalStats
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
+        statisticsAssertion.close();
         statisticsAssertion = null;
-        if (queryRunner != null) {
-            queryRunner.close();
-            queryRunner = null;
-        }
     }
 
     @Test


### PR DESCRIPTION
Related to https://github.com/prestodb/presto/issues/10812

For most tests this is done automatically in `AbstractTestQueryFramework` (https://github.com/prestodb/presto/blob/master/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java#L85-L89). For others, we need to take care manually.