### PR TITLE
Remove PlanBuilder method which was not following convention

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushLimitThroughMarkDistinct.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushLimitThroughMarkDistinct.java
@@ -33,7 +33,7 @@ public class TestPushLimitThroughMarkDistinct
                         p.limit(
                                 1,
                                 p.markDistinct(
-                                        p.values(), p.symbol("foo"), emptyList())))
+                                        p.symbol("foo"), emptyList(), p.values())))
                 .matches(
                         node(MarkDistinctNode.class,
                                 node(LimitNode.class,
@@ -46,11 +46,11 @@ public class TestPushLimitThroughMarkDistinct
         tester().assertThat(new PushLimitThroughMarkDistinct())
                 .on(p ->
                         p.markDistinct(
+                                p.symbol("foo"),
+                                emptyList(),
                                 p.limit(
                                         1,
-                                        p.values()),
-                                p.symbol("foo"),
-                                emptyList()))
+                                        p.values())))
                 .doesNotFire();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -182,11 +182,6 @@ public class PlanBuilder
         return new LimitNode(idAllocator.getNextId(), source, limit, false);
     }
 
-    public MarkDistinctNode markDistinct(PlanNode source, Symbol markerSymbol, List<Symbol> distinctSymbols)
-    {
-        return new MarkDistinctNode(idAllocator.getNextId(), source, markerSymbol, distinctSymbols, Optional.empty());
-    }
-
     public TopNNode topN(long count, List<Symbol> orderBy, PlanNode source)
     {
         return new TopNNode(


### PR DESCRIPTION
Remove PlanBuilder method which was not following convention

Convention in PlanBuilder is that source argument is passed as last.
That way one can structure code like:
pb.node(
    ...
    pb.node(
      ...
      pb.node()))
