### PR TITLE
Generalize grouping set rewriter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/GroupingOperationRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/GroupingOperationRewriter.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.sql.planner;
 
-import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.FieldId;
 import com.facebook.presto.sql.analyzer.RelationId;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
@@ -23,7 +22,6 @@ import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.GroupingOperation;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.NodeRef;
-import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.SubscriptExpression;
 
 import java.util.List;
@@ -40,26 +38,21 @@ public final class GroupingOperationRewriter
 {
     private GroupingOperationRewriter() {}
 
-    public static Expression rewriteGroupingOperation(GroupingOperation expression, QuerySpecification queryNode, Analysis analysis, Optional<Symbol> groupIdSymbol)
+    public static Expression rewriteGroupingOperation(GroupingOperation expression, List<List<Expression>> groupingSets, Map<NodeRef<Expression>, FieldId> columnReferenceFields, Optional<Symbol> groupIdSymbol)
     {
-        requireNonNull(queryNode, "node is null");
-        requireNonNull(analysis, "analysis is null");
         requireNonNull(groupIdSymbol, "groupIdSymbol is null");
-
-        checkState(queryNode.getGroupBy().isPresent(), "GroupBy node must be present");
 
         // No GroupIdNode and a GROUPING() operation imply a single grouping, which
         // means that any columns specified as arguments to GROUPING() will be included
         // in the group and none of them will be aggregated over. Hence, re-write the
         // GroupingOperation to a constant literal of 0.
         // See SQL:2011:4.16.2 and SQL:2011:6.9.10.
-        if (analysis.getGroupingSets(queryNode).size() == 1) {
+        if (groupingSets.size() == 1) {
             return new LongLiteral("0");
         }
         else {
             checkState(groupIdSymbol.isPresent(), "groupId symbol is missing");
 
-            Map<NodeRef<Expression>, FieldId> columnReferenceFields = analysis.getColumnReferenceFields();
             RelationId relationId = columnReferenceFields.get(NodeRef.of(expression.getGroupingColumns().get(0))).getRelationId();
 
             List<Integer> columns = expression.getGroupingColumns().stream()
@@ -69,7 +62,7 @@ public final class GroupingOperationRewriter
                     .map(fieldId -> translateFieldToInteger(fieldId, relationId))
                     .collect(toImmutableList());
 
-            List<List<Integer>> groupingSetDescriptors = analysis.getGroupingSets(queryNode).stream()
+            List<List<Integer>> groupingSetDescriptors = groupingSets.stream()
                     .map(groupingSet -> groupingSet.stream()
                             .map(NodeRef::of)
                             .filter(columnReferenceFields::containsKey)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -571,7 +571,7 @@ class QueryPlanner
         projections.putIdentities(subPlan.getRoot().getOutputSymbols());
 
         for (GroupingOperation groupingOperation : analysis.getGroupingOperations(node)) {
-            Expression rewritten = GroupingOperationRewriter.rewriteGroupingOperation(groupingOperation, node, analysis, groupIdSymbol);
+            Expression rewritten = GroupingOperationRewriter.rewriteGroupingOperation(groupingOperation, analysis.getGroupingSets(node), analysis.getColumnReferenceFields(), groupIdSymbol);
             Type coercion = analysis.getCoercion(groupingOperation);
             Symbol symbol = symbolAllocator.newSymbol(rewritten, analysis.getTypeWithCoercions(groupingOperation));
             if (coercion != null) {


### PR DESCRIPTION
Break its dependency on Analysis and QuerySpecification node by passing
the required data directly. This is to prepare for the split between AST -> IR,
which requires getting rid of expression rewriters (AST -> AST) during planning
 and replace them with AST -> IR translations.

Extracted from https://github.com/prestodb/presto/pull/10816