### PR TITLE
Grow the batch size for OrcRecordReader from 1 row

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
@@ -68,6 +68,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.isOrcBloomFiltersEn
 import static com.facebook.presto.hive.HiveUtil.isDeserializerClass;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -209,7 +210,8 @@ public class OrcPageSourceFactory
                     start,
                     length,
                     hiveStorageTimeZone,
-                    systemMemoryUsage);
+                    systemMemoryUsage,
+                    INITIAL_BATCH_SIZE);
 
             return new OrcPageSource(
                     recordReader,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 import static org.joda.time.DateTimeZone.UTC;
@@ -66,7 +67,8 @@ public class TempFileReader
                     includedColumns,
                     OrcPredicate.TRUE,
                     UTC,
-                    newSimpleAggregatedMemoryContext());
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_WRITER_DATA_ERROR, "Failed to read temporary data");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcPageSourceMemoryTracking.java
@@ -177,11 +177,13 @@ public class TestOrcPageSourceMemoryTracking
         assertEquals(pageSource.getSystemMemoryUsage(), 0);
 
         long memoryUsage = -1;
-        for (int i = 0; i < 20; i++) {
+        int totalRows = 0;
+        while (totalRows < 20000) {
             assertFalse(pageSource.isFinished());
             Page page = pageSource.getNextPage();
             assertNotNull(page);
             Block block = page.getBlock(1);
+
             if (memoryUsage == -1) {
                 assertBetweenInclusive(pageSource.getSystemMemoryUsage(), 180000L, 189999L); // Memory usage before lazy-loading the block
                 createUnboundedVarcharType().getSlice(block, block.getPositionCount() - 1); // trigger loading for lazy block
@@ -193,14 +195,16 @@ public class TestOrcPageSourceMemoryTracking
                 createUnboundedVarcharType().getSlice(block, block.getPositionCount() - 1); // trigger loading for lazy block
                 assertEquals(pageSource.getSystemMemoryUsage(), memoryUsage);
             }
+            totalRows += page.getPositionCount();
         }
 
         memoryUsage = -1;
-        for (int i = 20; i < 40; i++) {
+        while (totalRows < 40000) {
             assertFalse(pageSource.isFinished());
             Page page = pageSource.getNextPage();
             assertNotNull(page);
             Block block = page.getBlock(1);
+
             if (memoryUsage == -1) {
                 assertBetweenInclusive(pageSource.getSystemMemoryUsage(), 180000L, 189999L); // Memory usage before lazy-loading the block
                 createUnboundedVarcharType().getSlice(block, block.getPositionCount() - 1); // trigger loading for lazy block
@@ -212,14 +216,16 @@ public class TestOrcPageSourceMemoryTracking
                 createUnboundedVarcharType().getSlice(block, block.getPositionCount() - 1); // trigger loading for lazy block
                 assertEquals(pageSource.getSystemMemoryUsage(), memoryUsage);
             }
+            totalRows += page.getPositionCount();
         }
 
         memoryUsage = -1;
-        for (int i = 40; i < 50; i++) {
+        while (totalRows < NUM_ROWS) {
             assertFalse(pageSource.isFinished());
             Page page = pageSource.getNextPage();
             assertNotNull(page);
             Block block = page.getBlock(1);
+
             if (memoryUsage == -1) {
                 assertBetweenInclusive(pageSource.getSystemMemoryUsage(), 90000L, 99999L); // Memory usage before lazy-loading the block
                 createUnboundedVarcharType().getSlice(block, block.getPositionCount() - 1); // trigger loading for lazy block
@@ -231,6 +237,7 @@ public class TestOrcPageSourceMemoryTracking
                 createUnboundedVarcharType().getSlice(block, block.getPositionCount() - 1); // trigger loading for lazy block
                 assertEquals(pageSource.getSystemMemoryUsage(), memoryUsage);
             }
+            totalRows += page.getPositionCount();
         }
 
         assertFalse(pageSource.isFinished());
@@ -310,7 +317,8 @@ public class TestOrcPageSourceMemoryTracking
         assertEquals(driverContext.getSystemMemoryUsage(), 0);
 
         long memoryUsage = -1;
-        for (int i = 0; i < 20; i++) {
+        int totalRows = 0;
+        while (totalRows < 20000) {
             assertFalse(operator.isFinished());
             Page page = operator.getOutput();
             assertNotNull(page);
@@ -322,10 +330,11 @@ public class TestOrcPageSourceMemoryTracking
             else {
                 assertEquals(driverContext.getSystemMemoryUsage(), memoryUsage);
             }
+            totalRows += page.getPositionCount();
         }
 
         memoryUsage = -1;
-        for (int i = 20; i < 40; i++) {
+        while (totalRows < 40000) {
             assertFalse(operator.isFinished());
             Page page = operator.getOutput();
             assertNotNull(page);
@@ -337,10 +346,11 @@ public class TestOrcPageSourceMemoryTracking
             else {
                 assertEquals(driverContext.getSystemMemoryUsage(), memoryUsage);
             }
+            totalRows += page.getPositionCount();
         }
 
         memoryUsage = -1;
-        for (int i = 40; i < 50; i++) {
+        while (totalRows < NUM_ROWS) {
             assertFalse(operator.isFinished());
             Page page = operator.getOutput();
             assertNotNull(page);
@@ -352,6 +362,7 @@ public class TestOrcPageSourceMemoryTracking
             else {
                 assertEquals(driverContext.getSystemMemoryUsage(), memoryUsage);
             }
+            totalRows += page.getPositionCount();
         }
 
         assertFalse(operator.isFinished());
@@ -371,10 +382,13 @@ public class TestOrcPageSourceMemoryTracking
 
         assertEquals(driverContext.getSystemMemoryUsage(), 0);
 
-        for (int i = 0; i < 50; i++) {
+        int totalRows = 0;
+        while (totalRows < NUM_ROWS) {
             assertFalse(operator.isFinished());
-            assertNotNull(operator.getOutput());
+            Page page = operator.getOutput();
+            assertNotNull(page);
             assertBetweenInclusive(driverContext.getSystemMemoryUsage(), 90_000L, 499_999L);
+            totalRows += page.getPositionCount();
         }
 
         // done... in the current implementation finish is not set until output returns a null page

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkOrcDecimalReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkOrcDecimalReader.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
 import static com.facebook.presto.orc.OrcTester.writeOrcColumnHive;
 import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
@@ -122,7 +123,8 @@ public class BenchmarkOrcDecimalReader
                     ImmutableMap.of(0, DECIMAL_TYPE),
                     OrcPredicate.TRUE,
                     DateTimeZone.UTC, // arbitrary
-                    newSimpleAggregatedMemoryContext());
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
         }
 
         private List<SqlDecimal> createDecimalValues()

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcRecordReader.LinearProbeRangeFinder.createTinyStripesRangeFinder;
 import static com.facebook.presto.orc.OrcRecordReader.wrapWithCacheIfTinyStripes;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
@@ -204,7 +205,8 @@ public class TestCachingOrcDataSource
                 ImmutableMap.of(0, VARCHAR),
                 (numberOfRows, statisticsByColumnIndex) -> true,
                 HIVE_STORAGE_TIME_ZONE,
-                newSimpleAggregatedMemoryContext());
+                newSimpleAggregatedMemoryContext(),
+                INITIAL_BATCH_SIZE);
         int positionCount = 0;
         while (true) {
             int batchSize = orcRecordReader.nextBatch();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.orc.metadata.CompressionKind.LZ4;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -60,7 +61,8 @@ public class TestOrcLz4
                 includedColumns,
                 OrcPredicate.TRUE,
                 DateTimeZone.UTC,
-                newSimpleAggregatedMemoryContext());
+                newSimpleAggregatedMemoryContext(),
+                INITIAL_BATCH_SIZE);
 
         int rows = 0;
         while (true) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
@@ -44,6 +44,8 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.BATCH_SIZE_GROWTH_FACTOR;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
 import static com.facebook.presto.orc.OrcTester.MAX_BLOCK_SIZE;
@@ -53,6 +55,7 @@ import static com.facebook.presto.orc.OrcTester.createSettableStructObjectInspec
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hive.ql.io.orc.CompressionKind.SNAPPY;
 import static org.testng.Assert.assertEquals;
@@ -67,7 +70,7 @@ public class TestOrcReaderPositions
         try (TempFile tempFile = new TempFile()) {
             createMultiStripeFile(tempFile.getFile());
 
-            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT)) {
+            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, MAX_BATCH_SIZE)) {
                 assertEquals(reader.getReaderRowCount(), 100);
                 assertEquals(reader.getReaderPosition(), 0);
                 assertEquals(reader.getFileRowCount(), reader.getReaderRowCount());
@@ -104,7 +107,7 @@ public class TestOrcReaderPositions
                         ((stats.getMin() == 180) && (stats.getMax() == 237));
             };
 
