### PR TITLE
Support case-insensitive parquet nested column name-based look up

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -61,6 +61,7 @@ public final class HiveSessionProperties
     private static final String RESPECT_TABLE_FORMAT = "respect_table_format";
     private static final String PARQUET_PREDICATE_PUSHDOWN_ENABLED = "parquet_predicate_pushdown_enabled";
     private static final String PARQUET_OPTIMIZED_READER_ENABLED = "parquet_optimized_reader_enabled";
+    private static final String PARQUET_USE_COLUMN_NAME = "parquet_use_column_names";
     private static final String MAX_SPLIT_SIZE = "max_split_size";
     private static final String MAX_INITIAL_SPLIT_SIZE = "max_initial_split_size";
     public static final String RCFILE_OPTIMIZED_WRITER_ENABLED = "rcfile_optimized_writer_enabled";
@@ -211,6 +212,11 @@ public final class HiveSessionProperties
                         PARQUET_PREDICATE_PUSHDOWN_ENABLED,
                         "Experimental: Parquet: Enable predicate pushdown for Parquet",
                         hiveClientConfig.isParquetPredicatePushdownEnabled(),
+                        false),
+                booleanSessionProperty(
+                        PARQUET_USE_COLUMN_NAME,
+                        "Experimental: Parquet: Access Parquet columns using names from the file",
+                        hiveClientConfig.isUseParquetColumnNames(),
                         false),
                 dataSizeSessionProperty(
                         MAX_SPLIT_SIZE,
@@ -377,6 +383,11 @@ public final class HiveSessionProperties
     public static boolean isParquetPredicatePushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PARQUET_PREDICATE_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isUseParquetColumnNames(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_USE_COLUMN_NAME, Boolean.class);
     }
 
     public static DataSize getMaxSplitSize(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getFieldIndex;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getParquetType;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.lookupColumnByName;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static parquet.io.ColumnIOConverter.constructField;
@@ -105,7 +106,7 @@ public class ParquetPageSource
             }
             else {
                 String columnName = useParquetColumnNames ? name : fileSchema.getFields().get(column.getHiveColumnIndex()).getName();
-                fieldsBuilder.add(constructField(type, messageColumnIO.getChild(columnName)));
+                fieldsBuilder.add(constructField(type, lookupColumnByName(messageColumnIO, columnName)));
             }
         }
         types = typesBuilder.build();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive.parquet;
 
 import com.facebook.presto.hive.FileFormatDataSourceStats;
 import com.facebook.presto.hive.HdfsEnvironment;
-import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.HivePageSourceFactory;
 import com.facebook.presto.hive.parquet.predicate.ParquetPredicate;
@@ -57,6 +56,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_MISSING_DATA;
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetOptimizedReaderEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetPredicatePushdownEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isUseParquetColumnNames;
 import static com.facebook.presto.hive.HiveUtil.getDeserializerClassName;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getColumnIO;
@@ -80,20 +80,13 @@ public class ParquetPageSourceFactory
             .build();
 
     private final TypeManager typeManager;
-    private final boolean useParquetColumnNames;
     private final HdfsEnvironment hdfsEnvironment;
     private final FileFormatDataSourceStats stats;
 
     @Inject
-    public ParquetPageSourceFactory(TypeManager typeManager, HiveClientConfig config, HdfsEnvironment hdfsEnvironment, FileFormatDataSourceStats stats)
-    {
-        this(typeManager, requireNonNull(config, "hiveClientConfig is null").isUseParquetColumnNames(), hdfsEnvironment, stats);
-    }
-
-    public ParquetPageSourceFactory(TypeManager typeManager, boolean useParquetColumnNames, HdfsEnvironment hdfsEnvironment, FileFormatDataSourceStats stats)
+    public ParquetPageSourceFactory(TypeManager typeManager, HdfsEnvironment hdfsEnvironment, FileFormatDataSourceStats stats)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
-        this.useParquetColumnNames = useParquetColumnNames;
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.stats = requireNonNull(stats, "stats is null");
     }
