### PR TITLE
Preserve original window frame expressions in plan instead of AST

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -690,9 +690,14 @@ class QueryPlanner
                 frameEndSymbol = Optional.of(subPlan.translate(frameEnd));
             }
 
-            WindowNode.Frame frame = new WindowNode.Frame(frameType,
-                    frameStartType, frameStartSymbol,
-                    frameEndType, frameEndSymbol);
+            WindowNode.Frame frame = new WindowNode.Frame(
+                    frameType,
+                    frameStartType,
+                    frameStartSymbol,
+                    frameEndType,
+                    frameEndSymbol,
+                    Optional.ofNullable(frameStart),
+                    Optional.ofNullable(frameEnd));
 
             TranslationMap outputTranslations = subPlan.copyTranslations();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -221,9 +221,14 @@ public class UnaliasSymbolReferences
 
         private WindowNode.Frame canonicalize(WindowNode.Frame frame)
         {
-            return new WindowNode.Frame(frame.getType(),
-                    frame.getStartType(), canonicalize(frame.getStartValue()),
-                    frame.getEndType(), canonicalize(frame.getEndValue()));
+            return new WindowNode.Frame(
+                    frame.getType(),
+                    frame.getStartType(),
+                    canonicalize(frame.getStartValue()),
+                    frame.getEndType(),
+                    canonicalize(frame.getEndValue()),
+                    frame.getOriginalStartValue(),
+                    frame.getOriginalEndValue());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/WindowNode.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.plan;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.sql.planner.OrderingScheme;
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.WindowFrame;
@@ -224,19 +225,35 @@ public class WindowNode
         private final FrameBound.Type endType;
         private final Optional<Symbol> endValue;
 
+        // This information is only used for printing the plan.
+        private final Optional<Expression> originalStartValue;
+        private final Optional<Expression> originalEndValue;
+
         @JsonCreator
         public Frame(
                 @JsonProperty("type") WindowFrame.Type type,
                 @JsonProperty("startType") FrameBound.Type startType,
                 @JsonProperty("startValue") Optional<Symbol> startValue,
                 @JsonProperty("endType") FrameBound.Type endType,
-                @JsonProperty("endValue") Optional<Symbol> endValue)
+                @JsonProperty("endValue") Optional<Symbol> endValue,
+                @JsonProperty("originalStartValue") Optional<Expression> originalStartValue,
+                @JsonProperty("originalEndValue") Optional<Expression> originalEndValue)
         {
             this.startType = requireNonNull(startType, "startType is null");
             this.startValue = requireNonNull(startValue, "startValue is null");
             this.endType = requireNonNull(endType, "endType is null");
             this.endValue = requireNonNull(endValue, "endValue is null");
             this.type = requireNonNull(type, "type is null");
+            this.originalStartValue = requireNonNull(originalStartValue, "originalStartValue is null");
+            this.originalEndValue = requireNonNull(originalEndValue, "originalEndValue is null");
+
+            if (startValue.isPresent()) {
+                checkArgument(originalStartValue.isPresent(), "originalStartValue must be present if startValue is present");
+            }
+
+            if (endValue.isPresent()) {
+                checkArgument(originalEndValue.isPresent(), "originalEndValue must be present if endValue is present");
+            }
         }
 
         @JsonProperty
@@ -269,27 +286,39 @@ public class WindowNode
             return endValue;
         }
 
-        @Override
-        public int hashCode()
+        @JsonProperty
+        public Optional<Expression> getOriginalStartValue()
         {
-            return Objects.hash(type, startType, startValue, endType, endValue);
+            return originalStartValue;
+        }
+
+        @JsonProperty
+        public Optional<Expression> getOriginalEndValue()
+        {
+            return originalEndValue;
         }
 
         @Override
