### PR TITLE
Fix SqlTime, SqlTimeWithTimeZone construction in tests

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/DateTimeTestingUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/DateTimeTestingUtils.java
@@ -21,9 +21,15 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
 
+import static java.lang.Math.toIntExact;
+import static java.time.ZoneOffset.UTC;
 import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public final class DateTimeTestingUtils
@@ -98,27 +104,23 @@ public final class DateTimeTestingUtils
             int minuteOfHour,
             int secondOfMinute,
             int millisOfSecond,
-            DateTimeZone baseZone,
-            TimeZoneKey timestampZone,
             Session session)
     {
-        return sqlTimeOf(hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond, baseZone, timestampZone, session.toConnectorSession());
+        LocalTime time = LocalTime.of(hourOfDay, minuteOfHour, secondOfMinute, toIntExact(MILLISECONDS.toNanos(millisOfSecond)));
+        return sqlTimeOf(time, session);
     }
 
-    public static SqlTime sqlTimeOf(
-            int hourOfDay,
-            int minuteOfHour,
-            int secondOfMinute,
-            int millisOfSecond,
-            DateTimeZone baseZone,
-            TimeZoneKey timestampZone,
-            ConnectorSession session)
+    public static SqlTime sqlTimeOf(LocalTime time, Session session)
     {
-        if (session.isLegacyTimestamp()) {
-            return new SqlTime(new DateTime(1970, 1, 1, hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond, baseZone).getMillis(), timestampZone);
+        if (session.toConnectorSession().isLegacyTimestamp()) {
+            long millisUtc = LocalDate.ofEpochDay(0)
+                    .atTime(time)
+                    .atZone(UTC)
+                    .withZoneSameLocal(ZoneId.of(session.getTimeZoneKey().getId()))
+                    .toInstant()
+                    .toEpochMilli();
+            return new SqlTime(millisUtc, session.getTimeZoneKey());
         }
-        else {
-            return new SqlTime(new DateTime(1970, 1, 1, hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond, DateTimeZone.UTC).getMillis());
-        }
+        return new SqlTime(NANOSECONDS.toMillis(time.toNanoOfDay()));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -490,8 +490,12 @@ public abstract class TestDateTimeFunctionsBase
 
         result = result.withMinuteOfHour(0);
         assertFunction("date_trunc('hour', " + TIME_LITERAL + ")", TimeType.TIME, toTime(result));
+    }
 
-        result = WEIRD_TIME;
+    @Test
+    public void testTruncateTimeWithTimeZone()
+    {
+        DateTime result = WEIRD_TIME;
         result = result.withMillisOfSecond(0);
         assertFunction("date_trunc('second', " + WEIRD_TIME_LITERAL + ")", TIME_WITH_TIME_ZONE, toTimeWithTimeZone(result));
 
@@ -568,7 +572,11 @@ public abstract class TestDateTimeFunctionsBase
         assertFunction("date_add('hour', 23, " + TIME_LITERAL + ")", TimeType.TIME, toTime(TIME.plusHours(23)));
         assertFunction("date_add('hour', -4, " + TIME_LITERAL + ")", TimeType.TIME, toTime(TIME.minusHours(4)));
         assertFunction("date_add('hour', -23, " + TIME_LITERAL + ")", TimeType.TIME, toTime(TIME.minusHours(23)));
+    }
 
+    @Test
+    public void testAddFieldToTimeWithTimeZone()
+    {
         assertFunction("date_add('millisecond', 3, " + WEIRD_TIME_LITERAL + ")", TIME_WITH_TIME_ZONE, toTimeWithTimeZone(WEIRD_TIME.plusMillis(3)));
         assertFunction("date_add('second', 3, " + WEIRD_TIME_LITERAL + ")", TIME_WITH_TIME_ZONE, toTimeWithTimeZone(WEIRD_TIME.plusSeconds(3)));
         assertFunction("date_add('minute', 3, " + WEIRD_TIME_LITERAL + ")", TIME_WITH_TIME_ZONE, toTimeWithTimeZone(WEIRD_TIME.plusMinutes(3)));
@@ -646,7 +654,11 @@ public abstract class TestDateTimeFunctionsBase
         assertFunction("date_diff('second', " + baseDateTimeLiteral + ", " + TIME_LITERAL + ")", BIGINT, (long) secondsBetween(baseDateTime, TIME).getSeconds());
         assertFunction("date_diff('minute', " + baseDateTimeLiteral + ", " + TIME_LITERAL + ")", BIGINT, (long) minutesBetween(baseDateTime, TIME).getMinutes());
         assertFunction("date_diff('hour', " + baseDateTimeLiteral + ", " + TIME_LITERAL + ")", BIGINT, (long) hoursBetween(baseDateTime, TIME).getHours());
+    }
 
+    @Test
+    public void testDateDiffTimeWithTimeZone()
+    {
         DateTime weirdBaseDateTime = new DateTime(1970, 1, 1, 7, 2, 9, 678, WEIRD_ZONE);
         String weirdBaseDateTimeLiteral = "TIME '07:02:09.678 +07:09'";
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -1028,6 +1028,7 @@ public abstract class TestDateTimeFunctionsBase
         }
     }
 