@@ -129,7 +122,7 @@ public class ParquetPageSourceFactory
                 fileSize,
                 schema,
                 columns,
-                useParquetColumnNames,
+                isUseParquetColumnNames(session),
                 typeManager,
                 isParquetPredicatePushdownEnabled(session),
                 effectivePredicate,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetRecordCursorProvider.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive.parquet;
 
 import com.facebook.presto.hive.FileFormatDataSourceStats;
 import com.facebook.presto.hive.HdfsEnvironment;
-import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.HiveRecordCursorProvider;
 import com.facebook.presto.spi.ConnectorSession;
@@ -35,6 +34,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetPredicatePushdownEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isUseParquetColumnNames;
 import static com.facebook.presto.hive.HiveUtil.getDeserializerClassName;
 import static java.util.Objects.requireNonNull;
 
@@ -46,19 +46,12 @@ public class ParquetRecordCursorProvider
             .add("parquet.hive.serde.ParquetHiveSerDe")
             .build();
 
-    private final boolean useParquetColumnNames;
     private final HdfsEnvironment hdfsEnvironment;
     private final FileFormatDataSourceStats stats;
 
     @Inject
-    public ParquetRecordCursorProvider(HiveClientConfig hiveClientConfig, HdfsEnvironment hdfsEnvironment, FileFormatDataSourceStats stats)
+    public ParquetRecordCursorProvider(HdfsEnvironment hdfsEnvironment, FileFormatDataSourceStats stats)
     {
-        this(requireNonNull(hiveClientConfig, "hiveClientConfig is null").isUseParquetColumnNames(), hdfsEnvironment, stats);
-    }
-
-    public ParquetRecordCursorProvider(boolean useParquetColumnNames, HdfsEnvironment hdfsEnvironment, FileFormatDataSourceStats stats)
-    {
-        this.useParquetColumnNames = useParquetColumnNames;
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.stats = requireNonNull(stats, "stats is null");
     }
@@ -91,7 +84,7 @@ public class ParquetRecordCursorProvider
                 fileSize,
                 schema,
                 columns,
-                useParquetColumnNames,
+                isUseParquetColumnNames(session),
                 typeManager,
                 isParquetPredicatePushdownEnabled(session),
                 effectivePredicate,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetTypeUtils.java
@@ -247,6 +247,27 @@ public final class ParquetTypeUtils
         return null;
     }
 
