### PR TITLE
Allow missing fields in structs in ORC

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
@@ -20,6 +20,7 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.RowBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
@@ -27,12 +28,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.StreamReaders.createStreamReader;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class StructStreamReader
@@ -96,18 +99,28 @@ public class StructStreamReader
         Block[] blocks = new Block[typeParameters.size()];
         if (presentStream == null) {
             for (int i = 0; i < typeParameters.size(); i++) {
-                StreamReader structField = structFields[i];
-                structField.prepareNextRead(nextBatchSize);
-                blocks[i] = structField.readBlock(typeParameters.get(i));
+                if (i < structFields.length) {
+                    StreamReader structField = structFields[i];
+                    structField.prepareNextRead(nextBatchSize);
+                    blocks[i] = structField.readBlock(typeParameters.get(i));
+                }
+                else {
+                    blocks[i] = getNullBlock(typeParameters.get(i), nextBatchSize);
+                }
             }
         }
         else {
             int nullValues = presentStream.getUnsetBits(nextBatchSize, nullVector);
             if (nullValues != nextBatchSize) {
                 for (int i = 0; i < typeParameters.size(); i++) {
-                    StreamReader structField = structFields[i];
-                    structField.prepareNextRead(nextBatchSize - nullValues);
-                    blocks[i] = structField.readBlock(typeParameters.get(i));
+                    if (i < structFields.length) {
+                        StreamReader structField = structFields[i];
+                        structField.prepareNextRead(nextBatchSize - nullValues);
+                        blocks[i] = structField.readBlock(typeParameters.get(i));
+                    }
+                    else {
+                        blocks[i] = getNullBlock(typeParameters.get(i), nextBatchSize - nullValues);
+                    }
                 }
             }
             else {
@@ -116,6 +129,11 @@ public class StructStreamReader
                 }
             }
         }
+
+        verify(Arrays.stream(blocks)
+                .mapToInt(Block::getPositionCount)
+                .distinct()
+                .count() == 1);
 
         // Struct is represented as a row block
         Block rowBlock = RowBlock.fromFieldBlocks(nullVector, blocks);
@@ -176,5 +194,13 @@ public class StructStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    private static Block getNullBlock(Type type, int positionCount)
+    {
+        Block nullValueBlock = type.createBlockBuilder(null, 1)
+                .appendNull()
+                .build();
+        return new RunLengthEncodedBlock(nullValueBlock, positionCount);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -238,6 +238,7 @@ public class OrcTester
     private boolean structuralNullTestsEnabled;
     private boolean reverseTestsEnabled;
     private boolean nullTestsEnabled;
+    private boolean missingStructFieldsTestsEnabled;
     private boolean skipBatchTestsEnabled;
     private boolean skipStripeTestsEnabled;
     private Set<Format> formats = ImmutableSet.of();
@@ -250,6 +251,7 @@ public class OrcTester
         orcTester.mapTestsEnabled = true;
         orcTester.listTestsEnabled = true;
         orcTester.nullTestsEnabled = true;
+        orcTester.missingStructFieldsTestsEnabled = true;
         orcTester.skipBatchTestsEnabled = true;
         orcTester.formats = ImmutableSet.of(ORC_12, ORC_11, DWRF);
         orcTester.compressions = ImmutableSet.of(ZLIB);
@@ -266,6 +268,7 @@ public class OrcTester
         orcTester.structuralNullTestsEnabled = true;
         orcTester.reverseTestsEnabled = true;
         orcTester.nullTestsEnabled = true;
+        orcTester.missingStructFieldsTestsEnabled = true;
         orcTester.skipBatchTestsEnabled = true;
         orcTester.skipStripeTestsEnabled = true;
         orcTester.formats = ImmutableSet.copyOf(Format.values());
@@ -322,14 +325,14 @@ public class OrcTester
         }
     }
 
