### PR TITLE
Wake up driver when async event allows operator to finish

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -42,6 +42,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.checkSuccess;
 import static io.airlift.concurrent.MoreFutures.getDone;
 import static java.lang.String.format;
@@ -253,6 +254,7 @@ public class HashBuilderOperator
         this.index = pagesIndexFactory.newPagesIndex(lookupSourceFactory.getTypes(), expectedPositions);
         this.lookupSourceFactory = lookupSourceFactory;
         lookupSourceFactoryDestroyed = lookupSourceFactory.isDestroyed();
+        lookupSourceFactoryDestroyed.addListener(operatorContext::notifyAsync, directExecutor());
 
         this.outputChannels = outputChannels;
         this.hashChannels = hashChannels;

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinBridgeDataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinBridgeDataManager.java
@@ -68,6 +68,25 @@ public class JoinBridgeDataManager<T>
                 NestedLoopJoinPagesBridge::destroy);
     }
 
+    public static JoinBridgeDataManager<SetBridge> semiJoin(
+            PipelineExecutionStrategy probeExecutionStrategy,
+            PipelineExecutionStrategy buildExecutionStrategy,
+            Function<Lifespan, SetBridge> setBridgeProvider,
+            List<Type> buildOutputTypes)
+    {
+        // Build side of semi join is always ungrouped today.
+        // If we want to change this in the future, this code will likely work, but needs to be tested.
+        checkArgument(buildExecutionStrategy == PipelineExecutionStrategy.UNGROUPED_EXECUTION, "Grouped execution for nested loop build is not supported");
+
+        return new JoinBridgeDataManager<>(
+                probeExecutionStrategy,
+                buildExecutionStrategy,
+                setBridgeProvider,
+                buildOutputTypes,
+                SharedSetBridge::new,
+                SetBridge::destroy);
+    }
+
     @VisibleForTesting
     public static JoinBridgeDataManager<LookupSourceFactory> lookupAllAtOnce(LookupSourceFactory factory)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinBridgeLifecycleManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinBridgeLifecycleManager.java
@@ -66,6 +66,17 @@ public class JoinBridgeLifecycleManager<T>
                 });
     }
 
+    public static JoinBridgeLifecycleManager<SetBridge> semiJoin(JoinBridgeDataManager<SetBridge> setManager)
+    {
+        return new JoinBridgeLifecycleManager<>(
+                INNER,
+                setManager,
+                SetBridge::destroy,
+                joinBridge -> {
+                    throw new UnsupportedOperationException();
+                });
+    }
+
     private final JoinType joinType;
     private final FreezeOnReadCounter factoryCount;
     private final JoinBridgeDataManager<T> joinBridgeDataManager;

--- a/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesBridge.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesBridge.java
@@ -19,7 +19,9 @@ public interface NestedLoopJoinPagesBridge
 {
     ListenableFuture<NestedLoopJoinPages> getPagesFuture();
 
-    ListenableFuture<?> setPages(NestedLoopJoinPages nestedLoopJoinPages);
+    void setPages(NestedLoopJoinPages nestedLoopJoinPages);
+
+    ListenableFuture<?> isDestroyed();
 
     void destroy();
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesSupplier.java
@@ -18,6 +18,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
 import static com.google.common.util.concurrent.Futures.transformAsync;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
@@ -35,12 +36,17 @@ public final class NestedLoopJoinPagesSupplier
     }
 
     @Override
