### PR TITLE
Avoid double counting dictionary when estimating stripe size

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -287,7 +287,7 @@ public class OrcWriter
         if (stripeRowCount == stripeMaxRowCount) {
             flushStripe(MAX_ROWS);
         }
-        else if (bufferedBytes + dictionaryCompressionOptimizer.getDictionaryMemoryBytes() > stripeMaxBytes) {
+        else if (bufferedBytes > stripeMaxBytes) {
             flushStripe(MAX_BYTES);
         }
         else if (dictionaryCompressionOptimizer.isFull(bufferedBytes)) {


### PR DESCRIPTION
SliceDictionaryColumnWriter.getBufferedBytes() already contains
dictionary bytes.