### PR TITLE
Add support for tagging memory allocations

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetReader.java
@@ -211,7 +211,7 @@ public class ParquetReader
     private byte[] allocateBlock(int length)
     {
         byte[] buffer = new byte[length];
-        LocalMemoryContext blockMemoryContext = currentRowGroupMemoryContext.newLocalMemoryContext();
+        LocalMemoryContext blockMemoryContext = currentRowGroupMemoryContext.newLocalMemoryContext(ParquetReader.class.getSimpleName());
         blockMemoryContext.setBytes(buffer.length);
         return buffer;
     }

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -366,6 +366,15 @@ public class ClusterMemoryManager
         return ImmutableMap.copyOf(pools);
     }
 
+    public synchronized Map<MemoryPoolId, MemoryPoolInfo> getMemoryPoolInfo()
+    {
+        ImmutableMap.Builder<MemoryPoolId, MemoryPoolInfo> builder = new ImmutableMap.Builder<>();
+        pools.forEach((poolId, memoryPool) -> {
+            builder.put(poolId, memoryPool.getInfo());
+        });
+        return builder.build();
+    }
+
     private synchronized boolean isClusterOutOfMemory()
     {
         ClusterMemoryPool reservedPool = pools.get(RESERVED_POOL);

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.memory;
 
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.memory.MemoryAllocation;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.memory.MemoryPoolInfo;
 import com.google.common.collect.ImmutableMap;
@@ -22,6 +23,7 @@ import org.weakref.jmx.Managed;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +60,9 @@ public class ClusterMemoryPool
     private final Map<QueryId, Long> queryMemoryReservations = new HashMap<>();
 
     @GuardedBy("this")
+    private final Map<QueryId, List<MemoryAllocation>> queryMemoryAllocations = new HashMap<>();
+
+    @GuardedBy("this")
     private final Map<QueryId, Long> queryMemoryRevocableReservations = new HashMap<>();
 
     public ClusterMemoryPool(MemoryPoolId id)
@@ -72,6 +77,7 @@ public class ClusterMemoryPool
                 reservedDistributedBytes,
                 reservedRevocableDistributedBytes,
                 ImmutableMap.copyOf(queryMemoryReservations),
+                ImmutableMap.copyOf(queryMemoryAllocations),
                 ImmutableMap.copyOf(queryMemoryRevocableReservations));
     }
 
@@ -141,6 +147,7 @@ public class ClusterMemoryPool
         reservedRevocableDistributedBytes = 0;
         this.assignedQueries = assignedQueries;
         this.queryMemoryReservations.clear();
+        this.queryMemoryAllocations.clear();
         this.queryMemoryRevocableReservations.clear();
 
         for (MemoryInfo info : memoryInfos) {
@@ -156,11 +163,35 @@ public class ClusterMemoryPool
                 for (Map.Entry<QueryId, Long> entry : poolInfo.getQueryMemoryReservations().entrySet()) {
                     queryMemoryReservations.merge(entry.getKey(), entry.getValue(), Long::sum);
                 }
+                for (Map.Entry<QueryId, List<MemoryAllocation>> entry : poolInfo.getQueryMemoryAllocations().entrySet()) {
+                    queryMemoryAllocations.merge(entry.getKey(), entry.getValue(), this::mergeQueryAllocations);
+                }
                 for (Map.Entry<QueryId, Long> entry : poolInfo.getQueryMemoryRevocableReservations().entrySet()) {
                     queryMemoryRevocableReservations.merge(entry.getKey(), entry.getValue(), Long::sum);
                 }
             }
         }
+    }
+
+    private List<MemoryAllocation> mergeQueryAllocations(List<MemoryAllocation> left, List<MemoryAllocation> right)
+    {
+        requireNonNull(left, "left is null");
+        requireNonNull(right, "right is null");
+
+        Map<String, MemoryAllocation> mergedAllocations = new HashMap<>();
+
+        for (MemoryAllocation allocation : left) {
+            mergedAllocations.put(allocation.getTag(), allocation);
+        }
+
+        for (MemoryAllocation allocation : right) {
+            mergedAllocations.merge(
+                    allocation.getTag(),
+                    allocation,
+                    (a, b) -> new MemoryAllocation(a.getTag(), a.getAllocation() + b.getAllocation()));
+        }
+
+        return new ArrayList<>(mergedAllocations.values());
     }
 
     @Override
@@ -195,6 +226,7 @@ public class ClusterMemoryPool
                 .add("blockedNodes", blockedNodes)
                 .add("assignedQueries", assignedQueries)
                 .add("queryMemoryReservations", queryMemoryReservations)
+                .add("queryMemoryAllocations", queryMemoryAllocations)
                 .add("queryMemoryRevocableReservations", queryMemoryRevocableReservations)
                 .toString();
     }

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -14,8 +14,11 @@
 package com.facebook.presto.memory;
 
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.memory.MemoryAllocation;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.memory.MemoryPoolInfo;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
@@ -24,9 +27,11 @@ import org.weakref.jmx.Managed;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
@@ -52,6 +57,11 @@ public class MemoryPool
     @GuardedBy("this")
     // TODO: It would be better if we just tracked QueryContexts, but their lifecycle is managed by a weak reference, so we can't do that
     private final Map<QueryId, Long> queryMemoryReservations = new HashMap<>();