-    public ListenableFuture<?> setPages(NestedLoopJoinPages nestedLoopJoinPages)
+    public void setPages(NestedLoopJoinPages nestedLoopJoinPages)
     {
         requireNonNull(nestedLoopJoinPages, "nestedLoopJoinPages is null");
         boolean wasSet = pagesFuture.set(nestedLoopJoinPages);
         checkState(wasSet, "pagesFuture already set");
-        return pagesNoLongerNeeded;
+    }
+
+    @Override
+    public ListenableFuture<?> isDestroyed()
+    {
+        return nonCancellationPropagating(pagesNoLongerNeeded);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexFactory.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Objects.requireNonNull;
@@ -141,12 +140,12 @@ public class PagesSpatialIndexFactory
      *
      * Returns a Future that completes once all the {@link SpatialJoinOperator}s have completed.
      */
-    public ListenableFuture<?> lendPagesSpatialIndex(Supplier<PagesSpatialIndex> pagesSpatialIndex)
+    public void lendPagesSpatialIndex(Supplier<PagesSpatialIndex> pagesSpatialIndex)
     {
         requireNonNull(pagesSpatialIndex, "pagesSpatialIndex is null");
 
         if (activeProbeOperators.getFreeFuture().isDone()) {
-            return NOT_BLOCKED;
+            return;
         }
 
         List<SettableFuture<PagesSpatialIndex>> settableFutures;
@@ -160,7 +159,10 @@ public class PagesSpatialIndexFactory
         for (SettableFuture<PagesSpatialIndex> settableFuture : settableFutures) {
             settableFuture.set(pagesSpatialIndex.get());
         }
+    }
 
+    public ListenableFuture<?> isDestroyed()
+    {
         return activeProbeOperators.getFreeFuture();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SetBridge.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SetBridge.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.type.Type;
+import com.google.common.util.concurrent.ListenableFuture;
+
+public interface SetBridge
+{
+    Type getType();
+
+    ListenableFuture<ChannelSet> getChannelSet();
+
+    void setChannelSet(ChannelSet channelSet);
+
+    ListenableFuture<?> isDestroyed();
+
+    void destroy();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/SetBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SetBuilderOperator.java
@@ -28,6 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
@@ -123,6 +124,7 @@ public class SetBuilderOperator
                 requireNonNull(operatorContext, "operatorContext is null"),
                 requireNonNull(joinCompiler, "joinCompiler is null"));
         setDestroyed = setBridge.isDestroyed();
+        setDestroyed.addListener(operatorContext::notifyAsync, directExecutor());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/SetSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SetSupplier.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.type.Type;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
+import static java.util.Objects.requireNonNull;
+
+public class SetSupplier
+        implements SetBridge
+{
+    private final Type type;
+    private final SettableFuture<ChannelSet> channelSetFuture = SettableFuture.create();
+    private final SettableFuture<?> setNoLongerNeeded = SettableFuture.create();
+
+    public SetSupplier(Type type)
+    {
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    public Type getType()
+    {
+        return type;
+    }
+
+    @Override
+    public ListenableFuture<ChannelSet> getChannelSet()
+    {
+        return channelSetFuture;
+    }
+
+    @Override
+    public void setChannelSet(ChannelSet channelSet)
+    {
+        requireNonNull(channelSet, "channelSet is null");
+        boolean wasSet = channelSetFuture.set(requireNonNull(channelSet, "channelSet is null"));
+        checkState(wasSet, "ChannelSet already set");
+    }
+
+    @Override
+    public ListenableFuture<?> isDestroyed()
+    {
+        return nonCancellationPropagating(setNoLongerNeeded);
+    }
+
+    @Override
+    public void destroy()
+    {
+        // Let the SetBuildOperator declare that it's finished.
+        setNoLongerNeeded.set(null);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/SharedNestedLoopJoinPagesBridge.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SharedNestedLoopJoinPagesBridge.java
@@ -43,9 +43,15 @@ public final class SharedNestedLoopJoinPagesBridge
     }
 
     @Override
-    public ListenableFuture<?> setPages(NestedLoopJoinPages nestedLoopJoinPages)
+    public void setPages(NestedLoopJoinPages nestedLoopJoinPages)
     {
-        return delegate.setPages(nestedLoopJoinPages);
+        delegate.setPages(nestedLoopJoinPages);
+    }
+
+    @Override
+    public ListenableFuture<?> isDestroyed()
+    {
+        return delegate.isDestroyed();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/SharedSetBridge.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SharedSetBridge.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.type.Type;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+
+public class SharedSetBridge
+        implements SetBridge
+{
+    private final SetBridge delegate;
+    private final Runnable onDestroy;
+
+    private final AtomicBoolean destroyed = new AtomicBoolean(false);
+
+    public SharedSetBridge(SetBridge delegate, Runnable onDestroy)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.onDestroy = requireNonNull(onDestroy, "onDestroy is null");
+    }
+
+    @Override
+    public Type getType()
+    {
+        return delegate.getType();
+    }
+
+    @Override
+    public ListenableFuture<ChannelSet> getChannelSet()
+    {
+        return delegate.getChannelSet();
+    }
+
+    @Override
+    public void setChannelSet(ChannelSet channelSet)
+    {
+        delegate.setChannelSet(channelSet);
+    }
+
+    @Override
+    public ListenableFuture<?> isDestroyed()
+    {
+        return delegate.isDestroyed();
+    }
+
+    @Override
+    public void destroy()
+    {
+        if (destroyed.compareAndSet(false, true)) {
+            onDestroy.run();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeSinkOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeSinkOperator.java
@@ -29,6 +29,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 
 public class LocalExchangeSinkOperator
@@ -105,6 +106,7 @@ public class LocalExchangeSinkOperator
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.sink = requireNonNull(sink, "sink is null");
         this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
+        sink.waitForFinished().addListener(operatorContext::notifyAsync, directExecutor());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeSourceOperator.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 
 public class LocalExchangeSourceOperator
@@ -80,6 +81,7 @@ public class LocalExchangeSourceOperator
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.source = requireNonNull(source, "source is null");
         operatorContext.setInfoSupplier(source::getBufferInfo);
+        source.waitForFinished().addListener(operatorContext::notifyAsync, directExecutor());
     }
 
     @Override


### PR DESCRIPTION
Join and exchange operators can close early when the linked
driver finishes.  This PR adds a method to wake a blocked
driver from an async event.