### PR TITLE
Start Presto and Hadoop at the same time in product tests

### DIFF
--- a/presto-product-tests/bin/run_on_docker.sh
+++ b/presto-product-tests/bin/run_on_docker.sh
@@ -166,15 +166,15 @@ environment_compose logs --no-color -f ${EXTERNAL_SERVICES} &
 
 HADOOP_LOGS_PID=$!
 
-# wait until hadoop processes is started
-retry check_hadoop
-
 # start presto containers
 environment_compose up -d ${PRESTO_SERVICES}
 
 # start docker logs for presto containers
 environment_compose logs --no-color -f ${PRESTO_SERVICES} &
 PRESTO_LOGS_PID=$!
+
+# wait until hadoop processes are started
+retry check_hadoop
 
 # wait until presto is started
 retry check_presto


### PR DESCRIPTION
Start Presto and Hadoop at the same time in product tests

Presto does not much depend on Hadoop (Hive). Using hive connector
depends on Hive being up and running.

That way it is a bit faster to run product tests.
