### PR TITLE
Enable schema owner to create, drop or rename his schema

### DIFF
--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.plugin.base.security.TableAccessControlRule.Ta
 import static com.facebook.presto.plugin.base.security.TableAccessControlRule.TablePrivilege.OWNERSHIP;
 import static com.facebook.presto.plugin.base.security.TableAccessControlRule.TablePrivilege.SELECT;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyAddColumn;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateSchema;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateTable;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateView;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyCreateViewWithSelect;
@@ -81,6 +82,30 @@ public class FileBasedAccessControl
     public Set<String> filterSchemas(ConnectorTransactionHandle transactionHandle, Identity identity, Set<String> schemaNames)
     {
         return schemaNames;
+    }
+
+    @Override
+    public void checkCanCreateSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        if (!isDatabaseOwner(identity, schemaName)) {
+            denyCreateSchema(schemaName);
+        }
+    }
+
+    @Override
+    public void checkCanDropSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+        if (!isDatabaseOwner(identity, schemaName)) {
+            denyDeleteTable(schemaName);
+        }
+    }
+
+    @Override
+    public void checkCanRenameSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName, String newSchemaName)
+    {
+        if (!isDatabaseOwner(identity, schemaName) || !isDatabaseOwner(identity, newSchemaName)) {
+            denyRenameColumn(schemaName);
+        }
     }
 
     @Override

--- a/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
@@ -41,6 +41,19 @@ public class TestFileBasedAccessControl
         accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("bob", "test"));
         assertDenied(() -> accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("bob"), new SchemaTableName("test", "test")));
         assertDenied(() -> accessControl.checkCanCreateTable(TRANSACTION_HANDLE, user("admin"), new SchemaTableName("secret", "test")));
+
+        accessControl.checkCanCreateSchema(TRANSACTION_HANDLE, user("bob"), "bob");
+        assertDenied(() -> accessControl.checkCanCreateSchema(TRANSACTION_HANDLE, user("bob"), "admin"));
+        accessControl.checkCanCreateSchema(TRANSACTION_HANDLE, user("admin"), "bob");
+        accessControl.checkCanCreateSchema(TRANSACTION_HANDLE, user("admin"), "admin");
+
+        accessControl.checkCanDropSchema(TRANSACTION_HANDLE, user("bob"), "bob");
+        assertDenied(() -> accessControl.checkCanDropSchema(TRANSACTION_HANDLE, user("bob"), "admin"));
+        accessControl.checkCanDropSchema(TRANSACTION_HANDLE, user("admin"), "bob");
+        accessControl.checkCanDropSchema(TRANSACTION_HANDLE, user("admin"), "admin");
+
+        assertDenied(() -> accessControl.checkCanRenameSchema(TRANSACTION_HANDLE, user("bob"), "bob", "bob2"));
+        accessControl.checkCanRenameSchema(TRANSACTION_HANDLE, user("admin"), "bob", "bob2");
     }
 
     @Test


### PR DESCRIPTION
Enable schema owner to create, drop or rename his schema

Enable owner of the schema to create, drop or rename the schema he owns
in FileBasedAccessControl.
