### PR TITLE
Add support for query pushdown to S3 using S3Select

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -111,9 +111,9 @@ security options in the Hive connector.
 Hive Configuration Properties
 -----------------------------
 
-================================================== ============================================================ ============
+================================================== ============================================================ ==============
 Property Name                                      Description                                                  Default
-================================================== ============================================================ ============
+================================================== ============================================================ ==============
 ``hive.metastore.uri``                             The URI(s) of the Hive metastore to connect to using the
                                                    Thrift protocol. If multiple URIs are provided, the first
                                                    URI is used by default and the rest of the URIs are
@@ -179,7 +179,10 @@ Property Name                                      Description                  
 ``hive.collect-column-statistics-on-write``        Enables automatic column level statistics collection         ``false``
                                                    on write. See `Table Statistics <#table-statistics>`__ for
                                                    details.
-================================================== ============================================================ ============
+``hive.s3select-pushdown.enabled``                 Enable query pushdown to AWS S3 Select service.               ``false``
+``hive.s3select-pushdown.max-connections``         Maximum number of simultaneously open connections to S3 for    500
+                                                   S3SelectPushdown.
+================================================== ============================================================ ==============
 
 Amazon S3 Configuration
 -----------------------
@@ -340,6 +343,55 @@ classpath and must be able to communicate with your custom key management system
 the ``org.apache.hadoop.conf.Configurable`` interface from the Hadoop Java API, then the Hadoop configuration
 will be passed in after the object instance is created and before it is asked to provision or retrieve any
 encryption keys.