-    private void testStructRoundTrip(Type type, List<?> readValues)
+    private void testStructRoundTrip(Type type, List<?> values)
             throws Exception
     {
         Type rowType = rowType(type, type, type);
         // values in simple struct
         testRoundTripType(
                 rowType,
-                readValues.stream()
+                values.stream()
                         .map(OrcTester::toHiveStruct)
                         .collect(toList()));
 
@@ -337,16 +340,31 @@ public class OrcTester
             // values and nulls in simple struct
             testRoundTripType(
                     rowType,
-                    insertNullEvery(5, readValues).stream()
+                    insertNullEvery(5, values).stream()
                             .map(OrcTester::toHiveStruct)
                             .collect(toList()));
 
             // all null values in simple struct
             testRoundTripType(
                     rowType,
-                    readValues.stream()
+                    values.stream()
                             .map(value -> toHiveStruct(null))
                             .collect(toList()));
+        }
+
+        if (missingStructFieldsTestsEnabled) {
+            Type readType = rowType(type, type, type, type, type, type);
+            Type writeType = rowType(type, type, type);
+
+            List writeValues = values.stream()
+                    .map(OrcTester::toHiveStruct)
+                    .collect(toList());
+
+            List readValues = values.stream()
+                    .map(OrcTester::toHiveStructWithNull)
+                    .collect(toList());
+
+            assertRoundTrip(writeType, readType, writeValues, readValues, true);
         }
     }
 
@@ -435,15 +453,20 @@ public class OrcTester
     public void assertRoundTrip(Type type, List<?> readValues)
             throws Exception
     {
-        assertRoundTrip(type, readValues, true);
+        assertRoundTrip(type, type, readValues, readValues, true);
     }
 
-    public void assertRoundTrip(Type type, List<?> readValues, boolean verifyWithHiveReader)
+    public void assertRoundTrip(Type type, List<?> readValues, boolean verifyWithHiveReader) throws Exception
+    {
+        assertRoundTrip(type, type, readValues, readValues, verifyWithHiveReader);
+    }
+
+    private void assertRoundTrip(Type writeType, Type readType, List<?> writeValues, List<?> readValues, boolean verifyWithHiveReader)
             throws Exception
     {
         OrcWriterStats stats = new OrcWriterStats();
         for (Format format : formats) {
-            if (!format.supportsType(type)) {
+            if (!format.supportsType(readType)) {
                 return;
             }
 
@@ -454,27 +477,27 @@ public class OrcTester
                 // write Hive, read Presto
                 if (hiveSupported) {
                     try (TempFile tempFile = new TempFile()) {
-                        writeOrcColumnHive(tempFile.getFile(), format, compression, type, readValues.iterator());
-                        assertFileContentsPresto(type, tempFile, readValues, false, false, orcEncoding, format, true);
+                        writeOrcColumnHive(tempFile.getFile(), format, compression, writeType, writeValues.iterator());
+                        assertFileContentsPresto(readType, tempFile, readValues, false, false, orcEncoding, format, true);
                     }
                 }
 
                 // write Presto, read Hive and Presto
                 try (TempFile tempFile = new TempFile()) {
-                    writeOrcColumnPresto(tempFile.getFile(), format, compression, type, readValues.iterator(), stats);
+                    writeOrcColumnPresto(tempFile.getFile(), format, compression, writeType, writeValues.iterator(), stats);
 
                     if (verifyWithHiveReader && hiveSupported) {
-                        assertFileContentsHive(type, tempFile, format, readValues);
+                        assertFileContentsHive(readType, tempFile, format, readValues);
                     }
 
-                    assertFileContentsPresto(type, tempFile, readValues, false, false, orcEncoding, format, false);
+                    assertFileContentsPresto(readType, tempFile, readValues, false, false, orcEncoding, format, false);
 
                     if (skipBatchTestsEnabled) {
-                        assertFileContentsPresto(type, tempFile, readValues, true, false, orcEncoding, format, false);
+                        assertFileContentsPresto(readType, tempFile, readValues, true, false, orcEncoding, format, false);
                     }
 
                     if (skipStripeTestsEnabled) {
-                        assertFileContentsPresto(type, tempFile, readValues, false, true, orcEncoding, format, false);
+                        assertFileContentsPresto(readType, tempFile, readValues, false, true, orcEncoding, format, false);
                     }
                 }
             }
@@ -922,6 +945,11 @@ public class OrcTester
             Object field = fields.get(i);
             newFields.add(decodeRecordReaderValue(fieldType, field));
         }
+
+        for (int j = fields.size(); j < fieldTypes.size(); j++) {
+            newFields.add(null);
+        }
+
         return newFields;
     }
 
