### PR TITLE
Heuristically account for auxiliary structures in getOutputSizeInBytes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
@@ -93,7 +93,7 @@ public class CostCalculatorUsingExchanges
     @Override
     public PlanNodeCostEstimate calculateCost(PlanNode node, StatsProvider stats, Lookup lookup, Session session, Map<Symbol, Type> types)
     {
-        CostEstimator costEstimator = new CostEstimator(numberOfNodes.getAsInt(), stats);
+        CostEstimator costEstimator = new CostEstimator(numberOfNodes.getAsInt(), stats, types);
         return node.accept(costEstimator, null);
     }
 
@@ -102,11 +102,13 @@ public class CostCalculatorUsingExchanges
     {
         private final int numberOfNodes;
         private final StatsProvider stats;
+        private final Map<Symbol, Type> types;
 
-        CostEstimator(int numberOfNodes, StatsProvider stats)
+        CostEstimator(int numberOfNodes, StatsProvider stats, Map<Symbol, Type> types)
         {
             this.numberOfNodes = numberOfNodes;
             this.stats = requireNonNull(stats, "stats is null");
+            this.types = requireNonNull(types, "types is null");
         }
 
         @Override
@@ -124,7 +126,7 @@ public class CostCalculatorUsingExchanges
         @Override
         public PlanNodeCostEstimate visitAssignUniqueId(AssignUniqueId node, Void context)
         {
-            return cpuCost(getStats(node).getOutputSizeInBytes(ImmutableList.of(node.getIdColumn())));
+            return cpuCost(getStats(node).getOutputSizeInBytes(ImmutableList.of(node.getIdColumn()), types));
         }
 
         @Override
@@ -137,19 +139,19 @@ public class CostCalculatorUsingExchanges
         public PlanNodeCostEstimate visitTableScan(TableScanNode node, Void context)
         {
             // TODO: add network cost, based on input size in bytes? Or let connector provide this cost?
-            return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols()));
+            return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
         public PlanNodeCostEstimate visitFilter(FilterNode node, Void context)
         {
-            return cpuCost(getStats(node.getSource()).getOutputSizeInBytes(node.getOutputSymbols()));
+            return cpuCost(getStats(node.getSource()).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
         public PlanNodeCostEstimate visitProject(ProjectNode node, Void context)
         {
-            return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols()));
+            return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         @Override
@@ -157,8 +159,8 @@ public class CostCalculatorUsingExchanges
         {
             PlanNodeStatsEstimate aggregationStats = getStats(node);
             PlanNodeStatsEstimate sourceStats = getStats(node.getSource());
-            double cpuCost = sourceStats.getOutputSizeInBytes(node.getSource().getOutputSymbols());
-            double memoryCost = aggregationStats.getOutputSizeInBytes(node.getOutputSymbols());
+            double cpuCost = sourceStats.getOutputSizeInBytes(node.getSource().getOutputSymbols(), types);
+            double memoryCost = aggregationStats.getOutputSizeInBytes(node.getOutputSymbols(), types);
             return new PlanNodeCostEstimate(cpuCost, memoryCost, 0);
         }
 
@@ -180,9 +182,9 @@ public class CostCalculatorUsingExchanges
             PlanNodeStatsEstimate buildStats = getStats(build);
             PlanNodeStatsEstimate outputStats = getStats(join);
 
-            double buildSideSize = buildStats.getOutputSizeInBytes(build.getOutputSymbols());
-            double probeSideSize = probeStats.getOutputSizeInBytes(probe.getOutputSymbols());
-            double joinOutputSize = outputStats.getOutputSizeInBytes(join.getOutputSymbols());
+            double buildSideSize = buildStats.getOutputSizeInBytes(build.getOutputSymbols(), types);
+            double probeSideSize = probeStats.getOutputSizeInBytes(probe.getOutputSymbols(), types);
+            double joinOutputSize = outputStats.getOutputSizeInBytes(join.getOutputSymbols(), types);
 
             double cpuCost = probeSideSize +
                     buildSideSize * numberOfNodesMultiplier +
@@ -202,7 +204,7 @@ public class CostCalculatorUsingExchanges
         @Override
         public PlanNodeCostEstimate visitExchange(ExchangeNode node, Void context)
         {
-            return calculateExchangeCost(numberOfNodes, getStats(node), node.getOutputSymbols(), node.getType(), node.getScope());
+            return calculateExchangeCost(numberOfNodes, getStats(node), node.getOutputSymbols(), node.getType(), node.getScope(), types);
         }
 
         @Override
@@ -234,7 +236,7 @@ public class CostCalculatorUsingExchanges
             // so proper cost estimation is not that important. Second, since LimitNode can lead to incomplete evaluation
             // of the source, true cost estimation should be implemented as a "constraint" enforced on a sub-tree and
             // evaluated in context of actual source node type (and their sources).
-            return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols()));
+            return cpuCost(getStats(node).getOutputSizeInBytes(node.getOutputSymbols(), types));
         }
 
         private PlanNodeStatsEstimate getStats(PlanNode node)
@@ -248,9 +250,10 @@ public class CostCalculatorUsingExchanges
             PlanNodeStatsEstimate exchangeStats,
             List<Symbol> symbols,
             ExchangeNode.Type type,
-            ExchangeNode.Scope scope)
+            ExchangeNode.Scope scope,
+            Map<Symbol, Type> types)
     {
-        double exchangeSize = exchangeStats.getOutputSizeInBytes(symbols);
+        double exchangeSize = exchangeStats.getOutputSizeInBytes(symbols, types);
 
         double network;
         double cpu = 0;

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -35,7 +35,7 @@ import static java.util.Objects.requireNonNull;
 
 public class PlanNodeStatsEstimate
 {
-    private static final double DEFAULT_DATA_SIZE_PER_COLUMN = 10;
+    private static final double DEFAULT_DATA_SIZE_PER_COLUMN = 50;
     public static final PlanNodeStatsEstimate UNKNOWN_STATS = builder().build();
 
     private final double outputRowCount;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -1377,7 +1377,7 @@ public class PlanPrinter
             PlanNodeCostEstimate cost = costProvider.getCumulativeCost(node);
             return String.format("{rows: %s (%s), cpu: %s, memory: %s, network: %s}",
                     formatAsLong(stats.getOutputRowCount()),
-                    formatEstimateAsDataSize(stats.getOutputSizeInBytes(node.getOutputSymbols())),
+                    formatEstimateAsDataSize(stats.getOutputSizeInBytes(node.getOutputSymbols(), types)),
                     formatDouble(cost.getCpuCost()),
                     formatDouble(cost.getMemoryCost()),
                     formatDouble(cost.getNetworkCost()));


### PR DESCRIPTION
    Auxiliary structures size was ignored when output size
    was computed for symbol. This causes large underestimation
    for VARCHAR/CHAR columns if average row length extracted from
    Hive stats is small (e.g: 1 or 2 bytes). Even though actual
    row data is small Presto still processes Blocks with large
    auxiliary structures that cause CPU overhead. Not including
    those in stats causes wrong join orders to be selected.