### PR TITLE
Avoid Class#newInstance()

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -615,7 +615,7 @@ public abstract class AbstractTestHiveFileFormats
     private static <T> T newInstance(String className, Class<T> superType)
             throws ReflectiveOperationException
     {
-        return HiveStorageFormat.class.getClassLoader().loadClass(className).asSubclass(superType).newInstance();
+        return HiveStorageFormat.class.getClassLoader().loadClass(className).asSubclass(superType).getConstructor().newInstance();
     }
 
     public static Object getFieldFromCursor(RecordCursor cursor, Type type, int field)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
@@ -172,9 +172,9 @@ public class StateCompiler
 
         Class<? extends AccumulatorStateSerializer> serializerClass = defineClass(definition, AccumulatorStateSerializer.class, callSiteBinder.getBindings(), classLoader);
         try {
-            return (AccumulatorStateSerializer<T>) serializerClass.newInstance();
+            return (AccumulatorStateSerializer<T>) serializerClass.getConstructor().newInstance();
         }
-        catch (InstantiationException | IllegalAccessException e) {
+        catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
     }
@@ -400,9 +400,9 @@ public class StateCompiler
 
         Class<? extends AccumulatorStateFactory> factoryClass = defineClass(definition, AccumulatorStateFactory.class, classLoader);
         try {
-            return (AccumulatorStateFactory<T>) factoryClass.newInstance();
+            return (AccumulatorStateFactory<T>) factoryClass.getConstructor().newInstance();
         }
-        catch (InstantiationException | IllegalAccessException e) {
+        catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionCompiler.java
@@ -80,7 +80,7 @@ public class ExpressionCompiler
         Class<? extends CursorProcessor> cursorProcessor = cursorProcessors.getUnchecked(new CacheKey(filter, projections, uniqueKey));
         return () -> {
             try {
-                return cursorProcessor.newInstance();
+                return cursorProcessor.getConstructor().newInstance();
             }
             catch (ReflectiveOperationException e) {
                 throw new RuntimeException(e);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
@@ -90,7 +90,7 @@ public class OrderingCompiler
         PagesIndexComparator comparator;
         try {
             Class<? extends PagesIndexComparator> pagesHashStrategyClass = compilePagesIndexComparator(sortTypes, sortChannels, sortOrders);
-            comparator = pagesHashStrategyClass.newInstance();
+            comparator = pagesHashStrategyClass.getConstructor().newInstance();
         }
         catch (Throwable e) {
             log.error(e, "Error compiling comparator for channels %s with order %s", sortChannels, sortChannels);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -407,7 +407,7 @@ public class PageFunctionCompiler
 
         return () -> {
             try {
-                return functionClass.newInstance();
+                return functionClass.getConstructor().newInstance();
             }
             catch (ReflectiveOperationException e) {
                 throw new PrestoException(COMPILER_ERROR, e);

--- a/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
+++ b/presto-testing-server-launcher/src/main/java/com/facebook/presto/server/testing/TestingPrestoServerLauncher.java
@@ -51,7 +51,7 @@ public class TestingPrestoServerLauncher
     {
         try (TestingPrestoServer server = new TestingPrestoServer()) {
             for (String pluginClass : options.getPluginClassNames()) {
-                Plugin plugin = (Plugin) Class.forName(pluginClass).newInstance();
+                Plugin plugin = (Plugin) Class.forName(pluginClass).getConstructor().newInstance();
                 server.installPlugin(plugin);
             }
 

--- a/src/modernizer/violations.xml
+++ b/src/modernizer/violations.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0"?>
 <modernizer>
     <violation>
+        <name>java/lang/Class.newInstance:()Ljava/lang/Object;</name>
+        <version>1.1</version>
+        <comment>Prefer Class.getConstructor().newInstance()</comment>
+    </violation>
+
+    <violation>
         <name>com/google/common/primitives/Ints.checkedCast:(J)I</name>
         <version>1.8</version>
         <comment>Prefer Math.toIntExact(long)</comment>


### PR DESCRIPTION
This method propagates checked exceptions uncleanly and generally should
not be used.  In many places we already did
`.getConstructor().newInstance()`, this fixes the remaining ones.