### PR TITLE
Implement approx_distinct for more types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -514,6 +514,7 @@ public class FunctionRegistry
                 .scalar(DecimalOperators.Negation.class)
                 .scalar(DecimalOperators.HashCode.class)
                 .scalar(DecimalOperators.Indeterminate.class)
+                .scalar(DecimalOperators.XxHash64Operator.class)
                 .functions(IDENTITY_CAST, CAST_FROM_UNKNOWN)
                 .scalar(ArrayLessThanOperator.class)
                 .scalar(ArrayLessThanOrEqualOperator.class)

--- a/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DateOperators.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.AbstractIntType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 import org.joda.time.chrono.ISOChronology;
 
 import java.util.concurrent.TimeUnit;
@@ -39,6 +40,7 @@ import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.util.DateTimeUtils.parseDate;
 import static com.facebook.presto.util.DateTimeUtils.printDate;
@@ -182,5 +184,12 @@ public final class DateOperators
     public static boolean indeterminate(@SqlType(StandardTypes.DATE) long value, @IsNull boolean isNull)
     {
         return isNull;
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.DATE) long value)
+    {
+        return XxHash64.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalOperators.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -48,6 +49,7 @@ import static com.facebook.presto.spi.function.OperatorType.MODULUS;
 import static com.facebook.presto.spi.function.OperatorType.MULTIPLY;
 import static com.facebook.presto.spi.function.OperatorType.NEGATION;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.spi.type.Decimals.encodeUnscaledValue;
 import static com.facebook.presto.spi.type.Decimals.longTenToNth;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -626,14 +628,14 @@ public final class DecimalOperators
     public static final class HashCode
     {
         @LiteralParameters({"p", "s"})
-        @SqlType("bigint")
+        @SqlType(StandardTypes.BIGINT)
         public static long hashCode(@SqlType("decimal(p, s)") long value)
         {
             return value;
         }
 
         @LiteralParameters({"p", "s"})
-        @SqlType("bigint")
+        @SqlType(StandardTypes.BIGINT)
         public static long hashCode(@SqlType("decimal(p, s)") Slice value)
         {
             return UnscaledDecimal128Arithmetic.hash(value);
@@ -655,6 +657,24 @@ public final class DecimalOperators
         public static boolean indeterminate(@SqlType("decimal(p, s)") Slice value, @IsNull boolean isNull)
         {
             return isNull;
+        }
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    public static final class XxHash64Operator
+    {
+        @LiteralParameters({"p", "s"})
+        @SqlType(StandardTypes.BIGINT)
+        public static long xxHash64(@SqlType("decimal(p, s)") long value)
+        {
+            return XxHash64.hash(value);
+        }
+
+        @LiteralParameters({"p", "s"})
+        @SqlType(StandardTypes.BIGINT)
+        public static long xxHash64(@SqlType("decimal(p, s)") Slice value)
+        {
+            return XxHash64.hash(value);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntegerOperators.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -44,6 +45,7 @@ import static com.facebook.presto.spi.function.OperatorType.NEGATION;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SATURATED_FLOOR_CAST;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
@@ -279,5 +281,12 @@ public final class IntegerOperators
     public static boolean indeterminate(@SqlType(StandardTypes.INTEGER) long value, @IsNull boolean isNull)
     {
         return isNull;
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.INTEGER) long value)
+    {
+        return XxHash64.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/IpAddressOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IpAddressOperators.java
@@ -39,6 +39,7 @@ import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.System.arraycopy;
@@ -101,6 +102,13 @@ public final class IpAddressOperators
     @ScalarOperator(HASH_CODE)
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.IPADDRESS) Slice value)
+    {
+        return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.IPADDRESS) Slice value)
     {
         return XxHash64.hash(value);
     }

--- a/presto-main/src/main/java/com/facebook/presto/type/RealOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RealOperators.java
@@ -25,6 +25,7 @@ import com.google.common.math.DoubleMath;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static com.facebook.presto.spi.function.OperatorType.ADD;
@@ -45,7 +46,9 @@ import static com.facebook.presto.spi.function.OperatorType.NEGATION;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SATURATED_FLOOR_CAST;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
@@ -163,6 +166,13 @@ public final class RealOperators
     public static long hashCode(@SqlType(StandardTypes.REAL) long value)
     {
         return AbstractIntType.hash((int) value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.REAL) long value)
+    {
+        return XxHash64.hash(floatToIntBits(intBitsToFloat((int) value)));
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/com/facebook/presto/type/RealOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RealOperators.java
@@ -165,7 +165,7 @@ public final class RealOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType(StandardTypes.REAL) long value)
     {
-        return AbstractIntType.hash((int) value);
+        return AbstractIntType.hash(floatToIntBits(intBitsToFloat((int) value)));
     }
 
     @ScalarOperator(XX_HASH_64)

--- a/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/SmallintOperators.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -44,6 +45,7 @@ import static com.facebook.presto.spi.function.OperatorType.NEGATION;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SATURATED_FLOOR_CAST;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
@@ -267,5 +269,12 @@ public final class SmallintOperators
     public static boolean indeterminate(@SqlType(StandardTypes.SMALLINT) long value, @IsNull boolean isNull)
     {
         return isNull;
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.SMALLINT) long value)
+    {
+        return XxHash64.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimeOperators.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 import org.joda.time.chrono.ISOChronology;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -37,6 +38,7 @@ import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.util.DateTimeUtils.parseTimeWithoutTimeZone;
 import static com.facebook.presto.util.DateTimeUtils.printTimeWithoutTimeZone;
@@ -174,6 +176,13 @@ public final class TimeOperators
     public static long hashCode(@SqlType(StandardTypes.TIME) long value)
     {
         return AbstractLongType.hash(value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.TIME) long value)
+    {
+        return XxHash64.hash(value);
     }
 
     @ScalarOperator(IS_DISTINCT_FROM)

--- a/presto-main/src/main/java/com/facebook/presto/type/TimeWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimeWithTimeZoneOperators.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 import org.joda.time.chrono.ISOChronology;
 
 import java.time.Instant;
@@ -39,6 +40,7 @@ import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.spi.type.DateTimeEncoding.unpackZoneKey;
 import static com.facebook.presto.util.DateTimeUtils.parseTimeWithTimeZone;
@@ -165,6 +167,13 @@ public final class TimeWithTimeZoneOperators
     public static long hashCode(@SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long value)
     {
         return AbstractLongType.hash(unpackMillisUtc(value));
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long value)
+    {
+        return XxHash64.hash(unpackMillisUtc(value));
     }
 
     @ScalarOperator(IS_DISTINCT_FROM)

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 import org.joda.time.chrono.ISOChronology;
 
 import java.util.concurrent.TimeUnit;
@@ -40,6 +41,7 @@ import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.type.DateTimeOperators.modulo24Hour;
 import static com.facebook.presto.util.DateTimeUtils.parseTimestampWithoutTimeZone;
@@ -241,5 +243,12 @@ public final class TimestampOperators
     public static boolean indeterminate(@SqlType(StandardTypes.TIMESTAMP) long value, @IsNull boolean isNull)
     {
         return isNull;
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.TIMESTAMP) long value)
+    {
+        return XxHash64.hash(value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TimestampWithTimeZoneOperators.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 import org.joda.time.chrono.ISOChronology;
 
 import java.util.concurrent.TimeUnit;
@@ -40,6 +41,7 @@ import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.spi.type.DateTimeEncoding.unpackZoneKey;
@@ -202,6 +204,13 @@ public final class TimestampWithTimeZoneOperators
     public static long hashCode(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long value)
     {
         return AbstractLongType.hash(unpackMillisUtc(value));
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long value)
+    {
+        return XxHash64.hash(unpackMillisUtc(value));
     }
 
     @ScalarOperator(IS_DISTINCT_FROM)

--- a/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TinyintOperators.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.TinyintType;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -42,6 +43,7 @@ import static com.facebook.presto.spi.function.OperatorType.MULTIPLY;
 import static com.facebook.presto.spi.function.OperatorType.NEGATION;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
@@ -229,6 +231,13 @@ public final class TinyintOperators
     public static long hashCode(@SqlType(StandardTypes.TINYINT) long value)
     {
         return TinyintType.hash((byte) value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.TINYINT) long value)
+    {
+        return XxHash64.hash(value);
     }
 
     @ScalarOperator(IS_DISTINCT_FROM)

--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
@@ -232,7 +232,7 @@ public final class VarcharOperators
     @SqlType(StandardTypes.BIGINT)
     public static long hashCode(@SqlType("varchar(x)") Slice value)
     {
-        return XxHash64.hash(value);
+        return xxHash64(value);
     }
 
     @LiteralParameters({"x", "y"})

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateCountDistinct.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateCountDistinct.java
@@ -108,7 +108,7 @@ public abstract class AbstractTestApproximateCountDistinct
         }
 
         assertLessThan(stats.getMean(), 1.0e-2);
-        assertLessThan(Math.abs(stats.getStandardDeviation() - maxStandardError), 1.0e-2);
+        assertLessThan(stats.getStandardDeviation(), 1.0e-2 + maxStandardError);
     }
 
     @Test(dataProvider = "provideStandardErrors")

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateCountDistinct.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestApproximateCountDistinct.java
@@ -48,6 +48,11 @@ public abstract class AbstractTestApproximateCountDistinct
 
     protected static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
 
+    protected int getUniqueValuesCount()
+    {
+        return 20000;
+    }
+
     @DataProvider(name = "provideStandardErrors")
     public Object[][] provideStandardErrors()
     {
@@ -78,7 +83,8 @@ public abstract class AbstractTestApproximateCountDistinct
     @Test(dataProvider = "provideStandardErrors")
     public void testMixedNullsAndNonNulls(double maxStandardError)
     {
-        List<Object> baseline = createRandomSample(10000, 15000);
+        int uniques = getUniqueValuesCount();
+        List<Object> baseline = createRandomSample(uniques, (int) (uniques * 1.5));
 
         // Randomly insert nulls
         // We need to retain the preexisting order to ensure that the HLL can generate the same estimates.
@@ -97,7 +103,7 @@ public abstract class AbstractTestApproximateCountDistinct
         DescriptiveStatistics stats = new DescriptiveStatistics();
 
         for (int i = 0; i < 500; ++i) {
-            int uniques = ThreadLocalRandom.current().nextInt(20000) + 1;
+            int uniques = ThreadLocalRandom.current().nextInt(getUniqueValuesCount()) + 1;
 
             List<Object> values = createRandomSample(uniques, (int) (uniques * 1.5));
 
@@ -115,7 +121,7 @@ public abstract class AbstractTestApproximateCountDistinct
     public void testMultiplePositionsPartial(double maxStandardError)
     {
         for (int i = 0; i < 100; ++i) {
-            int uniques = ThreadLocalRandom.current().nextInt(20000) + 1;
+            int uniques = ThreadLocalRandom.current().nextInt(getUniqueValuesCount()) + 1;
             List<Object> values = createRandomSample(uniques, (int) (uniques * 1.5));
             assertEquals(estimateCountPartial(values, maxStandardError), estimateGroupByCount(values, maxStandardError));
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctInteger.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctInteger.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+
+public class TestApproximateCountDistinctInteger
+        extends AbstractTestApproximateCountDistinct
+{
+    @Override
+    public InternalAggregationFunction getAggregationFunction()
+    {
+        return metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("approx_distinct", AGGREGATE, BIGINT.getTypeSignature(), INTEGER.getTypeSignature(), DOUBLE.getTypeSignature()));
+    }
+
+    @Override
+    public Type getValueType()
+    {
+        return INTEGER;
+    }
+
+    @Override
+    public Object randomValue()
+    {
+        return (long) ThreadLocalRandom.current().nextInt();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctIpAddress.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctIpAddress.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slices;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.type.IpAddressType.IPADDRESS;
+
+public class TestApproximateCountDistinctIpAddress
+        extends AbstractTestApproximateCountDistinct
+{
+    @Override
+    public InternalAggregationFunction getAggregationFunction()
+    {
+        return metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("approx_distinct", AGGREGATE, BIGINT.getTypeSignature(), IPADDRESS.getTypeSignature(), DOUBLE.getTypeSignature()));
+    }
+
+    @Override
+    public Type getValueType()
+    {
+        return IPADDRESS;
+    }
+
+    @Override
+    public Object randomValue()
+    {
+        byte[] bytes = new byte[16];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return Slices.wrappedBuffer(bytes);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctLongDecimal.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctLongDecimal.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slices;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.Decimals.MAX_PRECISION;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+
+public class TestApproximateCountDistinctLongDecimal
+        extends AbstractTestApproximateCountDistinct
+{
+    private static final Type LONG_DECIMAL = createDecimalType(MAX_PRECISION);
+
+    @Override
+    public InternalAggregationFunction getAggregationFunction()
+    {
+        return metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("approx_distinct", AGGREGATE, BIGINT.getTypeSignature(), LONG_DECIMAL.getTypeSignature(), DOUBLE.getTypeSignature()));
+    }
+
+    @Override
+    public Type getValueType()
+    {
+        return LONG_DECIMAL;
+    }
+
+    @Override
+    public Object randomValue()
+    {
+        long low = ThreadLocalRandom.current().nextLong();
+        long high = ThreadLocalRandom.current().nextLong();
+        return Slices.wrappedLongArray(low, high);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctSmallint.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctSmallint.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+
+public class TestApproximateCountDistinctSmallint
+        extends AbstractTestApproximateCountDistinct
+{
+    @Override
+    public InternalAggregationFunction getAggregationFunction()
+    {
+        return metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("approx_distinct", AGGREGATE, BIGINT.getTypeSignature(), SMALLINT.getTypeSignature(), DOUBLE.getTypeSignature()));
+    }
+
+    @Override
+    public Type getValueType()
+    {
+        return SMALLINT;
+    }
+
+    @Override
+    public Object randomValue()
+    {
+        return ThreadLocalRandom.current().nextLong(Short.MIN_VALUE, Short.MAX_VALUE + 1);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctTinyint.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximateCountDistinctTinyint.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+
+public class TestApproximateCountDistinctTinyint
+        extends AbstractTestApproximateCountDistinct
+{
+    @Override
+    public InternalAggregationFunction getAggregationFunction()
+    {
+        return metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("approx_distinct", AGGREGATE, BIGINT.getTypeSignature(), TINYINT.getTypeSignature(), DOUBLE.getTypeSignature()));
+    }
+
+    @Override
+    public Type getValueType()
+    {
+        return TINYINT;
+    }
+
+    @Override
+    public Object randomValue()
+    {
+        return ThreadLocalRandom.current().nextLong(Byte.MIN_VALUE, Byte.MAX_VALUE + 1);
+    }
+
+    @Override
+    protected int getUniqueValuesCount()
+    {
+        return (Byte.MAX_VALUE - Byte.MIN_VALUE + 1) / 10;
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -660,12 +660,63 @@ public abstract class AbstractTestAggregations
     @Test
     public void testApproximateCountDistinct()
     {
+        // test date
+        assertQuery("SELECT approx_distinct(orderdate) FROM orders", "SELECT 2443");
+        assertQuery("SELECT approx_distinct(orderdate, 0.023) FROM orders", "SELECT 2443");
+
+        // test timestamp
+        assertQuery("SELECT approx_distinct(CAST(orderdate AS TIMESTAMP)) FROM orders", "SELECT 2384");
+        assertQuery("SELECT approx_distinct(CAST(orderdate AS TIMESTAMP), 0.023) FROM orders", "SELECT 2384");
+
+        // test timestamp with time zone
+        assertQuery("SELECT approx_distinct(CAST((orderdate) AS TIMESTAMP WITH TIME ZONE)) FROM orders", "SELECT 2384");
+        assertQuery("SELECT approx_distinct(CAST((orderdate) AS TIMESTAMP WITH TIME ZONE), 0.023) FROM orders", "SELECT 2384");
+
+        // test time
+        assertQuery("SELECT approx_distinct(CAST(from_unixtime(custkey) AS TIME)) FROM orders", "SELECT 993");
+        assertQuery("SELECT approx_distinct(CAST(from_unixtime(custkey) AS TIME), 0.023) FROM orders", "SELECT 993");
+
+        // test time with time zone
+        assertQuery("SELECT approx_distinct(CAST(from_unixtime(custkey) AS TIME WITH TIME ZONE)) FROM orders", "SELECT 993");
+        assertQuery("SELECT approx_distinct(CAST(from_unixtime(custkey) AS TIME WITH TIME ZONE), 0.023) FROM orders", "SELECT 993");
+
+        // test short decimal
+        assertQuery("SELECT approx_distinct(CAST(custkey AS DECIMAL(18, 0))) FROM orders", "SELECT 990");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS DECIMAL(18, 0)), 0.023) FROM orders", "SELECT 990");
+
+        // test long decimal
+        assertQuery("SELECT approx_distinct(CAST(custkey AS DECIMAL(25, 20))) FROM orders", "SELECT 1013");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS DECIMAL(25, 20)), 0.023) FROM orders", "SELECT 1013");
+
+        // test real
+        assertQuery("SELECT approx_distinct(CAST(custkey AS REAL)) FROM orders", "SELECT 1006");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS REAL), 0.023) FROM orders", "SELECT 1006");
+
+        // test bigint
         assertQuery("SELECT approx_distinct(custkey) FROM orders", "SELECT 990");
         assertQuery("SELECT approx_distinct(custkey, 0.023) FROM orders", "SELECT 990");
+
+        // test integer
+        assertQuery("SELECT approx_distinct(CAST(custkey AS INTEGER)) FROM orders", "SELECT 990");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS INTEGER), 0.023) FROM orders", "SELECT 990");
+
+        // test smallint
+        assertQuery("SELECT approx_distinct(CAST(custkey AS SMALLINT)) FROM orders", "SELECT 990");
+        assertQuery("SELECT approx_distinct(CAST(custkey AS SMALLINT), 0.023) FROM orders", "SELECT 990");
+
+        // test tinyint
+        assertQuery("SELECT approx_distinct(CAST((custkey % 128) AS TINYINT)) FROM orders", "SELECT 128");
+        assertQuery("SELECT approx_distinct(CAST((custkey % 128) AS TINYINT), 0.023) FROM orders", "SELECT 128");
+
+        // test double
         assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE)) FROM orders", "SELECT 1014");
         assertQuery("SELECT approx_distinct(CAST(custkey AS DOUBLE), 0.023) FROM orders", "SELECT 1014");
+
+        // test varchar
         assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR)) FROM orders", "SELECT 1036");
         assertQuery("SELECT approx_distinct(CAST(custkey AS VARCHAR), 0.023) FROM orders", "SELECT 1036");
+
+        // test varbinary
         assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR))) FROM orders", "SELECT 1036");
         assertQuery("SELECT approx_distinct(to_utf8(CAST(custkey AS VARCHAR)), 0.023) FROM orders", "SELECT 1036");
     }


### PR DESCRIPTION
- Previously implemented: 
`BIGINT`, `VARCHAR`, `VARBINARY`, `DOUBLE`
- Newly added in this commit (10 more): 
`INTEGER`, `SMALLINT`, `TINYINT`, `DECIMAL`, `REAL`,
`DATE`, `TIMESTAMP`, `TIMESTAMP WITH TIMEZONE`, `TIME, TIME WITH TIMEZONE`, 
`IPADDRESS`

I didn't support `BOOLEAN` because exact `COUNT DISTINCT` is better for boolean. 
I didn't support `CHAR` because it's not clear to me what's the right behavior when a CHAR value is padded. 
I didn't support `INTERVAL YEAR TO MONTH` and `INTERVAL DAY TO SECOND` because they are not very useful. 

Supports for geometry types (i.e `BING_TILE` and `GEOMETRY`), complex types (i.e. `ROW`, `ARRAY` and `MAP`) and `JSON` type can be added in the future if they are useful. 