+    @Test
     public void testParseDuration()
     {
         assertFunction("parse_duration('1234 ns')", INTERVAL_DAY_TIME, new SqlIntervalDayTime(0, 0, 0, 0, 0));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDateTimeOperatorsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDateTimeOperatorsBase.java
@@ -72,17 +72,17 @@ public abstract class TestDateTimeOperatorsBase
     @Test
     public void testTimePlusInterval()
     {
-        assertFunction("TIME '03:04:05.321' + INTERVAL '3' hour", TIME, sqlTimeOf(6, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("INTERVAL '3' hour + TIME '03:04:05.321'", TIME, sqlTimeOf(6, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("TIME '03:04:05.321' + INTERVAL '3' day", TIME, sqlTimeOf(3, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("INTERVAL '3' day + TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("TIME '03:04:05.321' + INTERVAL '3' month", TIME, sqlTimeOf(3, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("INTERVAL '3' month + TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("TIME '03:04:05.321' + INTERVAL '3' year", TIME, sqlTimeOf(3, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("INTERVAL '3' year + TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
+        assertFunction("TIME '03:04:05.321' + INTERVAL '3' hour", TIME, sqlTimeOf(6, 4, 5, 321, session));
+        assertFunction("INTERVAL '3' hour + TIME '03:04:05.321'", TIME, sqlTimeOf(6, 4, 5, 321, session));
+        assertFunction("TIME '03:04:05.321' + INTERVAL '3' day", TIME, sqlTimeOf(3, 4, 5, 321, session));
+        assertFunction("INTERVAL '3' day + TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, session));
+        assertFunction("TIME '03:04:05.321' + INTERVAL '3' month", TIME, sqlTimeOf(3, 4, 5, 321, session));
+        assertFunction("INTERVAL '3' month + TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, session));
+        assertFunction("TIME '03:04:05.321' + INTERVAL '3' year", TIME, sqlTimeOf(3, 4, 5, 321, session));
+        assertFunction("INTERVAL '3' year + TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, session));
 
-        assertFunction("TIME '03:04:05.321' + INTERVAL '27' hour", TIME, sqlTimeOf(6, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("INTERVAL '27' hour + TIME '03:04:05.321'", TIME, sqlTimeOf(6, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
+        assertFunction("TIME '03:04:05.321' + INTERVAL '27' hour", TIME, sqlTimeOf(6, 4, 5, 321, session));
+        assertFunction("INTERVAL '27' hour + TIME '03:04:05.321'", TIME, sqlTimeOf(6, 4, 5, 321, session));
 
         assertFunction("TIME '03:04:05.321 +05:09' + INTERVAL '3' hour",
                 TIME_WITH_TIME_ZONE,
@@ -182,12 +182,12 @@ public abstract class TestDateTimeOperatorsBase
     @Test
     public void testTimeMinusInterval()
     {
-        assertFunction("TIME '03:04:05.321' - INTERVAL '3' hour", TIME, sqlTimeOf(0, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("TIME '03:04:05.321' - INTERVAL '3' day", TIME, sqlTimeOf(3, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("TIME '03:04:05.321' - INTERVAL '3' month", TIME, sqlTimeOf(3, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("TIME '03:04:05.321' - INTERVAL '3' year", TIME, sqlTimeOf(3, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
+        assertFunction("TIME '03:04:05.321' - INTERVAL '3' hour", TIME, sqlTimeOf(0, 4, 5, 321, session));
+        assertFunction("TIME '03:04:05.321' - INTERVAL '3' day", TIME, sqlTimeOf(3, 4, 5, 321, session));
+        assertFunction("TIME '03:04:05.321' - INTERVAL '3' month", TIME, sqlTimeOf(3, 4, 5, 321, session));
+        assertFunction("TIME '03:04:05.321' - INTERVAL '3' year", TIME, sqlTimeOf(3, 4, 5, 321, session));
 
-        assertFunction("TIME '03:04:05.321' - INTERVAL '6' hour", TIME, sqlTimeOf(21, 4, 5, 321, TIME_ZONE, TIME_ZONE_KEY, session));
+        assertFunction("TIME '03:04:05.321' - INTERVAL '6' hour", TIME, sqlTimeOf(21, 4, 5, 321, session));
 
         assertFunction("TIME '03:04:05.321 +05:09' - INTERVAL '3' hour",
                 TIME_WITH_TIME_ZONE,

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimeBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimeBase.java
@@ -54,9 +54,9 @@ public abstract class TestTimeBase
     @Test
     public void testLiteral()
     {
-        assertFunction("TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, DATE_TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("TIME '03:04:05'", TIME, sqlTimeOf(3, 4, 5, 0, DATE_TIME_ZONE, TIME_ZONE_KEY, session));
-        assertFunction("TIME '03:04'", TIME, sqlTimeOf(3, 4, 0, 0, DATE_TIME_ZONE, TIME_ZONE_KEY, session));
+        assertFunction("TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, session));
+        assertFunction("TIME '03:04:05'", TIME, sqlTimeOf(3, 4, 5, 0, session));
+        assertFunction("TIME '03:04'", TIME, sqlTimeOf(3, 4, 0, 0, session));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZone.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZone.java
@@ -13,11 +13,25 @@
  */
 package com.facebook.presto.type;
 
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimeOf;
+
 public class TestTimeWithTimeZone
         extends TestTimeWithTimeZoneBase
 {
     public TestTimeWithTimeZone()
     {
         super(false);
+    }
+
+    @Test
+    @Override
+    public void testCastToTime()
+    {
+        assertFunction("cast(TIME '03:04:05.321 +07:09' as time)",
+                TIME,
+                sqlTimeOf(3, 4, 5, 321, session));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZoneBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZoneBase.java
@@ -74,7 +74,7 @@ public abstract class TestTimeWithTimeZoneBase
     }
 
     @Test
-    public void testSubstract()
+    public void testSubtract()
     {
         functionAssertions.assertFunctionString("TIME '14:15:16.432 +07:09' - TIME '03:04:05.321 +08:09'",
                 INTERVAL_DAY_TIME,

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZoneBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZoneBase.java
@@ -23,14 +23,12 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.function.OperatorType.INDETERMINATE;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKey;
 import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimeOf;
 import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
@@ -202,12 +200,7 @@ public abstract class TestTimeWithTimeZoneBase
     }
 
     @Test
-    public void testCastToTime()
-    {
-        assertFunction("cast(TIME '03:04:05.321 +07:09' as time)",
-                TIME,
-                sqlTimeOf(3, 4, 5, 321, WEIRD_ZONE, session.getTimeZoneKey(), session));
-    }
+    public abstract void testCastToTime();
 
     @Test
     public void testCastToTimestamp()

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZoneLegacy.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimeWithTimeZoneLegacy.java
@@ -13,11 +13,25 @@
  */
 package com.facebook.presto.type;
 
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimeOf;
+
 public class TestTimeWithTimeZoneLegacy
         extends TestTimeWithTimeZoneBase
 {
     public TestTimeWithTimeZoneLegacy()
     {
         super(true);
+    }
+
+    @Test
+    @Override
+    public void testCastToTime()
+    {
+        assertFunction("cast(TIME '03:04:05.321 +07:09' as time)",
+                TIME,
+                sqlTimeOf(2, 4, 5, 321, session));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampBase.java
@@ -60,7 +60,7 @@ public abstract class TestTimestampBase
     }
 
     @Test
-    public void testSubstract()
+    public void testSubtract()
     {
         functionAssertions.assertFunctionString("TIMESTAMP '2017-03-30 14:15:16.432' - TIMESTAMP '2016-03-29 03:04:05.321'",
                 INTERVAL_DAY_TIME,

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampBase.java
@@ -180,7 +180,7 @@ public abstract class TestTimestampBase
     @Test
     public void testCastToTime()
     {
-        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321' as time)", TIME, sqlTimeOf(3, 4, 5, 321, DATE_TIME_ZONE, TIME_ZONE_KEY, session));
+        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321' as time)", TIME, sqlTimeOf(3, 4, 5, 321, session));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZone.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZone.java
@@ -17,6 +17,7 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimeOf;
 
 public class TestTimestampWithTimeZone
         extends TestTimestampWithTimeZoneBase
@@ -26,10 +27,13 @@ public class TestTimestampWithTimeZone
         super(false);
     }
 
+    @Test
     @Override
     public void testCastToTime()
     {
-        super.testCastToTime();
+        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321 +07:09' as time)",
+                TIME,
+                sqlTimeOf(3, 4, 5, 321, session));
 
         functionAssertions.assertFunctionString("cast(TIMESTAMP '2001-1-22 03:04:05.321 +07:09' as time)",
                 TIME,

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneBase.java
@@ -27,14 +27,12 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.presto.spi.function.OperatorType.INDETERMINATE;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
-import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKey;
 import static com.facebook.presto.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
-import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimeOf;
 import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
@@ -254,12 +252,7 @@ public abstract class TestTimestampWithTimeZoneBase
     }
 
     @Test
-    public void testCastToTime()
-    {
-        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321 +07:09' as time)",
-                TIME,
-                sqlTimeOf(3, 4, 5, 321, WEIRD_ZONE, session.getTimeZoneKey(), session));
-    }
+    public abstract void testCastToTime();
 
     @Test
     public void testCastToTimeWithTimeZone()

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneBase.java
@@ -103,7 +103,7 @@ public abstract class TestTimestampWithTimeZoneBase
     }
 
     @Test
-    public void testSubstract()
+    public void testSubtract()
     {
         functionAssertions.assertFunctionString("TIMESTAMP '2017-03-30 14:15:16.432 +07:09' - TIMESTAMP '2016-03-29 03:04:05.321 +08:09'",
                 INTERVAL_DAY_TIME,

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneLegacy.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneLegacy.java
@@ -13,11 +13,25 @@
  */
 package com.facebook.presto.type;
 
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimeOf;
+
 public class TestTimestampWithTimeZoneLegacy
         extends TestTimestampWithTimeZoneBase
 {
     public TestTimestampWithTimeZoneLegacy()
     {
         super(true);
+    }
+
+    @Test
+    @Override
+    public void testCastToTime()
+    {
+        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321 +07:09' as time)",
+                TIME,
+                sqlTimeOf(2, 4, 5, 321, session));
     }
 }


### PR DESCRIPTION
`DateTime` being used to represent TIME, TIME WITH TIME ZONE  in tests
makes only sense from internal representation's perspective, but it also makes
tests less clear and requiring normalization routines.