### PR TITLE
Add support for Linux ppc64le

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hadoop</groupId>
                 <artifactId>hadoop-apache2</artifactId>
-                <version>2.7.4-2</version>
+                <version>2.7.4-3</version>
             </dependency>
 
             <dependency>

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -40,18 +40,42 @@ final class PrestoSystemRequirements
 
     public static void verifyJvmRequirements()
     {
+        verifyJvmVendor();
+        verifyJavaVersion();
+        verify64BitJvm();
+        verifyOsArchitecture();
+        verifyByteOrder();
+        verifyUsingG1Gc();
+        verifyFileDescriptor();
+        verifySlice();
+    }
+
+    private static void verifyJvmVendor()
+    {
         String vendor = StandardSystemProperty.JAVA_VENDOR.value();
         if (!"Oracle Corporation".equals(vendor)) {
             failRequirement("Presto requires an Oracle or OpenJDK JVM (found %s)", vendor);
         }
+    }
 
-        verifyJavaVersion();
-
+    private static void verify64BitJvm()
+    {
         String dataModel = System.getProperty("sun.arch.data.model");
         if (!"64".equals(dataModel)) {
             failRequirement("Presto requires a 64-bit JVM (found %s)", dataModel);
         }
+    }
 
+    private static void verifyByteOrder()
+    {
+        ByteOrder order = ByteOrder.nativeOrder();
+        if (!order.equals(ByteOrder.LITTLE_ENDIAN)) {
+            failRequirement("Presto requires a little endian platform (found %s)", order);
+        }
+    }
+
+    private static void verifyOsArchitecture()
+    {
         String osName = StandardSystemProperty.OS_NAME.value();
         String osArch = StandardSystemProperty.OS_ARCH.value();
         if ("Linux".equals(osName)) {
@@ -67,16 +91,6 @@ final class PrestoSystemRequirements
         else {
             failRequirement("Presto requires Linux or Mac OS X (found %s)", osName);
         }
-
-        if (!ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)) {
-            failRequirement("Presto requires a little endian platform (found %s)", ByteOrder.nativeOrder());
-        }
-
-        verifyUsingG1Gc();
-
-        verifyFileDescriptor();
-
-        verifySlice();
     }
 
     private static void verifyJavaVersion()

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -79,8 +79,11 @@ final class PrestoSystemRequirements
         String osName = StandardSystemProperty.OS_NAME.value();
         String osArch = StandardSystemProperty.OS_ARCH.value();
         if ("Linux".equals(osName)) {
-            if (!"amd64".equals(osArch)) {
-                failRequirement("Presto requires x86-64 or amd64 on Linux (found %s)", osArch);
+            if (!"amd64".equals(osArch) && !"ppc64le".equals(osArch)) {
+                failRequirement("Presto requires amd64 or ppc64le on Linux (found %s)", osArch);
+            }
+            if ("ppc64le".equals(osArch)) {
+                warnRequirement("Support for the POWER architecture is experimental");
             }
         }
         else if ("Mac OS X".equals(osName)) {


### PR DESCRIPTION
The Hadoop dependency is a snapshot. I will release it and update to the
release version before merging this PR.
See https://github.com/prestodb/presto-hadoop-apache2/pull/29

The full build with tests will not run on ppc64le due to various missing
native binaries used by the tests.