+    /**
+     * Parquet column names are case-sensitive unlike Hive, which converts all column names to lowercase.
+     * Therefore, when we look up columns we first check for exact match, and if that fails we look for a case-insensitive match.
+     */
+    public static ColumnIO lookupColumnByName(GroupColumnIO groupColumnIO, String columnName)
+    {
+        ColumnIO columnIO = groupColumnIO.getChild(columnName);
+
+        if (columnIO != null) {
+            return columnIO;
+        }
+
+        for (int i = 0; i < groupColumnIO.getChildrenCount(); i++) {
+            if (groupColumnIO.getChild(i).getName().equalsIgnoreCase(columnName)) {
+                return groupColumnIO.getChild(i);
+            }
+        }
+
+        return null;
+    }
+
     public static Optional<Type> createDecimalType(RichColumnDescriptor descriptor)
     {
         if (descriptor.getPrimitiveType().getOriginalType() != DECIMAL) {

--- a/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
+++ b/presto-hive/src/main/java/parquet/io/ColumnIOConverter.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getArrayElementColumn;
 import static com.facebook.presto.hive.parquet.ParquetTypeUtils.getMapKeyValueColumn;
+import static com.facebook.presto.hive.parquet.ParquetTypeUtils.lookupColumnByName;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
 import static com.facebook.presto.spi.type.StandardTypes.ROW;
@@ -60,7 +61,7 @@ public class ColumnIOConverter
             for (int i = 0; i < fields.size(); i++) {
                 NamedTypeSignature namedTypeSignature = fields.get(i).getNamedTypeSignature();
                 String name = namedTypeSignature.getName().get().toLowerCase(Locale.ENGLISH);
-                Optional<Field> field = constructField(parameters.get(i), groupColumnIO.getChild(name));
+                Optional<Field> field = constructField(parameters.get(i), lookupColumnByName(groupColumnIO, name));
                 structHasParameters |= field.isPresent();
                 fieldsBuilder.add(field);
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -74,7 +74,7 @@ public final class HiveTestUtils
                 .add(new RcFilePageSourceFactory(TYPE_MANAGER, testHdfsEnvironment, stats))
                 .add(new OrcPageSourceFactory(TYPE_MANAGER, hiveClientConfig, testHdfsEnvironment, stats))
                 .add(new DwrfPageSourceFactory(TYPE_MANAGER, testHdfsEnvironment, stats))
-                .add(new ParquetPageSourceFactory(TYPE_MANAGER, hiveClientConfig, testHdfsEnvironment, stats))
+                .add(new ParquetPageSourceFactory(TYPE_MANAGER, testHdfsEnvironment, stats))
                 .build();
     }
 
@@ -82,7 +82,7 @@ public final class HiveTestUtils
     {
         HdfsEnvironment testHdfsEnvironment = createTestHdfsEnvironment(hiveClientConfig);
         return ImmutableSet.<HiveRecordCursorProvider>builder()
-                .add(new ParquetRecordCursorProvider(hiveClientConfig, testHdfsEnvironment, new FileFormatDataSourceStats()))
+                .add(new ParquetRecordCursorProvider(testHdfsEnvironment, new FileFormatDataSourceStats()))
                 .add(new GenericHiveRecordCursorProvider(testHdfsEnvironment))
                 .build();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -192,7 +192,7 @@ public enum FileFormat
         @Override
         public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
         {
-            HivePageSourceFactory pageSourceFactory = new ParquetPageSourceFactory(TYPE_MANAGER, false, hdfsEnvironment, new FileFormatDataSourceStats());
+            HivePageSourceFactory pageSourceFactory = new ParquetPageSourceFactory(TYPE_MANAGER, hdfsEnvironment, new FileFormatDataSourceStats());
             return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.PARQUET);
         }
 
@@ -298,7 +298,7 @@ public enum FileFormat
         @Override
         public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
         {
-            HiveRecordCursorProvider cursorProvider = new ParquetRecordCursorProvider(false, hdfsEnvironment, new FileFormatDataSourceStats());
+            HiveRecordCursorProvider cursorProvider = new ParquetRecordCursorProvider(hdfsEnvironment, new FileFormatDataSourceStats());
             return createPageSource(cursorProvider, session, targetFile, columnNames, columnTypes, HiveStorageFormat.PARQUET);
         }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -209,7 +209,7 @@ public abstract class AbstractTestParquetReader
         Type structType = RowType.from(asList(field("a", BIGINT), field("b", BOOLEAN), field("c", VARCHAR)));
         tester.testSingleLevelArrayRoundTrip(
                 getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, asList(javaLongObjectInspector, javaBooleanObjectInspector, javaStringObjectInspector))),
-                values, values, new ArrayType(structType), Optional.of(customSchemaArrayOfStucts));
+                values, values, "self", new ArrayType(structType), Optional.of(customSchemaArrayOfStucts));
     }
 
     @Test
@@ -545,7 +545,7 @@ public abstract class AbstractTestParquetReader
         Iterable<Map<String, String>> mapsStringString = createNullableTestMaps(mapStringKeys, stringPrimitives);
 
         List<String> struct1FieldNames = asList("mapIntStringField", "stringArrayField", "intField");
-        Iterable<?> stucts1 = createNullableTestStructs(mapsIntString, arraysString, intPrimitives);
+        Iterable<?> structs1 = createNullableTestStructs(mapsIntString, arraysString, intPrimitives);
         ObjectInspector struct1ObjectInspector = getStandardStructObjectInspector(struct1FieldNames,
                 asList(
                         getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
@@ -557,7 +557,7 @@ public abstract class AbstractTestParquetReader
                 field("intField", INTEGER)));
 
         List<String> struct2FieldNames = asList("mapIntStringField", "stringArrayField", "structField");
