### PR TITLE
Add memory tracking for StreamReader local buffers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -22,6 +23,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -34,12 +36,15 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class BooleanStreamReader
         implements StreamReader
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(BooleanStreamReader.class).instanceSize();
+
     private final StreamDescriptor streamDescriptor;
 
     private int readOffset;
@@ -58,9 +63,12 @@ public class BooleanStreamReader
 
     private boolean rowGroupOpen;
 
-    public BooleanStreamReader(StreamDescriptor streamDescriptor)
+    private LocalMemoryContext systemMemoryContext;
+
+    public BooleanStreamReader(StreamDescriptor streamDescriptor, LocalMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
     }
 
     @Override
@@ -131,6 +139,7 @@ public class BooleanStreamReader
         int requiredVectorLength = min(nextBatchSize, MAX_BATCH_SIZE);
         if (nullVector.length < requiredVectorLength) {
             nullVector = new boolean[requiredVectorLength];
+            systemMemoryContext.setBytes(getRetainedSizeInBytes());
         }
     }
 
@@ -178,5 +187,18 @@ public class BooleanStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+        nullVector = null;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(nullVector);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -23,6 +24,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -35,12 +37,15 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class ByteStreamReader
         implements StreamReader
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteStreamReader.class).instanceSize();
+
     private final StreamDescriptor streamDescriptor;
 
     private int readOffset;
@@ -59,9 +64,12 @@ public class ByteStreamReader
 
     private boolean rowGroupOpen;
 
-    public ByteStreamReader(StreamDescriptor streamDescriptor)
+    private LocalMemoryContext systemMemoryContext;
+
+    public ByteStreamReader(StreamDescriptor streamDescriptor, LocalMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
     }
 
     @Override
@@ -132,6 +140,7 @@ public class ByteStreamReader
         int requiredVectorLength = min(nextBatchSize, MAX_BATCH_SIZE);
         if (nullVector.length < requiredVectorLength) {
             nullVector = new boolean[requiredVectorLength];
+            systemMemoryContext.setBytes(getRetainedSizeInBytes());
         }
     }
 
@@ -180,5 +189,18 @@ public class ByteStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+        nullVector = null;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(nullVector);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -23,6 +24,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -35,12 +37,15 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class DoubleStreamReader
         implements StreamReader
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DoubleStreamReader.class).instanceSize();
+
     private final StreamDescriptor streamDescriptor;
 
     private int readOffset;
@@ -59,9 +64,12 @@ public class DoubleStreamReader
 
     private boolean rowGroupOpen;
 
-    public DoubleStreamReader(StreamDescriptor streamDescriptor)
+    private LocalMemoryContext systemMemoryContext;
+
+    public DoubleStreamReader(StreamDescriptor streamDescriptor, LocalMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
     }
 
     @Override
@@ -132,6 +140,7 @@ public class DoubleStreamReader
         int requiredVectorLength = min(nextBatchSize, MAX_BATCH_SIZE);
         if (nullVector.length < requiredVectorLength) {
             nullVector = new boolean[requiredVectorLength];
+            systemMemoryContext.setBytes(getRetainedSizeInBytes());
         }
     }
 
@@ -180,5 +189,18 @@ public class DoubleStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+        nullVector = null;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(nullVector);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -23,6 +24,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -35,12 +37,15 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class FloatStreamReader
         implements StreamReader
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(FloatStreamReader.class).instanceSize();
+
     private final StreamDescriptor streamDescriptor;
 
     private int readOffset;
@@ -59,9 +64,12 @@ public class FloatStreamReader
 
     private boolean rowGroupOpen;
 
-    public FloatStreamReader(StreamDescriptor streamDescriptor)
+    private LocalMemoryContext systemMemoryContext;
+
+    public FloatStreamReader(StreamDescriptor streamDescriptor, LocalMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
     }
 
     @Override
@@ -132,6 +140,7 @@ public class FloatStreamReader
         int requiredVectorLength = min(nextBatchSize, MAX_BATCH_SIZE);
         if (nullVector.length < requiredVectorLength) {
             nullVector = new boolean[requiredVectorLength];
+            systemMemoryContext.setBytes(getRetainedSizeInBytes());
         }
     }
 