+
+    // This map keeps track of all the tagged allocations, e.g., query-1 -> ['TableScanOperator': 10MB, 'LazyOutputBuffer': 5MB, ...]
+    @GuardedBy("this")
+    private final Map<QueryId, Map<String, Long>> taggedMemoryAllocations = new HashMap<>();
+
     @GuardedBy("this")
     private final Map<QueryId, Long> queryMemoryRevocableReservations = new HashMap<>();
 
@@ -71,7 +81,15 @@ public class MemoryPool
 
     public synchronized MemoryPoolInfo getInfo()
     {
-        return new MemoryPoolInfo(maxBytes, reservedBytes, reservedRevocableBytes, queryMemoryReservations, queryMemoryRevocableReservations);
+        Map<QueryId, List<MemoryAllocation>> memoryAllocations = new HashMap<>();
+        taggedMemoryAllocations.forEach((queryId, allocationMap) -> {
+            List<MemoryAllocation> allocations = new ArrayList<>();
+            allocationMap.forEach((tag, allocation) -> {
+                allocations.add(new MemoryAllocation(tag, allocation));
+            });
+            memoryAllocations.put(queryId, allocations);
+        });
+        return new MemoryPoolInfo(maxBytes, reservedBytes, reservedRevocableBytes, queryMemoryReservations, memoryAllocations, queryMemoryRevocableReservations);
     }
 
     public void addListener(MemoryPoolListener listener)
@@ -87,7 +105,7 @@ public class MemoryPool
     /**
      * Reserves the given number of bytes. Caller should wait on the returned future, before allocating more memory.
      */