+
+S3SelectPushdown
+^^^^^^^^^^^^^^^^
+S3SelectPushdown enables pushing down projection (SELECT) and predicate (WHERE) processing to `S3 Select <https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html>`_. With S3SelectPushdown
+Presto only retrieves the required data from S3 instead of entire S3 objects reducing both latency and network usage.
+
+Is S3 Select a Good Fit For My Workload?
+########################################
+Performance of S3SelectPushdown depends on the amount of data filtered by the query. Filtering a large number of rows should
+result in better performance. If the query doesn't filter any data then pushdown may not add any additional value and user will
+be charged for S3 Select requests. Thus, we recommend that you benchmark your workloads with and without S3 Select to see
+if using it may be suitable for your workload. By default, S3SelectPushdown is disabled and you should enable it in production
+after proper benchmarking and cost analysis. For more information on S3 Select request cost, please see `Amazon S3 Cloud Storage Pricing Doc <https://aws.amazon.com/s3/pricing/>`_.
+
+Use the following guidelines to determine if S3 Select is a good fit for your workload:
+
+* Your query filters out more than half of the original data set.
+* Your query filter predicates use columns that have a data type supported by Presto and S3 Select.
+  The ``TIMESTAMP``, ``REAL``, and ``DOUBLE`` data types are not supported by S3 Select Pushdown. We recommend using
+  the decimal data type for numerical data. For more information about supported data types for S3 Select,
+  see `Data Types <https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference-data-types.html>` in the Amazon Simple Storage Service Developer Guide.
+* Your network connection between Amazon S3 and the Amazon EMR cluster has good transfer speed and available bandwidth.
+  Amazon S3 Select does not compress HTTP responses, so the response size may increase for compressed input files.
+
+Considerations and Limitations
+##############################
+* Only objects stored in CSV format are supported. Objects can be uncompressed or optionally compressed with gzip or bzip2.
+* The AllowQuotedRecordDelimiters property is not supported. If this property is specified, the query fails.
+* Amazon S3 server-side encryption with customer-provided encryption keys (SSE-C) and client-side encryption are not supported.
+* S3 Select Pushdown is not a substitute for using columnar or compressed file formats such as ORC and Parquet.
+
+Enabling S3 Select Pushdown
+###########################
+To enable S3 Select Pushdown, set ``hive.s3select-pushdown.enabled`` to true. The ``hive.s3select-pushdown.max-connections``
+value must also be set. For most workloads, the default setting of 500 should be adequate.
+
+For more information, please see the Understanding and Tuning ``hive.s3select-pushdown.max-connections`` section below.
+
+Understanding and Tuning hive.s3select-pushdown.max-connections
+###############################################################
+By default, Presto uses PrestoS3FileSystem or EMRFS as its file system, and ``fs.s3.maxConnections`` configuration option specifies
+the maximum number of connections the S3 client can open to Amazon S3 through EMRFS (default is 5000).
+S3 Select Pushdown bypasses the filesystems when accessing Amazon S3 for predicate operations. In this case, the value of
+``hive.s3select-pushdown.max-connections`` determines the maximum number of client connections allowed for those operations
+from worker nodes. However, when pushdown is not enabled, ```fs.s3.maxConnections`` config option is used to determine
+the max number of connections.
+
+If your workload experiences the error "Timeout waiting for connection from pool," increase the value of both
+``hive.s3select-pushdown.max-connections`` and ``fs.s3.maxConnections``.
 
 Table Statistics
 ----------------

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-hive</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -144,6 +144,8 @@ public class HiveClientConfig
     private String recordingPath;
     private boolean replay;
     private Duration recordingDuration = new Duration(0, MINUTES);
+    private boolean s3SelectPushdownEnabled;
+    private int s3SelectPushdownMaxConnections = 500;
 
     public int getMaxInitialSplits()
     {
@@ -1147,5 +1149,31 @@ public class HiveClientConfig
     public Duration getRecordingDuration()
     {
         return recordingDuration;
+    }
+
+    public boolean isS3SelectPushdownEnabled()
+    {
+        return s3SelectPushdownEnabled;
+    }
+
+    @Config("hive.s3select-pushdown.enabled")
+    @ConfigDescription("Enable query pushdown to AWS S3 Select service")
+    public HiveClientConfig setS3SelectPushdownEnabled(boolean s3SelectPushdownEnabled)
+    {
+        this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
+        return this;
+    }
+
+    @Min(1)
+    public int getS3SelectPushdownMaxConnections()
+    {
+        return s3SelectPushdownMaxConnections;
+    }
+
+    @Config("hive.s3select-pushdown.max-connections")
+    public HiveClientConfig setS3SelectPushdownMaxConnections(int s3SelectPushdownMaxConnections)
+    {
+        this.s3SelectPushdownMaxConnections = s3SelectPushdownMaxConnections;
+        return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.orc.DwrfPageSourceFactory;
 import com.facebook.presto.hive.orc.OrcPageSourceFactory;
 import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
 import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
+import com.facebook.presto.hive.s3.PrestoS3ClientFactory;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
@@ -74,7 +75,9 @@ public class HiveClientModule
         binder.bind(NamenodeStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(NamenodeStats.class).as(generatedNameOf(NamenodeStats.class, connectorId));
 
+        binder.bind(PrestoS3ClientFactory.class).in(Scopes.SINGLETON);
         Multibinder<HiveRecordCursorProvider> recordCursorProviderBinder = newSetBinder(binder, HiveRecordCursorProvider.class);
+        recordCursorProviderBinder.addBinding().to(S3SelectRecordCursorProvider.class).in(Scopes.SINGLETON);
         recordCursorProviderBinder.addBinding().to(GenericHiveRecordCursorProvider.class).in(Scopes.SINGLETON);
 
         binder.bind(HiveWriterStats.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -47,6 +47,7 @@ import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.hive.HivePageSourceProvider.ColumnMapping.toColumnHandles;
 import static com.facebook.presto.hive.HiveUtil.getPrefilledColumnValue;
+import static com.facebook.presto.hive.S3SelectRecordCursorProvider.S3_SELECT_PUSHDOWN_ENABLED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -90,10 +91,13 @@ public class HivePageSourceProvider
         HiveSplit hiveSplit = (HiveSplit) split;
         Path path = new Path(hiveSplit.getPath());
 
+        Configuration configuration = new Configuration(hdfsEnvironment.getConfiguration(new HdfsContext(session, hiveSplit.getDatabase(), hiveSplit.getTable()), path));
+        configuration.setBoolean(S3_SELECT_PUSHDOWN_ENABLED, hiveSplit.isS3SelectPushdownEnabled());
+
         Optional<ConnectorPageSource> pageSource = createHivePageSource(
                 cursorProviders,
                 pageSourceFactories,
-                hdfsEnvironment.getConfiguration(new HdfsContext(session, hiveSplit.getDatabase(), hiveSplit.getTable()), path),
+                configuration,
                 session,
                 path,
                 hiveSplit.getBucketNumber(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
@@ -25,12 +25,18 @@ public class HivePartitionMetadata
     private final Optional<Partition> partition;
     private final HivePartition hivePartition;
     private final Map<Integer, HiveTypeName> columnCoercions;
+    private final boolean s3SelectPushdownEnabled;
 
-    HivePartitionMetadata(HivePartition hivePartition, Optional<Partition> partition, Map<Integer, HiveTypeName> columnCoercions)
+    HivePartitionMetadata(
+            HivePartition hivePartition,
+            Optional<Partition> partition,
+            Map<Integer, HiveTypeName> columnCoercions,
+            boolean s3selectPushdownEnabled)
     {
         this.partition = requireNonNull(partition, "partition is null");
         this.hivePartition = requireNonNull(hivePartition, "hivePartition is null");
         this.columnCoercions = requireNonNull(columnCoercions, "columnCoercions is null");
+        this.s3SelectPushdownEnabled = s3selectPushdownEnabled;
     }
 
     public HivePartition getHivePartition()
@@ -49,5 +55,10 @@ public class HivePartitionMetadata
     public Map<Integer, HiveTypeName> getColumnCoercions()
     {
         return columnCoercions;
+    }
+
+    public boolean isS3SelectPushdownEnabled()
+    {
+        return s3SelectPushdownEnabled;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -74,6 +74,7 @@ public final class HiveSessionProperties
     private static final String IGNORE_CORRUPTED_STATISTICS = "ignore_corrupted_statistics";
     private static final String COLLECT_COLUMN_STATISTICS_ON_WRITE = "collect_column_statistics_on_write";
     private static final String OPTIMIZE_MISMATCHED_BUCKET_COUNT = "optimize_mismatched_bucket_count";
+    private static final String S3_SELECT_PUSHDOWN_ENABLED = "s3_select_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -284,6 +285,11 @@ public final class HiveSessionProperties
                         OPTIMIZE_MISMATCHED_BUCKET_COUNT,
                         "Experimenal: Enable optimization to avoid shuffle when bucket count is compatible but not the same",
                         hiveClientConfig.isOptimizeMismatchedBucketCount(),
+                                false),
+                booleanProperty(
+                        S3_SELECT_PUSHDOWN_ENABLED,
+                        "S3 Select pushdown enabled",
+                        hiveClientConfig.isS3SelectPushdownEnabled(),
                         false));
     }
 
@@ -442,6 +448,11 @@ public final class HiveSessionProperties
     public static boolean isSortedWritingEnabled(ConnectorSession session)
     {
         return session.getProperty(SORTED_WRITING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isS3SelectPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(S3_SELECT_PUSHDOWN_ENABLED, Boolean.class);
     }
 
     public static boolean isStatisticsEnabled(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -50,6 +50,7 @@ public class HiveSplit
     private final boolean forceLocalScheduling;
     private final Map<Integer, HiveType> columnCoercions; // key: hiveColumnIndex
     private final Optional<BucketConversion> bucketConversion;
+    private final boolean s3SelectPushdownEnabled;
 
     @JsonCreator
     public HiveSplit(
@@ -67,7 +68,8 @@ public class HiveSplit
             @JsonProperty("forceLocalScheduling") boolean forceLocalScheduling,
             @JsonProperty("effectivePredicate") TupleDomain<HiveColumnHandle> effectivePredicate,
             @JsonProperty("columnCoercions") Map<Integer, HiveType> columnCoercions,
-            @JsonProperty("bucketConversion") Optional<BucketConversion> bucketConversion)
+            @JsonProperty("bucketConversion") Optional<BucketConversion> bucketConversion,
+            @JsonProperty("s3SelectPushdownEnabled") boolean s3SelectPushdownEnabled)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(length >= 0, "length must be positive");
@@ -99,6 +101,7 @@ public class HiveSplit
         this.effectivePredicate = effectivePredicate;
         this.columnCoercions = columnCoercions;
         this.bucketConversion = bucketConversion;
+        this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
     }
 
     @JsonProperty
@@ -198,6 +201,12 @@ public class HiveSplit
         return !forceLocalScheduling;
     }
 
+    @JsonProperty
+    public boolean isS3SelectPushdownEnabled()
+    {
+        return s3SelectPushdownEnabled;
+    }
+
     @Override
     public Object getInfo()
     {
@@ -211,6 +220,7 @@ public class HiveSplit
                 .put("table", table)
                 .put("forceLocalScheduling", forceLocalScheduling)
                 .put("partitionName", partitionName)
+                .put("s3SelectPushdownEnabled", s3SelectPushdownEnabled)
                 .build();
     }
 
@@ -223,6 +233,7 @@ public class HiveSplit
                 .addValue(length)
                 .addValue(fileSize)
                 .addValue(effectivePredicate)
+                .addValue(s3SelectPushdownEnabled)
                 .toString();
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -376,7 +376,9 @@ class HiveSplitSource
                         internalSplit.isForceLocalScheduling(),
                         (TupleDomain<HiveColumnHandle>) compactEffectivePredicate,
                         transformValues(internalSplit.getColumnCoercions(), HiveTypeName::toHiveType),
-                        internalSplit.getBucketConversion()));
+                        internalSplit.getBucketConversion(),
+                        internalSplit.isS3SelectPushdownEnabled()));
+
                 internalSplit.increaseStart(splitBytes);
 
                 if (internalSplit.isDone()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
@@ -57,6 +57,7 @@ public class InternalHiveSplit
     private final boolean forceLocalScheduling;
     private final Map<Integer, HiveTypeName> columnCoercions;
     private final Optional<BucketConversion> bucketConversion;
+    private final boolean s3SelectPushdownEnabled;
 
     private long start;
     private int currentBlockIndex;
@@ -74,7 +75,8 @@ public class InternalHiveSplit
             boolean splittable,
             boolean forceLocalScheduling,
             Map<Integer, HiveTypeName> columnCoercions,
-            Optional<BucketConversion> bucketConversion)
+            Optional<BucketConversion> bucketConversion,
+            boolean s3SelectPushdownEnabled)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(end >= 0, "length must be positive");
@@ -101,6 +103,7 @@ public class InternalHiveSplit
         this.forceLocalScheduling = forceLocalScheduling;
         this.columnCoercions = ImmutableMap.copyOf(columnCoercions);
         this.bucketConversion = bucketConversion;
+        this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
     }
 
     public String getPath()
@@ -121,6 +124,11 @@ public class InternalHiveSplit
     public long getFileSize()
     {
         return fileSize;
+    }
+
+    public boolean isS3SelectPushdownEnabled()
+    {
+        return s3SelectPushdownEnabled;
     }
 
     public Properties getSchema()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/IonSqlQueryBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/IonSqlQueryBuilder.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.base.Joiner;
+import io.airlift.slice.Slice;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.Builder;
+import static com.google.common.collect.ImmutableList.builder;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.stream.Collectors.joining;
+import static org.joda.time.chrono.ISOChronology.getInstanceUTC;
+import static org.joda.time.format.ISODateTimeFormat.date;
+
+/**
+ * S3 Select uses Ion SQL++ query language. This class is used to construct a valid Ion SQL++ query
+ * to be evaluated with S3 Select on an S3 object.
+ */
+public class IonSqlQueryBuilder
+{
+    private static final DateTimeFormatter FORMATTER = date().withChronology(getInstanceUTC());
+    private static final String DATA_SOURCE = "S3Object s";
+    private final TypeManager typeManager;
+
+    IonSqlQueryBuilder(TypeManager typeManager)
+    {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    String buildSql(List<HiveColumnHandle> columns, TupleDomain<HiveColumnHandle> tupleDomain)
+    {
+        StringBuilder sql = new StringBuilder("SELECT ");
+
+        if (columns.isEmpty()) {
+            sql.append("' '");
+        }
+        else {
+            String columnNames = columns.stream()
+                    .map(column -> format("s._%d", column.getHiveColumnIndex() + 1))
+                    .collect(joining(", "));
+            sql.append(columnNames);
+        }
+
+        sql.append(" FROM ");
+        sql.append(DATA_SOURCE);
+
+        List<String> clauses = toConjuncts(columns, tupleDomain);
+        if (!clauses.isEmpty()) {
+            sql.append(" WHERE ")
+                    .append(Joiner.on(" AND ").join(clauses));
+        }
+
+        return sql.toString();
+    }
+
+    private List<String> toConjuncts(List<HiveColumnHandle> columns, TupleDomain<HiveColumnHandle> tupleDomain)
+    {
+        Builder<String> builder = builder();
+        for (HiveColumnHandle column : columns) {
+            Type type = column.getHiveType().getType(typeManager);
+            if (tupleDomain.getDomains().isPresent() && isSupported(type)) {
+                Domain domain = tupleDomain.getDomains().get().get(column);
+                if (domain != null) {
+                    builder.add(toPredicate(domain, type, column.getHiveColumnIndex()));
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    private static boolean isSupported(Type type)
+    {
+        Type validType = requireNonNull(type, "type is null");
+        return validType.equals(BIGINT) ||
+                validType.equals(TINYINT) ||
+                validType.equals(SMALLINT) ||
+                validType.equals(INTEGER) ||
+                validType instanceof DecimalType ||
+                /*
+                 * Double and Real Types loose precision. Thus, they are not pushed down to S3. Please use Decimal Type if push down is desired.
+                 * validType.equals(DoubleType.DOUBLE) ||
+                 * validType.equals(RealType.REAL) ||
+                 */
+                validType.equals(BOOLEAN) ||
+                validType.equals(DATE) ||
+                /*
+                 * Pushing down timestamp to s3select is problematic due to following reasons:
+                 * 1) Presto bug: TIMESTAMP behaviour does not match sql standard (https://github.com/prestodb/presto/issues/7122)
+                 * 2) Presto uses the timezone from client to convert the timestamp if no timezone is provided, however, s3select is a different service and this could lead to unexpected results.
+                 * 3) ION SQL compare timestamps using precision, timestamps with different precisions are not equal even actually they present the same instant of time. This could lead to unexpected results.
+                 *
+                 * validType.equals(TimestampType.TIMESTAMP) ||
+                 */
+                validType instanceof VarcharType;
+    }
+
+    private String toPredicate(Domain domain, Type type, int position)
+    {
+        checkArgument(domain.getType().isOrderable(), "Domain type must be orderable");
+
+        if (domain.getValues().isNone()) {
+            if (domain.isNullAllowed()) {
+                return format("s._%d", position + 1) + " = '' ";
+            }
+            return "FALSE";
+        }
+
+        if (domain.getValues().isAll()) {
+            if (domain.isNullAllowed()) {
+                return "TRUE";
+            }
+            return format("s._%d", position + 1) + " <> '' ";
+        }
+
+        List<String> disjuncts = new ArrayList<>();
+        List<Object> singleValues = new ArrayList<>();
+        for (Range range : domain.getValues().getRanges().getOrderedRanges()) {
+            checkState(!range.isAll());
+            if (range.isSingleValue()) {
+                singleValues.add(range.getLow().getValue());
+                continue;
+            }
+            List<String> rangeConjuncts = new ArrayList<>();
+            if (!range.getLow().isLowerUnbounded()) {
+                switch (range.getLow().getBound()) {
+                    case ABOVE:
+                        rangeConjuncts.add(toPredicate(">", range.getLow().getValue(), type, position));
+                        break;
+                    case EXACTLY:
+                        rangeConjuncts.add(toPredicate(">=", range.getLow().getValue(), type, position));
+                        break;
+                    case BELOW:
+                        throw new IllegalArgumentException("Low marker should never use BELOW bound");
+                    default:
+                        throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
+                }
+            }
+            if (!range.getHigh().isUpperUnbounded()) {
+                switch (range.getHigh().getBound()) {
+                    case ABOVE:
+                        throw new IllegalArgumentException("High marker should never use ABOVE bound");
+                    case EXACTLY:
+                        rangeConjuncts.add(toPredicate("<=", range.getHigh().getValue(), type, position));
+                        break;
+                    case BELOW:
+                        rangeConjuncts.add(toPredicate("<", range.getHigh().getValue(), type, position));
+                        break;
+                    default:
+                        throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
+                }
+            }
+            // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
+            checkState(!rangeConjuncts.isEmpty());
+            disjuncts.add("(" + Joiner.on(" AND ").join(rangeConjuncts) + ")");
+        }
+
+        // Add back all of the possible single values either as an equality or an IN predicate
+        if (singleValues.size() == 1) {
+            disjuncts.add(toPredicate("=", getOnlyElement(singleValues), type, position));
+        }
+        else if (singleValues.size() > 1) {
+            List<String> values = new ArrayList<>();
+            for (Object value : singleValues) {
+                checkType(type);
+                values.add(valueToQuery(type, value));
+            }
+            disjuncts.add(createColumn(type, position) + " IN (" + Joiner.on(",").join(values) + ")");
+        }
+
+        // Add nullability disjuncts
+        checkState(!disjuncts.isEmpty());
+        if (domain.isNullAllowed()) {
+            disjuncts.add(format("s._%d", position + 1) + " = '' ");
+        }
+
+        return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
+    }
+
+    private String toPredicate(String operator, Object value, Type type, int position)
+    {
+        checkType(type);
+
+        return format("%s %s %s", createColumn(type, position), operator, valueToQuery(type, value));
+    }
+
+    private static void checkType(Type type)
+    {
+        checkArgument(isSupported(type), "Type not supported: %s", type);
+    }
+
+    private static String valueToQuery(Type type, Object value)
+    {
+        if (type.equals(BIGINT)) {
+            return String.valueOf(((long) value));
+        }
+        if (type.equals(DoubleType.DOUBLE)) {
+            return value.toString();
+        }
+        if (type.equals(INTEGER)) {
+            return String.valueOf(((Number) value).intValue());
+        }
+        if (type.equals(SMALLINT)) {
+            return String.valueOf(((Number) value).shortValue());
+        }
+        if (type.equals(TINYINT)) {
+            return String.valueOf(((Number) value).byteValue());
+        }
+        if (type.equals(RealType.REAL)) {
+            return String.valueOf(intBitsToFloat(((Number) value).intValue()));
+        }
+        if (type.equals(BOOLEAN)) {
+            return String.valueOf(value);
+        }
+        if (type.equals(DATE)) {
+            return "`" + FORMATTER.print(DAYS.toMillis((long) value)) + "`";
+        }
+        if (type.equals(TimestampType.TIMESTAMP)) {
+            return String.valueOf((long) value);
+        }
+        if (type.equals(VarcharType.VARCHAR)) {
+            return "'" + ((Slice) value).toStringUtf8() + "'";
+        }
+        if (type instanceof DecimalType) {
+            if (Decimals.isLongDecimal(type)) {
+                return Decimals.toString((Slice) value, ((DecimalType) type).getScale());
+            }
+            return Decimals.toString((long) value, ((DecimalType) type).getScale());
+        }
+        return "'" + ((Slice) value).toStringUtf8() + "'";
+    }
+
+    private String createColumn(Type type, int position)
+    {
+        String column = format("s._%d", position + 1);
+
+        if (type.equals(BIGINT)) {
+            return formatPredicate(column, "INT");
+        }
+        if (type.equals(INTEGER)) {
+            return formatPredicate(column, "INT");
+        }
+        if (type.equals(SMALLINT)) {
+            return formatPredicate(column, "INT");
+        }
+        if (type.equals(TINYINT)) {
+            return formatPredicate(column, "INT");
+        }
+        if (type.equals(DoubleType.DOUBLE)) {
+            return formatPredicate(column, "FLOAT");
+        }
+        if (type.equals(RealType.REAL)) {
+            return formatPredicate(column, "FLOAT");
+        }
+        if (type.equals(BOOLEAN)) {
+            return formatPredicate(column, "BOOL");
+        }
+        if (type.equals(DATE)) {
+            return formatPredicate(column, "TIMESTAMP");
+        }
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            return formatPredicate(format("DECIMAL(%s,%s)", decimalType.getPrecision(), decimalType.getScale()), column);
+        }
+        return column;
+    }
+
+    private String formatPredicate(String column, String type)
+    {
+        return format("case %s when '' then null else CAST(%s AS %s) end", column, column, type);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectCsvRecordReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectCsvRecordReader.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.amazonaws.services.s3.model.CSVInput;
+import com.amazonaws.services.s3.model.CSVOutput;
+import com.amazonaws.services.s3.model.CompressionType;
+import com.amazonaws.services.s3.model.ExpressionType;
+import com.amazonaws.services.s3.model.InputSerialization;
+import com.amazonaws.services.s3.model.OutputSerialization;
+import com.amazonaws.services.s3.model.SelectObjectContentRequest;
+import com.facebook.presto.hive.s3.PrestoS3ClientFactory;
+import com.facebook.presto.hive.s3.PrestoS3FileSystem;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import java.net.URI;
+import java.util.Properties;
+
+import static com.facebook.presto.hive.S3SelectPushdown.S3SelectSupportedCompressionCodecs.BZIP2;
+import static com.facebook.presto.hive.S3SelectPushdown.S3SelectSupportedCompressionCodecs.GZIP;
+import static org.apache.hadoop.hive.serde.serdeConstants.ESCAPE_CHAR;
+import static org.apache.hadoop.hive.serde.serdeConstants.QUOTE_CHAR;
+
+public class S3SelectCsvRecordReader
+        extends S3SelectLineRecordReader
+{
+    /*
+     * Sentinel unicode comment character (http://www.unicode.org/faq/private_use.html#nonchar_codes).
+     * It is expected that \uFDD0 sentinel comment character is not the first character in any row of user's CSV S3 object.
+     * The rows starting with \uFDD0 will be skipped by S3Select and will not be a part of the result set or aggregations.
+     * To process CSV objects that may contain \uFDD0 as first row character please disable S3SelectPushdown.
+     * TODO: Remove this proxy logic when S3Select API supports disabling of row level comments.
+     */
+
+    private static final String COMMENTS_CHAR_STR = "\uFDD0";
+
+    S3SelectCsvRecordReader(
+            Configuration configuration,
+            HiveClientConfig clientConfig,
+            Path path,
+            long start,
+            long length,
+            Properties schema,
+            String ionSqlQuery,
+            PrestoS3ClientFactory s3ClientFactory)
+    {
+        super(configuration, clientConfig, path, start, length, schema, ionSqlQuery, s3ClientFactory);
+    }
+
+    @Override
+    public SelectObjectContentRequest buildSelectObjectRequest(Properties schema, String query, Path path)
+    {
+        SelectObjectContentRequest selectObjectRequest = new SelectObjectContentRequest();
+        URI uri = path.toUri();
+        selectObjectRequest.setBucketName(PrestoS3FileSystem.getBucketName(uri));
+        selectObjectRequest.setKey(PrestoS3FileSystem.keyFromPath(path));
+        selectObjectRequest.setExpression(query);
+        selectObjectRequest.setExpressionType(ExpressionType.SQL);
+
+        String fieldDelimiter = getFieldDelimiter(schema);
+        String quoteChar = schema.getProperty(QUOTE_CHAR, null);
+        String escapeChar = schema.getProperty(ESCAPE_CHAR, null);
+
+        CSVInput selectObjectCSVInputSerialization = new CSVInput();
+        selectObjectCSVInputSerialization.setRecordDelimiter(lineDelimiter);
+        selectObjectCSVInputSerialization.setFieldDelimiter(fieldDelimiter);
+        selectObjectCSVInputSerialization.setComments(COMMENTS_CHAR_STR);
+        selectObjectCSVInputSerialization.setQuoteCharacter(quoteChar);
+        selectObjectCSVInputSerialization.setQuoteEscapeCharacter(escapeChar);
+        InputSerialization selectObjectInputSerialization = new InputSerialization();
+        if (path.getName().endsWith(GZIP.getExtension())) {
+            selectObjectInputSerialization.setCompressionType(CompressionType.GZIP);
+        }
+        else if (path.getName().endsWith(BZIP2.getExtension())) {
+            selectObjectInputSerialization.setCompressionType(CompressionType.BZIP2);
+        }
+
+        selectObjectInputSerialization.setCsv(selectObjectCSVInputSerialization);
+        selectObjectRequest.setInputSerialization(selectObjectInputSerialization);
+
+        OutputSerialization selectObjectOutputSerialization = new OutputSerialization();
+        CSVOutput selectObjectCSVOutputSerialization = new CSVOutput();
+        selectObjectCSVOutputSerialization.setRecordDelimiter(lineDelimiter);
+        selectObjectCSVOutputSerialization.setFieldDelimiter(fieldDelimiter);
+        selectObjectCSVOutputSerialization.setQuoteCharacter(quoteChar);
+        selectObjectCSVOutputSerialization.setQuoteEscapeCharacter(escapeChar);
+        selectObjectOutputSerialization.setCsv(selectObjectCSVOutputSerialization);
+        selectObjectRequest.setOutputSerialization(selectObjectOutputSerialization);
+
+        return selectObjectRequest;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectLineRecordReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectLineRecordReader.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.SelectObjectContentRequest;
+import com.facebook.presto.hive.s3.HiveS3Config;
+import com.facebook.presto.hive.s3.PrestoS3ClientFactory;
+import com.facebook.presto.hive.s3.PrestoS3SelectClient;
+import com.facebook.presto.hive.s3.UnrecoverableS3OperationException;
+import com.google.common.io.Closer;
+import io.airlift.units.Duration;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.util.LineReader;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import static com.facebook.presto.hive.RetryDriver.retry;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_MAX_BACKOFF_TIME;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_MAX_CLIENT_RETRIES;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_MAX_RETRY_TIME;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.hadoop.hive.serde.serdeConstants.FIELD_DELIM;
+import static org.apache.hadoop.hive.serde.serdeConstants.LINE_DELIM;
+import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_FORMAT;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+
+@ThreadSafe
+public abstract class S3SelectLineRecordReader
+        implements RecordReader<LongWritable, Text>
+{
+    private InputStream selectObjectContent;
+    private long processedRecords;
+    private long recordsFromS3;
+    private long position;
+    private LineReader reader;
+    private boolean isFirstLine;
+    private static final Duration BACKOFF_MIN_SLEEP = new Duration(1, SECONDS);
+    private final PrestoS3SelectClient selectClient;
+    final String lineDelimiter;
+    private final long start;
+    private final long end;
+    private final int maxAttempts;
+    private final Duration maxBackoffTime;
+    private final Duration maxRetryTime;
+    private final Closer closer = Closer.create();
+    private final SelectObjectContentRequest selectObjectContentRequest;
+
+    S3SelectLineRecordReader(
+            Configuration configuration,
+            HiveClientConfig clientConfig,
+            Path path,
+            long start,
+            long length,
+            Properties schema,
+            String ionSqlQuery,
+            PrestoS3ClientFactory s3ClientFactory)
+    {
+        requireNonNull(configuration, "configuration is null");
+        requireNonNull(clientConfig, "clientConfig is null");
+        requireNonNull(schema, "schema is null");
+        requireNonNull(path, "path is null");
+        requireNonNull(ionSqlQuery, "ionSqlQuery is null");
+        requireNonNull(s3ClientFactory, "s3ClientFactory is null");
+        this.selectClient = new PrestoS3SelectClient(configuration, clientConfig, s3ClientFactory);
+        closer.register(selectClient);
+        this.lineDelimiter = (schema).getProperty(LINE_DELIM, "\n");
+        this.processedRecords = 0;
+        this.recordsFromS3 = 0;
+        this.start = start;
+        this.position = this.start;
+        this.end = this.start + length;
+        this.isFirstLine = true;
+        this.selectObjectContentRequest = buildSelectObjectRequest(schema, ionSqlQuery, path);
+        HiveS3Config defaults = new HiveS3Config();
+        this.maxAttempts = configuration.getInt(S3_MAX_CLIENT_RETRIES, defaults.getS3MaxClientRetries()) + 1;
+        this.maxBackoffTime = Duration.valueOf(configuration.get(S3_MAX_BACKOFF_TIME, defaults.getS3MaxBackoffTime().toString()));
+        this.maxRetryTime = Duration.valueOf(configuration.get(S3_MAX_RETRY_TIME, defaults.getS3MaxRetryTime().toString()));
+    }
+
+    public abstract SelectObjectContentRequest buildSelectObjectRequest(Properties schema, String query, Path path);
+
+    private int readLine(Text value)
+            throws IOException
+    {
+        try {
+            return retry()
+                    .maxAttempts(maxAttempts)
+                    .exponentialBackoff(BACKOFF_MIN_SLEEP, maxBackoffTime, maxRetryTime, 2.0)
+                    .stopOn(InterruptedException.class, UnrecoverableS3OperationException.class)
+                    .run("readRecordsContentStream", () -> {
+                        if (isFirstLine) {
+                            recordsFromS3 = 0;
+                            selectObjectContent = selectClient.getRecordsContent(selectObjectContentRequest);
+                            closer.register(selectObjectContent);
+                            reader = new LineReader(selectObjectContent, lineDelimiter.getBytes(StandardCharsets.UTF_8));
+                            closer.register(reader);
+                            isFirstLine = false;
+                        }
+                        try {
+                            return reader.readLine(value);
+                        }
+                        catch (RuntimeException e) {
+                            isFirstLine = true;
+                            recordsFromS3 = 0;
+                            if (e instanceof AmazonS3Exception) {
+                                switch (((AmazonS3Exception) e).getStatusCode()) {
+                                    case SC_FORBIDDEN:
+                                    case SC_NOT_FOUND:
+                                    case SC_BAD_REQUEST:
+                                        throw new UnrecoverableS3OperationException(selectClient.getBucketName(), selectClient.getKeyName(), e);
+                                }
+                            }
+                            throw e;
+                        }
+                    });
+        }
+        catch (Exception e) {
+            throwIfInstanceOf(e, IOException.class);
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public synchronized boolean next(LongWritable key, Text value)
+            throws IOException
+    {
+        while (true) {
+            int bytes = readLine(value);
+            if (bytes <= 0) {
+                if (!selectClient.isRequestComplete()) {
+                    throw new RuntimeException("S3 Select request was incomplete as End Event was not received.");
+                }
+                return false;
+            }
+            if (++recordsFromS3 > processedRecords) {
+                position += bytes;
+                processedRecords++;
+                key.set(processedRecords);
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public LongWritable createKey()
+    {
+        return new LongWritable();
+    }
+
+    @Override
+    public Text createValue()
+    {
+        return new Text();
+    }
+
+    @Override
+    public long getPos()
+    {
+        return position;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        closer.close();
+    }
+
+    @Override
+    public float getProgress()
+    {
+        return ((float) (position - start)) / (end - start);
+    }
+
+    String getFieldDelimiter(Properties schema)
+    {
+        return schema.getProperty(FIELD_DELIM, schema.getProperty(SERIALIZATION_FORMAT));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectPushdown.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.log.Logger;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.compress.BZip2Codec;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.GzipCodec;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.TextInputFormat;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.facebook.presto.hive.HiveUtil.getCompressionCodec;
+import static com.facebook.presto.hive.HiveUtil.getDeserializerClassName;
+import static com.facebook.presto.hive.HiveUtil.getInputFormatName;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
+import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_LOCATION;
+
+/**
+ * S3SelectPushdown uses Amazon S3 Select to push down queries to Amazon S3. This allows Presto to retrieve only a
+ * subset of data rather than retrieving the full S3 object thus improving Presto query performance.
+ */
+public class S3SelectPushdown
+{
+    private static final Logger LOG = Logger.get(S3SelectPushdown.class);
+    private static final Set<String> SUPPORTED_S3_PREFIXES = ImmutableSet.of(
+            "s3://", "s3a://", "s3n://");
+    private static final Set<String> SUPPORTED_SERDES = ImmutableSet.of(
+            "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe");
+    private static final Set<String> SUPPORTED_INPUT_FORMATS = ImmutableSet.of(
+            "org.apache.hadoop.mapred.TextInputFormat");
+    private static final Set<String> SUPPORTED_COLUMN_TYPES = ImmutableSet.of(
+            "boolean",
+            "int",
+            "tinyint",
+            "smallint",
+            "bigint",
+            "string",
+            "float",
+            "double",
+            "decimal",
+            "date",
+            "timestamp");
+
+    private final HiveClientConfig hiveClientConfig;
+
+    S3SelectPushdown(HiveClientConfig hiveClientConfig)
+    {
+        this.hiveClientConfig = requireNonNull(hiveClientConfig);
+    }
+
+    private static boolean isSerdeSupported(Properties schema)
+    {
+        String serdeName = getDeserializerClassName(schema);
+
+        if (!SUPPORTED_SERDES.contains(serdeName)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isInputFormatSupported(Properties schema)
+    {
+        String inputFormat = getInputFormatName(schema);
+
+        if (!SUPPORTED_INPUT_FORMATS.contains(inputFormat)) {
+            return false;
+        }
+        return true;
+    }
+
+    public static boolean isCompressionCodecSupported(InputFormat inputFormat, Path path)
+    {
+        if (inputFormat instanceof TextInputFormat) {
+            try {
+                Optional<CompressionCodec> compressionCodec = getCompressionCodec((TextInputFormat) inputFormat, path);
+                if (!compressionCodec.isPresent() ||
+                        stream(S3SelectSupportedCompressionCodecs.values())
+                                .anyMatch(codec -> codec.getCodecClass().isInstance(compressionCodec.get()))) {
+                    return true;
+                }
+            }
+            catch (IllegalAccessException | NoSuchFieldException e) {
+                LOG.error(e, "Failed to find compressionCodec for inputFormat: %s", inputFormat.getClass().getName());
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private static boolean areColumnTypesSupported(List<Column> columns)
+    {
+        if (columns == null || columns.isEmpty()) {
+            return false;
+        }
+
+        for (Column column : columns) {
+            String type = column.getType().getHiveTypeName().toString();
+            if (type.startsWith(StandardTypes.DECIMAL)) {
+                // skip precision and scale when check decimal type
+                type = StandardTypes.DECIMAL;
+            }
+            if (!SUPPORTED_COLUMN_TYPES.contains(type.toLowerCase(Locale.ENGLISH))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isS3SelectEnabled(ConnectorSession session)
+    {
+        if (!hiveClientConfig.isS3SelectPushdownEnabled()) {
+            return false;
+        }
+
+        if (!HiveSessionProperties.isS3SelectPushdownEnabled(session)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean isS3Storage(Properties schema)
+    {
+        String location = schema.getProperty(META_TABLE_LOCATION);
+        return location != null && SUPPORTED_S3_PREFIXES.stream().anyMatch(location::startsWith);
+    }
+
+    boolean shouldOptimizeTable(ConnectorSession session, Table table, Optional<Partition> partition)
+    {
+        if (!isS3SelectEnabled(session)) {
+            return false;
+        }
+        // Hive table partitions could be on different storages,
+        // as a result, we have to check each individual partition
+        Properties schema;
+        if (partition.isPresent()) {
+            schema = getHiveSchema(partition.get(), table);
+        }
+        else {
+            schema = getHiveSchema(table);
+        }
+
+        return shouldOptimizeTable(table, schema);
+    }
+
+    private boolean shouldOptimizeTable(Table table, Properties schema)
+    {
+        return isS3Storage(schema) &&
+                isSerdeSupported(schema) &&
+                isInputFormatSupported(schema) &&
+                areColumnTypesSupported(table.getDataColumns());
+    }
+
+    public enum S3SelectSupportedCompressionCodecs {
+        GZIP(".gz", GzipCodec.class),
+        BZIP2(".bz2", BZip2Codec.class);
+
+        private final String extension;
+        private final Class<? extends CompressionCodec> codecClass;
+
+        S3SelectSupportedCompressionCodecs(
+                String extension,
+                Class<? extends CompressionCodec> codecClass)
+        {
+            this.extension = extension;
+            this.codecClass = codecClass;
+        }
+
+        public String getExtension()
+        {
+            return extension;
+        }
+
+        private Class<? extends CompressionCodec> getCodecClass()
+        {
+            return codecClass;
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectRecordCursor.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.type.TypeManager;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.RecordReader;
+import org.joda.time.DateTimeZone;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static org.apache.hadoop.hive.serde.serdeConstants.LIST_COLUMNS;
+import static org.apache.hadoop.hive.serde.serdeConstants.LIST_COLUMN_TYPES;
+import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_DDL;
+
+class S3SelectRecordCursor<K, V extends Writable>
+        extends GenericHiveRecordCursor
+{
+    private static final String THRIFT_STRUCT = "struct";
+    private static final String START_STRUCT = "{";
+    private static final String END_STRUCT = "}";
+    private static final String FIELD_SEPARATOR = ",";
+    private static final String EMPTY_STRING = "";
+    private static final String SPACE = " ";
+
+    S3SelectRecordCursor(
+            Configuration configuration,
+            Path path,
+            RecordReader recordReader,
+            long totalBytes,
+            Properties splitSchema,
+            List<HiveColumnHandle> columns,
+            DateTimeZone hiveStorageTimeZone,
+            TypeManager typeManager)
+    {
+        super(configuration, path, recordReader, totalBytes, updateSplitSchema(splitSchema, columns), columns, hiveStorageTimeZone, typeManager);
+    }
+
+    // since s3select only returns the required column, not the whole columns
+    // we need to update the split schema to include only the required columns
+    // otherwise, Serde could not deserialize output from s3select to row data correctly
+    static Properties updateSplitSchema(Properties splitSchema, List<HiveColumnHandle> columns)
+    {
+        requireNonNull(splitSchema, "splitSchema is null");
+        requireNonNull(columns, "columns is null");
+        // clone split properties for update so as not to affect the original one,
+        // which could be used by other logic
+        Properties updatedSchema = new Properties();
+        updatedSchema.putAll(splitSchema);
+        updatedSchema.setProperty(LIST_COLUMNS, buildColumns(columns));
+        updatedSchema.setProperty(LIST_COLUMN_TYPES, buildColumnTypes(columns));
+        ThriftDDL thriftDDL = parseThriftDDL(splitSchema.getProperty(SERIALIZATION_DDL));
+        thriftDDL = filterThriftDDL(thriftDDL, columns);
+        updatedSchema.setProperty(SERIALIZATION_DDL, thriftDDLToString(thriftDDL));
+        return updatedSchema;
+    }
+
+    private static String buildColumns(List<HiveColumnHandle> columns)
+    {
+        if (columns == null || columns.isEmpty()) {
+            return EMPTY_STRING;
+        }
+        return columns.stream().map(HiveColumnHandle::getName).collect(Collectors.joining(","));
+    }
+
+    private static String buildColumnTypes(List<HiveColumnHandle> columns)
+    {
+        if (columns == null || columns.isEmpty()) {
+            return EMPTY_STRING;
+        }
+        return columns
+                .stream()
+                .map(column -> column.getHiveType().getTypeInfo().getTypeName())
+                .collect(Collectors.joining(","));
+    }
+
+    private static ThriftDDL parseThriftDDL(String ddl)
+    {
+        if (isNullOrEmpty(ddl)) {
+            return null;
+        }
+        String[] parts = ddl.trim().split("\\s+");
+        checkArgument(parts.length >= 5, "Invalid thrift DDL " + ddl);
+        checkArgument(THRIFT_STRUCT.equals(parts[0]), "ThriftDDL should start with " + THRIFT_STRUCT);
+        ThriftDDL thriftDDL = new ThriftDDL();
+        thriftDDL.setTableName(parts[1]);
+        checkArgument(START_STRUCT.equals(parts[2]), "Invalid thrift DDL " + ddl);
+        checkArgument(parts[parts.length - 1].endsWith(END_STRUCT), "Invalid thrift DDL " + ddl);
+        parts[parts.length - 1] = parts[parts.length - 1].substring(0, parts[parts.length - 1].length() - 1);
+        List<ThriftField> fields = new ArrayList<>();
+        for (int i = 3; i < parts.length - 1; i += 2) {
+            ThriftField thriftField = new ThriftField();
+            thriftField.setType(parts[i]);
+            if (parts[i + 1].endsWith(FIELD_SEPARATOR)) {
+                parts[i + 1] = parts[i + 1].substring(0, parts[i + 1].length() - 1);
+            }
+            thriftField.setName(parts[i + 1]);
+            fields.add(thriftField);
+        }
+        thriftDDL.setFields(fields);
+
+        return thriftDDL;
+    }
+
+    private static ThriftDDL filterThriftDDL(ThriftDDL thriftDDL, List<HiveColumnHandle> columns)
+    {
+        if (thriftDDL == null) {
+            return null;
+        }
+        List<ThriftField> fields = thriftDDL.getFields();
+        if (fields == null || fields.isEmpty()) {
+            return thriftDDL;
+        }
+        Set<String> columnNames = columns.stream()
+                .map(HiveColumnHandle::getName)
+                .collect(toImmutableSet());
+        List<ThriftField> filteredFields = fields.stream()
+                .filter(field -> columnNames.contains(field.getName()))
+                .collect(toList());
+        thriftDDL.setFields(filteredFields);
+
+        return thriftDDL;
+    }
+
+    private static String thriftDDLToString(ThriftDDL thriftDDL)
+    {
+        if (thriftDDL == null) {
+            return EMPTY_STRING;
+        }
+        List<ThriftField> fields = thriftDDL.getFields();
+        if (fields == null || fields.isEmpty()) {
+            return EMPTY_STRING;
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(THRIFT_STRUCT)
+                .append(SPACE)
+                .append(thriftDDL.getTableName())
+                .append(SPACE)
+                .append(START_STRUCT);
+        stringBuilder.append(fields.stream()
+                .map(field -> SPACE + field.getType() + SPACE + field.getName())
+                .collect(Collectors.joining(",")));
+        stringBuilder.append(END_STRUCT);
+
+        return stringBuilder.toString();
+    }
+
+    private static class ThriftField
+    {
+        private String type;
+        private String name;
+
+        private String getType()
+        {
+            return type;
+        }
+
+        private void setType(String type)
+        {
+            checkArgument(!isNullOrEmpty(type), "type is null or empty string");
+            this.type = type;
+        }
+
+        private String getName()
+        {
+            return name;
+        }
+
+        private void setName(String name)
+        {
+            requireNonNull(name, "name is null");
+            this.name = name;
+        }
+    }
+
+    private static class ThriftDDL
+    {
+        private String tableName;
+        private List<ThriftField> fields;
+
+        private String getTableName()
+        {
+            return tableName;
+        }
+
+        private void setTableName(String tableName)
+        {
+            checkArgument(!isNullOrEmpty(tableName), "tableName is null or empty string");
+            this.tableName = tableName;
+        }
+
+        private List<ThriftField> getFields()
+        {
+            return fields;
+        }
+
+        private void setFields(List<ThriftField> fields)
+        {
+            requireNonNull(fields, "fields is null");
+            this.fields = fields;
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectRecordCursorProvider.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.s3.PrestoS3ClientFactory;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTimeZone;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
+import static com.facebook.presto.hive.HiveUtil.getDeserializerClassName;
+import static java.util.Objects.requireNonNull;
+
+public class S3SelectRecordCursorProvider
+        implements HiveRecordCursorProvider
+{
+    public static final String S3_SELECT_PUSHDOWN_ENABLED = "s3.select-pushdown.enabled";
+
+    private static final Set<String> CSV_SERDES = ImmutableSet.of("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe");
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HiveClientConfig clientConfig;
+    private final PrestoS3ClientFactory s3ClientFactory;
+
+    @Inject
+    public S3SelectRecordCursorProvider(
+            HdfsEnvironment hdfsEnvironment,
+            HiveClientConfig clientConfig,
+            PrestoS3ClientFactory s3ClientFactory)
+    {
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.clientConfig = requireNonNull(clientConfig, "clientConfig is null");
+        this.s3ClientFactory = requireNonNull(s3ClientFactory, "s3ClientFactory is null");
+    }
+
+    @Override
+    public Optional<RecordCursor> createRecordCursor(
+            Configuration configuration,
+            ConnectorSession session,
+            Path path,
+            long start,
+            long length,
+            long fileSize,
+            Properties schema,
+            List<HiveColumnHandle> columns,
+            TupleDomain<HiveColumnHandle> effectivePredicate,
+            DateTimeZone hiveStorageTimeZone,
+            TypeManager typeManager)
+    {
+        boolean isS3SelectPushdownEnabled = configuration.getBoolean(S3_SELECT_PUSHDOWN_ENABLED, false);
+        if (!isS3SelectPushdownEnabled) {
+            return Optional.empty();
+        }
+
+        try {
+            this.hdfsEnvironment.getFileSystem(session.getUser(), path, configuration);
+        }
+        catch (IOException e) {
+            throw new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed getting filesystem for path: " + path, e);
+        }
+
+        String serdeName = getDeserializerClassName(schema);
+        if (CSV_SERDES.contains(serdeName)) {
+            IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
+            String ionSqlQuery = buildQuery(queryBuilder, columns, effectivePredicate);
+            S3SelectLineRecordReader recordReader = new S3SelectCsvRecordReader(configuration, clientConfig, path, start, length, schema, ionSqlQuery, s3ClientFactory);
+            return Optional.of(new S3SelectRecordCursor(configuration, path, recordReader, length, schema, columns, hiveStorageTimeZone, typeManager));
+        }
+
+        // unsupported serdes
+        return Optional.empty();
+    }
+
+    private String buildQuery(IonSqlQueryBuilder queryBuilder, List<HiveColumnHandle> columns, TupleDomain<HiveColumnHandle> effectivePredicate)
+    {
+        return queryBuilder.buildSql(columns, effectivePredicate);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3ClientFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3ClientFactory.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.s3;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.metrics.RequestMetricCollector;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Builder;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.facebook.presto.hive.HiveClientConfig;
+import io.airlift.units.Duration;
+import org.apache.hadoop.conf.Configuration;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import static com.amazonaws.regions.Regions.US_EAST_1;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ENDPOINT;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_PIN_CLIENT_TO_CURRENT_REGION;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Verify.verify;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+
+/**
+ * This factory provides AmazonS3 client required for executing S3SelectPushdown requests.
+ * Normal S3 GET requests use AmazonS3 clients initialized in PrestoS3FileSystem or EMRFS.
+ * The ideal state will be to merge this logic with the two file systems and get rid of this
+ * factory class.
+ * Please do not use the client provided by this factory for any other use cases.
+ */
+public class PrestoS3ClientFactory
+{
+    private static final String S3_ACCESS_KEY = "presto.s3.access-key";
+    private static final String S3_SECRET_KEY = "presto.s3.secret-key";
+    private static final String S3_CREDENTIALS_PROVIDER = "presto.s3.credentials-provider";
+    private static final String S3_USE_INSTANCE_CREDENTIALS = "presto.s3.use-instance-credentials";
+    private static final String S3_CONNECT_TIMEOUT = "presto.s3.connect-timeout";
+    private static final String S3_SOCKET_TIMEOUT = "presto.s3.socket-timeout";
+    private static final String S3_SSL_ENABLED = "presto.s3.ssl.enabled";
+    private static final String S3_MAX_ERROR_RETRIES = "presto.s3.max-error-retries";
+    private static final String S3_USER_AGENT_PREFIX = "presto.s3.user-agent-prefix";
+    private static final String S3_SELECT_PUSHDOWN_MAX_CONNECTIONS = "hive.s3select-pushdown.max-connections";
+    private static String s3UserAgentSuffix = "presto";
+    @GuardedBy("this")
+    private AmazonS3 s3Client;
+
+    synchronized AmazonS3 getS3Client(Configuration config, HiveClientConfig clientConfig)
+    {
+        if (s3Client != null) {
+            return s3Client;
+        }
+
+        HiveS3Config defaults = new HiveS3Config();
+        String userAgentPrefix = config.get(S3_USER_AGENT_PREFIX, defaults.getS3UserAgentPrefix());
+        int maxErrorRetries = config.getInt(S3_MAX_ERROR_RETRIES, defaults.getS3MaxErrorRetries());
+        boolean sslEnabled = config.getBoolean(S3_SSL_ENABLED, defaults.isS3SslEnabled());
+        Duration connectTimeout = Duration.valueOf(config.get(S3_CONNECT_TIMEOUT, defaults.getS3ConnectTimeout().toString()));
+        Duration socketTimeout = Duration.valueOf(config.get(S3_SOCKET_TIMEOUT, defaults.getS3SocketTimeout().toString()));
+        int maxConnections = config.getInt(S3_SELECT_PUSHDOWN_MAX_CONNECTIONS, clientConfig.getS3SelectPushdownMaxConnections());
+
+        if (clientConfig.isS3SelectPushdownEnabled()) {
+            s3UserAgentSuffix = "presto-select";
+        }
+
+        ClientConfiguration clientConfiguration = new ClientConfiguration()
+                .withMaxErrorRetry(maxErrorRetries)
+                .withProtocol(sslEnabled ? Protocol.HTTPS : Protocol.HTTP)
+                .withConnectionTimeout(toIntExact(connectTimeout.toMillis()))
+                .withSocketTimeout(toIntExact(socketTimeout.toMillis()))
+                .withMaxConnections(maxConnections)
+                .withUserAgentPrefix(userAgentPrefix)
+                .withUserAgentSuffix(s3UserAgentSuffix);
+
+        PrestoS3FileSystemStats stats = new PrestoS3FileSystemStats();
+        RequestMetricCollector metricCollector = new PrestoS3FileSystemMetricCollector(stats);
+        AWSCredentialsProvider awsCredentialsProvider = getAwsCredentialsProvider(config, defaults);
+        AmazonS3Builder<? extends AmazonS3Builder, ? extends AmazonS3> clientBuilder = AmazonS3Client.builder()
+                .withCredentials(awsCredentialsProvider)
+                .withClientConfiguration(clientConfiguration)
+                .withMetricsCollector(metricCollector)
+                .enablePathStyleAccess();
+
+        boolean regionOrEndpointSet = false;
+
+        String endpoint = config.get(S3_ENDPOINT);
+        boolean pinS3ClientToCurrentRegion = config.getBoolean(S3_PIN_CLIENT_TO_CURRENT_REGION, defaults.isPinS3ClientToCurrentRegion());
+        verify(!pinS3ClientToCurrentRegion || endpoint == null,
+                "Invalid configuration: either endpoint can be set or S3 client can be pinned to the current region");
+
+        // use local region when running inside of EC2
+        if (pinS3ClientToCurrentRegion) {
+            Region region = Regions.getCurrentRegion();
+            if (region != null) {
+                clientBuilder.withRegion(region.getName());
+                regionOrEndpointSet = true;
+            }
+        }
+
+        if (!isNullOrEmpty(endpoint)) {
+            clientBuilder.withEndpointConfiguration(new EndpointConfiguration(endpoint, null));
+            regionOrEndpointSet = true;
+        }
+
+        if (!regionOrEndpointSet) {
+            clientBuilder.withRegion(US_EAST_1);
+            clientBuilder.setForceGlobalBucketAccessEnabled(true);
+        }
+
+        s3Client = clientBuilder.build();
+        return s3Client;
+    }
+
+    private AWSCredentialsProvider getAwsCredentialsProvider(Configuration conf, HiveS3Config defaults)
+    {
+        Optional<AWSCredentials> credentials = getAwsCredentials(conf);
+        if (credentials.isPresent()) {
+            return new AWSStaticCredentialsProvider(credentials.get());
+        }
+
+        boolean useInstanceCredentials = conf.getBoolean(S3_USE_INSTANCE_CREDENTIALS, defaults.isS3UseInstanceCredentials());
+        if (useInstanceCredentials) {
+            return InstanceProfileCredentialsProvider.getInstance();
+        }
+
+        String providerClass = conf.get(S3_CREDENTIALS_PROVIDER);
+        if (!isNullOrEmpty(providerClass)) {
+            return getCustomAWSCredentialsProvider(conf, providerClass);
+        }
+
+        throw new RuntimeException("S3 credentials not configured");
+    }
+
+    private static AWSCredentialsProvider getCustomAWSCredentialsProvider(Configuration conf, String providerClass)
+    {
+        try {
+            return conf.getClassByName(providerClass)
+                    .asSubclass(AWSCredentialsProvider.class)
+                    .getConstructor(URI.class, Configuration.class)
+                    .newInstance(null, conf);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(format("Error creating an instance of %s", providerClass), e);
+        }
+    }
+
+    private static Optional<AWSCredentials> getAwsCredentials(Configuration conf)
+    {
+        String accessKey = conf.get(S3_ACCESS_KEY);
+        String secretKey = conf.get(S3_SECRET_KEY);
+
+        if (isNullOrEmpty(accessKey) || isNullOrEmpty(secretKey)) {
+            return Optional.empty();
+        }
+        return Optional.of(new BasicAWSCredentials(accessKey, secretKey));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -532,21 +532,6 @@ public class PrestoS3FileSystem
                 .iterator();
     }
 
-    /**
-     * This exception is for stopping retries for S3 calls that shouldn't be retried.
-     * For example, "Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: Forbidden (Service: Amazon S3; Status Code: 403 ..."
-     */
-    @VisibleForTesting
-    static class UnrecoverableS3OperationException
-            extends RuntimeException
-    {
-        public UnrecoverableS3OperationException(Path path, Throwable cause)
-        {
-            // append the path info to the message
-            super(format("%s (Path: %s)", cause, path), cause);
-        }
-    }
-
     @VisibleForTesting
     ObjectMetadata getS3ObjectMetadata(Path path)
             throws IOException
@@ -615,7 +600,7 @@ public class PrestoS3FileSystem
         return keyFromPath(p1).equals(keyFromPath(p2));
     }
 
-    private static String keyFromPath(Path path)
+    public static String keyFromPath(Path path)
     {
         checkArgument(path.isAbsolute(), "Path is not absolute: %s", path);
         String key = nullToEmpty(path.toUri().getPath());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3SelectClient.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3SelectClient.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.SelectObjectContentEventVisitor;
+import com.amazonaws.services.s3.model.SelectObjectContentRequest;
+import com.amazonaws.services.s3.model.SelectObjectContentResult;
+import com.facebook.presto.hive.HiveClientConfig;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.amazonaws.services.s3.model.SelectObjectContentEvent.EndEvent;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoS3SelectClient
+        implements Closeable
+{
+    private AmazonS3 s3Client;
+    private boolean isRequestComplete;
+    private SelectObjectContentRequest selectObjectRequest;
+    private SelectObjectContentResult selectObjectContentResult;
+
+    public PrestoS3SelectClient(Configuration config, HiveClientConfig clientConfig, PrestoS3ClientFactory s3ClientFactory)
+    {
+        requireNonNull(config, "config is null");
+        requireNonNull(clientConfig, "clientConfig is null");
+        requireNonNull(s3ClientFactory, "s3ClientFactory is null");
+        this.s3Client = s3ClientFactory.getS3Client(config, clientConfig);
+    }
+
+    public InputStream getRecordsContent(SelectObjectContentRequest selectObjectRequest)
+    {
+        this.selectObjectRequest = requireNonNull(selectObjectRequest, "selectObjectRequest is null");
+        this.selectObjectContentResult = s3Client.selectObjectContent(selectObjectRequest);
+        return selectObjectContentResult.getPayload()
+                .getRecordsInputStream(
+                        new SelectObjectContentEventVisitor()
+                        {
+                            @Override
+                            public void visit(EndEvent endEvent)
+                            {
+                                isRequestComplete = true;
+                            }
+                        });
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (selectObjectContentResult != null) {
+            selectObjectContentResult.close();
+            selectObjectContentResult = null;
+            selectObjectRequest = null;
+        }
+    }
+
+    public String getKeyName()
+    {
+        return selectObjectRequest.getKey();
+    }
+
+    public String getBucketName()
+    {
+        return selectObjectRequest.getBucketName();
+    }
+
+    /**
+     * The End Event indicates all matching records have been transmitted.
+     * If the End Event is not received, the results may be incomplete.
+     */
+    public boolean isRequestComplete()
+    {
+        return isRequestComplete;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/UnrecoverableS3OperationException.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/UnrecoverableS3OperationException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.s3;
+
+import org.apache.hadoop.fs.Path;
+
+import static java.lang.String.format;
+
+/**
+ * This exception is for stopping retries for S3 calls that shouldn't be retried.
+ * For example, "Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: Forbidden (Service: Amazon S3; Status Code: 403 ..."
+ */
+public class UnrecoverableS3OperationException
+        extends RuntimeException
+{
+    UnrecoverableS3OperationException(Path path, Throwable cause)
+    {
+        // append the path info to the message
+        super(format("%s (Path: %s)", cause, path), cause);
+    }
+
+    public UnrecoverableS3OperationException(String bucket, String key, Throwable cause)
+    {
+        // append bucket and key to the message
+        super(format("%s (Bucket: %s, Key: %s)", cause, bucket, key));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
@@ -19,6 +19,7 @@ import com.facebook.presto.hive.HiveSplit.BucketConversion;
 import com.facebook.presto.hive.HiveTypeName;
 import com.facebook.presto.hive.InternalHiveSplit;
 import com.facebook.presto.hive.InternalHiveSplit.InternalHiveBlock;
+import com.facebook.presto.hive.S3SelectPushdown;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -58,6 +59,7 @@ public class InternalHiveSplitFactory
     private final Map<Integer, HiveTypeName> columnCoercions;
     private final Optional<BucketConversion> bucketConversion;
     private final boolean forceLocalScheduling;
+    private final boolean s3SelectPushdownEnabled;
 
     public InternalHiveSplitFactory(
             FileSystem fileSystem,
@@ -68,7 +70,8 @@ public class InternalHiveSplitFactory
             TupleDomain<HiveColumnHandle> effectivePredicate,
             Map<Integer, HiveTypeName> columnCoercions,
             Optional<BucketConversion> bucketConversion,
-            boolean forceLocalScheduling)
+            boolean forceLocalScheduling,
+            boolean s3SelectPushdownEnabled)
     {
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
@@ -79,6 +82,7 @@ public class InternalHiveSplitFactory
         this.columnCoercions = requireNonNull(columnCoercions, "columnCoercions is null");
         this.bucketConversion = requireNonNull(bucketConversion, "bucketConversion is null");
         this.forceLocalScheduling = forceLocalScheduling;
+        this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
     }
 
     public String getPartitionName()
@@ -184,7 +188,13 @@ public class InternalHiveSplitFactory
                 splittable,
                 forceLocalScheduling && allBlocksHaveRealAddress(blocks),
                 columnCoercions,
-                bucketConversion));
+                bucketConversion,
+                checkS3SelectPushdownBasedOnCompressionCodec(s3SelectPushdownEnabled, inputFormat, path)));
+    }
+
+    private static boolean checkS3SelectPushdownBasedOnCompressionCodec(boolean doesPartitionSupportS3SelectPushdown, InputFormat inputFormat, Path path)
+    {
+        return doesPartitionSupportS3SelectPushdown && S3SelectPushdown.isCompressionCodecSupported(inputFormat, path);
     }
 
     private static void checkBlocks(List<InternalHiveBlock> blocks, long start, long length)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -763,7 +763,8 @@ public abstract class AbstractTestHiveClient
                 hiveClientConfig.getMaxPartitionBatchSize(),
                 hiveClientConfig.getMaxInitialSplits(),
                 hiveClientConfig.getSplitLoaderConcurrency(),
-                false);
+                false,
+                new S3SelectPushdown(hiveClientConfig));
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(hiveClientConfig),
                 hdfsEnvironment,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -195,7 +195,8 @@ public abstract class AbstractTestHiveFileSystem
                 config.getMaxPartitionBatchSize(),
                 config.getMaxInitialSplits(),
                 config.getSplitLoaderConcurrency(),
-                config.getRecursiveDirWalkerEnabled());
+                config.getRecursiveDirWalkerEnabled(),
+                new S3SelectPushdown(config));
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(config),
                 hdfsEnvironment,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -39,10 +39,13 @@ import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
 
+import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
 import static java.util.stream.Collectors.toList;
 
 public final class HiveTestUtils
@@ -142,5 +145,15 @@ public final class HiveTestUtils
                 ImmutableList.copyOf(elementTypeSignatures.stream()
                         .map(TypeSignatureParameter::of)
                         .collect(toList())));
+    }
+
+    public static Long shortDecimal(String value)
+    {
+        return new BigDecimal(value).unscaledValue().longValueExact();
+    }
+
+    public static Slice longDecimal(String value)
+    {
+        return encodeScaledValue(new BigDecimal(value));
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -245,7 +245,8 @@ public class TestBackgroundHiveSplitLoader
                         new HivePartitionMetadata(
                                 new HivePartition(new SchemaTableName("testSchema", "table_name")),
                                 Optional.empty(),
-                                ImmutableMap.of()));
+                                ImmutableMap.of(),
+                                false));
 
         ConnectorSession connectorSession = new TestingConnectorSession(
                 new HiveSessionProperties(new HiveClientConfig().setMaxSplitSize(new DataSize(1.0, GIGABYTE)), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
@@ -301,7 +302,8 @@ public class TestBackgroundHiveSplitLoader
                         return new HivePartitionMetadata(
                                 new HivePartition(new SchemaTableName("testSchema", "table_name")),
                                 Optional.empty(),
-                                ImmutableMap.of());
+                                ImmutableMap.of(),
+                                false);
                     case 1:
                         throw new RuntimeException("OFFLINE");
                     default:

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -111,7 +111,10 @@ public class TestHiveClientConfig
                 .setRecordingPath(null)
                 .setRecordingDuration(new Duration(0, TimeUnit.MINUTES))
                 .setReplay(false)
-                .setCollectColumnStatisticsOnWrite(false));
+                .setCollectColumnStatisticsOnWrite(false)
+                .setCollectColumnStatisticsOnWrite(false)
+                .setS3SelectPushdownEnabled(false)
+                .setS3SelectPushdownMaxConnections(500));
     }
 
     @Test
@@ -192,6 +195,8 @@ public class TestHiveClientConfig
                 .put("hive.metastore-recoding-duration", "42s")
                 .put("hive.replay-metastore-recording", "true")
                 .put("hive.collect-column-statistics-on-write", "true")
+                .put("hive.s3select-pushdown.enabled", "true")
+                .put("hive.s3select-pushdown.max-connections", "1234")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -268,7 +273,10 @@ public class TestHiveClientConfig
                 .setRecordingPath("/foo/bar")
                 .setRecordingDuration(new Duration(42, TimeUnit.SECONDS))
                 .setReplay(true)
-                .setCollectColumnStatisticsOnWrite(true);
+                .setCollectColumnStatisticsOnWrite(true)
+                .setCollectColumnStatisticsOnWrite(true)
+                .setS3SelectPushdownEnabled(true)
+                .setS3SelectPushdownMaxConnections(1234);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -228,7 +228,8 @@ public class TestHivePageSink
                 false,
                 TupleDomain.all(),
                 ImmutableMap.of(),
-                Optional.empty());
+                Optional.empty(),
+                false);
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config), getDefaultHiveRecordCursorProvider(config), getDefaultHiveDataStreamFactories(config), TYPE_MANAGER);
         return provider.createPageSource(transaction, getSession(config), split, ImmutableList.copyOf(getColumnHandles()));
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -61,7 +61,8 @@ public class TestHiveSplit
                 Optional.of(new HiveSplit.BucketConversion(
                         32,
                         16,
-                        ImmutableList.of(new HiveColumnHandle("col", HIVE_LONG, BIGINT.getTypeSignature(), 5, ColumnType.REGULAR, Optional.of("comment"))))));
+                        ImmutableList.of(new HiveColumnHandle("col", HIVE_LONG, BIGINT.getTypeSignature(), 5, ColumnType.REGULAR, Optional.of("comment"))))),
+                false);
 
         String json = codec.toJson(expected);
         HiveSplit actual = codec.fromJson(json);
@@ -79,5 +80,6 @@ public class TestHiveSplit
         assertEquals(actual.getColumnCoercions(), expected.getColumnCoercions());
         assertEquals(actual.getBucketConversion(), expected.getBucketConversion());
         assertEquals(actual.isForceLocalScheduling(), expected.isForceLocalScheduling());
+        assertEquals(actual.isS3SelectPushdownEnabled(), expected.isS3SelectPushdownEnabled());
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -306,7 +306,8 @@ public class TestHiveSplitSource
                     true,
                     false,
                     ImmutableMap.of(),
-                    Optional.empty());
+                    Optional.empty(),
+                    false);
         }
 
         private static Properties properties(String key, String value)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestIonSqlQueryBuilder.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestIonSqlQueryBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.SortedRangeSet;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.type.TypeRegistry;
+import com.facebook.presto.util.DateTimeUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveTestUtils.longDecimal;
+import static com.facebook.presto.hive.HiveTestUtils.shortDecimal;
+import static com.facebook.presto.hive.HiveType.HIVE_DATE;
+import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
+import static com.facebook.presto.hive.HiveType.HIVE_INT;
+import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.hive.HiveType.HIVE_TIMESTAMP;
+import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
+import static com.facebook.presto.spi.predicate.ValueSet.ofRanges;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.StandardTypes.DECIMAL;
+import static com.facebook.presto.spi.type.StandardTypes.INTEGER;
+import static com.facebook.presto.spi.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static org.testng.Assert.assertEquals;
+
+public class TestIonSqlQueryBuilder
+{
+    @Test
+    public void testBuildSQL()
+    {
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(new TypeRegistry());
+        List<HiveColumnHandle> columns = ImmutableList.of(
+                new HiveColumnHandle("n_nationkey", HIVE_INT, parseTypeSignature(INTEGER), 0, REGULAR, Optional.empty()),
+                new HiveColumnHandle("n_name", HIVE_STRING, parseTypeSignature(VARCHAR), 1, REGULAR, Optional.empty()),
+                new HiveColumnHandle("n_regionkey", HIVE_INT, parseTypeSignature(INTEGER), 2, REGULAR, Optional.empty()));
+
+        assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s",
+                queryBuilder.buildSql(columns, TupleDomain.all()));
+        TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
+                columns.get(2), Domain.create(SortedRangeSet.copyOf(BIGINT, ImmutableList.of(Range.equal(BIGINT, 3L))), false)));
+        assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s WHERE (case s._3 when '' then null else CAST(s._3 AS INT) end = 3)",
+                queryBuilder.buildSql(columns, tupleDomain));
+    }
+
+    @Test
+    public void testEmptyColumns()
+    {
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(new TypeRegistry());
+        assertEquals("SELECT ' ' FROM S3Object s", queryBuilder.buildSql(ImmutableList.of(), TupleDomain.all()));
+    }
+
+    @Test
+    public void testDecimalColumns()
+    {
+        TypeManager typeManager = new TypeRegistry();
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(typeManager);
+        List<HiveColumnHandle> columns = ImmutableList.of(
+                new HiveColumnHandle("quantity", HiveType.valueOf("decimal(20,0)"), parseTypeSignature(DECIMAL), 0, REGULAR, Optional.empty()),
+                new HiveColumnHandle("extendedprice", HiveType.valueOf("decimal(20,2)"), parseTypeSignature(DECIMAL), 1, REGULAR, Optional.empty()),
+                new HiveColumnHandle("discount", HiveType.valueOf("decimal(10,2)"), parseTypeSignature(DECIMAL), 2, REGULAR, Optional.empty()));
+        DecimalType decimalType = DecimalType.createDecimalType(10, 2);
+        TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(
+                ImmutableMap.of(
+                        columns.get(0), Domain.create(ofRanges(Range.lessThan(DecimalType.createDecimalType(20, 0), longDecimal("50"))), false),
+                        columns.get(1), Domain.create(ofRanges(Range.equal(HiveType.valueOf("decimal(20,2)").getType(typeManager), longDecimal("0.05"))), false),
+                        columns.get(2), Domain.create(ofRanges(Range.range(decimalType, shortDecimal("0.0"), true, shortDecimal("0.02"), true)), false)));
+        assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s WHERE ((case s._1 when '' then null else CAST(s._1 AS DECIMAL(20,0)) end < 50)) AND " +
+                        "(case s._2 when '' then null else CAST(s._2 AS DECIMAL(20,2)) end = 0.05) AND ((case s._3 when '' then null else CAST(s._3 AS DECIMAL(10,2)) " +
+                        "end >= 0.00 AND case s._3 when '' then null else CAST(s._3 AS DECIMAL(10,2)) end <= 0.02))",
+                queryBuilder.buildSql(columns, tupleDomain));
+    }
+
+    @Test
+    public void testDateColumn()
+    {
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(new TypeRegistry());
+        List<HiveColumnHandle> columns = ImmutableList.of(
+                new HiveColumnHandle("t1", HIVE_TIMESTAMP, parseTypeSignature(TIMESTAMP), 0, REGULAR, Optional.empty()),
+                new HiveColumnHandle("t2", HIVE_DATE, parseTypeSignature(StandardTypes.DATE), 1, REGULAR, Optional.empty()));
+        TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
+                columns.get(1), Domain.create(SortedRangeSet.copyOf(DATE, ImmutableList.of(Range.equal(DATE, (long) DateTimeUtils.parseDate("2001-08-22")))), false)));
+
+        assertEquals("SELECT s._1, s._2 FROM S3Object s WHERE (case s._2 when '' then null else CAST(s._2 AS TIMESTAMP) end = `2001-08-22`)", queryBuilder.buildSql(columns, tupleDomain));
+    }
+
+    @Test
+    public void testNotPushDoublePredicates()
+    {
+        IonSqlQueryBuilder queryBuilder = new IonSqlQueryBuilder(new TypeRegistry());
+        List<HiveColumnHandle> columns = ImmutableList.of(
+                new HiveColumnHandle("quantity", HIVE_INT, parseTypeSignature(INTEGER), 0, REGULAR, Optional.empty()),
+                new HiveColumnHandle("extendedprice", HIVE_DOUBLE, parseTypeSignature(StandardTypes.DOUBLE), 1, REGULAR, Optional.empty()),
+                new HiveColumnHandle("discount", HIVE_DOUBLE, parseTypeSignature(StandardTypes.DOUBLE), 2, REGULAR, Optional.empty()));
+        TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(
+                ImmutableMap.of(
+                        columns.get(0), Domain.create(ofRanges(Range.lessThan(BIGINT, 50L)), false),
+                        columns.get(1), Domain.create(ofRanges(Range.equal(DOUBLE, 0.05)), false),
+                        columns.get(2), Domain.create(ofRanges(Range.range(DOUBLE, 0.0, true, 0.02, true)), false)));
+        assertEquals("SELECT s._1, s._2, s._3 FROM S3Object s WHERE ((case s._1 when '' then null else CAST(s._1 AS INT) end < 50))",
+                queryBuilder.buildSql(columns, tupleDomain));
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestS3SelectRecordCursor.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestS3SelectRecordCursor.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TestingTypeManager;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.mapred.RecordReader;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveType.HIVE_INT;
+import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.hive.S3SelectRecordCursor.updateSplitSchema;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.joining;
+import static org.apache.hadoop.hive.serde.serdeConstants.LIST_COLUMNS;
+import static org.apache.hadoop.hive.serde.serdeConstants.LIST_COLUMN_TYPES;
+import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_DDL;
+import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
+import static org.testng.Assert.assertEquals;
+
+public class TestS3SelectRecordCursor
+{
+    private static final String LAZY_SERDE_CLASS_NAME = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe";
+
+    private static final HiveColumnHandle ARTICLE_COLUMN = new HiveColumnHandle("article", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), 1, REGULAR, Optional.empty());
+    private static final HiveColumnHandle AUTHOR_COLUMN = new HiveColumnHandle("author", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), 1, REGULAR, Optional.empty());
+    private static final HiveColumnHandle DATE_ARTICLE_COLUMN = new HiveColumnHandle("date_pub", HIVE_INT, parseTypeSignature(StandardTypes.DATE), 1, REGULAR, Optional.empty());
+    private static final HiveColumnHandle QUANTITY_COLUMN = new HiveColumnHandle("quantity", HIVE_INT, parseTypeSignature(StandardTypes.INTEGER), 1, REGULAR, Optional.empty());
+    private static final HiveColumnHandle[] DEFAULT_TEST_COLUMNS = {ARTICLE_COLUMN, AUTHOR_COLUMN, DATE_ARTICLE_COLUMN, QUANTITY_COLUMN};
+    private static final RecordReader MOCK_RECORD_READER = new RecordReader() {
+        @Override
+        public boolean next(Object o, Object o2)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object createKey()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object createValue()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getPos()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public float getProgress()
+        {
+            throw new UnsupportedOperationException();
+        }
+    };
+    private static final HiveColumnHandle MOCK_HIVE_COLUMN_HANDLE = new HiveColumnHandle("mockName", HiveType.HIVE_FLOAT, parseTypeSignature(StandardTypes.DOUBLE), 88, PARTITION_KEY, Optional.empty());
+    private static final TypeManager MOCK_TYPE_MANAGER = new TestingTypeManager();
+    private static final Path MOCK_PATH = new Path("mockPath");
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNullPointExceptionWhenSplitSchemaIsNull()
+    {
+        new S3SelectRecordCursor(
+                new Configuration(),
+                MOCK_PATH,
+                MOCK_RECORD_READER,
+                100L,
+                null,
+                singletonList(MOCK_HIVE_COLUMN_HANDLE),
+                DateTimeZone.UTC,
+                MOCK_TYPE_MANAGER);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNullPointExceptionWhenColumnsIsNull()
+    {
+        new S3SelectRecordCursor(
+                new Configuration(),
+                MOCK_PATH,
+                MOCK_RECORD_READER,
+                100L,
+                new Properties(),
+                null,
+                DateTimeZone.UTC,
+                MOCK_TYPE_MANAGER);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionWhenSerialDDLLengthLowerThan5()
+    {
+        String ddlSerializationValue = "struct article { }";
+        buildSplitSchema(ddlSerializationValue, DEFAULT_TEST_COLUMNS);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionWhenSerialDDLNotStartingWithStruct()
+    {
+        String ddlSerializationValue = "foo article { varchar article varchar }";
+        buildSplitSchema(ddlSerializationValue, DEFAULT_TEST_COLUMNS);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionWhenMissingOpenStartStruct()
+    {
+        String ddlSerializationValue = "struct article varchar article varchar }";
+        buildSplitSchema(ddlSerializationValue, DEFAULT_TEST_COLUMNS);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionWhenDDlFormatNotCorrect()
+    {
+        String ddlSerializationValue = "struct article{varchar article varchar author date date_pub int quantity";
+        buildSplitSchema(ddlSerializationValue, DEFAULT_TEST_COLUMNS);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionWhenEndOfStructNotFound()
+    {
+        String ddlSerializationValue = "struct article { varchar article varchar author date date_pub int quantity ";
+        buildSplitSchema(ddlSerializationValue, DEFAULT_TEST_COLUMNS);
+    }
+
+    @Test
+    public void shouldFilterColumnsWhichDoesNotMatchInTheHiveTable()
+    {
+        String ddlSerializationValue = "struct article { varchar address varchar company date date_pub int quantity}";
+        String expectedDDLSerialization = "struct article { date date_pub, int quantity}";
+        assertEquals(buildSplitSchema(ddlSerializationValue, DEFAULT_TEST_COLUMNS),
+                buildExpectedProperties(expectedDDLSerialization, DEFAULT_TEST_COLUMNS));
+    }
+
+    @Test
+    public void shouldReturnOnlyQuantityColumnInTheDDl()
+    {
+        String ddlSerializationValue = "struct article { varchar address varchar company date date_pub int quantity}";
+        String expectedDDLSerialization = "struct article { int quantity}";
+        assertEquals(buildSplitSchema(ddlSerializationValue, ARTICLE_COLUMN, QUANTITY_COLUMN),
+                buildExpectedProperties(expectedDDLSerialization, ARTICLE_COLUMN, QUANTITY_COLUMN));
+    }
+
+    @Test
+    public void shouldReturnProperties()
+    {
+        String ddlSerializationValue = "struct article { varchar article varchar author date date_pub int quantity}";
+        String expectedDDLSerialization = "struct article { varchar article, varchar author, date date_pub, int quantity}";
+        assertEquals(buildSplitSchema(ddlSerializationValue, DEFAULT_TEST_COLUMNS),
+                buildExpectedProperties(expectedDDLSerialization, DEFAULT_TEST_COLUMNS));
+    }
+
+    @Test
+    public void shouldReturnPropertiesWithoutDoubleCommaInColumnsName()
+    {
+        String ddlSerializationValue = "struct article { varchar article, varchar author, date date_pub, int quantity }";
+        String expectedDDLSerialization = "struct article { varchar article, varchar author, date date_pub, int quantity}";
+        assertEquals(buildSplitSchema(ddlSerializationValue, DEFAULT_TEST_COLUMNS),
+                buildExpectedProperties(expectedDDLSerialization, DEFAULT_TEST_COLUMNS));
+    }
+
+    @Test
+    public void shouldOnlyGetColumnTypeFromHiveObjectAndNotFromDDLSerial()
+    {
+        String ddlSerializationValue = "struct article { int article, double author, xxxx date_pub, int quantity }";
+        String expectedDDLSerialization = "struct article { int article, double author, xxxx date_pub, int quantity}";
+        assertEquals(buildSplitSchema(ddlSerializationValue, DEFAULT_TEST_COLUMNS),
+                buildExpectedProperties(expectedDDLSerialization, DEFAULT_TEST_COLUMNS));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNullPointerExceptionWhenColumnsIsNull()
+    {
+        updateSplitSchema(new Properties(), null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldThrowNullPointerExceptionWhenSchemaIsNull()
+    {
+        updateSplitSchema(null, ImmutableList.of());
+    }
+
+    private Properties buildSplitSchema(String ddlSerializationValue, HiveColumnHandle... columns)
+    {
+        Properties properties = new Properties();
+        properties.put(SERIALIZATION_LIB, LAZY_SERDE_CLASS_NAME);
+        properties.put(SERIALIZATION_DDL, ddlSerializationValue);
+        return updateSplitSchema(properties, asList(columns));
+    }
+
+    private Properties buildExpectedProperties(String expectedDDLSerialization, HiveColumnHandle... expectedColumns)
+    {
+        String expectedColumnsType = getTypes(expectedColumns);
+        String expectedColumnsName = getName(expectedColumns);
+        Properties propExpected = new Properties();
+        propExpected.put(LIST_COLUMNS, expectedColumnsName);
+        propExpected.put(SERIALIZATION_LIB, LAZY_SERDE_CLASS_NAME);
+        propExpected.put(SERIALIZATION_DDL, expectedDDLSerialization);
+        propExpected.put(LIST_COLUMN_TYPES, expectedColumnsType);
+        return propExpected;
+    }
+
+    private String getName(HiveColumnHandle[] expectedColumns)
+    {
+        return Stream.of(expectedColumns)
+                .map(HiveColumnHandle::getName)
+                .collect(joining(","));
+    }
+
+    private String getTypes(HiveColumnHandle[] expectedColumns)
+    {
+        return Stream.of(expectedColumns)
+                .map(HiveColumnHandle::getHiveType)
+                .map(HiveType::getTypeInfo)
+                .map(TypeInfo::getTypeName)
+                .collect(joining(","));
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -26,7 +26,6 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.EncryptionMaterials;
 import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
-import com.facebook.presto.hive.s3.PrestoS3FileSystem.UnrecoverableS3OperationException;
 import com.google.common.base.VerifyException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;


### PR DESCRIPTION
This change will allow Presto users to improve the performance of their queries using S3SelectPushdown.
It pushes down projections and predicate evaluations to S3. As a result
Presto doesn't need to download full S3 objects and only data required to answer the user's query
is returned to Presto, thereby improving performance.


S3SelectPushdown Technical Document: [S3SelectPushdown.pdf](https://github.com/prestodb/presto/files/2406949/S3SelectPushdown.pdf)
