### PR TITLE
Make TestLegacyLogFunction single threaded

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyLogFunction.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLegacyLogFunction.java
@@ -23,6 +23,8 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static org.testng.Assert.assertEquals;
 
+// run single threaded to avoid creating multiple query runners at once
+@Test(singleThreaded = true)
 public class TestLegacyLogFunction
 {
     private static final String QUERY = "SELECT LOG(25, 5)";


### PR DESCRIPTION
This avoids creating multiple query runners at once.