-    public ListenableFuture<?> reserve(QueryId queryId, long bytes)
+    public ListenableFuture<?> reserve(QueryId queryId, Optional<String> allocationTag, long bytes)
     {
         checkArgument(bytes >= 0, "bytes is negative");
 
@@ -95,6 +113,7 @@ public class MemoryPool
         synchronized (this) {
             if (bytes != 0) {
                 queryMemoryReservations.merge(queryId, bytes, Long::sum);
+                allocationTag.ifPresent(tag -> updateTaggedMemoryAllocations(queryId, tag, bytes));
             }
             reservedBytes += bytes;
             if (getFreeBytes() <= 0) {
@@ -111,6 +130,11 @@ public class MemoryPool
 
         onMemoryReserved();
         return result;
+    }
+
+    public ListenableFuture<?> reserve(QueryId queryId, long bytes)
+    {
+        return reserve(queryId, Optional.empty(), bytes);
     }
 
     private void onMemoryReserved()
@@ -147,7 +171,7 @@ public class MemoryPool
     /**
      * Try to reserve the given number of bytes. Return value indicates whether the caller may use the requested memory.
      */
-    public boolean tryReserve(QueryId queryId, long bytes)
+    public boolean tryReserve(QueryId queryId, Optional<String> allocationTag, long bytes)
     {
         checkArgument(bytes >= 0, "bytes is negative");
         synchronized (this) {
@@ -157,6 +181,7 @@ public class MemoryPool
             reservedBytes += bytes;
             if (bytes != 0) {
                 queryMemoryReservations.merge(queryId, bytes, Long::sum);
+                allocationTag.ifPresent(tag -> updateTaggedMemoryAllocations(queryId, tag, bytes));
             }
         }
 
@@ -164,7 +189,12 @@ public class MemoryPool
         return true;
     }
 
-    public synchronized void free(QueryId queryId, long bytes)
+    public boolean tryReserve(QueryId queryId, long bytes)
+    {
+        return tryReserve(queryId, Optional.empty(), bytes);
+    }
+
+    public synchronized void free(QueryId queryId, Optional<String> allocationTag, long bytes)
     {
         checkArgument(bytes >= 0, "bytes is negative");
         checkArgument(reservedBytes >= bytes, "tried to free more memory than is reserved");
@@ -179,15 +209,22 @@ public class MemoryPool
         queryReservation -= bytes;
         if (queryReservation == 0) {
             queryMemoryReservations.remove(queryId);
+            taggedMemoryAllocations.remove(queryId);
         }
         else {
             queryMemoryReservations.put(queryId, queryReservation);
+            allocationTag.ifPresent(tag -> updateTaggedMemoryAllocations(queryId, tag, -bytes));
         }
         reservedBytes -= bytes;
         if (getFreeBytes() > 0 && future != null) {
             future.set(null);
             future = null;
         }
+    }
+
+    public synchronized void free(QueryId queryId, long bytes)
+    {
+        free(queryId, Optional.empty(), bytes);
     }
 
     public synchronized void freeRevocable(QueryId queryId, long bytes)
@@ -285,5 +322,26 @@ public class MemoryPool
         {
             throw new UnsupportedOperationException("cancellation is not supported");
         }
+    }
+
+    private synchronized void updateTaggedMemoryAllocations(QueryId queryId, String allocationTag, long delta)
+    {
+        Map<String, Long> allocations = taggedMemoryAllocations.computeIfAbsent(queryId, ignored -> new HashMap<>());
+        allocations.compute(allocationTag, (ignored, oldValue) -> {
+            if (oldValue == null) {
+                return delta;
+            }
+            long newValue = oldValue.longValue() + delta;
+            if (newValue == 0) {
+                return null;
+            }
+            return newValue;
+        });
+    }
+
+    @VisibleForTesting
+    synchronized Map<QueryId, Map<String, Long>> getTaggedMemoryAllocations()
+    {
+        return ImmutableMap.copyOf(taggedMemoryAllocations);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryResource.java
@@ -14,15 +14,20 @@
 package com.facebook.presto.memory;
 
 import com.facebook.presto.execution.TaskManager;
+import com.facebook.presto.spi.memory.MemoryPoolId;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
 /**
  * Manages memory pools on this worker node
@@ -47,5 +52,18 @@ public class MemoryResource
     {
         taskManager.updateMemoryPoolAssignments(request);
         return memoryManager.getInfo();
+    }
+
+    @GET
+    @Path("{poolId}")
+    public Response getMemoryInfo(@PathParam("poolId") String poolId)
+    {
+        MemoryPool memoryPool = memoryManager.getPool(new MemoryPoolId(poolId));
+        if (memoryPool == null) {
+            return Response.status(NOT_FOUND).build();
+        }
+        return Response.ok()
+                .entity(memoryPool.getInfo())
+                .build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
@@ -92,7 +92,7 @@ public class AggregationOperator
     public AggregationOperator(OperatorContext operatorContext, Step step, List<AccumulatorFactory> accumulatorFactories)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(AggregationOperator.class.getSimpleName());
         this.userMemoryContext = operatorContext.localUserMemoryContext();
 
         requireNonNull(step, "step is null");

--- a/presto-main/src/main/java/com/facebook/presto/operator/FilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FilterAndProjectOperator.java
@@ -45,7 +45,7 @@ public class FilterAndProjectOperator
     {
         this.processor = requireNonNull(processor, "processor is null");
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.outputMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        this.outputMemoryContext = operatorContext.newLocalSystemMemoryContext(FilterAndProjectOperator.class.getSimpleName());
         this.mergingOutput = requireNonNull(mergingOutput, "mergingOutput is null");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -407,7 +407,7 @@ public class HashBuilderOperator
         spiller = Optional.of(singleStreamSpillerFactory.create(
                 index.getTypes(),
                 operatorContext.getSpillContext().newLocalSpillContext(),
-                operatorContext.newLocalSystemMemoryContext()));
+                operatorContext.newLocalSystemMemoryContext(HashBuilderOperator.class.getSimpleName())));
         return getSpiller().spill(index.getPages());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -130,6 +130,7 @@ public class OperatorContext
         this.revocableMemoryFuture = new AtomicReference<>(SettableFuture.create());
         this.revocableMemoryFuture.get().set(null);
         this.operatorMemoryContext = requireNonNull(operatorMemoryContext, "operatorMemoryContext is null");
+        operatorMemoryContext.initializeLocalMemoryContexts(operatorType);
 
         collectTimings = driverContext.isVerboseStats() && driverContext.isCpuTimerEnabled();
     }
@@ -254,9 +255,9 @@ public class OperatorContext
     }
 
     // caller should close this context as it's a new context
-    public LocalMemoryContext newLocalSystemMemoryContext()
+    public LocalMemoryContext newLocalSystemMemoryContext(String allocationTag)
     {
-        return new InternalLocalMemoryContext(operatorMemoryContext.newSystemMemoryContext(), memoryFuture, this::updatePeakMemoryReservations, true);
+        return new InternalLocalMemoryContext(operatorMemoryContext.newSystemMemoryContext(allocationTag), memoryFuture, this::updatePeakMemoryReservations, true);
     }
 
     // caller shouldn't close this context as it's managed by the OperatorContext
@@ -670,9 +671,9 @@ public class OperatorContext
         }
 
         @Override
-        public LocalMemoryContext newLocalMemoryContext()
+        public LocalMemoryContext newLocalMemoryContext(String allocationTag)
         {
-            return new InternalLocalMemoryContext(delegate.newLocalMemoryContext(), memoryFuture, allocationListener, true);
+            return new InternalLocalMemoryContext(delegate.newLocalMemoryContext(allocationTag), memoryFuture, allocationListener, true);
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
@@ -223,7 +223,7 @@ public class PartitionedOutputOperator
                 maxMemory);
 
         operatorContext.setInfoSupplier(this::getInfo);
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(PartitionedOutputOperator.class.getSimpleName());
         this.partitionsInitialRetainedSize = this.partitionFunction.getRetainedSizeInBytes();
         this.systemMemoryContext.setBytes(partitionsInitialRetainedSize);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -106,6 +106,8 @@ public class PipelineContext
         this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
         this.yieldExecutor = requireNonNull(yieldExecutor, "yieldExecutor is null");
         this.pipelineMemoryContext = requireNonNull(pipelineMemoryContext, "pipelineMemoryContext is null");
+        // Initialize the local memory contexts with the ExchangeOperator tag as ExchangeOperator will do the local memory allocations
+        pipelineMemoryContext.initializeLocalMemoryContexts(ExchangeOperator.class.getSimpleName());
     }
 
     public TaskContext getTaskContext()

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -90,8 +90,8 @@ public class ScanFilterAndProjectOperator
         this.planNodeId = requireNonNull(sourceId, "sourceId is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
-        this.pageSourceMemoryContext = operatorContext.newLocalSystemMemoryContext();
-        this.pageBuilderMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        this.pageSourceMemoryContext = operatorContext.newLocalSystemMemoryContext(ScanFilterAndProjectOperator.class.getSimpleName());
+        this.pageBuilderMemoryContext = operatorContext.newLocalSystemMemoryContext(ScanFilterAndProjectOperator.class.getSimpleName());
         this.mergingOutput = requireNonNull(mergingOutput, "mergingOutput is null");
 
         this.pageBuilder = new PageBuilder(ImmutableList.copyOf(requireNonNull(types, "types is null")));

--- a/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
@@ -102,7 +102,7 @@ public class StreamingAggregationOperator
     public StreamingAggregationOperator(OperatorContext operatorContext, List<Type> sourceTypes, List<Type> groupByTypes, List<Integer> groupByChannels, Step step, List<AccumulatorFactory> accumulatorFactories, JoinCompiler joinCompiler)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(StreamingAggregationOperator.class.getSimpleName());
         this.userMemoryContext = operatorContext.localUserMemoryContext();
         this.groupByTypes = ImmutableList.copyOf(requireNonNull(groupByTypes, "groupByTypes is null"));
         this.groupByChannels = Ints.toArray(requireNonNull(groupByChannels, "groupByChannels is null"));

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -113,7 +113,7 @@ public class TableScanOperator
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(TableScanOperator.class.getSimpleName());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
@@ -136,7 +136,7 @@ public class TableWriterOperator
             List<Integer> inputChannels)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.pageSinkMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        this.pageSinkMemoryContext = operatorContext.newLocalSystemMemoryContext(TableWriterOperator.class.getSimpleName());
         this.pageSink = requireNonNull(pageSink, "pageSink is null");
         this.inputChannels = requireNonNull(inputChannels, "inputChannels is null");
         this.operatorContext.setInfoSupplier(this::getInfo);

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -18,6 +18,7 @@ import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskState;
 import com.facebook.presto.execution.TaskStateMachine;
+import com.facebook.presto.execution.buffer.LazyOutputBuffer;
 import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.memory.QueryContextVisitor;
 import com.facebook.presto.memory.context.LocalMemoryContext;
@@ -136,6 +137,8 @@ public class TaskContext
         this.yieldExecutor = requireNonNull(yieldExecutor, "yieldExecutor is null");
         this.session = session;
         this.taskMemoryContext = requireNonNull(taskMemoryContext, "taskMemoryContext is null");
+        // Initialize the local memory contexts with the LazyOutputBuffer tag as LazyOutputBuffer will do the local memory allocations
+        taskMemoryContext.initializeLocalMemoryContexts(LazyOutputBuffer.class.getSimpleName());
         this.verboseStats = verboseStats;
         this.cpuTimerEnabled = cpuTimerEnabled;
         this.totalPartitions = requireNonNull(totalPartitions, "totalPartitions is null");

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -127,7 +127,7 @@ public class InMemoryHashAggregationBuilder
         this.operatorContext = operatorContext;
         this.partial = step.isOutputPartial();
         this.maxPartialMemory = maxPartialMemory.toBytes();
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(InMemoryHashAggregationBuilder.class.getSimpleName());
         this.localUserMemoryContext = operatorContext.localUserMemoryContext();
 
         // wrapper each function with an aggregator

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -275,7 +275,7 @@ public class SpillableHashAggregationBuilder
                 hashChannel,
                 operatorContext,
                 sortedPages,
-                operatorContext.newLocalSystemMemoryContext(),
+                operatorContext.newLocalSystemMemoryContext(SpillableHashAggregationBuilder.class.getSimpleName()),
                 memoryLimitForMerge,
                 hashAggregationBuilder.getKeyChannels(),
                 joinCompiler));

--- a/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
@@ -97,6 +97,15 @@ public class ClusterStatsResource
     }
 
     @GET
+    @Path("memory")
+    public Response getClusterMemoryPoolInfo()
+    {
+        return Response.ok()
+                .entity(clusterMemoryManager.getMemoryPoolInfo())
+                .build();
+    }
+
+    @GET
     @Path("workerMemory")
     public Response getWorkerMemoryInfo()
     {

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
@@ -141,7 +141,7 @@ public class StatementResource
 
         SessionContext sessionContext = new HttpRequestSessionContext(servletRequest);
 
-        ExchangeClient exchangeClient = exchangeClientSupplier.get(new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()));
+        ExchangeClient exchangeClient = exchangeClientSupplier.get(new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), StatementResource.class.getSimpleName()));
         Query query = Query.create(
                 sessionContext,
                 statement,

--- a/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpiller.java
@@ -182,7 +182,7 @@ public class GenericPartitioningSpiller
     {
         Optional<SingleStreamSpiller> spiller = spillers[partition];
         if (!spiller.isPresent()) {
-            spiller = Optional.of(closer.register(spillerFactory.create(types, spillContext, memoryContext.newLocalMemoryContext())));
+            spiller = Optional.of(closer.register(spillerFactory.create(types, spillContext, memoryContext.newLocalMemoryContext(GenericPartitioningSpiller.class.getSimpleName()))));
             spillers[partition] = spiller;
         }
         return spiller.get();

--- a/presto-main/src/main/java/com/facebook/presto/spiller/GenericSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/GenericSpiller.java
@@ -60,7 +60,7 @@ public class GenericSpiller
     public ListenableFuture<?> spill(Iterator<Page> pageIterator)
     {
         checkNoSpillInProgress();
-        SingleStreamSpiller singleStreamSpiller = singleStreamSpillerFactory.create(types, spillContext, aggregatedMemoryContext.newLocalMemoryContext());
+        SingleStreamSpiller singleStreamSpiller = singleStreamSpillerFactory.create(types, spillContext, aggregatedMemoryContext.newLocalMemoryContext(GenericSpiller.class.getSimpleName()));
         closer.register(singleStreamSpiller);
         singleStreamSpillers.add(singleStreamSpiller);
         previousSpill = singleStreamSpiller.spill(pageIterator);

--- a/presto-main/src/main/java/com/facebook/presto/util/MergeSortedPages.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/MergeSortedPages.java
@@ -100,7 +100,7 @@ public final class MergeSortedPages
             AggregatedMemoryContext aggregatedMemoryContext,
             DriverYieldSignal yieldSignal)
     {
-        LocalMemoryContext memoryContext = aggregatedMemoryContext.newLocalMemoryContext();
+        LocalMemoryContext memoryContext = aggregatedMemoryContext.newLocalMemoryContext(MergeSortedPages.class.getSimpleName());
         PageBuilder pageBuilder = new PageBuilder(outputTypes);
         return pageWithPositions.transform(pageWithPositionOptional -> {
             if (yieldSignal.isSet()) {
@@ -145,7 +145,7 @@ public final class MergeSortedPages
     private static WorkProcessor<PageWithPosition> pageWithPositions(WorkProcessor<Page> pages, AggregatedMemoryContext aggregatedMemoryContext)
     {
         return pages.flatMap(page -> {
-            LocalMemoryContext memoryContext = aggregatedMemoryContext.newLocalMemoryContext();
+            LocalMemoryContext memoryContext = aggregatedMemoryContext.newLocalMemoryContext(MergeSortedPages.class.getSimpleName());
             memoryContext.setBytes(page.getRetainedSizeInBytes());
 
             return WorkProcessor.create(new WorkProcessor.Process<PageWithPosition>()

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -201,7 +201,7 @@ public class MockRemoteTaskFactory
                     TASK_INSTANCE_ID,
                     executor,
                     new DataSize(1, BYTE),
-                    () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()));
+                    () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"));
 
             this.fragment = requireNonNull(fragment, "fragment is null");
             this.nodeId = requireNonNull(nodeId, "nodeId is null");

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -616,7 +616,7 @@ public class TestSqlTaskExecution
                         .withBuffer(OUTPUT_BUFFER_ID, 0)
                         .withNoMoreBufferIds(),
                 new DataSize(1, MEGABYTE),
-                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()),
+                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 taskNotificationExecutor);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -1026,7 +1026,7 @@ public class TestArbitraryOutputBuffer
                 TASK_INSTANCE_ID,
                 new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
                 dataSize,
-                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()),
+                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 stateNotificationExecutor);
         buffer.setOutputBuffers(buffers);
         return buffer;

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -1062,13 +1063,13 @@ public class TestBroadcastOutputBuffer
         }
 
         @Override
-        public ListenableFuture<?> reserveMemory(long delta)
+        public ListenableFuture<?> reserveMemory(Optional<String> allocationTag, long delta)
         {
             return blockedFuture;
         }
 
         @Override
-        public boolean tryReserveMemory(long delta)
+        public boolean tryReserveMemory(Optional<String> allocationTag, long delta)
         {
             return true;
         }
@@ -1085,7 +1086,7 @@ public class TestBroadcastOutputBuffer
                 TASK_INSTANCE_ID,
                 new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
                 dataSize,
-                () -> memoryContext.newLocalMemoryContext(),
+                () -> memoryContext.newLocalMemoryContext("test"),
                 notificationExecutor);
         buffer.setOutputBuffers(outputBuffers);
         return buffer;
@@ -1147,7 +1148,7 @@ public class TestBroadcastOutputBuffer
                 TASK_INSTANCE_ID,
                 new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
                 dataSize,
-                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()),
+                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 stateNotificationExecutor);
         buffer.setOutputBuffers(outputBuffers);
         return buffer;

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
@@ -846,7 +846,7 @@ public class TestPartitionedOutputBuffer
                 new StateMachine<>("bufferState", stateNotificationExecutor, OPEN, TERMINAL_BUFFER_STATES),
                 buffers,
                 dataSize,
-                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()),
+                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 stateNotificationExecutor);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/memory/LowMemoryKillerTestingUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/LowMemoryKillerTestingUtils.java
@@ -72,6 +72,7 @@ public class LowMemoryKillerTestingUtils
                                 nodeReservation.getGeneral().getTotalReservedBytes(),
                                 0,
                                 nodeReservation.getGeneral().getReservationByQuery(),
+                                ImmutableMap.of(),
                                 ImmutableMap.of()));
             }
             if (nodeReservation.getReserved().getTotalReservedBytes() > 0) {
@@ -82,6 +83,7 @@ public class LowMemoryKillerTestingUtils
                                 nodeReservation.getReserved().getTotalReservedBytes(),
                                 0,
                                 nodeReservation.getReserved().getReservationByQuery(),
+                                ImmutableMap.of(),
                                 ImmutableMap.of()));
             }
             result.add(new MemoryInfo(new DataSize(maxReservedPoolBytes + maxGeneralPoolBytes, BYTE), pools.build()));

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -122,7 +122,7 @@ public class TestMemoryTracking
     public void testOperatorAllocations()
     {
         MemoryTrackingContext operatorMemoryContext = operatorContext.getOperatorMemoryContext();
-        LocalMemoryContext systemMemory = operatorContext.newLocalSystemMemoryContext();
+        LocalMemoryContext systemMemory = operatorContext.newLocalSystemMemoryContext("test");
         LocalMemoryContext userMemory = operatorContext.localUserMemoryContext();
         LocalMemoryContext revocableMemory = operatorContext.localRevocableMemoryContext();
         userMemory.setBytes(100);
@@ -145,7 +145,7 @@ public class TestMemoryTracking
     @Test
     public void testLocalTotalMemoryLimitExceeded()
     {
-        LocalMemoryContext systemMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        LocalMemoryContext systemMemoryContext = operatorContext.newLocalSystemMemoryContext("test");
         systemMemoryContext.setBytes(100);
         assertOperatorMemoryAllocations(operatorContext.getOperatorMemoryContext(), 0, 100, 0);
         systemMemoryContext.setBytes(queryMaxTotalMemory.toBytes());
@@ -197,7 +197,7 @@ public class TestMemoryTracking
     @Test
     public void testStats()
     {
-        LocalMemoryContext systemMemory = operatorContext.newLocalSystemMemoryContext();
+        LocalMemoryContext systemMemory = operatorContext.newLocalSystemMemoryContext("test");
         LocalMemoryContext userMemory = operatorContext.localUserMemoryContext();
         userMemory.setBytes(100_000_000);
         systemMemory.setBytes(200_000_000);
@@ -257,7 +257,7 @@ public class TestMemoryTracking
     @Test
     public void testRevocableMemoryAllocations()
     {
-        LocalMemoryContext systemMemory = operatorContext.newLocalSystemMemoryContext();
+        LocalMemoryContext systemMemory = operatorContext.newLocalSystemMemoryContext("test");
         LocalMemoryContext userMemory = operatorContext.localUserMemoryContext();
         LocalMemoryContext revocableMemory = operatorContext.localRevocableMemoryContext();
         revocableMemory.setBytes(100_000_000);
@@ -331,7 +331,7 @@ public class TestMemoryTracking
     @Test
     public void testDestroy()
     {
-        LocalMemoryContext newLocalSystemMemoryContext = operatorContext.newLocalSystemMemoryContext();
+        LocalMemoryContext newLocalSystemMemoryContext = operatorContext.newLocalSystemMemoryContext("test");
         LocalMemoryContext newLocalUserMemoryContext = operatorContext.localUserMemoryContext();
         LocalMemoryContext newLocalRevocableMemoryContext = operatorContext.localRevocableMemoryContext();
         newLocalSystemMemoryContext.setBytes(100_000);

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
@@ -82,6 +82,7 @@ public class TestQueryContext
                     new SpillSpaceTracker(new DataSize(0, BYTE)));
 
             // Use memory
+            queryContext.getQueryMemoryContext().initializeLocalMemoryContexts("test");
             LocalMemoryContext userMemoryContext = queryContext.getQueryMemoryContext().localUserMemoryContext();
             LocalMemoryContext revocableMemoryContext = queryContext.getQueryMemoryContext().localRevocableMemoryContext();
             assertTrue(userMemoryContext.setBytes(3).isDone());

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
@@ -206,7 +206,7 @@ public class BenchmarkPartitionedOutputOperator
                     new StateMachine<>("bufferState", SCHEDULER, OPEN, TERMINAL_BUFFER_STATES),
                     buffers,
                     dataSize,
-                    () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()),
+                    () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                     SCHEDULER);
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -101,7 +101,7 @@ public class TestExchangeClient
                 true,
                 new TestingHttpClient(processor, scheduler),
                 scheduler,
-                new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()),
+                new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
 
         exchangeClient.addLocation(location);
@@ -140,7 +140,7 @@ public class TestExchangeClient
                 true,
                 new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))),
                 scheduler,
-                new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()),
+                new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
 
         URI location1 = URI.create("http://localhost:8081/foo");
@@ -212,7 +212,7 @@ public class TestExchangeClient
                 true,
                 new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))),
                 scheduler,
-                new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()),
+                new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
 
         exchangeClient.addLocation(location);
@@ -294,7 +294,7 @@ public class TestExchangeClient
                 true,
                 new TestingHttpClient(processor, newCachedThreadPool(daemonThreadsNamed("test-%s"))),
                 scheduler,
-                new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext()),
+                new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
         exchangeClient.addLocation(location);
         exchangeClient.noMoreLocations();

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpiller.java
@@ -67,7 +67,7 @@ public class TestFileSingleStreamSpiller
         PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(new TypeRegistry()), false);
         PagesSerde serde = serdeFactory.createPagesSerde();
         SpillerStats spillerStats = new SpillerStats();
-        LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext();
+        LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
         FileSingleStreamSpiller spiller = new FileSingleStreamSpiller(serde, executor, spillPath.toPath(), spillerStats, bytes -> {}, memoryContext);
 
         Page page = buildPage();

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpillerFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestFileSingleStreamSpillerFactory.java
@@ -91,7 +91,7 @@ public class TestFileSingleStreamSpillerFactory
         Page page = buildPage();
         List<SingleStreamSpiller> spillers = new ArrayList<>();
         for (int i = 0; i < 10; ++i) {
-            SingleStreamSpiller singleStreamSpiller = spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext());
+            SingleStreamSpiller singleStreamSpiller = spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
             getUnchecked(singleStreamSpiller.spill(page));
             spillers.add(singleStreamSpiller);
         }
@@ -123,7 +123,7 @@ public class TestFileSingleStreamSpillerFactory
                 spillPaths,
                 0.0);
 
-        spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext());
+        spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "No spill paths configured")
@@ -137,7 +137,7 @@ public class TestFileSingleStreamSpillerFactory
                 new SpillerStats(),
                 spillPaths,
                 1.0);
-        spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext());
+        spillerFactory.create(types, bytes -> {}, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
     }
 
     @Test

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/AbstractAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/AbstractAggregatedMemoryContext.java
@@ -20,6 +20,8 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.Optional;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.String.format;
 
@@ -41,9 +43,9 @@ abstract class AbstractAggregatedMemoryContext
     }
 
     @Override
-    public LocalMemoryContext newLocalMemoryContext()
+    public LocalMemoryContext newLocalMemoryContext(String allocationTag)
     {
-        return new SimpleLocalMemoryContext(this);
+        return new SimpleLocalMemoryContext(this, allocationTag);
     }
 
     @Override
@@ -82,9 +84,9 @@ abstract class AbstractAggregatedMemoryContext
         usedBytes = addExact(usedBytes, bytes);
     }
 
-    abstract ListenableFuture<?> updateBytes(long bytes);
+    abstract ListenableFuture<?> updateBytes(Optional<String> allocationTag, long bytes);
 
-    abstract boolean tryUpdateBytes(long delta);
+    abstract boolean tryUpdateBytes(Optional<String> allocationTag, long delta);
 
     @Nullable
     abstract AbstractAggregatedMemoryContext getParent();

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/AggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/AggregatedMemoryContext.java
@@ -27,7 +27,7 @@ public interface AggregatedMemoryContext
 
     AggregatedMemoryContext newAggregatedMemoryContext();
 
-    LocalMemoryContext newLocalMemoryContext();
+    LocalMemoryContext newLocalMemoryContext(String allocationTag);
 
     long getBytes();
 

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/ChildAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/ChildAggregatedMemoryContext.java
@@ -15,6 +15,8 @@ package com.facebook.presto.memory.context;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.util.Optional;
+
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
@@ -31,19 +33,19 @@ class ChildAggregatedMemoryContext
     }
 
     @Override
-    synchronized ListenableFuture<?> updateBytes(long bytes)
+    synchronized ListenableFuture<?> updateBytes(Optional<String> allocationTag, long bytes)
     {
         checkState(!isClosed(), "ChildAggregatedMemoryContext is already closed");
         // update the parent before updating usedBytes as it may throw a runtime exception (e.g., ExceededMemoryLimitException)
-        ListenableFuture<?> future = parentMemoryContext.updateBytes(bytes);
+        ListenableFuture<?> future = parentMemoryContext.updateBytes(allocationTag, bytes);
         addBytes(bytes);
         return future;
     }
 
     @Override
-    synchronized boolean tryUpdateBytes(long delta)
+    synchronized boolean tryUpdateBytes(Optional<String> allocationTag, long delta)
     {
-        if (parentMemoryContext.tryUpdateBytes(delta)) {
+        if (parentMemoryContext.tryUpdateBytes(allocationTag, delta)) {
             addBytes(delta);
             return true;
         }
@@ -58,6 +60,6 @@ class ChildAggregatedMemoryContext
 
     void closeContext()
     {
-        parentMemoryContext.updateBytes(-getBytes());
+        parentMemoryContext.updateBytes(Optional.empty(), -getBytes());
     }
 }

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryReservationHandler.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryReservationHandler.java
@@ -15,16 +15,18 @@ package com.facebook.presto.memory.context;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.util.Optional;
+
 public interface MemoryReservationHandler
 {
     /**
      * @return a future that signals the caller to block before reserving more memory.
      */
-    ListenableFuture<?> reserveMemory(long delta);
+    ListenableFuture<?> reserveMemory(Optional<String> allocationTag, long delta);
 
     /**
      * Try reserving the given number of bytes.
      * @return true if reservation is successful, false otherwise.
      */
-    boolean tryReserveMemory(long delta);
+    boolean tryReserveMemory(Optional<String> allocationTag, long delta);
 }

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/RootAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/RootAggregatedMemoryContext.java
@@ -15,6 +15,8 @@ package com.facebook.presto.memory.context;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.util.Optional;
+
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -31,10 +33,10 @@ class RootAggregatedMemoryContext
     }
 
     @Override
