### PR TITLE
Add /v1/cluster/workerMemory endpoint

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/RemoteNodeMemory.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/RemoteNodeMemory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.memory;
 
+import com.facebook.presto.spi.Node;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
@@ -50,6 +51,7 @@ public class RemoteNodeMemory
 {
     private static final Logger log = Logger.get(RemoteNodeMemory.class);
 
+    private final Node node;
     private final HttpClient httpClient;
     private final URI memoryInfoUri;
     private final JsonCodec<MemoryInfo> memoryInfoCodec;
@@ -60,8 +62,14 @@ public class RemoteNodeMemory
     private final AtomicLong lastWarningLogged = new AtomicLong();
     private final AtomicLong currentAssignmentVersion = new AtomicLong(-1);
 
-    public RemoteNodeMemory(HttpClient httpClient, JsonCodec<MemoryInfo> memoryInfoCodec, JsonCodec<MemoryPoolAssignmentsRequest> assignmentsRequestJsonCodec, URI memoryInfoUri)
+    public RemoteNodeMemory(
+            Node node,
+            HttpClient httpClient,
+            JsonCodec<MemoryInfo> memoryInfoCodec,
+            JsonCodec<MemoryPoolAssignmentsRequest> assignmentsRequestJsonCodec,
+            URI memoryInfoUri)
     {
+        this.node = requireNonNull(node, "node is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.memoryInfoUri = requireNonNull(memoryInfoUri, "memoryInfoUri is null");
         this.memoryInfoCodec = requireNonNull(memoryInfoCodec, "memoryInfoCodec is null");
@@ -76,6 +84,11 @@ public class RemoteNodeMemory
     public Optional<MemoryInfo> getInfo()
     {
         return memoryInfo.get();
+    }
+
+    public Node getNode()
+    {
+        return node;
     }
 
     public void asyncRefresh(MemoryPoolAssignmentsRequest assignments)

--- a/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
@@ -17,6 +17,7 @@ import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
+import com.facebook.presto.memory.ClusterMemoryManager;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.spi.NodeState;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -27,6 +28,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -37,13 +39,15 @@ public class ClusterStatsResource
     private final InternalNodeManager nodeManager;
     private final QueryManager queryManager;
     private final boolean isIncludeCoordinator;
+    private final ClusterMemoryManager clusterMemoryManager;
 
     @Inject
-    public ClusterStatsResource(NodeSchedulerConfig nodeSchedulerConfig, InternalNodeManager nodeManager, QueryManager queryManager)
+    public ClusterStatsResource(NodeSchedulerConfig nodeSchedulerConfig, InternalNodeManager nodeManager, QueryManager queryManager, ClusterMemoryManager clusterMemoryManager)
     {
         this.isIncludeCoordinator = requireNonNull(nodeSchedulerConfig, "nodeSchedulerConfig is null").isIncludeCoordinator();
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
+        this.clusterMemoryManager = requireNonNull(clusterMemoryManager, "clusterMemoryManager is null");
     }
 
     @GET
@@ -90,6 +94,15 @@ public class ClusterStatsResource
         }
 
         return new ClusterStats(runningQueries, blockedQueries, queuedQueries, activeNodes, runningDrivers, memoryReservation, totalInputRows, totalInputBytes, totalCpuTimeSecs);
+    }
+
+    @GET
+    @Path("workerMemory")
+    public Response getWorkerMemoryInfo()
+    {
+        return Response.ok()
+                .entity(clusterMemoryManager.getWorkerMemoryInfo())
+                .build();
     }
 
     public static class ClusterStats


### PR DESCRIPTION
This new endpoint provides the coordinator's view of the worker
memory pools. This info can be useful when debugging cluster ooms.

```
"5f3cbd7b-d15f-4b4e-9ab7-e42ad412e519 [127.0.0.1]": {
		"totalNodeMemory": "2672505652B",
		"pools": {
			"reserved": {
				"maxBytes": 1145359564,
				"reservedBytes": 0,
				"reservedRevocableBytes": 0,
				"queryMemoryReservations": {},
				"queryMemoryRevocableReservations": {},
				"freeBytes": 1145359564
			},
			"general": {
				"maxBytes": 1527146088,
				"reservedBytes": 0,
				"reservedRevocableBytes": 0,
				"queryMemoryReservations": {},
				"queryMemoryRevocableReservations": {},
				"freeBytes": 1527146088
			}
		}
	}
```