-            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, predicate, BIGINT)) {
+            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, predicate, BIGINT, MAX_BATCH_SIZE)) {
                 assertEquals(reader.getFileRowCount(), 100);
                 assertEquals(reader.getReaderRowCount(), 40);
                 assertEquals(reader.getFilePosition(), 0);
@@ -147,7 +150,7 @@ public class TestOrcReaderPositions
                 return (stats.getMin() == 50_000) || (stats.getMin() == 60_000);
             };
 
-            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, predicate, BIGINT)) {
+            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, predicate, BIGINT, MAX_BATCH_SIZE)) {
                 assertEquals(reader.getFileRowCount(), rowCount);
                 assertEquals(reader.getReaderRowCount(), rowCount);
                 assertEquals(reader.getFilePosition(), 0);
@@ -190,13 +193,13 @@ public class TestOrcReaderPositions
         // then bounded by MAX_BLOCK_SIZE = 1MB because 1024 X 1200B > 1MB
         try (TempFile tempFile = new TempFile()) {
             // create single strip file with multiple row groups
-            int rowsInRowGroup = 10_000;
+            int rowsInRowGroup = 10000;
             int rowGroupCounts = 10;
             int baseStringBytes = 300;
             int rowCount = rowsInRowGroup * rowGroupCounts;
             createGrowingSequentialFile(tempFile.getFile(), rowCount, rowsInRowGroup, baseStringBytes);
 
-            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, VARCHAR)) {
+            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, VARCHAR, MAX_BATCH_SIZE)) {
                 assertEquals(reader.getFileRowCount(), rowCount);
                 assertEquals(reader.getReaderRowCount(), rowCount);
                 assertEquals(reader.getFilePosition(), 0);
@@ -210,6 +213,7 @@ public class TestOrcReaderPositions
                     if (batchSize == -1) {
                         break;
                     }
+
                     rowCountsInCurrentRowGroup += batchSize;
 
                     Block block = reader.readBlock(VARCHAR, 0);
@@ -252,7 +256,7 @@ public class TestOrcReaderPositions
             int rowCount = rowsInRowGroup * rowGroupCounts;
             createSequentialFile(tempFile.getFile(), rowCount);
 
-            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT)) {
+            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, MAX_BATCH_SIZE)) {
                 assertEquals(reader.getFileRowCount(), rowCount);
                 assertEquals(reader.getReaderRowCount(), rowCount);
                 assertEquals(reader.getFilePosition(), 0);
@@ -297,6 +301,71 @@ public class TestOrcReaderPositions
             Footer footer = orcReader.getFooter();
             Map<String, String> readMetadata = Maps.transformValues(footer.getUserMetadata(), Slice::toStringAscii);
             assertEquals(readMetadata, metadata);
+        }
+    }
+
+    @Test
+    public void testBatchSizeGrowth()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            // Create a file with 5 stripes of 20 rows each.
+            createMultiStripeFile(tempFile.getFile());
+
+            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, INITIAL_BATCH_SIZE)) {
+                assertEquals(reader.getReaderRowCount(), 100);
+                assertEquals(reader.getReaderPosition(), 0);
+                assertEquals(reader.getFileRowCount(), reader.getReaderRowCount());
+                assertEquals(reader.getFilePosition(), reader.getReaderPosition());
+
+                // The batch size should start from INITIAL_BATCH_SIZE and grow by BATCH_SIZE_GROWTH_FACTOR.
+                // For INITIAL_BATCH_SIZE = 1 and BATCH_SIZE_GROWTH_FACTOR = 2, the batchSize sequence should be
+                // 1, 2, 4, 8, 5, 20, 20, 20, 20
+                int totalReadRows = 0;
+                int nextBatchSize = INITIAL_BATCH_SIZE;
+                int expectedBatchSize = INITIAL_BATCH_SIZE;
+                int rowCountsInCurrentRowGroup = 0;
+                while (true) {
+                    int batchSize = reader.nextBatch();
+                    if (batchSize == -1) {
+                        break;
+                    }
+
+                    assertEquals(batchSize, expectedBatchSize);
+                    assertEquals(reader.getReaderPosition(), totalReadRows);
+                    assertEquals(reader.getFilePosition(), reader.getReaderPosition());
+                    assertCurrentBatch(reader, (int) reader.getReaderPosition(), batchSize);
+
+                    if (nextBatchSize > 20 - rowCountsInCurrentRowGroup) {
+                        nextBatchSize *= BATCH_SIZE_GROWTH_FACTOR;
+                    }
+                    else {
+                        nextBatchSize = batchSize * BATCH_SIZE_GROWTH_FACTOR;
+                    }
+                    rowCountsInCurrentRowGroup += batchSize;
+                    totalReadRows += batchSize;
+                    if (rowCountsInCurrentRowGroup == 20) {
+                        rowCountsInCurrentRowGroup = 0;
+                    }
+                    else if (rowCountsInCurrentRowGroup > 20) {
+                        assertTrue(false, "read more rows in the current row group");
+                    }
+
+                    expectedBatchSize = min(min(nextBatchSize, MAX_BATCH_SIZE), 20 - rowCountsInCurrentRowGroup);
+                }
+
+                assertEquals(reader.getReaderPosition(), 100);
+                assertEquals(reader.getFilePosition(), reader.getReaderPosition());
+            }
+        }
+    }
+
+    private static void assertCurrentBatch(OrcRecordReader reader, int rowIndex, int batchSize)
+            throws IOException
+    {
+        Block block = reader.readBlock(BIGINT, 0);
+        for (int i = 0; i < batchSize; i++) {
+            assertEquals(BIGINT.getLong(block, i), (rowIndex + i) * 3);
         }
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -85,6 +85,7 @@ import java.util.concurrent.TimeoutException;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.raptor.RaptorColumnHandle.isBucketNumberColumn;
 import static com.facebook.presto.raptor.RaptorColumnHandle.isHiddenColumn;
 import static com.facebook.presto.raptor.RaptorColumnHandle.isShardRowIdColumn;
@@ -258,7 +259,7 @@ public class OrcStorageManager
 
             OrcPredicate predicate = getPredicate(effectivePredicate, indexMap);
 
-            OrcRecordReader recordReader = reader.createRecordReader(includedColumns.build(), predicate, UTC, systemMemoryUsage);
+            OrcRecordReader recordReader = reader.createRecordReader(includedColumns.build(), predicate, UTC, systemMemoryUsage, INITIAL_BATCH_SIZE);
 
             Optional<ShardRewriter> shardRewriter = Optional.empty();
             if (transactionId.isPresent()) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
@@ -66,7 +67,7 @@ public final class ShardStats
             throws IOException
     {
         int columnIndex = columnIndex(orcReader.getColumnNames(), columnId);
-        OrcRecordReader reader = orcReader.createRecordReader(ImmutableMap.of(columnIndex, type), OrcPredicate.TRUE, UTC, newSimpleAggregatedMemoryContext());
+        OrcRecordReader reader = orcReader.createRecordReader(ImmutableMap.of(columnIndex, type), OrcPredicate.TRUE, UTC, newSimpleAggregatedMemoryContext(), INITIAL_BATCH_SIZE);
 
         if (type.equals(BooleanType.BOOLEAN)) {
             return indexBoolean(type, reader, columnIndex, columnId);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static org.testng.Assert.assertEquals;
@@ -77,7 +78,7 @@ final class OrcTestingUtil
 
     public static OrcRecordReader createRecordReader(OrcReader orcReader, Map<Integer, Type> includedColumns)
     {
-        return orcReader.createRecordReader(includedColumns, OrcPredicate.TRUE, DateTimeZone.UTC, newSimpleAggregatedMemoryContext());
+        return orcReader.createRecordReader(includedColumns, OrcPredicate.TRUE, DateTimeZone.UTC, newSimpleAggregatedMemoryContext(), MAX_BATCH_SIZE);
     }
 
     public static byte[] octets(int... values)


### PR DESCRIPTION
In the past we have seen large number of humongous allocations on the
cluster worker nodes. The size of each block could be as high
as 80MB, and the total allocation could be as high as 100GB per worker
node. This situation happens when reading map or array types. One of the
reason is that when we read the nested types like map and array, we
didn't take the number of elements within each cell into account when
caculating the batch size. A single map cell could contain 10K entries
in some cases and the total data entries read could be 10M. Currently
we read the first block and bound the batch size accordingly, but the
first block might already contain too many (e.g. millions of) entries.

This commit is to change the first read from 1024 rows to 1 row, then
exponentially grow the batch size until it hits the 1024-row bound or
the max block size bound (16MB), then adjust the batch size for each
batch later on. The growth factor BATCH_SIZE_GROWTH_FACTOR is defined
as 2 for now.

To show the result of this change, we did an experiment reading a
column of type MAP<INT,ARRAY<BIGINT>> where each row contains around
10K entries. Before the change the block sizes were around 80MB, and
after this change the block sizes were bounded around 16MB.

The number of rows read and block sizes before the change:
Reading 979 rows. block size: 76853564
Reading 979 rows. block size: 75622553
Reading 1011 rows. block size: 80844513
Reading 1024 rows. block size: 81683180
Reading 70 rows. block size: 5939036
Reading 1022 rows. block size: 77635114
Reading 997 rows. block size: 75353930
Reading 989 rows. block size: 81052672

The number of rows read and block sizes after the change:
(suppose the growth factor is 32)
Reading one column:
Reading 1 rows. block size: 81185
Reading 32 rows. block size: 2560714
Reading 206 rows. block size: 16128454
Reading 206 rows. block size: 16150072
Reading 206 rows. block size: 16120201
Reading 206 rows. block size: 15966427
Reading 145 rows. block size: 11342435

Reading two columns:
Reading 1 rows. block size 80141 block size 64409
Reading 32 rows. block size 2423968 block size 2821975
Reading 99 rows. block size 7631865 block size 7972065
Reading 99 rows. block size 7481655 block size 8050815

(suppose the growth factor is 2)
Reading 1 rows Block size 78956
Reading 2 rows Block size 110110
Reading 4 rows Block size 250065
Reading 8 rows Block size 424828
Reading 16 rows Block size 949918
Reading 32 rows Block size 2493616
Reading 64 rows Block size 5577162
Reading 128 rows Block size 12501611
Reading 190 rows Block size 18751822
Reading 190 rows Block size 18767870
Reading 190 rows Block size 18718009
Reading 170 rows Block size 12666075