@@ -1229,6 +1257,11 @@ public class OrcTester
     private static List<Object> toHiveStruct(Object input)
     {
         return asList(input, input, input);
+    }
+
+    private static List<Object> toHiveStructWithNull(Object input)
+    {
+        return asList(input, input, input, null, null, null);
     }
 
     private static Map<Object, Object> toHiveMap(Object input, Object nullKeyValue)


### PR DESCRIPTION
### Summary

Structs can have missing fields if the the table schema has changed to add nested fields, but the underlying ORC files are not updated. Earlier Presto would fail with an `ArrayIndexOutOfBounds` exception. Now, the missing fields will be marked as null.

This behavior will allow Presto to support addition of fields to structs without needing to change the underlying data.

### Steps to reproduce the problem
When the table schema has struct fields that the underlying ORC file does not have, Presto errors out and fails to read the ORC file. Here are steps to reproduce the problem:

```shell
# Clean table location
bin/hdfs dfs -rm -r -f /user/hive/warehouse/test_schema.db/test_tbl/
bin/hdfs dfs -rm -r -f /user/hive/warehouse/test_schema.db/test_tbl2/
```

Create tables and insert data
```sql
DROP TABLE test_schema.test_tbl;

CREATE EXTERNAL TABLE `test_schema.test_tbl`(
  `a` string,  
  `b` struct<ts:STRING, topic:STRING>)
ROW FORMAT SERDE
  'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
STORED AS INPUTFORMAT
  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
OUTPUTFORMAT
  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat';

INSERT INTO table test_schema.test_tbl SELECT 'a_val1', named_struct('ts', 'b1ts','topic', 'b1topic');

DROP TABLE test_schema.test_tbl2;
CREATE EXTERNAL TABLE `test_schema.test_tbl2`( 
  `a` string,
  `b` struct<ts:STRING>)
ROW FORMAT SERDE
  'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
STORED AS INPUTFORMAT
  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
OUTPUTFORMAT
  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat';

INSERT INTO table test_schema.test_tbl2 SELECT 'a_val2', named_struct('ts', 'b2ts');
```

Copy data over
```
bin/hdfs dfs -cp /user/hive/warehouse/test_schema.db/test_tbl2/000000_0 /user/hive/warehouse/test_schema.db/test_tbl/from_test_tbl2
```

Query from Hive (this works as expected):
```
hive> select * from test_schema.test_tbl;
a_val1	{"ts":"b1ts","topic":"b1topic"}
a_val2	{"ts":"b2ts","topic":null}
```

Query from Presto (This fails with the following):
```java
java.lang.ArrayIndexOutOfBoundsException: 1
	at com.facebook.presto.orc.reader.StructStreamReader.readBlock(StructStreamReader.java:100)
	at com.facebook.presto.orc.OrcRecordReader.readBlock(OrcRecordReader.java:370)
	at com.facebook.presto.hive.orc.OrcPageSource$OrcBlockLoader.load(OrcPageSource.java:240)
	at com.facebook.presto.hive.orc.OrcPageSource$OrcBlockLoader.load(OrcPageSource.java:216)
	at com.facebook.presto.spi.block.LazyBlock.assureLoaded(LazyBlock.java:256)
	at com.facebook.presto.spi.Page.assureLoaded(Page.java:230)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:265)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:337)
	at com.facebook.presto.operator.Driver.lambda$processFor$6(Driver.java:241)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:614)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:235)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:622)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
	at com.facebook.presto.execution.executor.LegacyPrioritizedSplitRunner.process(LegacyPrioritizedSplitRunner.java:23)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:485)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)```
```

### The solution
With the changes in this PR Presto will output:
```
presto> SELECT * FROM hive.test_schema.test_tbl;
   a    |            b
--------+--------------------------
 a_val2 | {ts=b2ts, topic=null}  <-- This is the important row, with the topic set to null
 a_val1 | {ts=b1ts, topic=b1topic}
(2 rows)

Query 20180625_221954_00001_94ydd, FINISHED, 1 node
Splits: 18 total, 18 done (100.00%)
0:03 [2 rows, 795B] [0 rows/s, 292B/s]
```
https://github.com/prestodb/presto/issues/10941