-        Iterable<?> structs2 = createNullableTestStructs(mapsIntString, arraysString, stucts1);
+        Iterable<?> structs2 = createNullableTestStructs(mapsIntString, arraysString, structs1);
         ObjectInspector struct2ObjectInspector = getStandardStructObjectInspector(struct2FieldNames,
                 asList(
                         getStandardMapObjectInspector(javaIntObjectInspector, javaStringObjectInspector),
@@ -581,7 +581,7 @@ public abstract class AbstractTestParquetReader
                 field("booleanField", BOOLEAN)));
 
         List<String> struct4FieldNames = asList("mapIntDoubleField", "booleanArrayField", "structField");
-        Iterable<?> stucts4 = createNullableTestStructs(mapsIntDouble, arraysBoolean, structs3);
+        Iterable<?> structs4 = createNullableTestStructs(mapsIntDouble, arraysBoolean, structs3);
         ObjectInspector struct4ObjectInspector = getStandardStructObjectInspector(struct4FieldNames,
                 asList(
                         getStandardMapObjectInspector(javaIntObjectInspector, javaDoubleObjectInspector),
@@ -604,7 +604,7 @@ public abstract class AbstractTestParquetReader
                         getStandardMapObjectInspector(javaStringObjectInspector, javaStringObjectInspector));
         List<Type> types = ImmutableList.of(struct1Type, struct2Type, struct3Type, struct4Type, mapType(INTEGER, DOUBLE), new ArrayType(BOOLEAN), mapType(VARCHAR, VARCHAR));
 
-        Iterable<?>[] values = new Iterable<?>[] {stucts1, structs2, structs3, stucts4, mapsIntDouble, arraysBoolean, mapsStringString};
+        Iterable<?>[] values = new Iterable<?>[] {structs1, structs2, structs3, structs4, mapsIntDouble, arraysBoolean, mapsStringString};
         tester.assertRoundTrip(objectInspectors, values, values, structFieldNames, types, Optional.empty());
     }
 
@@ -920,7 +920,7 @@ public abstract class AbstractTestParquetReader
                         getStandardListObjectInspector(javaStringObjectInspector),
                         getStandardListObjectInspector(
                                 getStandardStructObjectInspector(contactsFieldNames, asList(javaStringObjectInspector, javaStringObjectInspector))))),
-                values, values, addressBookType, Optional.of(parquetSchema));
+                values, values, "address_book", addressBookType, Optional.of(parquetSchema));
     }
 
     @Test
@@ -946,7 +946,7 @@ public abstract class AbstractTestParquetReader
         ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaStringObjectInspector));
         ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
         ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
-        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+        tester.testRoundTrip(aInspector, aValues, aValues, "a", aType, Optional.of(parquetSchema));
     }
 
     @Test
@@ -972,7 +972,7 @@ public abstract class AbstractTestParquetReader
         ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaIntObjectInspector));
         ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
         ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
-        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+        tester.testRoundTrip(aInspector, aValues, aValues, "a", aType, Optional.of(parquetSchema));
     }
 
     @Test
@@ -998,7 +998,7 @@ public abstract class AbstractTestParquetReader
         ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaIntObjectInspector));
         ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
         ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
-        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+        tester.testRoundTrip(aInspector, aValues, aValues, "a", aType, Optional.of(parquetSchema));
     }
 
     @Test
@@ -1024,7 +1024,7 @@ public abstract class AbstractTestParquetReader
         ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaIntObjectInspector));
         ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
         ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
-        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+        tester.testRoundTrip(aInspector, aValues, aValues, "a", aType, Optional.of(parquetSchema));
     }
 
     @Test
@@ -1050,7 +1050,7 @@ public abstract class AbstractTestParquetReader
         ObjectInspector cInspector = getStandardStructObjectInspector(singletonList("d"), singletonList(javaStringObjectInspector));
         ObjectInspector bInspector = getStandardStructObjectInspector(singletonList("c"), singletonList(cInspector));
         ObjectInspector aInspector = getStandardStructObjectInspector(singletonList("b"), singletonList(bInspector));
