### PR TITLE
Mention config property names when validating memory configuration

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/LocalMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/LocalMemoryManager.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.memory.NodeMemoryConfig.QUERY_MAX_MEMORY_PER_NODE_CONFIG;
+import static com.facebook.presto.memory.NodeMemoryConfig.QUERY_MAX_TOTAL_MEMORY_PER_NODE_CONFIG;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.units.DataSize.Unit.BYTE;
@@ -58,8 +59,11 @@ public final class LocalMemoryManager
     {
         validateHeapHeadroom(config, availableMemory);
         maxMemory = new DataSize(availableMemory - config.getHeapHeadroom().toBytes(), BYTE);
-        checkArgument(config.getMaxQueryMemoryPerNode().toBytes() <= config.getMaxQueryTotalMemoryPerNode().toBytes(),
-                "Max query memory per node cannot be greater than the max query total memory per node.");
+        checkArgument(
+                config.getMaxQueryMemoryPerNode().toBytes() <= config.getMaxQueryTotalMemoryPerNode().toBytes(),
+                "Max query memory per node (%s) cannot be greater than the max query total memory per node (%s).",
+                QUERY_MAX_MEMORY_PER_NODE_CONFIG,
+                QUERY_MAX_TOTAL_MEMORY_PER_NODE_CONFIG);
         ImmutableMap.Builder<MemoryPoolId, MemoryPool> builder = ImmutableMap.builder();
         builder.put(RESERVED_POOL, new MemoryPool(RESERVED_POOL, config.getMaxQueryTotalMemoryPerNode()));
         long generalPoolSize = maxMemory.toBytes() - config.getMaxQueryTotalMemoryPerNode().toBytes();

--- a/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
@@ -26,6 +26,7 @@ public class NodeMemoryConfig
 {
     public static final long AVAILABLE_HEAP_MEMORY = Runtime.getRuntime().maxMemory();
     public static final String QUERY_MAX_MEMORY_PER_NODE_CONFIG = "query.max-memory-per-node";
+    public static final String QUERY_MAX_TOTAL_MEMORY_PER_NODE_CONFIG = "query.max-total-memory-per-node";
 
     private boolean isLegacySystemPoolEnabled;
 
@@ -66,7 +67,7 @@ public class NodeMemoryConfig
         return maxQueryTotalMemoryPerNode;
     }
 
-    @Config("query.max-total-memory-per-node")
+    @Config(QUERY_MAX_TOTAL_MEMORY_PER_NODE_CONFIG)
     public NodeMemoryConfig setMaxQueryTotalMemoryPerNode(DataSize maxQueryTotalMemoryPerNode)
     {
         this.maxQueryTotalMemoryPerNode = maxQueryTotalMemoryPerNode;


### PR DESCRIPTION
This validates aforementioned settings, optionally producing something like this:

```
2018-07-13T14:38:03.600+0200	INFO	main	Bootstrap	node.internal-address                                                 null                              null
2018-07-13T14:38:03.600+0200	INFO	main	Bootstrap	node.pool                                                             general                           general
2018-07-13T14:38:04.257+0200	ERROR	main	com.facebook.presto.server.PrestoServer	Unable to create injector, see the following errors:

1) Error: Invalid configuration property with prefix '': query.max-total-memory-per-node must be greater than query.max-memory-per-node (for class com.facebook.presto.memory.NodeMemoryConfig.queryMaxTotalMemoryPerNodeGreaterThanMaxMemoryPerNode)

1 error
com.google.inject.CreationException: Unable to create injector, see the following errors:

1) Error: Invalid configuration property with prefix '': query.max-total-memory-per-node must be greater than query.max-memory-per-node (for class com.facebook.presto.memory.NodeMemoryConfig.queryMaxTotalMemoryPerNodeGreaterThanMaxMemoryPerNode)

1 error
	at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:543)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:159)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:106)
	at com.google.inject.Guice.createInjector(Guice.java:87)
	at io.airlift.bootstrap.Bootstrap.initialize(Bootstrap.java:241)
	at com.facebook.presto.server.PrestoServer.run(PrestoServer.java:115)
	at com.facebook.presto.server.PrestoServer.main(PrestoServer.java:67)
```