-    synchronized ListenableFuture<?> updateBytes(long bytes)
+    synchronized ListenableFuture<?> updateBytes(Optional<String> allocationTag, long bytes)
     {
         checkState(!isClosed(), "RootAggregatedMemoryContext is already closed");
-        ListenableFuture<?> future = reservationHandler.reserveMemory(bytes);
+        ListenableFuture<?> future = reservationHandler.reserveMemory(allocationTag, bytes);
         addBytes(bytes);
         // make sure we never block queries below guaranteedMemory
         if (getBytes() < guaranteedMemory) {
@@ -44,9 +46,9 @@ class RootAggregatedMemoryContext
     }
 
     @Override
-    synchronized boolean tryUpdateBytes(long delta)
+    synchronized boolean tryUpdateBytes(Optional<String> allocationTag, long delta)
     {
-        if (reservationHandler.tryReserveMemory(delta)) {
+        if (reservationHandler.tryReserveMemory(allocationTag, delta)) {
             addBytes(delta);
             return true;
         }
@@ -62,6 +64,6 @@ class RootAggregatedMemoryContext
     @Override
     void closeContext()
     {
-        reservationHandler.reserveMemory(-getBytes());
+        reservationHandler.reserveMemory(Optional.empty(), -getBytes());
     }
 }

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/SimpleAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/SimpleAggregatedMemoryContext.java
@@ -15,6 +15,8 @@ package com.facebook.presto.memory.context;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.util.Optional;
+
 import static com.google.common.base.Preconditions.checkState;
 
 /**
@@ -24,7 +26,7 @@ class SimpleAggregatedMemoryContext
         extends AbstractAggregatedMemoryContext
 {
     @Override
-    synchronized ListenableFuture<?> updateBytes(long bytes)
+    synchronized ListenableFuture<?> updateBytes(Optional<String> allocationTag, long bytes)
     {
         checkState(!isClosed(), "SimpleAggregatedMemoryContext is already closed");
         addBytes(bytes);
@@ -32,7 +34,7 @@ class SimpleAggregatedMemoryContext
     }
 
     @Override
-    synchronized boolean tryUpdateBytes(long delta)
+    synchronized boolean tryUpdateBytes(Optional<String> allocationTag, long delta)
     {
         addBytes(delta);
         return true;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
@@ -66,9 +66,9 @@ public final class OrcInputStream
         // memory reserved in the systemMemoryContext is never release and instead it is
         // expected that the context itself will be destroyed at the end of the read
         requireNonNull(systemMemoryContext, "systemMemoryContext is null");
-        this.bufferMemoryUsage = systemMemoryContext.newLocalMemoryContext();
+        this.bufferMemoryUsage = systemMemoryContext.newLocalMemoryContext(OrcInputStream.class.getSimpleName());
         checkArgument(sliceInputRetainedSizeInBytes >= 0, "sliceInputRetainedSizeInBytes is negative");
-        systemMemoryContext.newLocalMemoryContext().setBytes(sliceInputRetainedSizeInBytes);
+        systemMemoryContext.newLocalMemoryContext(OrcInputStream.class.getSimpleName()).setBytes(sliceInputRetainedSizeInBytes);
 
         if (!decompressor.isPresent()) {
             this.current = sliceInput;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/memory/MemoryAllocation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/memory/MemoryAllocation.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.memory;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+public final class MemoryAllocation
+{
+    private final String tag;
+    private final long allocation;
+
+    @JsonCreator
+    public MemoryAllocation(
+            @JsonProperty("tag") String tag,
+            @JsonProperty("allocation") long allocation)
+    {
+        this.tag = requireNonNull(tag, "tag is null");
+        this.allocation = allocation;
+    }
+
+    @JsonProperty
+    public String getTag()
+    {
+        return tag;
+    }
+
+    @JsonProperty
+    public long getAllocation()
+    {
+        return allocation;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/memory/MemoryPoolInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/memory/MemoryPoolInfo.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -29,6 +30,7 @@ public final class MemoryPoolInfo
     private final long reservedBytes;
     private final long reservedRevocableBytes;
     private final Map<QueryId, Long> queryMemoryReservations;
+    private final Map<QueryId, List<MemoryAllocation>> queryMemoryAllocations;
     private final Map<QueryId, Long> queryMemoryRevocableReservations;
 
     @JsonCreator
@@ -37,12 +39,14 @@ public final class MemoryPoolInfo
             @JsonProperty("reservedBytes") long reservedBytes,
             @JsonProperty("reservedRevocableBytes") long reservedRevocableBytes,
             @JsonProperty("queryMemoryReservations") Map<QueryId, Long> queryMemoryReservations,
+            @JsonProperty("queryMemoryAllocations") Map<QueryId, List<MemoryAllocation>> queryMemoryAllocations,
             @JsonProperty("queryMemoryRevocableReservations") Map<QueryId, Long> queryMemoryRevocableReservations)
     {
         this.maxBytes = maxBytes;
         this.reservedBytes = reservedBytes;
         this.reservedRevocableBytes = reservedRevocableBytes;
         this.queryMemoryReservations = unmodifiableMap(new HashMap<>(queryMemoryReservations));
+        this.queryMemoryAllocations = unmodifiableMap(new HashMap<>(queryMemoryAllocations));
         this.queryMemoryRevocableReservations = unmodifiableMap(new HashMap<>(queryMemoryRevocableReservations));
     }
 
@@ -74,6 +78,12 @@ public final class MemoryPoolInfo
     public Map<QueryId, Long> getQueryMemoryReservations()
     {
         return queryMemoryReservations;
+    }
+
+    @JsonProperty
+    public Map<QueryId, List<MemoryAllocation>> getQueryMemoryAllocations()
+    {
+        return queryMemoryAllocations;
     }
 
     @JsonProperty


### PR DESCRIPTION
This will help us understand and monitor how much memory is allocated
for each active query at a fine granularity -- how much memory is being
used by table scan, exchange buffers, and the join operators, etc.

Each worker can be monitored through the /v1/memory/{pool_id} endpoint
and the coordinator has an aggregate cluster view at /v1/cluster/memory.

Here is a sample output from `/v1/cluster/memory` with two running queries:

```
...

"queryMemoryAllocations": {
	"20180710_233941_00005_77z72": [
                {
			"tag": "InMemoryHashAggregationBuilder",
			"allocation": 4570656
		},
		{
			"tag": "PartitionedOutputOperator",
			"allocation": 12288
		},
		{
			"tag": "ScanFilterAndProjectOperator",
			"allocation": 11799696
		}
	],
	"20180710_233934_00004_77z72": [
                {
			"tag": "PartitionedOutputOperator",
			"allocation": 68099003
		},
		{
			"tag": "ScanFilterAndProjectOperator",
			"allocation": 34089607
		},
		{
			"tag": "ExchangeOperator",
			"allocation": 28066530
		},
		{
			"tag": "HashBuilderOperator",
			"allocation": 56311250
		}
	]
}
...
```