@@ -180,5 +189,18 @@ public class FloatStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+        nullVector = null;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(nullVector);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongStreamReader.java
@@ -13,14 +13,18 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.io.Closer;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY;
@@ -33,16 +37,18 @@ import static java.util.Objects.requireNonNull;
 public class LongStreamReader
         implements StreamReader
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongStreamReader.class).instanceSize();
+
     private final StreamDescriptor streamDescriptor;
     private final LongDirectStreamReader directReader;
     private final LongDictionaryStreamReader dictionaryReader;
     private StreamReader currentReader;
 
-    public LongStreamReader(StreamDescriptor streamDescriptor)
+    public LongStreamReader(StreamDescriptor streamDescriptor, AggregatedMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new LongDirectStreamReader(streamDescriptor);
-        dictionaryReader = new LongDictionaryStreamReader(streamDescriptor);
+        directReader = new LongDirectStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(LongStreamReader.class.getSimpleName()));
+        dictionaryReader = new LongDictionaryStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(LongStreamReader.class.getSimpleName()));
     }
 
     @Override
@@ -89,5 +95,23 @@ public class LongStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    @Override
+    public void close()
+    {
+        try (Closer closer = Closer.create()) {
+            closer.register(() -> directReader.close());
+            closer.register(() -> dictionaryReader.close());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + directReader.getRetainedSizeInBytes() + dictionaryReader.getRetainedSizeInBytes();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
+import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,6 +55,7 @@ import static java.util.Objects.requireNonNull;
 public class SliceDirectStreamReader
         implements StreamReader
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(SliceDirectStreamReader.class).instanceSize();
     private static final int ONE_GIGABYTE = toIntExact(new DataSize(1, GIGABYTE).toBytes());
 
     private final StreamDescriptor streamDescriptor;
@@ -255,5 +257,16 @@ public class SliceDirectStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReader.java
@@ -33,4 +33,8 @@ public interface StreamReader
 
     void startRowGroup(InputStreamSources dataStreamSources)
             throws IOException;
+
+    void close();
+
+    long getRetainedSizeInBytes();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReaders.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.orc.StreamDescriptor;
 import org.joda.time.DateTimeZone;
 
@@ -22,37 +23,40 @@ public final class StreamReaders
     {
     }
 
-    public static StreamReader createStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public static StreamReader createStreamReader(
+            StreamDescriptor streamDescriptor,
+            DateTimeZone hiveStorageTimeZone,
+            AggregatedMemoryContext systemMemoryContext)
     {
         switch (streamDescriptor.getStreamType()) {
             case BOOLEAN:
-                return new BooleanStreamReader(streamDescriptor);
+                return new BooleanStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case BYTE:
-                return new ByteStreamReader(streamDescriptor);
+                return new ByteStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case SHORT:
             case INT:
             case LONG:
             case DATE:
-                return new LongStreamReader(streamDescriptor);
+                return new LongStreamReader(streamDescriptor, systemMemoryContext);
             case FLOAT:
-                return new FloatStreamReader(streamDescriptor);
+                return new FloatStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case DOUBLE:
-                return new DoubleStreamReader(streamDescriptor);
+                return new DoubleStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case BINARY:
             case STRING:
             case VARCHAR:
             case CHAR:
-                return new SliceStreamReader(streamDescriptor);
+                return new SliceStreamReader(streamDescriptor, systemMemoryContext);
             case TIMESTAMP:
-                return new TimestampStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new TimestampStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case LIST:
-                return new ListStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new ListStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
             case STRUCT:
-                return new StructStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new StructStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
             case MAP:
-                return new MapStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new MapStreamReader(streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
             case DECIMAL:
-                return new DecimalStreamReader(streamDescriptor);
+                return new DecimalStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case UNION:
             default:
                 throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getStreamType());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.Serializer;
+import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.io.Writable;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.util.HashMap;
+
+import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
+import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
+import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
+import static com.facebook.presto.orc.OrcTester.createCustomOrcRecordReader;
+import static com.facebook.presto.orc.OrcTester.createOrcRecordWriter;
+import static com.facebook.presto.orc.OrcTester.createSettableStructObjectInspector;
+import static com.facebook.presto.spi.block.MethodHandleUtil.compose;
+import static com.facebook.presto.spi.block.MethodHandleUtil.nativeValueGetter;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.testing.Assertions.assertGreaterThan;
+import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
+import static org.testng.Assert.assertEquals;
+
+public class TestOrcReaderMemoryUsage
+{
+    private static final TypeManager TYPE_MANAGER = new TypeRegistry();
+
+    public TestOrcReaderMemoryUsage()
+    {
+        // Associate TYPE_MANAGER with a function registry.
+        new FunctionRegistry(TYPE_MANAGER, new BlockEncodingManager(TYPE_MANAGER), new FeaturesConfig());
+    }
+
+    @Test
+    public void testVarcharTypeWithoutNulls()
+            throws Exception
+    {
+        int rows = 5000;
+        OrcRecordReader reader = null;
+        try (TempFile tempFile = createSingleColumnVarcharFile(rows, 10)) {
+            reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, VARCHAR, INITIAL_BATCH_SIZE);
+            assertInitialRetainedSizes(reader, rows);
+
+            long stripeReaderRetainedSize = reader.getCurrentStripeRetainedSizeInBytes();
+            long streamReaderRetainedSize = reader.getStreamReaderRetainedSizeInBytes();
+            long readerRetainedSize = reader.getRetainedSizeInBytes();
+            long readerSystemMemoryUsage = reader.getSystemMemoryUsage();
+
+            while (true) {
+                int batchSize = reader.nextBatch();
+                if (batchSize == -1) {
+                    break;
+                }
+
+                Block block = reader.readBlock(BIGINT, 0);
+                assertEquals(block.getPositionCount(), batchSize);
+
+                // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
+                // increasing during the test, which will cause the StreamReader buffer sizes to increase too.
+                if (batchSize < MAX_BATCH_SIZE) {
+                    continue;
+                }
+
+                // StripeReader memory should increase after reading a block.
+                assertGreaterThan(reader.getCurrentStripeRetainedSizeInBytes(), stripeReaderRetainedSize);
+                // We also account for the StreamReader local buffers. For SliceDictionaryStreamReader, there are two
+                // buffers: isNullVector and inDictionaryVector, and each buffer has 1024 boolean values.
+                assertGreaterThanOrEqual(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 2048L);
+                // The total retained size and system memory usage should be strictly larger than 2048L because of the instance sizes.
+                assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 2048L);
+                assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 2048L);
+            }
+        }
+        finally {
+            if (reader != null) {
+                reader.close();
+            }
+        }
+        assertClosedRetainedSizes(reader);
+    }
+
+    @Test
+    public void testBigIntTypeWithNulls()
+            throws Exception
+    {
+        int rows = 10000;
+        OrcRecordReader reader = null;
+        try (TempFile tempFile = createSingleColumnFileWithNullValues(rows)) {
+            reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, INITIAL_BATCH_SIZE);
+            assertInitialRetainedSizes(reader, rows);
+
+            long stripeReaderRetainedSize = reader.getCurrentStripeRetainedSizeInBytes();
+            long streamReaderRetainedSize = reader.getStreamReaderRetainedSizeInBytes();
+            long readerRetainedSize = reader.getRetainedSizeInBytes();
+            long readerSystemMemoryUsage = reader.getSystemMemoryUsage();
+
+            while (true) {
+                int batchSize = reader.nextBatch();
+                if (batchSize == -1) {
+                    break;
+                }
+
+                Block block = reader.readBlock(BIGINT, 0);
+                assertEquals(block.getPositionCount(), batchSize);
+
+                // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
+                // increasing during the test, which will cause the StreamReader buffer sizes to increase too.
+                if (batchSize < MAX_BATCH_SIZE) {
+                    continue;
+                }
+
+                // StripeReader memory should increase after reading a block.
+                assertGreaterThan(reader.getCurrentStripeRetainedSizeInBytes(), stripeReaderRetainedSize);
+                // We also account for the StreamReader local buffers. For LongDirectStreamReader, there is one
+                // buffer isNullVector, and it has 1024 boolean values.
+                assertGreaterThanOrEqual(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 1024L);
+                // The total retained size and system memory usage should be strictly larger than 2048L because of the instance sizes.
+                assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 1024L);
+                assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 1024L);
+            }
+        }
+        finally {
+            if (reader != null) {
+                reader.close();
+            }
+        }
+        assertClosedRetainedSizes(reader);
+    }
+
+    @Test
+    public void testMapTypeWithNulls()
+            throws Exception
+    {
+        Type keyType = BIGINT;
+        Type valueType = BIGINT;
+
+        MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
+        MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+        MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
+        MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+        MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
+
+        MapType mapType = new MapType(
+                keyType,
+                valueType,
+                keyBlockNativeEquals,
+                keyBlockEquals,
+                keyNativeHashCode,
+                keyBlockHashCode);
+
+        int rows = 10000;
+        OrcRecordReader reader = null;
+        try (TempFile tempFile = createSingleColumnMapFileWithNullValues(mapType, rows)) {
+            reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, mapType, INITIAL_BATCH_SIZE);
+            assertInitialRetainedSizes(reader, rows);
+
+            long stripeReaderRetainedSize = reader.getCurrentStripeRetainedSizeInBytes();
+            long streamReaderRetainedSize = reader.getStreamReaderRetainedSizeInBytes();
+            long readerRetainedSize = reader.getRetainedSizeInBytes();
+            long readerSystemMemoryUsage = reader.getSystemMemoryUsage();
+
+            while (true) {
+                int batchSize = reader.nextBatch();
+                if (batchSize == -1) {
+                    break;
+                }
+
+                Block block = reader.readBlock(mapType, 0);
+                assertEquals(block.getPositionCount(), batchSize);
+
+                // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
+                // increasing during the test, which will cause the StreamReader buffer sizes to increase too.
+                if (batchSize < MAX_BATCH_SIZE) {
+                    continue;
+                }
+
+                // StripeReader memory should increase after reading a block.
+                assertGreaterThan(reader.getCurrentStripeRetainedSizeInBytes(), stripeReaderRetainedSize);
+                // We also account the StreamReader local buffers. For MapStreamReader, there is a
+                // keyStreamReader(LongStreamReader) and a valueStreamReader(LongStreamReader), and each of them is
+                // holding a isNullVector buffer which has 1024 boolean values.
+                assertGreaterThanOrEqual(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 2048L);
+                // The total retained size and system memory usage should be strictly larger than 2048L because of the instance sizes.
+                assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 2048L);
+                assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 2048L);
+            }
+        }
+        finally {
+            if (reader != null) {
+                reader.close();
+            }
+        }
+        assertClosedRetainedSizes(reader);
+    }
+
+    /**
+     * Write a file that contains a number of rows with 1 BIGINT column, and some rows have null values.
+     */
+    private static TempFile createSingleColumnFileWithNullValues(int rows)
+            throws IOException, ReflectiveOperationException, SerDeException
+    {
+        Serializer serde = new OrcSerde();
+        TempFile tempFile = new TempFile();
+        FileSinkOperator.RecordWriter writer = createOrcRecordWriter(tempFile.getFile(), ORC_12, CompressionKind.NONE, BIGINT);
+        SettableStructObjectInspector objectInspector = createSettableStructObjectInspector("test", BIGINT);
+        Object row = objectInspector.create();
+        StructField field = objectInspector.getAllStructFieldRefs().get(0);
+
+        for (int i = 0; i < rows; i++) {
+            if (i % 10 == 0) {
+                objectInspector.setStructFieldData(row, field, null);
+            }
+            else {
+                objectInspector.setStructFieldData(row, field, (long) i);
+            }
+
+            Writable record = serde.serialize(row, objectInspector);
+            writer.write(record);
+        }
+
+        writer.close(false);
+        return tempFile;
+    }
+
+    /**
+     * Write a file that contains a number of rows with 1 VARCHAR column, and all values are not null.
+     */
+    private static TempFile createSingleColumnVarcharFile(int count, int length)
+            throws Exception
+    {
+        Serializer serde = new OrcSerde();
+        TempFile tempFile = new TempFile();
+        FileSinkOperator.RecordWriter writer = createOrcRecordWriter(tempFile.getFile(), ORC_12, CompressionKind.NONE, VARCHAR);
+        SettableStructObjectInspector objectInspector = createSettableStructObjectInspector("test", VARCHAR);
+        Object row = objectInspector.create();
+        StructField field = objectInspector.getAllStructFieldRefs().get(0);
+
+        for (int i = 0; i < count; i++) {
+            objectInspector.setStructFieldData(row, field, Strings.repeat("0", length));
+            Writable record = serde.serialize(row, objectInspector);
+            writer.write(record);
+        }
+
+        writer.close(false);
+        return tempFile;
+    }
+
+    /**
+     * Write a file that contains a given number of maps where each row has 10 entries in total
+     * and some entries have null keys/values.
+     */
+    private static TempFile createSingleColumnMapFileWithNullValues(Type mapType, int rows)
+            throws IOException, ReflectiveOperationException, SerDeException
+    {
+        Serializer serde = new OrcSerde();
+        TempFile tempFile = new TempFile();
+        FileSinkOperator.RecordWriter writer = createOrcRecordWriter(tempFile.getFile(), ORC_12, CompressionKind.NONE, mapType);
+        SettableStructObjectInspector objectInspector = createSettableStructObjectInspector("test", mapType);
+        Object row = objectInspector.create();
+        StructField field = objectInspector.getAllStructFieldRefs().get(0);
+
+        for (int i = 1; i <= rows; i++) {
+            HashMap<Long, Long> map = new HashMap<>();
+
+            for (int j = 1; j <= 8; j++) {
+                Long value = (long) j;
+                map.put(value, value);
+            }
+
+            // Add null values so that the StreamReader nullVectors are not empty.
+            map.put(null, 0L);
+            map.put(0L, null);
+
+            objectInspector.setStructFieldData(row, field, map);
+            Writable record = serde.serialize(row, objectInspector);
+            writer.write(record);
+        }
+        writer.close(false);
+        return tempFile;
+    }
+
+    private static void assertInitialRetainedSizes(OrcRecordReader reader, int rows)
+    {
+        assertEquals(reader.getReaderRowCount(), rows);
+        assertEquals(reader.getReaderPosition(), 0);
+        assertEquals(reader.getCurrentStripeRetainedSizeInBytes(), 0);
+        // there will be object overheads
+        assertGreaterThan(reader.getStreamReaderRetainedSizeInBytes(), 0L);
+        // there will be object overheads
+        assertGreaterThan(reader.getRetainedSizeInBytes(), 0L);
+        assertEquals(reader.getSystemMemoryUsage(), 0);
+    }
+
+    private static void assertClosedRetainedSizes(OrcRecordReader reader)
+    {
+        assertEquals(reader.getCurrentStripeRetainedSizeInBytes(), 0);
+        // after close() we still account for the StreamReader instance sizes.
+        assertGreaterThan(reader.getStreamReaderRetainedSizeInBytes(), 0L);
+        // after close() we still account for the StreamReader instance sizes.
+        assertGreaterThan(reader.getRetainedSizeInBytes(), 0L);
+        assertEquals(reader.getSystemMemoryUsage(), 0);
+    }
+}


### PR DESCRIPTION
We use some vectors as local buffers in the StreamReaders, but they were
not tracked in the system pool. This amount is inegligible, because
there is one thread created for each stage/task/split, and for each
thread, multiple StreamReaders would be created depending on the number
of columns and column type. The number of StreamReaders could be very
big. And each StreamReader could hold buffers of a few KB. Altogher
this can be a large amount.

This commit is to track this part of memory usage as part of the
PageSource system memory usage.

We also try to include the instance sizes for the StreamReaders that
have at least one local buffer. The StreamReaders that don't have a
local buffer were not counted, i.e. all non-leaf level ones, like
ListStreamReader, MapStreamReader, and SliceDirectStreamReader, which
is a leaf level StreamReader but does not use a local buffer. This is
trying to follow the MemoryContext usage convention and not to confuse
people by updating the MemoryContext in each constructors. This missing
part could be a couple of dozens of MB on each worker node and not
significant.