-        public boolean equals(Object obj)
+        public boolean equals(Object o)
         {
-            if (this == obj) {
+            if (this == o) {
                 return true;
             }
-            if (obj == null || getClass() != obj.getClass()) {
+            if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            Frame other = (Frame) obj;
-            return Objects.equals(this.type, other.type) &&
-                    Objects.equals(this.startType, other.startType) &&
-                    Objects.equals(this.startValue, other.startValue) &&
-                    Objects.equals(this.endType, other.endType) &&
-                    Objects.equals(this.endValue, other.endValue);
+            Frame frame = (Frame) o;
+            return type == frame.type &&
+                    startType == frame.startType &&
+                    Objects.equals(startValue, frame.startValue) &&
+                    endType == frame.endType &&
+                    Objects.equals(endValue, frame.endValue);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(type, startType, startValue, endType, endValue, originalStartValue, originalEndValue);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -158,6 +158,8 @@ public class TestTypeValidator
                 FrameBound.Type.UNBOUNDED_PRECEDING,
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         WindowNode.Function function = new WindowNode.Function(functionCall, signature, frame);
@@ -309,6 +311,8 @@ public class TestTypeValidator
                 FrameBound.Type.UNBOUNDED_PRECEDING,
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         WindowNode.Function function = new WindowNode.Function(functionCall, signature, frame);
@@ -346,6 +350,8 @@ public class TestTypeValidator
                 FrameBound.Type.UNBOUNDED_PRECEDING,
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         WindowNode.Function function = new WindowNode.Function(functionCall, signature, frame);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowFrameProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/WindowFrameProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.WindowFrame;
 
@@ -48,12 +49,19 @@ public class WindowFrameProvider
     @Override
     public WindowNode.Frame getExpectedValue(SymbolAliases aliases)
     {
+        // synthetize original start/end value to keep the constructor of the frame happy. These are irrelevant for the purpose
+        // of testing the plan structure.
+        Optional<Expression> originalStartValue = startValue.map(alias -> alias.toSymbol(aliases).toSymbolReference());
+        Optional<Expression> originalEndValue = endValue.map(alias -> alias.toSymbol(aliases).toSymbolReference());
+
         return new WindowNode.Frame(
                 type,
                 startType,
                 startValue.map(alias -> alias.toSymbol(aliases)),
                 endType,
-                endValue.map(alias -> alias.toSymbol(aliases)));
+                endValue.map(alias -> alias.toSymbol(aliases)),
+                originalStartValue,
+                originalEndValue);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
@@ -48,8 +48,15 @@ import static com.facebook.presto.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
 public class TestMergeAdjacentWindows
         extends BaseRuleTest
 {
-    private static final WindowNode.Frame frame = new WindowNode.Frame(WindowFrame.Type.RANGE, UNBOUNDED_PRECEDING,
-            Optional.empty(), CURRENT_ROW, Optional.empty());
+    private static final WindowNode.Frame frame = new WindowNode.Frame(
+            WindowFrame.Type.RANGE,
+            UNBOUNDED_PRECEDING,
+            Optional.empty(),
+            CURRENT_ROW,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+
     private static final Signature signature = new Signature(
             "avg",
             FunctionKind.WINDOW,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
@@ -227,7 +227,9 @@ public class TestPruneWindowColumns
                                                 UNBOUNDED_PRECEDING,
                                                 Optional.of(startValue1),
                                                 CURRENT_ROW,
-                                                Optional.of(endValue1))),
+                                                Optional.of(endValue1),
+                                                Optional.of(startValue1.toSymbolReference()),
+                                                Optional.of(endValue2.toSymbolReference()))),
                                 output2,
                                 new WindowNode.Function(
                                         new FunctionCall(QualifiedName.of("min"), ImmutableList.of(input2.toSymbolReference())),
@@ -237,7 +239,9 @@ public class TestPruneWindowColumns
                                                 UNBOUNDED_PRECEDING,
                                                 Optional.of(startValue2),
                                                 CURRENT_ROW,
-                                                Optional.of(endValue2)))),
+                                                Optional.of(endValue2),
+                                                Optional.of(startValue2.toSymbolReference()),
+                                                Optional.of(endValue2.toSymbolReference())))),
                         hash,
                         p.values(
                                 inputs.stream()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
@@ -46,8 +46,15 @@ public class TestSwapAdjacentWindowsBySpecifications
 
     public TestSwapAdjacentWindowsBySpecifications()
     {
-        frame = new WindowNode.Frame(WindowFrame.Type.RANGE, UNBOUNDED_PRECEDING,
-                Optional.empty(), CURRENT_ROW, Optional.empty());
+        frame = new WindowNode.Frame(
+                WindowFrame.Type.RANGE,
+                UNBOUNDED_PRECEDING,
+                Optional.empty(),
+                CURRENT_ROW,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
         signature = new Signature(
                 "avg",
                 FunctionKind.WINDOW,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
@@ -103,6 +103,8 @@ public class TestWindowNode
                 FrameBound.Type.UNBOUNDED_PRECEDING,
                 Optional.empty(),
                 FrameBound.Type.UNBOUNDED_FOLLOWING,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         PlanNodeId id = newId();

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ExpressionTreeRewriter.java
@@ -508,7 +508,7 @@ public final class ExpressionTreeRewriter<C>
                     if (start.getValue().isPresent()) {
                         Expression value = rewrite(start.getValue().get(), context.get());
                         if (value != start.getValue().get()) {
-                            start = new FrameBound(start.getType(), value, start.getOriginalValue().get());
+                            start = new FrameBound(start.getType(), value);
                         }
                     }
 
@@ -518,8 +518,7 @@ public final class ExpressionTreeRewriter<C>
                         if (value.isPresent()) {
                             Expression rewrittenValue = rewrite(value.get(), context.get());
                             if (rewrittenValue != value.get()) {
-                                rewrittenEnd = Optional.of(new FrameBound(rewrittenEnd.get().getType(),
-                                        rewrittenValue, rewrittenEnd.get().getOriginalValue().get()));
+                                rewrittenEnd = Optional.of(new FrameBound(rewrittenEnd.get().getType(), rewrittenValue));
                             }
                         }
                     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FrameBound.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FrameBound.java
@@ -36,7 +36,6 @@ public class FrameBound
 
     private final Type type;
     private final Optional<Expression> value;
-    private final Optional<Expression> originalValue;
 
     public FrameBound(Type type)
     {
@@ -48,27 +47,26 @@ public class FrameBound
         this(Optional.of(location), type);
     }
 
-    public FrameBound(Type type, Expression value, Expression originalValue)
+    public FrameBound(Type type, Expression value)
     {
-        this(Optional.empty(), type, value, originalValue);
+        this(Optional.empty(), type, value);
     }
 
     private FrameBound(Optional<NodeLocation> location, Type type)
     {
-        this(location, type, null, null);
+        this(location, type, null);
     }
 
     public FrameBound(NodeLocation location, Type type, Expression value)
     {
-        this(Optional.of(location), type, value, value);
+        this(Optional.of(location), type, value);
     }
 
-    private FrameBound(Optional<NodeLocation> location, Type type, Expression value, Expression originalValue)
+    private FrameBound(Optional<NodeLocation> location, Type type, Expression value)
     {
         super(location);
         this.type = requireNonNull(type, "type is null");
         this.value = Optional.ofNullable(value);
-        this.originalValue = Optional.ofNullable(originalValue);
     }
 
     public Type getType()
@@ -79,11 +77,6 @@ public class FrameBound
     public Optional<Expression> getValue()
     {
         return value;
-    }
-
-    public Optional<Expression> getOriginalValue()
-    {
-        return originalValue;
     }
 
     @Override


### PR DESCRIPTION
Instead of recording the expressions prior to being transformed into
symbols in the AST node, store the information in the corresponding
WindowNode. This information is only used for printing the plan
and is a more natural place to do it.

Extracted from https://github.com/prestodb/presto/pull/10816 with comments addressed.