-        tester.testRoundTrip(aInspector, aValues, aValues, aType, Optional.of(parquetSchema));
+        tester.testRoundTrip(aInspector, aValues, aValues, "a", aType, Optional.of(parquetSchema));
     }
 
     @Test
@@ -1137,7 +1137,7 @@ public abstract class AbstractTestParquetReader
                 "  }" +
                 "} ");
         Iterable<List<Integer>> nonNullArrayElements = createTestArrays(intsBetween(0, 31_234));
-        tester.testSingleLevelArrayRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), nonNullArrayElements, nonNullArrayElements, new ArrayType(INTEGER), Optional.of(parquetMrAvroSchema));
+        tester.testSingleLevelArrayRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), nonNullArrayElements, nonNullArrayElements, "my_list", new ArrayType(INTEGER), Optional.of(parquetMrAvroSchema));
     }
 
     @Test
@@ -1152,7 +1152,7 @@ public abstract class AbstractTestParquetReader
                 "  } " +
                 "}");
         Iterable<List<Integer>> values = createTestArrays(limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
-        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(parquetMrAvroSchema));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, "my_list", new ArrayType(INTEGER), Optional.of(parquetMrAvroSchema));
     }
 
     /**
@@ -1171,7 +1171,7 @@ public abstract class AbstractTestParquetReader
                 "  }" +
                 "} ");
         Iterable<List<Integer>> nonNullArrayElements = createTestArrays(intsBetween(0, 31_234));
-        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), nonNullArrayElements, nonNullArrayElements, new ArrayType(INTEGER), Optional.of(parquetMrNullableSpecSchema));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), nonNullArrayElements, nonNullArrayElements, "my_list", new ArrayType(INTEGER), Optional.of(parquetMrNullableSpecSchema));
 
         MessageType parquetMrNonNullSpecSchema = parseMessageType("message hive_schema {" +
                 "  required group my_list (LIST){" +
@@ -1191,7 +1191,7 @@ public abstract class AbstractTestParquetReader
                 "    }" +
                 "  }" +
                 "} ");
-        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(sparkSchema));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, "my_list", new ArrayType(INTEGER), Optional.of(sparkSchema));
 
         MessageType hiveSchema = parseMessageType("message hive_schema {" +
                 "  optional group my_list (LIST){" +
@@ -1200,7 +1200,7 @@ public abstract class AbstractTestParquetReader
                 "    }" +
                 "  }" +
                 "} ");
-        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(hiveSchema));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, "my_list", new ArrayType(INTEGER), Optional.of(hiveSchema));
 
         MessageType customNamingSchema = parseMessageType("message hive_schema {" +
                 "  optional group my_list (LIST){" +
@@ -1209,7 +1209,7 @@ public abstract class AbstractTestParquetReader
                 "    }" +
                 "  }" +
                 "} ");
-        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, new ArrayType(INTEGER), Optional.of(customNamingSchema));
+        tester.testRoundTrip(getStandardListObjectInspector(javaIntObjectInspector), values, values, "my_list", new ArrayType(INTEGER), Optional.of(customNamingSchema));
     }
 
     /**
@@ -1233,7 +1233,7 @@ public abstract class AbstractTestParquetReader
                 "    }  " +
                 "  }" +
                 "}   ");
-        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, mapType(VARCHAR, INTEGER), Optional.of(map));
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, "my_map", mapType(VARCHAR, INTEGER), Optional.of(map));
 
         // Map<String, Integer> (nullable map, non-null values)
         map = parseMessageType("message hive_schema {" +
@@ -1244,7 +1244,7 @@ public abstract class AbstractTestParquetReader
                 "    }  " +
                 "  }" +
                 "}   ");
-        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, mapType(VARCHAR, INTEGER), Optional.of(map));
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, "my_map", mapType(VARCHAR, INTEGER), Optional.of(map));
 
         // Map<String, Integer> (non-null map, nullable values)
         map = parseMessageType("message hive_schema {" +
@@ -1303,7 +1303,7 @@ public abstract class AbstractTestParquetReader
                 "    }   " +
                 "  }" +
                 " }  ");
-        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), nullableValues, nullableValues, mapType(VARCHAR, INTEGER), Optional.of(map));
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), nullableValues, nullableValues, "my_map", mapType(VARCHAR, INTEGER), Optional.of(map));
 
         // Map<String, Integer> (nullable map, nullable values)
         map = parseMessageType("message hive_schema {" +
@@ -1314,7 +1314,7 @@ public abstract class AbstractTestParquetReader
                 "    }   " +
                 "  }" +
                 " }  ");
-        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), nullableValues, nullableValues, mapType(VARCHAR, INTEGER), Optional.of(map));
+        tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), nullableValues, nullableValues, "my_map", mapType(VARCHAR, INTEGER), Optional.of(map));
     }
 
     @Test

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -24,6 +24,7 @@ import com.facebook.presto.hive.parquet.write.SingleLevelArrayMapKeyValuesSchema
 import com.facebook.presto.hive.parquet.write.SingleLevelArraySchemaConverter;
 import com.facebook.presto.hive.parquet.write.TestMapredParquetOutputFormat;
 import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordPageSource;
@@ -110,20 +111,24 @@ public class ParquetTester
 {
     public static final DateTimeZone HIVE_STORAGE_TIME_ZONE = DateTimeZone.forID("Asia/Katmandu");
     private static final boolean OPTIMIZED = true;
-    private static final HiveClientConfig HIVE_CLIENT_CONFIG = getHiveClientConfig();
+    private static final HiveClientConfig HIVE_CLIENT_CONFIG = createHiveClientConfig(false);
     private static final HdfsEnvironment HDFS_ENVIRONMENT = createTestHdfsEnvironment(HIVE_CLIENT_CONFIG);
     private static final TestingConnectorSession SESSION = new TestingConnectorSession(new HiveSessionProperties(HIVE_CLIENT_CONFIG, new OrcFileWriterConfig()).getSessionProperties());
+    private static final TestingConnectorSession SESSION_USE_NAME = new TestingConnectorSession(new HiveSessionProperties(createHiveClientConfig(true), new OrcFileWriterConfig()).getSessionProperties());
     private static final List<String> TEST_COLUMN = singletonList("test");
 
     private Set<CompressionCodecName> compressions = ImmutableSet.of();
 
     private Set<WriterVersion> versions = ImmutableSet.of();
 
+    private Set<TestingConnectorSession> sessions = ImmutableSet.of();
+
     public static ParquetTester quickParquetTester()
     {
         ParquetTester parquetTester = new ParquetTester();
         parquetTester.compressions = ImmutableSet.of(GZIP);
         parquetTester.versions = ImmutableSet.of(PARQUET_1_0);
+        parquetTester.sessions = ImmutableSet.of(SESSION);
         return parquetTester;
     }
 
@@ -132,6 +137,7 @@ public class ParquetTester
         ParquetTester parquetTester = new ParquetTester();
         parquetTester.compressions = ImmutableSet.of(GZIP, UNCOMPRESSED, SNAPPY, LZO);
         parquetTester.versions = ImmutableSet.copyOf(WriterVersion.values());
+        parquetTester.sessions = ImmutableSet.of(SESSION, SESSION_USE_NAME);
         return parquetTester;
     }
 
@@ -255,38 +261,43 @@ public class ParquetTester
     {
         for (WriterVersion version : versions) {
             for (CompressionCodecName compressionCodecName : compressions) {
-                try (TempFile tempFile = new TempFile("test", "parquet")) {
-                    JobConf jobConf = new JobConf();
-                    jobConf.setEnum(COMPRESSION, compressionCodecName);
-                    jobConf.setBoolean(ENABLE_DICTIONARY, true);
-                    jobConf.setEnum(WRITER_VERSION, version);
-                    writeParquetColumn(
-                            jobConf,
-                            tempFile.getFile(),
-                            compressionCodecName,
-                            createTableProperties(columnNames, objectInspectors),
-                            getStandardStructObjectInspector(columnNames, objectInspectors),
-                            getIterators(writeValues),
-                            parquetSchema,
-                            singleLevelArray);
-                    assertFileContents(
-                            tempFile.getFile(),
-                            getIterators(readValues),
-                            columnNames,
-                            columnTypes);
+                for (ConnectorSession session : sessions) {
+                    try (TempFile tempFile = new TempFile("test", "parquet")) {
+                        JobConf jobConf = new JobConf();
+                        jobConf.setEnum(COMPRESSION, compressionCodecName);
+                        jobConf.setBoolean(ENABLE_DICTIONARY, true);
+                        jobConf.setEnum(WRITER_VERSION, version);
+                        writeParquetColumn(
+                                jobConf,
+                                tempFile.getFile(),
+                                compressionCodecName,
+                                createTableProperties(columnNames, objectInspectors),
+                                getStandardStructObjectInspector(columnNames, objectInspectors),
+                                getIterators(writeValues),
+                                parquetSchema,
+                                singleLevelArray);
+                        assertFileContents(
+                                session,
+                                tempFile.getFile(),
+                                getIterators(readValues),
+                                columnNames,
+                                columnTypes);
+                    }
                 }
             }
         }
     }
 
-    private static void assertFileContents(File dataFile,
+    private static void assertFileContents(
+            ConnectorSession session,
+            File dataFile,
             Iterator<?>[] expectedValues,
             List<String> columnNames,
             List<Type> columnTypes)
             throws IOException
     {
         try (ConnectorPageSource pageSource = getFileFormat().createFileFormatReader(
-                SESSION,
+                session,
                 HDFS_ENVIRONMENT,
                 dataFile,
                 columnNames,
@@ -395,12 +406,13 @@ public class ParquetTester
         return Collections.unmodifiableList(values);
     }
 
-    private static HiveClientConfig getHiveClientConfig()
+    private static HiveClientConfig createHiveClientConfig(boolean useParquetColumnNames)
     {
         HiveClientConfig config = new HiveClientConfig();
-        config.setHiveStorageFormat(HiveStorageFormat.PARQUET);
-        config.setParquetOptimizedReaderEnabled(OPTIMIZED);
-        config.setParquetPredicatePushdownEnabled(OPTIMIZED);
+        config.setHiveStorageFormat(HiveStorageFormat.PARQUET)
+                .setParquetOptimizedReaderEnabled(OPTIMIZED)
+                .setParquetPredicatePushdownEnabled(OPTIMIZED)
+                .setUseParquetColumnNames(useParquetColumnNames);
         return config;
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -194,6 +194,18 @@ public class ParquetTester
         testRoundTrip(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, TEST_COLUMN, singletonList(type), parquetSchema, true);
     }
 
+    public void testRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, String columnName, Type type, Optional<MessageType> parquetSchema)
+            throws Exception
+    {
+        testRoundTrip(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, singletonList(columnName), singletonList(type), parquetSchema, false);
+    }
+
+    public void testSingleLevelArrayRoundTrip(ObjectInspector objectInspector, Iterable<?> writeValues, Iterable<?> readValues, String columnName, Type type, Optional<MessageType> parquetSchema)
+            throws Exception
+    {
+        testRoundTrip(singletonList(objectInspector), new Iterable<?>[] {writeValues}, new Iterable<?>[] {readValues}, singletonList(columnName), singletonList(type), parquetSchema, true);
+    }
+
     public void testRoundTrip(List<ObjectInspector> objectInspectors, Iterable<?>[] writeValues, Iterable<?>[] readValues, List<String> columnNames, List<Type> columnTypes, Optional<MessageType> parquetSchema, boolean singleLevelArray)
             throws Exception
     {


### PR DESCRIPTION
The existing tests for optimized parquet reader only cover the cases using index-based parquet column lookup(a.k.a `useParquetColumnNames` is false) . And `testComplexNestedStructs` will be failed because the deeply nested columns contain uppercase characters. This patch can fix this error.
This patch has been verified in production for a few days. 

In addition, adding the `parquet_use_column_names` to override the default setting `hive.parquet.use-column-names` in a session base gives more convenience in testing and real use case.