### PR TITLE
Update to docker images version 6

### DIFF
--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -23,7 +23,7 @@ function export_canonical_path() {
 
 source "${BASH_SOURCE%/*}/../../../bin/locations.sh"
 
-export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-5}
+export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-6}
 export HADOOP_BASE_IMAGE=${HADOOP_BASE_IMAGE:-"prestodb/hdp2.6-hive"}
 
 # The following variables are defined to enable running product tests with arbitrary/downloaded jars


### PR DESCRIPTION
Includes JDK update (https://github.com/prestodb/docker-images/pull/24). 
Does not include TZ change (https://github.com/prestodb/docker-images/pull/22), this will go in 7.