### PR TITLE
Expose debug port for Presto server in product tests

### DIFF
--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -31,6 +31,7 @@ services:
     command: /docker/volumes/conf/docker/files/presto-launcher-wrapper.sh singlenode run
     ports:
       - '8080:8080'
+      - '5005:5005'
     depends_on:
        - hadoop-master
     volumes:


### PR DESCRIPTION
Expose debug port for Presto server in product tests

By default Presto server does not expose 5005 port for debugger, it has
to be manually changed in jvm.config. But when jvm.config is changed to
expose that debug port, then docker compose configuration has to be also
changed.

When only docker compose is changed that 5005 is forwarded from
Presto container and jvm.config is not changed, then 5005 port
can be still used for other purpouses (probably to debug the other java process).

Thanks to this change, it is just a bit easier to debug Presto server
process in product tests. One file less to edit (remember).
