### PR TITLE
Collect column statistics on write [v2]

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
@@ -37,6 +37,7 @@ import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -102,7 +103,7 @@ public class AccumuloMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         clearRollback();
         return Optional.empty();
@@ -212,7 +213,7 @@ public class AccumuloMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         clearRollback();
         return Optional.empty();

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
@@ -173,7 +174,7 @@ public class JdbcMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         JdbcOutputTableHandle handle = (JdbcOutputTableHandle) tableHandle;
         jdbcClient.commitCreateTable(handle);
@@ -203,7 +204,7 @@ public class JdbcMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         JdbcOutputTableHandle jdbcInsertHandle = (JdbcOutputTableHandle) tableHandle;
         jdbcClient.finishInsertTable(jdbcInsertHandle);

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -159,7 +160,7 @@ public class BlackHoleMetadata
     public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
     {
         ConnectorOutputTableHandle outputTableHandle = beginCreateTable(session, tableMetadata, Optional.empty());
-        finishCreateTable(session, outputTableHandle, ImmutableList.of());
+        finishCreateTable(session, outputTableHandle, ImmutableList.of(), ImmutableList.of());
     }
 
     @Override
@@ -220,7 +221,7 @@ public class BlackHoleMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         BlackHoleOutputTableHandle blackHoleOutputTableHandle = (BlackHoleOutputTableHandle) tableHandle;
         BlackHoleTableHandle table = blackHoleOutputTableHandle.getTable();
@@ -236,7 +237,7 @@ public class BlackHoleMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         return Optional.empty();
     }

--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleMetadata.java
@@ -65,7 +65,7 @@ public class TestBlackHoleMetadata
 
         assertThatNoTableIsCreated();
 
-        metadata.finishCreateTable(SESSION, table, ImmutableList.of());
+        metadata.finishCreateTable(SESSION, table, ImmutableList.of(), ImmutableList.of());
 
         List<SchemaTableName> tables = metadata.listTables(SESSION, Optional.empty());
         assertTrue(tables.size() == 1, "Expected only one table.");

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -312,7 +313,7 @@ public class CassandraMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         return Optional.empty();
     }
@@ -339,7 +340,7 @@ public class CassandraMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         return Optional.empty();
     }

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -111,9 +111,9 @@ security options in the Hive connector.
 Hive Configuration Properties
 -----------------------------
 
-================================================== ============================================================ ==========
+================================================== ============================================================ ============
 Property Name                                      Description                                                  Default
-================================================== ============================================================ ==========
+================================================== ============================================================ ============
 ``hive.metastore.uri``                             The URI(s) of the Hive metastore to connect to using the
                                                    Thrift protocol. If multiple URIs are provided, the first
                                                    URI is used by default and the rest of the URIs are
@@ -175,7 +175,11 @@ Property Name                                      Description                  
 ``hive.non-managed-table-writes-enabled``          Enable writes to non-managed (external) Hive tables.         ``false``
 
 ``hive.non-managed-table-creates-enabled``         Enable creating non-managed (external) Hive tables.          ``true``
-================================================== ============================================================ ==========
+
+``hive.collect-column-statistics-on-write``        Enables automatic column level statistics collection         ``false``
+                                                   on write. See `Table Statistics <#table-statistics>`__ for
+                                                   details.
+================================================== ============================================================ ============
 
 Amazon S3 Configuration
 -----------------------
@@ -333,6 +337,36 @@ classpath and must be able to communicate with your custom key management system
 the ``org.apache.hadoop.conf.Configurable`` interface from the Hadoop Java API, then the Hadoop configuration
 will be passed in after the object instance is created and before it is asked to provision or retrieve any
 encryption keys.
+
+Table Statistics
+----------------
+
+The Hive connector automatically collects basic statistics
+(``numFiles', ``numRows``, ``rawDataSize``, ``totalSize``)
+on ``INSERT`` and ``CREATE TABLE AS`` operations.
+
+The Hive connector can also collect column level statistics:
+
+============= ====================================================================
+Column Type   Collectible Statistics
+============= ====================================================================
+``TINYINT``   number of nulls, number of distinct values, min/max values
+``SMALLINT``  number of nulls, number of distinct values, min/max values
+``INTEGER``   number of nulls, number of distinct values, min/max values
+``BIGINT``    number of nulls, number of distinct values, min/max values
+``DOUBLE``    number of nulls, number of distinct values, min/max values
+``REAL``      number of nulls, number of distinct values, min/max values
+``DECIMAL``   number of nulls, number of distinct values, min/max values
+``DATE``      number of nulls, number of distinct values, min/max values
+``TIMESTAMP`` number of nulls, number of distinct values, min/max values
+``VARCHAR``   number of nulls, number of distinct values
+``CHAR``      number of nulls, number of distinct values
+``VARBINARY`` number of nulls
+``BOOLEAN``   number of nulls, number of true/false values
+============= ====================================================================
+
+Automatic column level statistics collection on write is controlled by
+the ``collect-column-statistics-on-write`` catalog session property.
 
 Schema Evolution
 ----------------

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -135,6 +135,7 @@ public class HiveClientConfig
 
     private boolean tableStatisticsEnabled = true;
     private int partitionStatisticsSampleSize = 100;
+    private boolean collectColumnStatisticsOnWrite;
 
     public int getMaxInitialSplits()
     {
@@ -1071,6 +1072,19 @@ public class HiveClientConfig
     public HiveClientConfig setPartitionStatisticsSampleSize(int partitionStatisticsSampleSize)
     {
         this.partitionStatisticsSampleSize = partitionStatisticsSampleSize;
+        return this;
+    }
+
+    public boolean isCollectColumnStatisticsOnWrite()
+    {
+        return collectColumnStatisticsOnWrite;
+    }
+
+    @Config("hive.collect-column-statistics-on-write")
+    @ConfigDescription("Enables automatic column level statistics collection on write")
+    public HiveClientConfig setCollectColumnStatisticsOnWrite(boolean collectColumnStatisticsOnWrite)
+    {
+        this.collectColumnStatisticsOnWrite = collectColumnStatisticsOnWrite;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -17,6 +17,7 @@ import com.facebook.presto.hive.HdfsEnvironment.HdfsContext;
 import com.facebook.presto.hive.LocationService.WriteInfo;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.HiveColumnStatistics;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import com.facebook.presto.hive.metastore.Partition;
@@ -50,6 +51,7 @@ import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.ViewNotFoundException;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -59,8 +61,11 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.spi.security.PrivilegeInfo;
+import com.facebook.presto.spi.statistics.ColumnStatisticMetadata;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
 import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.annotations.VisibleForTesting;
@@ -162,6 +167,8 @@ import static com.facebook.presto.hive.metastore.StorageFormat.VIEW_STORAGE_FORM
 import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
 import static com.facebook.presto.hive.util.ConfigurationUtils.toJobConf;
 import static com.facebook.presto.hive.util.Statistics.ReduceOperator.ADD;
+import static com.facebook.presto.hive.util.Statistics.createComputedStatisticsToPartitionMap;
+import static com.facebook.presto.hive.util.Statistics.fromComputedStatistics;
 import static com.facebook.presto.hive.util.Statistics.reduce;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
@@ -169,6 +176,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
 import static com.facebook.presto.spi.statistics.TableStatistics.EMPTY_STATISTICS;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -913,14 +921,17 @@ public class HiveMetadata
             }
         }
 
+        Map<String, Type> columnTypes = handle.getInputColumns().stream()
+                .collect(toImmutableMap(HiveColumnHandle::getName, column -> column.getHiveType().getType(typeManager)));
+        Map<List<String>, ComputedStatistics> partitionComputedStatistics = createComputedStatisticsToPartitionMap(computedStatistics, handle.getPartitionedBy(), columnTypes);
+
         PartitionStatistics tableStatistics;
         if (table.getPartitionColumns().isEmpty()) {
-            tableStatistics = new PartitionStatistics(
-                    partitionUpdates.stream()
-                            .map(PartitionUpdate::getStatistics)
-                            .reduce((first, second) -> reduce(first, second, ADD))
-                            .orElse(createZeroStatistics()),
-                    ImmutableMap.of());
+            HiveBasicStatistics basicStatistics = partitionUpdates.stream()
+                    .map(PartitionUpdate::getStatistics)
+                    .reduce((first, second) -> reduce(first, second, ADD))
+                    .orElse(createZeroStatistics());
+            tableStatistics = createPartitionStatistics(session, basicStatistics, ImmutableList.of(), columnTypes, partitionComputedStatistics);
         }
         else {
             tableStatistics = new PartitionStatistics(createEmptyStatistics(), ImmutableMap.of());
@@ -933,7 +944,8 @@ public class HiveMetadata
                 Verify.verify(handle.getPartitionStorageFormat() == handle.getTableStorageFormat());
             }
             for (PartitionUpdate update : partitionUpdates) {
-                PartitionStatistics partitionStatistics = new PartitionStatistics(update.getStatistics(), ImmutableMap.of());
+                Partition partition = buildPartitionObject(session, table, update);
+                PartitionStatistics partitionStatistics = createPartitionStatistics(session, update.getStatistics(), partition.getValues(), columnTypes, partitionComputedStatistics);
                 metastore.addPartition(
                         session,
                         handle.getSchemaName(),
@@ -1120,6 +1132,13 @@ public class HiveMetadata
             }
         }
 
+        List<String> partitionedBy = table.get().getPartitionColumns().stream()
+                .map(Column::getName)
+                .collect(toImmutableList());
+        Map<String, Type> columnTypes = handle.getInputColumns().stream()
+                .collect(toImmutableMap(HiveColumnHandle::getName, column -> column.getHiveType().getType(typeManager)));
+        Map<List<String>, ComputedStatistics> partitionComputedStatistics = createComputedStatisticsToPartitionMap(computedStatistics, partitionedBy, columnTypes);
+
         for (PartitionUpdate partitionUpdate : partitionUpdates) {
             if (partitionUpdate.getName().isEmpty()) {
                 // insert into unpartitioned table
@@ -1129,18 +1148,19 @@ public class HiveMetadata
                         handle.getTableName(),
                         partitionUpdate.getWritePath(),
                         partitionUpdate.getFileNames(),
-                        new PartitionStatistics(partitionUpdate.getStatistics(), ImmutableMap.of()));
+                        createPartitionStatistics(session, partitionUpdate.getStatistics(), ImmutableList.of(), columnTypes, partitionComputedStatistics));
             }
             else if (partitionUpdate.getUpdateMode() == APPEND) {
                 // insert into existing partition
+                List<String> partitionValues = toPartitionValues(partitionUpdate.getName());
                 metastore.finishInsertIntoExistingPartition(
                         session,
                         handle.getSchemaName(),
                         handle.getTableName(),
-                        toPartitionValues(partitionUpdate.getName()),
+                        partitionValues,
                         partitionUpdate.getWritePath(),
                         partitionUpdate.getFileNames(),
-                        new PartitionStatistics(partitionUpdate.getStatistics(), ImmutableMap.of()));
+                        createPartitionStatistics(session, partitionUpdate.getStatistics(), partitionValues, columnTypes, partitionComputedStatistics));
             }
             else if (partitionUpdate.getUpdateMode() == NEW || partitionUpdate.getUpdateMode() == OVERWRITE) {
                 // insert into new partition or overwrite existing partition
@@ -1157,7 +1177,7 @@ public class HiveMetadata
                         handle.getTableName(),
                         partition,
                         partitionUpdate.getWritePath(),
-                        new PartitionStatistics(partitionUpdate.getStatistics(), ImmutableMap.of()));
+                        createPartitionStatistics(session, partitionUpdate.getStatistics(), partition.getValues(), columnTypes, partitionComputedStatistics));
             }
             else {
                 throw new IllegalArgumentException(format("Unsupported update mode: %s", partitionUpdate.getUpdateMode()));
@@ -1189,6 +1209,26 @@ public class HiveMetadata
                         .setBucketProperty(table.getStorage().getBucketProperty())
                         .setSerdeParameters(table.getStorage().getSerdeParameters()))
                 .build();
+    }
+
+    private PartitionStatistics createPartitionStatistics(
+            ConnectorSession session,
+            HiveBasicStatistics basicStatistics,
+            List<String> partitionValues,
+            Map<String, Type> columnTypes,
+            Map<List<String>, ComputedStatistics> partitionComputedStatistics)
+    {
+        Map<ColumnStatisticMetadata, Block> computedColumnStatistics = Optional.ofNullable(partitionComputedStatistics.get(partitionValues))
+                .map(ComputedStatistics::getColumnStatistics)
+                .orElse(ImmutableMap.of());
+        long rowCount = basicStatistics.getRowCount().orElseThrow(() -> new IllegalArgumentException("rowCount not present"));
+        Map<String, HiveColumnStatistics> columnStatistics = fromComputedStatistics(
+                session,
+                timeZone,
+                computedColumnStatistics,
+                columnTypes,
+                rowCount);
+        return new PartitionStatistics(basicStatistics, columnStatistics);
     }
 
     @Override
@@ -1516,6 +1556,36 @@ public class HiveMetadata
                                 .map(hiveTypeMap::get)
                                 .collect(toList())),
                 bucketedBy));
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        List<String> partitionedBy = firstNonNull(getPartitionedBy(tableMetadata.getProperties()), ImmutableList.of());
+        return getStatisticsCollectionMetadata(tableMetadata.getColumns(), partitionedBy);
+    }
+
+    private TableStatisticsMetadata getStatisticsCollectionMetadata(List<ColumnMetadata> columns, List<String> partitionedBy)
+    {
+        Set<ColumnStatisticMetadata> columnStatistics = columns.stream()
+                .filter(column -> !partitionedBy.contains(column.getName()))
+                .filter(column -> !column.isHidden())
+                .map(this::getColumnStatisticMetadata)
+                .flatMap(List::stream)
+                .collect(toImmutableSet());
+        return new TableStatisticsMetadata(columnStatistics, ImmutableSet.of(), partitionedBy);
+    }
+
+    private List<ColumnStatisticMetadata> getColumnStatisticMetadata(ColumnMetadata columnMetadata)
+    {
+        return getColumnStatisticMetadata(columnMetadata.getName(), metastore.getSupportedColumnStatistics(columnMetadata.getType()));
+    }
+
+    private List<ColumnStatisticMetadata> getColumnStatisticMetadata(String columnName, Set<ColumnStatisticType> statisticTypes)
+    {
+        return statisticTypes.stream()
+                .map(type -> new ColumnStatisticMetadata(columnName, type))
+                .collect(toImmutableList());
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -59,6 +59,7 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.spi.security.PrivilegeInfo;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -875,7 +876,7 @@ public class HiveMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         HiveOutputTableHandle handle = (HiveOutputTableHandle) tableHandle;
 
@@ -1089,7 +1090,7 @@ public class HiveMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         HiveInsertTableHandle handle = (HiveInsertTableHandle) insertHandle;
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -124,6 +124,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static com.facebook.presto.hive.HivePartitionManager.extractPartitionKeyValues;
 import static com.facebook.presto.hive.HiveSessionProperties.getHiveStorageFormat;
 import static com.facebook.presto.hive.HiveSessionProperties.isBucketExecutionEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isCollectColumnStatisticsOnWrite;
 import static com.facebook.presto.hive.HiveSessionProperties.isRespectTableFormat;
 import static com.facebook.presto.hive.HiveSessionProperties.isSortedWritingEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isStatisticsEnabled;
@@ -1561,6 +1562,9 @@ public class HiveMetadata
     @Override
     public TableStatisticsMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
+        if (!isCollectColumnStatisticsOnWrite(session)) {
+            return TableStatisticsMetadata.empty();
+        }
         List<String> partitionedBy = firstNonNull(getPartitionedBy(tableMetadata.getProperties()), ImmutableList.of());
         return getStatisticsCollectionMetadata(tableMetadata.getColumns(), partitionedBy);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -72,6 +72,7 @@ public final class HiveSessionProperties
     private static final String WRITER_SORT_BUFFER_SIZE = "writer_sort_buffer_size";
     private static final String STATISTICS_ENABLED = "statistics_enabled";
     private static final String PARTITION_STATISTICS_SAMPLE_SIZE = "partition_statistics_sample_size";
+    private static final String COLLECT_COLUMN_STATISTICS_ON_WRITE = "collect_column_statistics_on_write";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -260,6 +261,11 @@ public final class HiveSessionProperties
                         PARTITION_STATISTICS_SAMPLE_SIZE,
                         "Maximum sample size of the partitions column statistics",
                         hiveClientConfig.getPartitionStatisticsSampleSize(),
+                        false),
+                booleanProperty(
+                        COLLECT_COLUMN_STATISTICS_ON_WRITE,
+                        "Experimental: Enables automatic column level statistics collection on write",
+                        hiveClientConfig.isCollectColumnStatisticsOnWrite(),
                         false));
     }
 
@@ -440,6 +446,11 @@ public final class HiveSessionProperties
             throw new PrestoException(INVALID_SESSION_PROPERTY, format("%s must be greater than 0: %s", PARTITION_STATISTICS_SAMPLE_SIZE, size));
         }
         return size;
+    }
+
+    public static boolean isCollectColumnStatisticsOnWrite(ConnectorSession session)
+    {
+        return session.getProperty(COLLECT_COLUMN_STATISTICS_ON_WRITE, Boolean.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -18,6 +18,8 @@ import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.PartitionStatistics;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -258,9 +260,9 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public boolean supportsColumnStatistics()
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
     {
-        return delegate.supportsColumnStatistics();
+        return delegate.getSupportedColumnStatistics(type);
     }
 
     private Optional<Table> loadTable(HiveTableName hiveTableName)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -15,6 +15,8 @@ package com.facebook.presto.hive.metastore;
 
 import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.PartitionStatistics;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
 import java.util.Map;
@@ -30,7 +32,7 @@ public interface ExtendedHiveMetastore
 
     Optional<Table> getTable(String databaseName, String tableName);
 
-    boolean supportsColumnStatistics();
+    Set<ColumnStatisticType> getSupportedColumnStatistics(Type type);
 
     PartitionStatistics getTableStatistics(String databaseName, String tableName);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveColumnStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveColumnStatistics.java
@@ -31,6 +31,8 @@ import static java.util.Objects.requireNonNull;
 
 public class HiveColumnStatistics
 {
+    private static final HiveColumnStatistics EMPTY = HiveColumnStatistics.builder().build();
+
     private final Optional<IntegerStatistics> integerStatistics;
     private final Optional<DoubleStatistics> doubleStatistics;
     private final Optional<DecimalStatistics> decimalStatistics;
@@ -40,6 +42,11 @@ public class HiveColumnStatistics
     private final OptionalDouble averageColumnLength;
     private final OptionalLong nullsCount;
     private final OptionalLong distinctValuesCount;
+
+    public static HiveColumnStatistics empty()
+    {
+        return EMPTY;
+    }
 
     @JsonCreator
     public HiveColumnStatistics(
@@ -241,6 +248,11 @@ public class HiveColumnStatistics
                 .build();
     }
 
+    public static Builder builder(HiveColumnStatistics other)
+    {
+        return new Builder(other);
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -258,9 +270,36 @@ public class HiveColumnStatistics
         private OptionalLong nullsCount = OptionalLong.empty();
         private OptionalLong distinctValuesCount = OptionalLong.empty();
 
+        private Builder() {}
+
+        private Builder(HiveColumnStatistics other)
+        {
+            this.integerStatistics = other.getIntegerStatistics();
+            this.doubleStatistics = other.getDoubleStatistics();
+            this.decimalStatistics = other.getDecimalStatistics();
+            this.dateStatistics = other.getDateStatistics();
+            this.booleanStatistics = other.getBooleanStatistics();
+            this.maxColumnLength = other.getMaxColumnLength();
+            this.averageColumnLength = other.getAverageColumnLength();
+            this.nullsCount = other.getNullsCount();
+            this.distinctValuesCount = other.getDistinctValuesCount();
+        }
+
+        public Builder setIntegerStatistics(Optional<IntegerStatistics> integerStatistics)
+        {
+            this.integerStatistics = integerStatistics;
+            return this;
+        }
+
         public Builder setIntegerStatistics(IntegerStatistics integerStatistics)
         {
             this.integerStatistics = Optional.of(integerStatistics);
+            return this;
+        }
+
+        public Builder setDoubleStatistics(Optional<DoubleStatistics> doubleStatistics)
+        {
+            this.doubleStatistics = doubleStatistics;
             return this;
         }
 
@@ -270,15 +309,33 @@ public class HiveColumnStatistics
             return this;
         }
 
+        public Builder setDecimalStatistics(Optional<DecimalStatistics> decimalStatistics)
+        {
+            this.decimalStatistics = decimalStatistics;
+            return this;
+        }
+
         public Builder setDecimalStatistics(DecimalStatistics decimalStatistics)
         {
             this.decimalStatistics = Optional.of(decimalStatistics);
             return this;
         }
 
+        public Builder setDateStatistics(Optional<DateStatistics> dateStatistics)
+        {
+            this.dateStatistics = dateStatistics;
+            return this;
+        }
+
         public Builder setDateStatistics(DateStatistics dateStatistics)
         {
             this.dateStatistics = Optional.of(dateStatistics);
+            return this;
+        }
+
+        public Builder setBooleanStatistics(Optional<BooleanStatistics> booleanStatistics)
+        {
+            this.booleanStatistics = booleanStatistics;
             return this;
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -25,6 +25,8 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -148,6 +150,11 @@ public class SemiTransactionalHiveMetastore
             default:
                 throw new IllegalStateException("Unknown action type");
         }
+    }
+
+    public synchronized Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
+    {
+        return delegate.getSupportedColumnStatistics(type);
     }
 
     public synchronized PartitionStatistics getTableStatistics(String databaseName, String tableName)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -35,12 +35,15 @@ import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
 import com.facebook.presto.hive.metastore.PrincipalType;
 import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hive.metastore.thrift.ThriftMetastoreUtil;
 import com.facebook.presto.spi.ColumnNotFoundException;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -276,9 +279,9 @@ public class FileHiveMetastore
     }
 
     @Override
-    public boolean supportsColumnStatistics()
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
     {
-        return true;
+        return ThriftMetastoreUtil.getSupportedColumnStatistics(type);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -75,6 +75,8 @@ import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -215,9 +217,9 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public boolean supportsColumnStatistics()
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
     {
-        return false;
+        return ImmutableSet.of();
     }
 
     private Table getTableOrElseThrow(String databaseName, String tableName)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -27,6 +27,8 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
@@ -79,9 +81,9 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public boolean supportsColumnStatistics()
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
     {
-        return delegate.supportsColumnStatistics();
+        return delegate.getSupportedColumnStatistics(type);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -15,6 +15,8 @@ package com.facebook.presto.hive.metastore.thrift;
 
 import com.facebook.presto.hive.PartitionStatistics;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
@@ -73,7 +75,7 @@ public interface HiveMetastore
 
     Optional<Table> getTable(String databaseName, String tableName);
 
-    boolean supportsColumnStatistics();
+    Set<ColumnStatisticType> getSupportedColumnStatistics(Type type);
 
     PartitionStatistics getTableStatistics(String databaseName, String tableName);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -27,6 +27,8 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -238,9 +240,9 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public boolean supportsColumnStatistics()
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
     {
-        return true;
+        return ThriftMetastoreUtil.getSupportedColumnStatistics(type);
     }
 
     private static boolean isPrestoView(Table table)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/Statistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/Statistics.java
@@ -15,9 +15,22 @@ package com.facebook.presto.hive.util;
 
 import com.facebook.presto.hive.HiveBasicStatistics;
 import com.facebook.presto.hive.PartitionStatistics;
+import com.facebook.presto.hive.metastore.BooleanStatistics;
+import com.facebook.presto.hive.metastore.DateStatistics;
+import com.facebook.presto.hive.metastore.DecimalStatistics;
+import com.facebook.presto.hive.metastore.DoubleStatistics;
 import com.facebook.presto.hive.metastore.HiveColumnStatistics;
+import com.facebook.presto.hive.metastore.IntegerStatistics;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.statistics.ColumnStatisticMetadata;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.SqlDate;
+import com.facebook.presto.spi.type.SqlDecimal;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTimeZone;
@@ -25,11 +38,25 @@ import org.joda.time.DateTimeZone;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
+import java.util.Set;
 
+import static com.facebook.presto.hive.HiveWriteUtils.createPartitionValues;
 import static com.facebook.presto.hive.util.Statistics.ReduceOperator.ADD;
+import static com.facebook.presto.hive.util.Statistics.ReduceOperator.MAX;
+import static com.facebook.presto.hive.util.Statistics.ReduceOperator.MIN;
+import static com.facebook.presto.spi.statistics.ColumnStatisticType.MAX_VALUE;
+import static com.facebook.presto.spi.statistics.ColumnStatisticType.MIN_VALUE;
+import static com.facebook.presto.spi.statistics.ColumnStatisticType.NUMBER_OF_DISTINCT_VALUES;
+import static com.facebook.presto.spi.statistics.ColumnStatisticType.NUMBER_OF_NON_NULL_VALUES;
+import static com.facebook.presto.spi.statistics.ColumnStatisticType.NUMBER_OF_TRUE_VALUES;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -38,8 +65,14 @@ import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Sets.intersection;
 import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class Statistics
 {
@@ -49,19 +82,119 @@ public final class Statistics
     {
         return new PartitionStatistics(
                 reduce(first.getBasicStatistics(), second.getBasicStatistics(), ADD),
-                ImmutableMap.of());
+                merge(first.getColumnStatistics(), first.getBasicStatistics().getRowCount(), second.getColumnStatistics(), second.getBasicStatistics().getRowCount()));
     }
 
     public static HiveBasicStatistics reduce(HiveBasicStatistics first, HiveBasicStatistics second, ReduceOperator operator)
     {
         return new HiveBasicStatistics(
-                reduce(first.getFileCount(), second.getFileCount(), operator),
-                reduce(first.getRowCount(), second.getRowCount(), operator),
-                reduce(first.getInMemoryDataSizeInBytes(), second.getInMemoryDataSizeInBytes(), operator),
-                reduce(first.getOnDiskDataSizeInBytes(), second.getOnDiskDataSizeInBytes(), operator));
+                reduce(first.getFileCount(), second.getFileCount(), operator, false),
+                reduce(first.getRowCount(), second.getRowCount(), operator, false),
+                reduce(first.getInMemoryDataSizeInBytes(), second.getInMemoryDataSizeInBytes(), operator, false),
+                reduce(first.getOnDiskDataSizeInBytes(), second.getOnDiskDataSizeInBytes(), operator, false));
     }
 
-    private static OptionalLong reduce(OptionalLong first, OptionalLong second, ReduceOperator operator)
+    public static Map<String, HiveColumnStatistics> merge(
+            Map<String, HiveColumnStatistics> first,
+            OptionalLong firstRowCount,
+            Map<String, HiveColumnStatistics> second,
+            OptionalLong secondRowCount)
+    {
+        // only keep columns that have statistics for both sides
+        Set<String> columns = intersection(first.keySet(), second.keySet());
+        return columns.stream()
+                .collect(toImmutableMap(
+                        column -> column,
+                        column -> merge(first.get(column), firstRowCount, second.get(column), secondRowCount)));
+    }
+
+    public static HiveColumnStatistics merge(HiveColumnStatistics first, OptionalLong firstRowCount, HiveColumnStatistics second, OptionalLong secondRowCount)
+    {
+        return new HiveColumnStatistics(
+                mergeIntegerStatistics(first.getIntegerStatistics(), second.getIntegerStatistics()),
+                mergeDoubleStatistics(first.getDoubleStatistics(), second.getDoubleStatistics()),
+                mergeDecimalStatistics(first.getDecimalStatistics(), second.getDecimalStatistics()),
+                mergeDateStatistics(first.getDateStatistics(), second.getDateStatistics()),
+                mergeBooleanStatistics(first.getBooleanStatistics(), second.getBooleanStatistics()),
+                reduce(first.getMaxColumnLength(), second.getMaxColumnLength(), MAX, true),
+                mergeAverage(first.getAverageColumnLength(), firstRowCount, second.getAverageColumnLength(), secondRowCount),
+                reduce(first.getNullsCount(), second.getNullsCount(), ADD, false),
+                reduce(first.getDistinctValuesCount(), second.getDistinctValuesCount(), MAX, false));
+    }
+
+    private static Optional<IntegerStatistics> mergeIntegerStatistics(Optional<IntegerStatistics> first, Optional<IntegerStatistics> second)
+    {
+        // normally, either both or none is present
+        if (first.isPresent() && second.isPresent()) {
+            return Optional.of(new IntegerStatistics(
+                    reduce(first.get().getMin(), second.get().getMin(), MIN, true),
+                    reduce(first.get().getMax(), second.get().getMax(), MAX, true)));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<DoubleStatistics> mergeDoubleStatistics(Optional<DoubleStatistics> first, Optional<DoubleStatistics> second)
+    {
+        // normally, either both or none is present
+        if (first.isPresent() && second.isPresent()) {
+            return Optional.of(new DoubleStatistics(
+                    reduce(first.get().getMin(), second.get().getMin(), MIN, true),
+                    reduce(first.get().getMax(), second.get().getMax(), MAX, true)));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<DecimalStatistics> mergeDecimalStatistics(Optional<DecimalStatistics> first, Optional<DecimalStatistics> second)
+    {
+        // normally, either both or none is present
+        if (first.isPresent() && second.isPresent()) {
+            return Optional.of(new DecimalStatistics(
+                    reduce(first.get().getMin(), second.get().getMin(), MIN, true),
+                    reduce(first.get().getMax(), second.get().getMax(), MAX, true)));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<DateStatistics> mergeDateStatistics(Optional<DateStatistics> first, Optional<DateStatistics> second)
+    {
+        // normally, either both or none is present
+        if (first.isPresent() && second.isPresent()) {
+            return Optional.of(new DateStatistics(
+                    reduce(first.get().getMin(), second.get().getMin(), MIN, true),
+                    reduce(first.get().getMax(), second.get().getMax(), MAX, true)));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<BooleanStatistics> mergeBooleanStatistics(Optional<BooleanStatistics> first, Optional<BooleanStatistics> second)
+    {
+        // normally, either both or none is present
+        if (first.isPresent() && second.isPresent()) {
+            return Optional.of(new BooleanStatistics(
+                    reduce(first.get().getTrueCount(), second.get().getTrueCount(), ADD, false),
+                    reduce(first.get().getFalseCount(), second.get().getFalseCount(), ADD, false)));
+        }
+        return Optional.empty();
+    }
+
+    private static OptionalDouble mergeAverage(OptionalDouble first, OptionalLong firstRowCount, OptionalDouble second, OptionalLong secondRowCount)
+    {
+        if (first.isPresent() && second.isPresent()) {
+            if (!firstRowCount.isPresent() || !secondRowCount.isPresent()) {
+                return OptionalDouble.empty();
+            }
+            long totalRowCount = firstRowCount.getAsLong() + secondRowCount.getAsLong();
+            if (totalRowCount == 0) {
+                return OptionalDouble.empty();
+            }
+            double sumFirst = first.getAsDouble() * firstRowCount.getAsLong();
+            double sumSecond = second.getAsDouble() * secondRowCount.getAsLong();
+            return OptionalDouble.of((sumFirst + sumSecond) / totalRowCount);
+        }
+        return first.isPresent() ? first : second;
+    }
+
+    private static OptionalLong reduce(OptionalLong first, OptionalLong second, ReduceOperator operator, boolean returnFirstNonEmpty)
     {
         if (first.isPresent() && second.isPresent()) {
             switch (operator) {
@@ -69,9 +202,69 @@ public final class Statistics
                     return OptionalLong.of(first.getAsLong() + second.getAsLong());
                 case SUBTRACT:
                     return OptionalLong.of(first.getAsLong() - second.getAsLong());
+                case MAX:
+                    return OptionalLong.of(max(first.getAsLong(), second.getAsLong()));
+                case MIN:
+                    return OptionalLong.of(min(first.getAsLong(), second.getAsLong()));
+                default:
+                    throw new IllegalArgumentException("Unexpected operator: " + operator);
             }
         }
+        if (returnFirstNonEmpty) {
+            return first.isPresent() ? first : second;
+        }
         return OptionalLong.empty();
+    }
+
+    private static OptionalDouble reduce(OptionalDouble first, OptionalDouble second, ReduceOperator operator, boolean returnFirstNonEmpty)
+    {
+        if (first.isPresent() && second.isPresent()) {
+            switch (operator) {
+                case ADD:
+                    return OptionalDouble.of(first.getAsDouble() + second.getAsDouble());
+                case SUBTRACT:
+                    return OptionalDouble.of(first.getAsDouble() - second.getAsDouble());
+                case MAX:
+                    return OptionalDouble.of(max(first.getAsDouble(), second.getAsDouble()));
+                case MIN:
+                    return OptionalDouble.of(min(first.getAsDouble(), second.getAsDouble()));
+                default:
+                    throw new IllegalArgumentException("Unexpected operator: " + operator);
+            }
+        }
+        if (returnFirstNonEmpty) {
+            return first.isPresent() ? first : second;
+        }
+        return OptionalDouble.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Comparable<? super T>> Optional<T> reduce(Optional<T> first, Optional<T> second, ReduceOperator operator, boolean returnFirstNonEmpty)
+    {
+        if (first.isPresent() && second.isPresent()) {
+            switch (operator) {
+                case MAX:
+                    return Optional.of(max(first.get(), second.get()));
+                case MIN:
+                    return Optional.of(min(first.get(), second.get()));
+                default:
+                    throw new IllegalArgumentException("Unexpected operator: " + operator);
+            }
+        }
+        if (returnFirstNonEmpty) {
+            return first.isPresent() ? first : second;
+        }
+        return Optional.empty();
+    }
+
+    private static <T extends Comparable<? super T>> T max(T first, T second)
+    {
+        return first.compareTo(second) >= 0 ? first : second;
+    }
+
+    private static <T extends Comparable<? super T>> T min(T first, T second)
+    {
+        return first.compareTo(second) <= 0 ? first : second;
     }
 
     public static Range getMinMaxAsPrestoNativeValues(HiveColumnStatistics statistics, Type type, DateTimeZone timeZone)
@@ -134,6 +327,134 @@ public final class Statistics
         return Decimals.encodeUnscaledValue(unscaled);
     }
 
+    public static Map<List<String>, ComputedStatistics> createComputedStatisticsToPartitionMap(
+            Collection<ComputedStatistics> computedStatistics,
+            List<String> partitionColumns,
+            Map<String, Type> columnTypes)
+    {
+        List<Type> partitionColumnTypes = partitionColumns.stream()
+                .map(columnTypes::get)
+                .collect(toImmutableList());
+
+        return computedStatistics.stream()
+                .collect(toImmutableMap(statistics -> getPartitionValues(statistics, partitionColumns, partitionColumnTypes), statistics -> statistics));
+    }
+
+    private static List<String> getPartitionValues(ComputedStatistics statistics, List<String> partitionColumns, List<Type> partitionColumnTypes)
+    {
+        checkArgument(statistics.getGroupingColumns().equals(partitionColumns),
+                "Unexpected grouping. Partition columns: %s. Grouping columns: %s", partitionColumns, statistics.getGroupingColumns());
+        Page partitionColumnsPage = new Page(1, statistics.getGroupingValues().toArray(new Block[] {}));
+        return createPartitionValues(partitionColumnTypes, partitionColumnsPage, 0);
+    }
+
+    public static Map<String, HiveColumnStatistics> fromComputedStatistics(
+            ConnectorSession session,
+            DateTimeZone timeZone,
+            Map<ColumnStatisticMetadata, Block> computedStatistics,
+            Map<String, Type> columnTypes,
+            long rowCount)
+    {
+        return createColumnToComputedStatisticsMap(computedStatistics).entrySet().stream()
+                .collect(toImmutableMap(Entry::getKey, entry -> createHiveColumnStatistics(session, timeZone, entry.getValue(), columnTypes.get(entry.getKey()), rowCount)));
+    }
+
+    private static Map<String, Map<ColumnStatisticType, Block>> createColumnToComputedStatisticsMap(Map<ColumnStatisticMetadata, Block> computedStatistics)
+    {
+        Map<String, Map<ColumnStatisticType, Block>> result = new HashMap<>();
+        computedStatistics.forEach((metadata, block) -> {
+            Map<ColumnStatisticType, Block> columnStatistics = result.computeIfAbsent(metadata.getColumnName(), key -> new HashMap<>());
+            columnStatistics.put(metadata.getStatisticType(), block);
+        });
+        return result.entrySet()
+                .stream()
+                .collect(toImmutableMap(Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue())));
+    }
+
+    private static HiveColumnStatistics createHiveColumnStatistics(
+            ConnectorSession session,
+            DateTimeZone timeZone,
+            Map<ColumnStatisticType, Block> computedStatistics,
+            Type columnType,
+            long rowCount)
+    {
+        HiveColumnStatistics.Builder result = HiveColumnStatistics.builder();
+
+        // MIN_VALUE, MAX_VALUE
+        // We ask the engine to compute either both or neither
+        verify(computedStatistics.containsKey(MIN_VALUE) == computedStatistics.containsKey(MAX_VALUE));
+        if (computedStatistics.containsKey(MIN_VALUE)) {
+            setMinMax(session, timeZone, columnType, computedStatistics.get(MIN_VALUE), computedStatistics.get(MAX_VALUE), result);
+        }
+
+        // NDV
+        if (computedStatistics.containsKey(NUMBER_OF_DISTINCT_VALUES)) {
+            result.setDistinctValuesCount(BIGINT.getLong(computedStatistics.get(NUMBER_OF_DISTINCT_VALUES), 0));
+        }
+
+        // NUMBER OF NULLS
+        if (computedStatistics.containsKey(NUMBER_OF_NON_NULL_VALUES)) {
+            result.setNullsCount(rowCount - BIGINT.getLong(computedStatistics.get(NUMBER_OF_NON_NULL_VALUES), 0));
+        }
+
+        // NUMBER OF FALSE, NUMBER OF TRUE
+        if (computedStatistics.containsKey(NUMBER_OF_TRUE_VALUES) && computedStatistics.containsKey(NUMBER_OF_NON_NULL_VALUES)) {
+            long numberOfTrue = BIGINT.getLong(computedStatistics.get(NUMBER_OF_TRUE_VALUES), 0);
+            long numberOfNonNullValues = BIGINT.getLong(computedStatistics.get(NUMBER_OF_NON_NULL_VALUES), 0);
+            result.setBooleanStatistics(new BooleanStatistics(OptionalLong.of(numberOfTrue), OptionalLong.of(numberOfNonNullValues - numberOfTrue)));
+        }
+        return result.build();
+    }
+
+    private static void setMinMax(ConnectorSession session, DateTimeZone timeZone, Type type, Block min, Block max, HiveColumnStatistics.Builder result)
+    {
+        if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(SMALLINT) || type.equals(TINYINT)) {
+            result.setIntegerStatistics(new IntegerStatistics(getIntegerValue(session, type, min), getIntegerValue(session, type, max)));
+        }
+        else if (type.equals(DOUBLE) || type.equals(REAL)) {
+            result.setDoubleStatistics(new DoubleStatistics(getDoubleValue(session, type, min), getDoubleValue(session, type, max)));
+        }
+        else if (type.equals(DATE)) {
+            result.setDateStatistics(new DateStatistics(getDateValue(session, type, min), getDateValue(session, type, max)));
+        }
+        else if (type.equals(TIMESTAMP)) {
+            result.setIntegerStatistics(new IntegerStatistics(getTimestampValue(timeZone, min), getTimestampValue(timeZone, max)));
+        }
+        else if (type instanceof DecimalType) {
+            result.setDecimalStatistics(new DecimalStatistics(getDecimalValue(session, type, min), getDecimalValue(session, type, max)));
+        }
+        else {
+            throw new IllegalArgumentException("Unexpected type: " + type);
+        }
+    }
+
+    private static OptionalLong getIntegerValue(ConnectorSession session, Type type, Block block)
+    {
+        // works for BIGINT as well as for other integer types TINYINT/SMALLINT/INTEGER that store values as byte/short/int
+        return block.isNull(0) ? OptionalLong.empty() : OptionalLong.of(((Number) type.getObjectValue(session, block, 0)).longValue());
+    }
+
+    private static OptionalDouble getDoubleValue(ConnectorSession session, Type type, Block block)
+    {
+        return block.isNull(0) ? OptionalDouble.empty() : OptionalDouble.of(((Number) type.getObjectValue(session, block, 0)).doubleValue());
+    }
+
+    private static Optional<LocalDate> getDateValue(ConnectorSession session, Type type, Block block)
+    {
+        return block.isNull(0) ? Optional.empty() : Optional.of(LocalDate.ofEpochDay(((SqlDate) type.getObjectValue(session, block, 0)).getDays()));
+    }
+
+    private static OptionalLong getTimestampValue(DateTimeZone timeZone, Block block)
+    {
+        // TODO #7122
+        return block.isNull(0) ? OptionalLong.empty() : OptionalLong.of(MILLISECONDS.toSeconds(timeZone.convertUTCToLocal(block.getLong(0, 0))));
+    }
+
+    private static Optional<BigDecimal> getDecimalValue(ConnectorSession session, Type type, Block block)
+    {
+        return block.isNull(0) ? Optional.empty() : Optional.of(((SqlDecimal) type.getObjectValue(session, block, 0)).toBigDecimal());
+    }
+
     private static Optional<Long> boxed(OptionalLong input)
     {
         return input.isPresent() ? Optional.of(input.getAsLong()) : Optional.empty();
@@ -148,6 +469,8 @@ public final class Statistics
     {
         ADD,
         SUBTRACT,
+        MIN,
+        MAX,
     }
 
     public static class Range

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -110,7 +110,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -2586,12 +2585,6 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         SchemaTableName tableName = temporaryTable("update_table_column_statistics");
-
-        ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
-        if (!metastoreClient.supportsColumnStatistics()) {
-            throw new SkipException("column level statistics are not supported");
-        }
-
         try {
             doCreateEmptyTable(tableName, ORC, STATISTICS_TABLE_COLUMNS);
             testUpdateTableStatistics(tableName, EMPTY_TABLE_STATISTICS, STATISTICS_1_1, STATISTICS_1_2, STATISTICS_2);
@@ -2606,12 +2599,6 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         SchemaTableName tableName = temporaryTable("update_table_column_statistics_empty_optional_fields");
-
-        ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
-        if (!metastoreClient.supportsColumnStatistics()) {
-            throw new SkipException("column level statistics are not supported");
-        }
-
         try {
             doCreateEmptyTable(tableName, ORC, STATISTICS_TABLE_COLUMNS);
             testUpdateTableStatistics(tableName, EMPTY_TABLE_STATISTICS, STATISTICS_EMPTY_OPTIONAL_FIELDS);
@@ -2673,12 +2660,6 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         SchemaTableName tableName = temporaryTable("update_partition_column_statistics");
-
-        ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
-        if (!metastoreClient.supportsColumnStatistics()) {
-            throw new SkipException("column level statistics are not supported");
-        }
-
         try {
             createDummyPartitionedTable(tableName, STATISTICS_PARTITIONED_TABLE_COLUMNS);
             testUpdatePartitionStatistics(
@@ -2697,12 +2678,6 @@ public abstract class AbstractTestHiveClient
             throws Exception
     {
         SchemaTableName tableName = temporaryTable("update_partition_column_statistics");
-
-        ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
-        if (!metastoreClient.supportsColumnStatistics()) {
-            throw new SkipException("column level statistics are not supported");
-        }
-
         try {
             createDummyPartitionedTable(tableName, STATISTICS_PARTITIONED_TABLE_COLUMNS);
             testUpdatePartitionStatistics(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1049,7 +1049,7 @@ public abstract class AbstractTestHiveClient
             sink.appendPage(dataBefore.toPage());
             Collection<Slice> fragments = getFutureValue(sink.finish());
 
-            metadata.finishInsert(session, insertTableHandle, fragments);
+            metadata.finishInsert(session, insertTableHandle, fragments, ImmutableList.of());
 
             transaction.commit();
         }
@@ -1113,7 +1113,7 @@ public abstract class AbstractTestHiveClient
             sink.appendPage(dataAfter.toPage());
             Collection<Slice> fragments = getFutureValue(sink.finish());
 
-            metadata.finishInsert(session, insertTableHandle, fragments);
+            metadata.finishInsert(session, insertTableHandle, fragments, ImmutableList.of());
 
             transaction.commit();
 
@@ -2323,7 +2323,7 @@ public abstract class AbstractTestHiveClient
             }
 
             // finish creating table
-            metadata.finishCreateTable(session, outputHandle, fragments);
+            metadata.finishCreateTable(session, outputHandle, fragments, ImmutableList.of());
 
             transaction.commit();
         }
@@ -2725,7 +2725,7 @@ public abstract class AbstractTestHiveClient
             List<ColumnMetadata> columns = ImmutableList.of(new ColumnMetadata("dummy", createUnboundedVarcharType()));
             ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(tableName, columns, createTableProperties(TEXTFILE));
             ConnectorOutputTableHandle handle = metadata.beginCreateTable(session, tableMetadata, Optional.empty());
-            metadata.finishCreateTable(session, handle, ImmutableList.of());
+            metadata.finishCreateTable(session, handle, ImmutableList.of(), ImmutableList.of());
 
             transaction.commit();
         }
@@ -2945,7 +2945,7 @@ public abstract class AbstractTestHiveClient
             }
 
             // commit the table
-            metadata.finishCreateTable(session, outputHandle, fragments);
+            metadata.finishCreateTable(session, outputHandle, fragments, ImmutableList.of());
 
             transaction.commit();
         }
@@ -3097,7 +3097,7 @@ public abstract class AbstractTestHiveClient
             sink.appendPage(CREATE_TABLE_DATA.toPage());
             sink.appendPage(CREATE_TABLE_DATA.toPage());
             Collection<Slice> fragments = getFutureValue(sink.finish());
-            metadata.finishInsert(session, insertTableHandle, fragments);
+            metadata.finishInsert(session, insertTableHandle, fragments, ImmutableList.of());
 
             // statistics, visible from within transaction
             HiveBasicStatistics tableStatistics = getBasicStatisticsForTable(transaction, tableName);
@@ -3307,7 +3307,7 @@ public abstract class AbstractTestHiveClient
             ConnectorPageSink sink = pageSinkProvider.createPageSink(transaction.getTransactionHandle(), session, insertTableHandle);
             sink.appendPage(CREATE_TABLE_PARTITIONED_DATA_2ND.toPage());
             Collection<Slice> fragments = getFutureValue(sink.finish());
-            metadata.finishInsert(session, insertTableHandle, fragments);
+            metadata.finishInsert(session, insertTableHandle, fragments, ImmutableList.of());
 
             // verify all temp files start with the unique prefix
             HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
@@ -3422,7 +3422,7 @@ public abstract class AbstractTestHiveClient
             sink.appendPage(CREATE_TABLE_PARTITIONED_DATA.toPage());
             sink.appendPage(CREATE_TABLE_PARTITIONED_DATA.toPage());
             Collection<Slice> fragments = getFutureValue(sink.finish());
-            metadata.finishInsert(session, insertTableHandle, fragments);
+            metadata.finishInsert(session, insertTableHandle, fragments, ImmutableList.of());
 
             // verify all temp files start with the unique prefix
             HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
@@ -3566,7 +3566,7 @@ public abstract class AbstractTestHiveClient
             Collection<Slice> fragments = getFutureValue(sink.finish());
 
             // commit the insert
-            metadata.finishInsert(session, insertTableHandle, fragments);
+            metadata.finishInsert(session, insertTableHandle, fragments, ImmutableList.of());
             transaction.commit();
         }
 
@@ -4456,7 +4456,7 @@ public abstract class AbstractTestHiveClient
                 rollbackIfEquals(tag, ROLLBACK_AFTER_APPEND_PAGE);
                 Collection<Slice> fragments = getFutureValue(sink.finish());
                 rollbackIfEquals(tag, ROLLBACK_AFTER_SINK_FINISH);
-                metadata.finishInsert(session, insertTableHandle, fragments);
+                metadata.finishInsert(session, insertTableHandle, fragments, ImmutableList.of());
                 rollbackIfEquals(tag, ROLLBACK_AFTER_FINISH_INSERT);
 
                 assertEquals(tag, COMMIT);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -371,7 +371,7 @@ public abstract class AbstractTestHiveFileSystem
             Collection<Slice> fragments = getFutureValue(sink.finish());
 
             // commit the table
-            metadata.finishCreateTable(session, outputHandle, fragments);
+            metadata.finishCreateTable(session, outputHandle, fragments, ImmutableList.of());
 
             transaction.commit();
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -102,6 +102,7 @@ public final class HiveQueryRunner
                     .put("hive.security", security)
                     .put("hive.max-partitions-per-scan", "1000")
                     .put("hive.assume-canonical-partition-keys", "true")
+                    .put("hive.collect-column-statistics-on-write", "true")
                     .build();
             Map<String, String> hiveBucketedProperties = ImmutableMap.<String, String>builder()
                     .putAll(hiveProperties)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -106,7 +106,8 @@ public class TestHiveClientConfig
                 .setWritesToNonManagedTablesEnabled(false)
                 .setCreatesOfNonManagedTablesEnabled(true)
                 .setHdfsWireEncryptionEnabled(false)
-                .setPartitionStatisticsSampleSize(100));
+                .setPartitionStatisticsSampleSize(100)
+                .setCollectColumnStatisticsOnWrite(false));
     }
 
     @Test
@@ -182,6 +183,7 @@ public class TestHiveClientConfig
                 .put("hive.non-managed-table-creates-enabled", "false")
                 .put("hive.hdfs.wire-encryption.enabled", "true")
                 .put("hive.partition-statistics-sample-size", "1234")
+                .put("hive.collect-column-statistics-on-write", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -253,7 +255,8 @@ public class TestHiveClientConfig
                 .setWritesToNonManagedTablesEnabled(true)
                 .setCreatesOfNonManagedTablesEnabled(false)
                 .setHdfsWireEncryptionEnabled(true)
-                .setPartitionStatisticsSampleSize(1234);
+                .setPartitionStatisticsSampleSize(1234)
+                .setCollectColumnStatisticsOnWrite(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -775,6 +775,14 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testCreatePartitionedUnionAll()
+    {
+        assertUpdate("CREATE TABLE test_create_partitioned_union_all (a varchar, ds varchar) WITH (partitioned_by = ARRAY['ds'])");
+        assertUpdate("INSERT INTO test_create_partitioned_union_all SELECT 'a', '2013-05-17' UNION ALL SELECT 'b', '2013-05-17'", 2);
+        assertUpdate("DROP TABLE test_create_partitioned_union_all");
+    }
+
+    @Test
     public void testInsertPartitionedBucketedTableFewRows()
     {
         // go through all storage formats to make sure the empty buckets are correctly created

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2558,6 +2558,110 @@ public class TestHiveIntegrationSmokeTest
         assertUpdate("DROP TABLE test_accounts");
     }
 
+    @Test
+    public void testCollectColumnStatisticsOnCreateTable()
+    {
+        String tableName = "test_collect_column_statistics_on_create_table";
+        assertUpdate(format("" +
+                "CREATE TABLE %s " +
+                "WITH ( " +
+                "   partitioned_by = ARRAY['p_varchar'] " +
+                ") " +
+                "AS " +
+                "SELECT c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_varbinary, p_varchar " +
+                "FROM ( " +
+                "  VALUES " +
+                "    (null, null, null, null, null, null, 'p1'), " +
+                "    (null, null, null, null, null, null, 'p1'), " +
+                "    (true, BIGINT '1', DOUBLE '2.2', TIMESTAMP '2012-08-08 01:00', CAST('abc1' AS VARCHAR), CAST('bcd1' AS VARBINARY), 'p1')," +
+                "    (false, BIGINT '0', DOUBLE '1.2', TIMESTAMP '2012-08-08 00:00', CAST('abc2' AS VARCHAR), CAST('bcd2' AS VARBINARY), 'p1')," +
+                "    (null, null, null, null, null, null, 'p2'), " +
+                "    (null, null, null, null, null, null, 'p2'), " +
+                "    (true, BIGINT '2', DOUBLE '3.3', TIMESTAMP '2012-09-09 01:00', CAST('cba1' AS VARCHAR), CAST('dcb1' AS VARBINARY), 'p2'), " +
+                "    (false, BIGINT '1', DOUBLE '2.3', TIMESTAMP '2012-09-09 00:00', CAST('cba2' AS VARCHAR), CAST('dcb2' AS VARBINARY), 'p2') " +
+                ") AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_varbinary, p_varchar)", tableName), 8);
+
+        assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1')", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1'), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2'), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, '2012-08-08 00:00:00.000', '2012-08-08 01:00:00.000'), " +
+                        "('c_varchar', null, 2.0E0, 0.5E0, null, null, null), " +
+                        "('c_varbinary', null, null, 0.5E0, null, null, null), " +
+                        "('p_varchar', null, 1.0E0, 0.0E0, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null)");
+        assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2')", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2'), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3'), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, '2012-09-09 00:00:00.000', '2012-09-09 01:00:00.000'), " +
+                        "('c_varchar', null, 2.0E0, 0.5E0, null, null, null), " +
+                        "('c_varbinary', null, null, 0.5E0, null, null, null), " +
+                        "('p_varchar', null, 1.0E0, 0.0E0, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null)");
+
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testCollectColumnStatisticsOnInsert()
+    {
+        String tableName = "test_collect_column_statistics_on_insert";
+        assertUpdate(format("" +
+                "CREATE TABLE %s ( " +
+                "   c_boolean BOOLEAN, " +
+                "   c_bigint BIGINT, " +
+                "   c_double DOUBLE, " +
+                "   c_timestamp TIMESTAMP, " +
+                "   c_varchar VARCHAR, " +
+                "   c_varbinary VARBINARY, " +
+                "   p_varchar VARCHAR " +
+                ") " +
+                "WITH ( " +
+                "   partitioned_by = ARRAY['p_varchar'] " +
+                ")", tableName));
+
+        assertUpdate(format("" +
+                "INSERT INTO %s " +
+                "SELECT c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_varbinary, p_varchar " +
+                "FROM ( " +
+                "  VALUES " +
+                "    (null, null, null, null, null, null, 'p1'), " +
+                "    (null, null, null, null, null, null, 'p1'), " +
+                "    (true, BIGINT '1', DOUBLE '2.2', TIMESTAMP '2012-08-08 01:00', CAST('abc1' AS VARCHAR), CAST('bcd1' AS VARBINARY), 'p1')," +
+                "    (false, BIGINT '0', DOUBLE '1.2', TIMESTAMP '2012-08-08 00:00', CAST('abc2' AS VARCHAR), CAST('bcd2' AS VARBINARY), 'p1')," +
+                "    (null, null, null, null, null, null, 'p2'), " +
+                "    (null, null, null, null, null, null, 'p2'), " +
+                "    (true, BIGINT '2', DOUBLE '3.3', TIMESTAMP '2012-09-09 01:00', CAST('cba1' AS VARCHAR), CAST('dcb1' AS VARBINARY), 'p2'), " +
+                "    (false, BIGINT '1', DOUBLE '2.3', TIMESTAMP '2012-09-09 00:00', CAST('cba2' AS VARCHAR), CAST('dcb2' AS VARBINARY), 'p2') " +
+                ") AS x (c_boolean, c_bigint, c_double, c_timestamp, c_varchar, c_varbinary, p_varchar)", tableName), 8);
+
+        assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p1')", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '0', '1'), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '1.2', '2.2'), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, '2012-08-08 00:00:00.000', '2012-08-08 01:00:00.000'), " +
+                        "('c_varchar', null, 2.0E0, 0.5E0, null, null, null), " +
+                        "('c_varbinary', null, null, 0.5E0, null, null, null), " +
+                        "('p_varchar', null, 1.0E0, 0.0E0, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null)");
+        assertQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_varchar = 'p2')", tableName),
+                "SELECT * FROM VALUES " +
+                        "('c_boolean', null, 2.0E0, 0.5E0, null, null, null), " +
+                        "('c_bigint', null, 2.0E0, 0.5E0, null, '1', '2'), " +
+                        "('c_double', null, 2.0E0, 0.5E0, null, '2.3', '3.3'), " +
+                        "('c_timestamp', null, 2.0E0, 0.5E0, null, '2012-09-09 00:00:00.000', '2012-09-09 01:00:00.000'), " +
+                        "('c_varchar', null, 2.0E0, 0.5E0, null, null, null), " +
+                        "('c_varbinary', null, null, 0.5E0, null, null, null), " +
+                        "('p_varchar', null, 1.0E0, 0.0E0, null, null, null), " +
+                        "(null, null, null, null, 4.0E0, null, null)");
+
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
     private Session getParallelWriteSession()
     {
         return Session.builder(getSession())

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
@@ -56,4 +56,28 @@ public class TestHiveClientGlueMetastore
     {
         // Glue metastore does not support column level statistics
     }
+
+    @Override
+    public void testUpdateTableColumnStatistics()
+    {
+        // column statistics are not supported by Glue
+    }
+
+    @Override
+    public void testUpdateTableColumnStatisticsEmptyOptionalFields()
+    {
+        // column statistics are not supported by Glue
+    }
+
+    @Override
+    public void testUpdatePartitionColumnStatistics()
+    {
+        // column statistics are not supported by Glue
+    }
+
+    @Override
+    public void testUpdatePartitionColumnStatisticsEmptyOptionalFields()
+    {
+        // column statistics are not supported by Glue
+    }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
@@ -21,6 +21,8 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -442,9 +444,9 @@ public class InMemoryHiveMetastore
     }
 
     @Override
-    public boolean supportsColumnStatistics()
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
     {
-        return true;
+        return ThriftMetastoreUtil.getSupportedColumnStatistics(type);
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/util/TestStatistics.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/util/TestStatistics.java
@@ -14,12 +14,31 @@
 package com.facebook.presto.hive.util;
 
 import com.facebook.presto.hive.HiveBasicStatistics;
+import com.facebook.presto.hive.metastore.BooleanStatistics;
+import com.facebook.presto.hive.metastore.DateStatistics;
+import com.facebook.presto.hive.metastore.DecimalStatistics;
+import com.facebook.presto.hive.metastore.DoubleStatistics;
+import com.facebook.presto.hive.metastore.HiveColumnStatistics;
+import com.facebook.presto.hive.metastore.IntegerStatistics;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalLong;
 
 import static com.facebook.presto.hive.HiveBasicStatistics.createEmptyStatistics;
 import static com.facebook.presto.hive.HiveBasicStatistics.createZeroStatistics;
+import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createBinaryColumnStatistics;
+import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createBooleanColumnStatistics;
+import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createDoubleColumnStatistics;
+import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createIntegerColumnStatistics;
 import static com.facebook.presto.hive.util.Statistics.ReduceOperator.ADD;
 import static com.facebook.presto.hive.util.Statistics.ReduceOperator.SUBTRACT;
+import static com.facebook.presto.hive.util.Statistics.merge;
 import static com.facebook.presto.hive.util.Statistics.reduce;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,5 +61,210 @@ public class TestStatistics
                 new HiveBasicStatistics(11, 9, 7, 5),
                 new HiveBasicStatistics(1, 2, 3, 4), SUBTRACT))
                 .isEqualTo(new HiveBasicStatistics(10, 7, 4, 1));
+    }
+
+    @Test
+    public void testMergeEmptyColumnStatistics()
+    {
+        assertMergeHiveColumnStatistics(HiveColumnStatistics.empty(), OptionalLong.empty(), HiveColumnStatistics.empty(), OptionalLong.empty(), HiveColumnStatistics.empty());
+    }
+
+    @Test
+    public void testMergeIntegerColumnStatistics()
+    {
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setIntegerStatistics(new IntegerStatistics(OptionalLong.empty(), OptionalLong.empty())).build(),
+                HiveColumnStatistics.builder().setIntegerStatistics(new IntegerStatistics(OptionalLong.empty(), OptionalLong.empty())).build(),
+                HiveColumnStatistics.builder().setIntegerStatistics(new IntegerStatistics(OptionalLong.empty(), OptionalLong.empty())).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setIntegerStatistics(new IntegerStatistics(OptionalLong.of(1), OptionalLong.of(2))).build(),
+                HiveColumnStatistics.builder().setIntegerStatistics(new IntegerStatistics(OptionalLong.empty(), OptionalLong.empty())).build(),
+                HiveColumnStatistics.builder().setIntegerStatistics(new IntegerStatistics(OptionalLong.of(1), OptionalLong.of(2))).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setIntegerStatistics(new IntegerStatistics(OptionalLong.of(1), OptionalLong.of(2))).build(),
+                HiveColumnStatistics.builder().setIntegerStatistics(new IntegerStatistics(OptionalLong.of(0), OptionalLong.of(3))).build(),
+                HiveColumnStatistics.builder().setIntegerStatistics(new IntegerStatistics(OptionalLong.of(0), OptionalLong.of(3))).build());
+    }
+
+    @Test
+    public void testMergeDoubleColumnStatistics()
+    {
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDoubleStatistics(new DoubleStatistics(OptionalDouble.empty(), OptionalDouble.empty())).build(),
+                HiveColumnStatistics.builder().setDoubleStatistics(new DoubleStatistics(OptionalDouble.empty(), OptionalDouble.empty())).build(),
+                HiveColumnStatistics.builder().setDoubleStatistics(new DoubleStatistics(OptionalDouble.empty(), OptionalDouble.empty())).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDoubleStatistics(new DoubleStatistics(OptionalDouble.of(1), OptionalDouble.of(2))).build(),
+                HiveColumnStatistics.builder().setDoubleStatistics(new DoubleStatistics(OptionalDouble.empty(), OptionalDouble.empty())).build(),
+                HiveColumnStatistics.builder().setDoubleStatistics(new DoubleStatistics(OptionalDouble.of(1), OptionalDouble.of(2))).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDoubleStatistics(new DoubleStatistics(OptionalDouble.of(1), OptionalDouble.of(2))).build(),
+                HiveColumnStatistics.builder().setDoubleStatistics(new DoubleStatistics(OptionalDouble.of(0), OptionalDouble.of(3))).build(),
+                HiveColumnStatistics.builder().setDoubleStatistics(new DoubleStatistics(OptionalDouble.of(0), OptionalDouble.of(3))).build());
+    }
+
+    @Test
+    public void testMergeDecimalColumnStatistics()
+    {
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDecimalStatistics(new DecimalStatistics(Optional.empty(), Optional.empty())).build(),
+                HiveColumnStatistics.builder().setDecimalStatistics(new DecimalStatistics(Optional.empty(), Optional.empty())).build(),
+                HiveColumnStatistics.builder().setDecimalStatistics(new DecimalStatistics(Optional.empty(), Optional.empty())).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDecimalStatistics(new DecimalStatistics(Optional.of(BigDecimal.valueOf(1)), Optional.of(BigDecimal.valueOf(2)))).build(),
+                HiveColumnStatistics.builder().setDecimalStatistics(new DecimalStatistics(Optional.empty(), Optional.empty())).build(),
+                HiveColumnStatistics.builder().setDecimalStatistics(new DecimalStatistics(Optional.of(BigDecimal.valueOf(1)), Optional.of(BigDecimal.valueOf(2)))).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDecimalStatistics(new DecimalStatistics(Optional.of(BigDecimal.valueOf(1)), Optional.of(BigDecimal.valueOf(2)))).build(),
+                HiveColumnStatistics.builder().setDecimalStatistics(new DecimalStatistics(Optional.of(BigDecimal.valueOf(0)), Optional.of(BigDecimal.valueOf(3)))).build(),
+                HiveColumnStatistics.builder().setDecimalStatistics(new DecimalStatistics(Optional.of(BigDecimal.valueOf(0)), Optional.of(BigDecimal.valueOf(3)))).build());
+    }
+
+    @Test
+    public void testMergeDateColumnStatistics()
+    {
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDateStatistics(new DateStatistics(Optional.empty(), Optional.empty())).build(),
+                HiveColumnStatistics.builder().setDateStatistics(new DateStatistics(Optional.empty(), Optional.empty())).build(),
+                HiveColumnStatistics.builder().setDateStatistics(new DateStatistics(Optional.empty(), Optional.empty())).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDateStatistics(new DateStatistics(Optional.of(LocalDate.ofEpochDay(1)), Optional.of(LocalDate.ofEpochDay(2)))).build(),
+                HiveColumnStatistics.builder().setDateStatistics(new DateStatistics(Optional.empty(), Optional.empty())).build(),
+                HiveColumnStatistics.builder().setDateStatistics(new DateStatistics(Optional.of(LocalDate.ofEpochDay(1)), Optional.of(LocalDate.ofEpochDay(2)))).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDateStatistics(new DateStatistics(Optional.of(LocalDate.ofEpochDay(1)), Optional.of(LocalDate.ofEpochDay(2)))).build(),
+                HiveColumnStatistics.builder().setDateStatistics(new DateStatistics(Optional.of(LocalDate.ofEpochDay(0)), Optional.of(LocalDate.ofEpochDay(3)))).build(),
+                HiveColumnStatistics.builder().setDateStatistics(new DateStatistics(Optional.of(LocalDate.ofEpochDay(0)), Optional.of(LocalDate.ofEpochDay(3)))).build());
+    }
+
+    @Test
+    public void testMergeBooleanColumnStatistics()
+    {
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setBooleanStatistics(new BooleanStatistics(OptionalLong.empty(), OptionalLong.empty())).build(),
+                HiveColumnStatistics.builder().setBooleanStatistics(new BooleanStatistics(OptionalLong.empty(), OptionalLong.empty())).build(),
+                HiveColumnStatistics.builder().setBooleanStatistics(new BooleanStatistics(OptionalLong.empty(), OptionalLong.empty())).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setBooleanStatistics(new BooleanStatistics(OptionalLong.of(1), OptionalLong.of(2))).build(),
+                HiveColumnStatistics.builder().setBooleanStatistics(new BooleanStatistics(OptionalLong.empty(), OptionalLong.empty())).build(),
+                HiveColumnStatistics.builder().setBooleanStatistics(new BooleanStatistics(OptionalLong.empty(), OptionalLong.empty())).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setBooleanStatistics(new BooleanStatistics(OptionalLong.of(1), OptionalLong.of(2))).build(),
+                HiveColumnStatistics.builder().setBooleanStatistics(new BooleanStatistics(OptionalLong.of(2), OptionalLong.of(3))).build(),
+                HiveColumnStatistics.builder().setBooleanStatistics(new BooleanStatistics(OptionalLong.of(3), OptionalLong.of(5))).build());
+    }
+
+    @Test
+    public void testMergeStringColumnStatistics()
+    {
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setMaxColumnLength(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setMaxColumnLength(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setMaxColumnLength(OptionalLong.empty()).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setMaxColumnLength(OptionalLong.of(1)).build(),
+                HiveColumnStatistics.builder().setMaxColumnLength(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setMaxColumnLength(OptionalLong.of(1)).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setMaxColumnLength(OptionalLong.of(2)).build(),
+                HiveColumnStatistics.builder().setMaxColumnLength(OptionalLong.of(3)).build(),
+                HiveColumnStatistics.builder().setMaxColumnLength(OptionalLong.of(3)).build());
+
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.empty()).build(),
+                OptionalLong.empty(),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.empty()).build(),
+                OptionalLong.empty(),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.empty()).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(4)).build(),
+                OptionalLong.empty(),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(6)).build(),
+                OptionalLong.empty(),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.empty()).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(4)).build(),
+                OptionalLong.empty(),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.empty()).build(),
+                OptionalLong.empty(),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(4)).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(4)).build(),
+                OptionalLong.of(1),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(6)).build(),
+                OptionalLong.of(1),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(5)).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(3)).build(),
+                OptionalLong.of(1),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(6)).build(),
+                OptionalLong.of(3),
+                HiveColumnStatistics.builder().setAverageColumnLength(OptionalDouble.of(5.25)).build());
+    }
+
+    @Test
+    public void testMergeGenericColumnStatistics()
+    {
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.of(1)).build(),
+                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.of(1)).build(),
+                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.of(2)).build(),
+                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.of(2)).build());
+
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setNullsCount(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setNullsCount(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setNullsCount(OptionalLong.empty()).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setNullsCount(OptionalLong.of(1)).build(),
+                HiveColumnStatistics.builder().setNullsCount(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setNullsCount(OptionalLong.empty()).build());
+        assertMergeHiveColumnStatistics(
+                HiveColumnStatistics.builder().setNullsCount(OptionalLong.of(1)).build(),
+                HiveColumnStatistics.builder().setNullsCount(OptionalLong.of(2)).build(),
+                HiveColumnStatistics.builder().setNullsCount(OptionalLong.of(3)).build());
+    }
+
+    @Test
+    public void testMergeHiveColumnStatisticsMap()
+    {
+        Map<String, HiveColumnStatistics> first = ImmutableMap.of(
+                "column1", createIntegerColumnStatistics(OptionalLong.of(1), OptionalLong.of(2), OptionalLong.of(3), OptionalLong.of(4)),
+                "column2", createDoubleColumnStatistics(OptionalDouble.of(2), OptionalDouble.of(3), OptionalLong.of(4), OptionalLong.of(5)),
+                "column3", createBinaryColumnStatistics(OptionalLong.of(5), OptionalDouble.of(5), OptionalLong.of(10)),
+                "column4", createBooleanColumnStatistics(OptionalLong.of(1), OptionalLong.of(2), OptionalLong.of(3)));
+        Map<String, HiveColumnStatistics> second = ImmutableMap.of(
+                "column5", createIntegerColumnStatistics(OptionalLong.of(1), OptionalLong.of(2), OptionalLong.of(3), OptionalLong.of(4)),
+                "column2", createDoubleColumnStatistics(OptionalDouble.of(1), OptionalDouble.of(4), OptionalLong.of(4), OptionalLong.of(6)),
+                "column3", createBinaryColumnStatistics(OptionalLong.of(6), OptionalDouble.of(5), OptionalLong.of(10)),
+                "column6", createBooleanColumnStatistics(OptionalLong.of(1), OptionalLong.of(2), OptionalLong.of(3)));
+        Map<String, HiveColumnStatistics> expected = ImmutableMap.of(
+                "column2", createDoubleColumnStatistics(OptionalDouble.of(1), OptionalDouble.of(4), OptionalLong.of(8), OptionalLong.of(6)),
+                "column3", createBinaryColumnStatistics(OptionalLong.of(6), OptionalDouble.of(5), OptionalLong.of(20)));
+        assertThat(merge(first, OptionalLong.of(5), second, OptionalLong.of(5))).isEqualTo(expected);
+        assertThat(merge(ImmutableMap.of(), OptionalLong.empty(), ImmutableMap.of(), OptionalLong.empty())).isEqualTo(ImmutableMap.of());
+    }
+
+    private static void assertMergeHiveColumnStatistics(HiveColumnStatistics first, HiveColumnStatistics second, HiveColumnStatistics expected)
+    {
+        assertMergeHiveColumnStatistics(first, OptionalLong.empty(), second, OptionalLong.empty(), expected);
+    }
+
+    private static void assertMergeHiveColumnStatistics(
+            HiveColumnStatistics first,
+            OptionalLong firstRowCount,
+            HiveColumnStatistics second,
+            OptionalLong secondRowCount,
+            HiveColumnStatistics expected)
+    {
+        assertThat(merge(first, firstRowCount, second, secondRowCount)).isEqualTo(expected);
+        assertThat(merge(second, secondRowCount, first, firstRowCount)).isEqualTo(expected);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -27,7 +27,9 @@ import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -167,9 +169,14 @@ public interface Metadata
     /**
      * Finish a table creation with data after the data is written.
      */
-    Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments);
+    Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics);
 
     Optional<NewTableLayout> getInsertLayout(Session session, TableHandle target);
+
+    /**
+     * Describes statistics that must be collected during a write.
+     */
+    TableStatisticsMetadata getStatisticsCollectionMetadata(Session session, String catalogName, ConnectorTableMetadata tableMetadata);
 
     /**
      * Start a SELECT/UPDATE/INSERT/DELETE query
@@ -190,7 +197,7 @@ public interface Metadata
     /**
      * Finish insert query
      */
-    Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments);
+    Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics);
 
     /**
      * Get the row ID column handle used with UpdatablePageSource.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -42,7 +42,9 @@ import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -577,6 +579,15 @@ public class MetadataManager
     }
 
     @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadata(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalogName);
+        ConnectorMetadata metadata = catalogMetadata.getMetadata();
+        ConnectorId connectorId = catalogMetadata.getConnectorId();
+        return metadata.getStatisticsCollectionMetadata(session.toConnectorSession(connectorId), tableMetadata);
+    }
+
+    @Override
     public Optional<NewTableLayout> getNewTableLayout(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
     {
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalogName);
@@ -638,11 +649,11 @@ public class MetadataManager
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
-        return metadata.finishCreateTable(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), fragments);
+        return metadata.finishCreateTable(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), fragments, computedStatistics);
     }
 
     @Override
@@ -657,11 +668,11 @@ public class MetadataManager
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
-        return metadata.finishInsert(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), fragments);
+        return metadata.finishInsert(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), fragments, computedStatistics);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/DevNullOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DevNullOperator.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+
+import static java.util.Objects.requireNonNull;
+
+public class DevNullOperator
+        implements Operator
+{
+    public static class DevNullOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+
+        public DevNullOperatorFactory(int operatorId, PlanNodeId planNodeId)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            return new DevNullOperator(driverContext.addOperatorContext(operatorId, planNodeId, DevNullOperator.class.getSimpleName()));
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            return new DevNullOperatorFactory(operatorId, planNodeId);
+        }
+    }
+
+    private final OperatorContext context;
+    private boolean finished;
+
+    public DevNullOperator(OperatorContext context)
+    {
+        this.context = requireNonNull(context, "context is null");
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return context;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finished;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        return null;
+    }
+
+    @Override
+    public void finish()
+    {
+        finished = true;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableFinishOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableFinishOperator.java
@@ -261,7 +261,7 @@ public class TableFinishOperator
         state = State.FINISHED;
 
         List<ComputedStatistics> statistics = getComputedStatistics();
-        outputMetadata = tableFinisher.finishTable(fragmentBuilder.build());
+        outputMetadata = tableFinisher.finishTable(fragmentBuilder.build(), statistics);
 
         // output page will only be constructed once,
         // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
@@ -317,6 +317,6 @@ public class TableFinishOperator
 
     public interface TableFinisher
     {
-        Optional<ConnectorOutputMetadata> finishTable(Collection<Slice> fragments);
+        Optional<ConnectorOutputMetadata> finishTable(Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2529,10 +2529,10 @@ public class LocalExecutionPlanner
         WriterTarget target = node.getTarget();
         return fragments -> {
             if (target instanceof CreateHandle) {
-                return metadata.finishCreateTable(session, ((CreateHandle) target).getHandle(), fragments);
+                return metadata.finishCreateTable(session, ((CreateHandle) target).getHandle(), fragments, ImmutableList.of());
             }
             else if (target instanceof InsertHandle) {
-                return metadata.finishInsert(session, ((InsertHandle) target).getHandle(), fragments);
+                return metadata.finishInsert(session, ((InsertHandle) target).getHandle(), fragments, ImmutableList.of());
             }
             else if (target instanceof DeleteHandle) {
                 metadata.finishDelete(session, ((DeleteHandle) target).getHandle(), fragments);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2659,12 +2659,12 @@ public class LocalExecutionPlanner
     private static TableFinisher createTableFinisher(Session session, TableFinishNode node, Metadata metadata)
     {
         WriterTarget target = node.getTarget();
-        return fragments -> {
+        return (fragments, statistics) -> {
             if (target instanceof CreateHandle) {
-                return metadata.finishCreateTable(session, ((CreateHandle) target).getHandle(), fragments, ImmutableList.of());
+                return metadata.finishCreateTable(session, ((CreateHandle) target).getHandle(), fragments, statistics);
             }
             else if (target instanceof InsertHandle) {
-                return metadata.finishInsert(session, ((InsertHandle) target).getHandle(), fragments, ImmutableList.of());
+                return metadata.finishInsert(session, ((InsertHandle) target).getHandle(), fragments, statistics);
             }
             else if (target instanceof DeleteHandle) {
                 metadata.finishDelete(session, ((DeleteHandle) target).getHandle(), fragments);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2146,10 +2146,8 @@ public class LocalExecutionPlanner
                     inputChannels,
                     session);
 
-            Map<Symbol, Integer> layout = ImmutableMap.<Symbol, Integer>builder()
-                    .put(node.getOutputSymbols().get(0), 0)
-                    .put(node.getOutputSymbols().get(1), 1)
-                    .build();
+            Map<Symbol, Integer> layout = IntStream.range(0, node.getOutputSymbols().size()).boxed()
+                    .collect(toImmutableMap(i -> node.getOutputSymbols().get(i), i -> i));
 
             return new PhysicalOperation(operatorFactory, layout, context, source);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -372,7 +372,8 @@ public class LogicalPlanner
                     columnNames,
                     writerOutputSymbols,
                     partitioningScheme,
-                    Optional.of(partialAggregation));
+                    Optional.of(partialAggregation),
+                    Optional.of(result.getDescriptor().map(aggregations.getMappings()::get)));
 
             TableFinishNode commitNode = new TableFinishNode(
                     idAllocator.getNextId(),
@@ -395,6 +396,7 @@ public class LogicalPlanner
                         columnNames,
                         writerOutputs,
                         partitioningScheme,
+                        Optional.empty(),
                         Optional.empty()),
                 target,
                 commitOutputs,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Field;
@@ -30,6 +31,7 @@ import com.facebook.presto.sql.analyzer.RelationId;
 import com.facebook.presto.sql.analyzer.RelationType;
 import com.facebook.presto.sql.analyzer.Scope;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.StatisticsAggregationPlanner.TableStatisticAggregation;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.DeleteNode;
@@ -38,6 +40,7 @@ import com.facebook.presto.sql.planner.plan.LimitNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.StatisticAggregations;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
@@ -58,10 +61,12 @@ import com.facebook.presto.sql.tree.Statement;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
@@ -73,7 +78,10 @@ import static com.facebook.presto.sql.planner.plan.TableWriterNode.InsertReferen
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.WriterTarget;
 import static com.facebook.presto.sql.planner.sanity.PlanSanityChecker.DISTRIBUTED_PLAN_SANITY_CHECKER;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Streams.zip;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -92,6 +100,7 @@ public class LogicalPlanner
     private final SymbolAllocator symbolAllocator = new SymbolAllocator();
     private final Metadata metadata;
     private final SqlParser sqlParser;
+    private final StatisticsAggregationPlanner statisticsAggregationPlanner;
 
     public LogicalPlanner(Session session,
             List<PlanOptimizer> planOptimizers,
@@ -122,6 +131,7 @@ public class LogicalPlanner
         this.idAllocator = idAllocator;
         this.metadata = metadata;
         this.sqlParser = sqlParser;
+        this.statisticsAggregationPlanner = new StatisticsAggregationPlanner(symbolAllocator, metadata);
     }
 
     public Plan plan(Analysis analysis)
@@ -216,12 +226,15 @@ public class LogicalPlanner
                 .map(ColumnMetadata::getName)
                 .collect(toImmutableList());
 
+        TableStatisticsMetadata statisticsMetadata = metadata.getStatisticsCollectionMetadata(session, destination.getCatalogName(), tableMetadata);
+
         return createTableWriterPlan(
                 analysis,
                 plan,
                 new CreateName(destination.getCatalogName(), tableMetadata, newTableLayout),
                 columnNames,
-                newTableLayout);
+                newTableLayout,
+                statisticsMetadata);
     }
 
     private RelationPlan createInsertPlan(Analysis analysis, Insert insertStatement)
@@ -275,13 +288,16 @@ public class LogicalPlanner
         plan = new RelationPlan(projectNode, scope, projectNode.getOutputSymbols());
 
         Optional<NewTableLayout> newTableLayout = metadata.getInsertLayout(session, insert.getTarget());
+        String catalogName = insert.getTarget().getConnectorId().getCatalogName();
+        TableStatisticsMetadata statisticsMetadata = metadata.getStatisticsCollectionMetadata(session, catalogName, tableMetadata.getMetadata());
 
         return createTableWriterPlan(
                 analysis,
                 plan,
                 new InsertReference(insert.getTarget()),
                 visibleTableColumnNames,
-                newTableLayout);
+                newTableLayout,
+                statisticsMetadata);
     }
 
     private RelationPlan createTableWriterPlan(
@@ -289,12 +305,9 @@ public class LogicalPlanner
             RelationPlan plan,
             WriterTarget target,
             List<String> columnNames,
-            Optional<NewTableLayout> writeTableLayout)
+            Optional<NewTableLayout> writeTableLayout,
+            TableStatisticsMetadata statisticsMetadata)
     {
-        List<Symbol> writerOutputs = ImmutableList.of(
-                symbolAllocator.newSymbol("partialrows", BIGINT),
-                symbolAllocator.newSymbol("fragment", VARBINARY));
-
         PlanNode source = plan.getRoot();
 
         if (!analysis.isCreateTableAsSelectWithData()) {
@@ -325,23 +338,69 @@ public class LogicalPlanner
                     outputLayout));
         }
 
-        PlanNode writerNode = new TableWriterNode(
-                idAllocator.getNextId(),
-                source,
-                target,
-                symbols,
-                columnNames,
-                writerOutputs,
-                partitioningScheme);
+        List<Symbol> writerOutputs = ImmutableList.of(
+                symbolAllocator.newSymbol("partialrows", BIGINT),
+                symbolAllocator.newSymbol("fragment", VARBINARY));
 
-        List<Symbol> outputs = ImmutableList.of(symbolAllocator.newSymbol("rows", BIGINT));
+        List<Symbol> commitOutputs = ImmutableList.of(symbolAllocator.newSymbol("rows", BIGINT));
+
+        if (!statisticsMetadata.isEmpty()) {
+            verify(columnNames.size() == symbols.size(), "columnNames.size() != symbols.size(): %s and %s", columnNames, symbols);
+            Map<String, Symbol> columnToSymbolMap = zip(columnNames.stream(), symbols.stream(), SimpleImmutableEntry::new)
+                    .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+
+            TableStatisticAggregation result = statisticsAggregationPlanner.createStatisticsAggregation(statisticsMetadata, columnToSymbolMap);
+
+            StatisticAggregations.Parts aggregations = result.getAggregations().createPartialAggregations(symbolAllocator, metadata.getFunctionRegistry());
+
+            // partial aggregation is run within the TableWriteOperator to calculate the statistics for
+            // the data consumed by the TableWriteOperator
+            // final aggregation is run within the TableFinishOperator to summarize collected statistics
+            // by the partial aggregation from all of the writer nodes
+            StatisticAggregations partialAggregation = aggregations.getPartialAggregation();
+            List<Symbol> writerOutputSymbols = ImmutableList.<Symbol>builder()
+                    .addAll(writerOutputs)
+                    .addAll(partialAggregation.getGroupingSymbols())
+                    .addAll(partialAggregation.getAggregations().keySet())
+                    .build();
+
+            PlanNode writerNode = new TableWriterNode(
+                    idAllocator.getNextId(),
+                    source,
+                    target,
+                    symbols,
+                    columnNames,
+                    writerOutputSymbols,
+                    partitioningScheme,
+                    Optional.of(partialAggregation));
+
+            TableFinishNode commitNode = new TableFinishNode(
+                    idAllocator.getNextId(),
+                    writerNode,
+                    target,
+                    commitOutputs,
+                    Optional.of(aggregations.getFinalAggregation()),
+                    Optional.of(result.getDescriptor()));
+
+            return new RelationPlan(commitNode, analysis.getRootScope(), commitOutputs);
+        }
+
         TableFinishNode commitNode = new TableFinishNode(
                 idAllocator.getNextId(),
-                writerNode,
+                new TableWriterNode(
+                        idAllocator.getNextId(),
+                        source,
+                        target,
+                        symbols,
+                        columnNames,
+                        writerOutputs,
+                        partitioningScheme,
+                        Optional.empty()),
                 target,
-                outputs);
-
-        return new RelationPlan(commitNode, analysis.getRootScope(), outputs);
+                commitOutputs,
+                Optional.empty(),
+                Optional.empty());
+        return new RelationPlan(commitNode, analysis.getRootScope(), commitOutputs);
     }
 
     private RelationPlan createDeletePlan(Analysis analysis, Delete node)
@@ -350,7 +409,13 @@ public class LogicalPlanner
                 .plan(node);
 
         List<Symbol> outputs = ImmutableList.of(symbolAllocator.newSymbol("rows", BIGINT));
-        TableFinishNode commitNode = new TableFinishNode(idAllocator.getNextId(), deleteNode, deleteNode.getTarget(), outputs);
+        TableFinishNode commitNode = new TableFinishNode(
+                idAllocator.getNextId(),
+                deleteNode,
+                deleteNode.getTarget(),
+                outputs,
+                Optional.empty(),
+                Optional.empty());
 
         return new RelationPlan(commitNode, analysis.getScope(node), commitNode.getOutputSymbols());
     }
@@ -413,7 +478,7 @@ public class LogicalPlanner
     private static Map<NodeRef<LambdaArgumentDeclaration>, Symbol> buildLambdaDeclarationToSymbolMap(Analysis analysis, SymbolAllocator symbolAllocator)
     {
         Map<NodeRef<LambdaArgumentDeclaration>, Symbol> resultMap = new LinkedHashMap<>();
-        for (Map.Entry<NodeRef<Expression>, Type> entry : analysis.getTypes().entrySet()) {
+        for (Entry<NodeRef<Expression>, Type> entry : analysis.getTypes().entrySet()) {
             if (!(entry.getKey().getNode() instanceof LambdaArgumentDeclaration)) {
                 continue;
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/StatisticsAggregationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/StatisticsAggregationPlanner.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.statistics.ColumnStatisticMetadata;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.statistics.TableStatisticType;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.StatisticAggregations;
+import com.facebook.presto.sql.planner.plan.StatisticAggregationsDescriptor;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
+
+public class StatisticsAggregationPlanner
+{
+    private final SymbolAllocator symbolAllocator;
+    private final Metadata metadata;
+
+    public StatisticsAggregationPlanner(SymbolAllocator symbolAllocator, Metadata metadata)
+    {
+        this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    public TableStatisticAggregation createStatisticsAggregation(TableStatisticsMetadata statisticsMetadata, Map<String, Symbol> columnToSymbolMap)
+    {
+        StatisticAggregationsDescriptor.Builder<Symbol> descriptor = StatisticAggregationsDescriptor.builder();
+
+        List<String> groupingColumns = statisticsMetadata.getGroupingColumns();
+        List<Symbol> groupingSymbols = groupingColumns.stream()
+                .map(columnToSymbolMap::get)
+                .collect(toImmutableList());
+
+        for (int i = 0; i < groupingSymbols.size(); i++) {
+            descriptor.addGrouping(groupingSymbols.get(i), groupingColumns.get(i));
+        }
+
+        ImmutableMap.Builder<Symbol, AggregationNode.Aggregation> aggregations = ImmutableMap.builder();
+        FunctionRegistry functionRegistry = metadata.getFunctionRegistry();
+        for (TableStatisticType type : statisticsMetadata.getTableStatistics()) {
+            if (type != ROW_COUNT) {
+                throw new PrestoException(NOT_SUPPORTED, "Table-wide statistic type not supported: " + type);
+            }
+            QualifiedName count = QualifiedName.of("count");
+            AggregationNode.Aggregation aggregation = new AggregationNode.Aggregation(
+                    new FunctionCall(count, ImmutableList.of()),
+                    functionRegistry.resolveFunction(count, ImmutableList.of()),
+                    Optional.empty());
+            Symbol symbol = symbolAllocator.newSymbol("rowCount", BIGINT);
+            aggregations.put(symbol, aggregation);
+            descriptor.addTableStatistic(symbol, ROW_COUNT);
+        }
+
+        for (ColumnStatisticMetadata columnStatisticMetadata : statisticsMetadata.getColumnStatistics()) {
+            String columnName = columnStatisticMetadata.getColumnName();
+            ColumnStatisticType statisticType = columnStatisticMetadata.getStatisticType();
+            Symbol inputSymbol = columnToSymbolMap.get(columnName);
+            verify(inputSymbol != null, "inputSymbol is null");
+            Type inputType = symbolAllocator.getTypes().get(inputSymbol);
+            verify(inputType != null, "inputType is null for symbol: %s", inputSymbol);
+            ColumnStatisticsAggregation aggregation = createColumnAggregation(statisticType, inputSymbol, inputType);
+            Symbol symbol = symbolAllocator.newSymbol(statisticType + ":" + columnName, aggregation.getOutputType());
+            aggregations.put(symbol, aggregation.getAggregation());
+            descriptor.addColumnStatistic(symbol, columnStatisticMetadata);
+        }
+
+        StatisticAggregations aggregation = new StatisticAggregations(aggregations.build(), groupingSymbols);
+        return new TableStatisticAggregation(aggregation, descriptor.build());
+    }
+
+    private ColumnStatisticsAggregation createColumnAggregation(ColumnStatisticType statisticType, Symbol input, Type inputType)
+    {
+        switch (statisticType) {
+            case MIN_VALUE:
+                return createAggregation(QualifiedName.of("min"), input.toSymbolReference(), inputType, inputType);
+            case MAX_VALUE:
+                return createAggregation(QualifiedName.of("max"), input.toSymbolReference(), inputType, inputType);
+            case NUMBER_OF_DISTINCT_VALUES:
+                return createAggregation(QualifiedName.of("approx_distinct"), input.toSymbolReference(), inputType, BIGINT);
+            case NUMBER_OF_NON_NULL_VALUES:
+                return createAggregation(QualifiedName.of("count"), input.toSymbolReference(), inputType, BIGINT);
+            case NUMBER_OF_TRUE_VALUES:
+                return createAggregation(QualifiedName.of("count_if"), input.toSymbolReference(), BOOLEAN, BIGINT);
+            default:
+                throw new IllegalArgumentException("Unsupported statistic type: " + statisticType);
+        }
+    }
+
+    private ColumnStatisticsAggregation createAggregation(QualifiedName functionName, SymbolReference input, Type inputType, Type outputType)
+    {
+        Signature signature = metadata.getFunctionRegistry().resolveFunction(functionName, TypeSignatureProvider.fromTypes(ImmutableList.of(inputType)));
+        Type resolvedType = metadata.getType(getOnlyElement(signature.getArgumentTypes()));
+        verify(resolvedType.equals(inputType), "resolved function input type does not match the input type: %s != %s", resolvedType, inputType);
+        return new ColumnStatisticsAggregation(
+                new AggregationNode.Aggregation(
+                        new FunctionCall(functionName, ImmutableList.of(input)),
+                        signature,
+                        Optional.empty()),
+                outputType);
+    }
+
+    public static class TableStatisticAggregation
+    {
+        private final StatisticAggregations aggregations;
+        private final StatisticAggregationsDescriptor<Symbol> descriptor;
+
+        private TableStatisticAggregation(
+                StatisticAggregations aggregations,
+                StatisticAggregationsDescriptor<Symbol> descriptor)
+        {
+            this.aggregations = requireNonNull(aggregations, "statisticAggregations is null");
+            this.descriptor = requireNonNull(descriptor, "descriptor is null");
+        }
+
+        public StatisticAggregations getAggregations()
+        {
+            return aggregations;
+        }
+
+        public StatisticAggregationsDescriptor<Symbol> getDescriptor()
+        {
+            return descriptor;
+        }
+    }
+
+    public static class ColumnStatisticsAggregation
+    {
+        private final AggregationNode.Aggregation aggregation;
+        private final Type outputType;
+
+        private ColumnStatisticsAggregation(AggregationNode.Aggregation aggregation, Type outputType)
+        {
+            this.aggregation = requireNonNull(aggregation, "aggregation is null");
+            this.outputType = requireNonNull(outputType, "outputType is null");
+        }
+
+        public AggregationNode.Aggregation getAggregation()
+        {
+            return aggregation;
+        }
+
+        public Type getOutputType()
+        {
+            return outputType;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
@@ -96,7 +96,8 @@ public class BeginTableWrite
                     node.getColumnNames(),
                     node.getOutputSymbols(),
                     node.getPartitioningScheme(),
-                    node.getStatisticsAggregation());
+                    node.getStatisticsAggregation(),
+                    node.getStatisticsAggregationDescriptor());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
@@ -95,7 +95,8 @@ public class BeginTableWrite
                     node.getColumns(),
                     node.getColumnNames(),
                     node.getOutputSymbols(),
-                    node.getPartitioningScheme());
+                    node.getPartitioningScheme(),
+                    node.getStatisticsAggregation());
         }
 
         @Override
@@ -121,7 +122,13 @@ public class BeginTableWrite
             context.get().addMaterializedHandle(originalTarget, newTarget);
             child = child.accept(this, context);
 
-            return new TableFinishNode(node.getId(), child, newTarget, node.getOutputSymbols());
+            return new TableFinishNode(
+                    node.getId(),
+                    child,
+                    newTarget,
+                    node.getOutputSymbols(),
+                    node.getStatisticsAggregation(),
+                    node.getStatisticsAggregationDescriptor());
         }
 
         public TableWriterNode.WriterTarget getTarget(PlanNode node)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -625,7 +625,8 @@ public class PruneUnreferencedOutputs
                     node.getColumnNames(),
                     node.getOutputSymbols(),
                     node.getPartitioningScheme(),
-                    node.getStatisticsAggregation());
+                    node.getStatisticsAggregation(),
+                    node.getStatisticsAggregationDescriptor());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -15,12 +15,16 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.sql.planner.OrderingScheme;
+import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.plan.StatisticAggregations;
+import com.facebook.presto.sql.planner.plan.TableFinishNode;
+import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.TopNNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
@@ -33,9 +37,11 @@ import com.google.common.collect.ImmutableMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 public class SymbolMapper
@@ -82,14 +88,8 @@ public class SymbolMapper
     private AggregationNode map(AggregationNode node, PlanNode source, PlanNodeId newNodeId)
     {
         ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
-        for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
-            Symbol symbol = entry.getKey();
-            Aggregation aggregation = entry.getValue();
-
-            aggregations.put(map(symbol), new Aggregation(
-                    (FunctionCall) map(aggregation.getCall()),
-                    aggregation.getSignature(),
-                    aggregation.getMask().map(this::map)));
+        for (Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
+            aggregations.put(map(entry.getKey()), map(entry.getValue()));
         }
 
         List<List<Symbol>> groupingSets = node.getGroupingSets().stream()
@@ -105,6 +105,14 @@ public class SymbolMapper
                 node.getStep(),
                 node.getHashSymbol().map(this::map),
                 node.getGroupIdSymbol().map(this::map));
+    }
+
+    private Aggregation map(Aggregation aggregation)
+    {
+        return new Aggregation(
+                (FunctionCall) map(aggregation.getCall()),
+                aggregation.getSignature(),
+                aggregation.getMask().map(this::map));
     }
 
     public TopNNode map(TopNNode node, PlanNode source, PlanNodeId newNodeId)
@@ -127,6 +135,64 @@ public class SymbolMapper
                 node.getCount(),
                 new OrderingScheme(symbols.build(), orderings.build()),
                 node.getStep());
+    }
+
+    public TableWriterNode map(TableWriterNode node, PlanNode source)
+    {
+        return map(node, source, node.getId());
+    }
+
+    public TableWriterNode map(TableWriterNode node, PlanNode source, PlanNodeId newNodeId)
+    {
+        // Intentionally does not use canonicalizeAndDistinct as that would remove columns
+        ImmutableList<Symbol> columns = node.getColumns().stream()
+                .map(this::map)
+                .collect(toImmutableList());
+
+        return new TableWriterNode(
+                newNodeId,
+                source,
+                node.getTarget(),
+                columns,
+                node.getColumnNames(),
+                map(node.getOutputSymbols()),
+                node.getPartitioningScheme().map(partitioningScheme -> canonicalize(partitioningScheme, source)),
+                node.getStatisticsAggregation().map(this::map));
+    }
+
+    public TableFinishNode map(TableFinishNode node, PlanNode source)
+    {
+        return new TableFinishNode(
+                node.getId(),
+                source,
+                node.getTarget(),
+                map(node.getOutputSymbols()),
+                node.getStatisticsAggregation().map(this::map),
+                node.getStatisticsAggregationDescriptor().map(descriptor -> descriptor.map(this::map)));
+    }
+
+    private PartitioningScheme canonicalize(PartitioningScheme scheme, PlanNode source)
+    {
+        return new PartitioningScheme(
+                scheme.getPartitioning().translate(this::map),
+                mapAndDistinct(source.getOutputSymbols()),
+                scheme.getHashColumn().map(this::map),
+                scheme.isReplicateNullsAndAny(),
+                scheme.getBucketToPartition());
+    }
+
+    private StatisticAggregations map(StatisticAggregations statisticAggregations)
+    {
+        Map<Symbol, Aggregation> aggregations = statisticAggregations.getAggregations().entrySet().stream()
+                .collect(toImmutableMap(entry -> map(entry.getKey()), entry -> map(entry.getValue())));
+        return new StatisticAggregations(aggregations, map(statisticAggregations.getGroupingSymbols()));
+    }
+
+    private List<Symbol> map(List<Symbol> outputs)
+    {
+        return outputs.stream()
+                .map(this::map)
+                .collect(toImmutableList());
     }
 
     private List<Symbol> mapAndDistinct(List<Symbol> outputs)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.plan.StatisticAggregations;
+import com.facebook.presto.sql.planner.plan.StatisticAggregationsDescriptor;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.TopNNode;
@@ -157,7 +158,8 @@ public class SymbolMapper
                 node.getColumnNames(),
                 map(node.getOutputSymbols()),
                 node.getPartitioningScheme().map(partitioningScheme -> canonicalize(partitioningScheme, source)),
-                node.getStatisticsAggregation().map(this::map));
+                node.getStatisticsAggregation().map(this::map),
+                node.getStatisticsAggregationDescriptor().map(this::map));
     }
 
     public TableFinishNode map(TableFinishNode node, PlanNode source)
@@ -186,6 +188,11 @@ public class SymbolMapper
         Map<Symbol, Aggregation> aggregations = statisticAggregations.getAggregations().entrySet().stream()
                 .collect(toImmutableMap(entry -> map(entry.getKey()), entry -> map(entry.getValue())));
         return new StatisticAggregations(aggregations, map(statisticAggregations.getGroupingSymbols()));
+    }
+
+    private StatisticAggregationsDescriptor<Symbol> map(StatisticAggregationsDescriptor<Symbol> descriptor)
+    {
+        return descriptor.map(this::map);
     }
 
     private List<Symbol> map(List<Symbol> outputs)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -372,7 +372,9 @@ public class UnaliasSymbolReferences
         @Override
         public PlanNode visitTableFinish(TableFinishNode node, RewriteContext<Void> context)
         {
-            return context.defaultRewrite(node);
+            PlanNode source = context.rewrite(node.getSource());
+            SymbolMapper mapper = new SymbolMapper(mapping);
+            return mapper.map(node, source);
         }
 
         @Override
@@ -556,20 +558,8 @@ public class UnaliasSymbolReferences
         public PlanNode visitTableWriter(TableWriterNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getSource());
-
-            // Intentionally does not use canonicalizeAndDistinct as that would remove columns
-            ImmutableList<Symbol> columns = node.getColumns().stream()
-                    .map(this::canonicalize)
-                    .collect(toImmutableList());
-
-            return new TableWriterNode(
-                    node.getId(),
-                    source,
-                    node.getTarget(),
-                    columns,
-                    node.getColumnNames(),
-                    node.getOutputSymbols(),
-                    node.getPartitioningScheme().map(partitioningScheme -> canonicalizePartitionFunctionBinding(partitioningScheme, source)));
+            SymbolMapper mapper = new SymbolMapper(mapping);
+            return mapper.map(node, source);
         }
 
         @Override
@@ -730,25 +720,6 @@ public class UnaliasSymbolReferences
                 }
             }
             return builder.build();
-        }
-
-        private PartitioningScheme canonicalizePartitionFunctionBinding(PartitioningScheme scheme, PlanNode source)
-        {
-            Set<Symbol> addedOutputs = new HashSet<>();
-            ImmutableList.Builder<Symbol> outputs = ImmutableList.builder();
-            for (Symbol symbol : source.getOutputSymbols()) {
-                Symbol canonicalOutput = canonicalize(symbol);
-                if (addedOutputs.add(canonicalOutput)) {
-                    outputs.add(canonicalOutput);
-                }
-            }
-
-            return new PartitioningScheme(
-                    scheme.getPartitioning().translate(this::canonicalize),
-                    outputs.build(),
-                    canonicalize(scheme.getHashColumn()),
-                    scheme.isReplicateNullsAndAny(),
-                    scheme.getBucketToPartition());
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregations.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class StatisticAggregations
+{
+    private final Map<Symbol, Aggregation> aggregations;
+    private final List<Symbol> groupingSymbols;
+
+    @JsonCreator
+    public StatisticAggregations(
+            @JsonProperty("aggregations") Map<Symbol, Aggregation> aggregations,
+            @JsonProperty("groupingSymbols") List<Symbol> groupingSymbols)
+    {
+        this.aggregations = ImmutableMap.copyOf(requireNonNull(aggregations, "aggregations is null"));
+        this.groupingSymbols = ImmutableList.copyOf(requireNonNull(groupingSymbols, "groupingSymbols is null"));
+    }
+
+    @JsonProperty
+    public Map<Symbol, Aggregation> getAggregations()
+    {
+        return aggregations;
+    }
+
+    @JsonProperty
+    public List<Symbol> getGroupingSymbols()
+    {
+        return groupingSymbols;
+    }
+
+    public Parts createPartialAggregations(SymbolAllocator symbolAllocator, FunctionRegistry functionRegistry)
+    {
+        ImmutableMap.Builder<Symbol, Aggregation> partialAggregation = ImmutableMap.builder();
+        ImmutableMap.Builder<Symbol, Aggregation> finalAggregation = ImmutableMap.builder();
+        for (Map.Entry<Symbol, Aggregation> entry : aggregations.entrySet()) {
+            Aggregation originalAggregation = entry.getValue();
+            Signature signature = originalAggregation.getSignature();
+            InternalAggregationFunction function = functionRegistry.getAggregateFunctionImplementation(signature);
+            Symbol partialSymbol = symbolAllocator.newSymbol(signature.getName(), function.getIntermediateType());
+            partialAggregation.put(partialSymbol, new Aggregation(originalAggregation.getCall(), signature, originalAggregation.getMask()));
+            finalAggregation.put(entry.getKey(),
+                    new Aggregation(
+                            new FunctionCall(QualifiedName.of(signature.getName()), ImmutableList.of(partialSymbol.toSymbolReference())),
+                            signature,
+                            Optional.empty()));
+        }
+        return new Parts(
+                new StatisticAggregations(partialAggregation.build(), groupingSymbols),
+                new StatisticAggregations(finalAggregation.build(), groupingSymbols));
+    }
+
+    public static class Parts
+    {
+        private final StatisticAggregations partialAggregation;
+        private final StatisticAggregations finalAggregation;
+
+        public Parts(StatisticAggregations partialAggregation, StatisticAggregations finalAggregation)
+        {
+            this.partialAggregation = requireNonNull(partialAggregation, "partialAggregation is null");
+            this.finalAggregation = requireNonNull(finalAggregation, "finalAggregation is null");
+        }
+
+        public StatisticAggregations getPartialAggregation()
+        {
+            return partialAggregation;
+        }
+
+        public StatisticAggregations getFinalAggregation()
+        {
+            return finalAggregation;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregationsDescriptor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregationsDescriptor.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.spi.statistics.ColumnStatisticMetadata;
+import com.facebook.presto.spi.statistics.TableStatisticType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+public class StatisticAggregationsDescriptor<T>
+{
+    private final Map<T, String> grouping;
+    private final Map<T, TableStatisticType> tableStatistics;
+    private final Map<T, ColumnStatisticMetadata> columnStatistics;
+
+    @JsonCreator
+    public StatisticAggregationsDescriptor(
+            @JsonProperty("grouping") Map<T, String> grouping,
+            @JsonProperty("tableStatistics") Map<T, TableStatisticType> tableStatistics,
+            @JsonProperty("columnStatistics") Map<T, ColumnStatisticMetadata> columnStatistics)
+    {
+        this.grouping = ImmutableMap.copyOf(requireNonNull(grouping, "grouping is null"));
+        this.tableStatistics = ImmutableMap.copyOf(requireNonNull(tableStatistics, "tableStatistics is null"));
+        this.columnStatistics = ImmutableMap.copyOf(requireNonNull(columnStatistics, "columnStatistics is null"));
+    }
+
+    @JsonProperty
+    public Map<T, String> getGrouping()
+    {
+        return grouping;
+    }
+
+    @JsonProperty
+    public Map<T, TableStatisticType> getTableStatistics()
+    {
+        return tableStatistics;
+    }
+
+    @JsonProperty
+    public Map<T, ColumnStatisticMetadata> getColumnStatistics()
+    {
+        return columnStatistics;
+    }
+
+    public static <B> Builder<B> builder()
+    {
+        return new Builder<>();
+    }
+
+    public <T2> StatisticAggregationsDescriptor<T2> map(Function<T, T2> mapper)
+    {
+        return new StatisticAggregationsDescriptor<>(
+                map(this.getGrouping(), mapper),
+                map(this.getTableStatistics(), mapper),
+                map(this.getColumnStatistics(), mapper));
+    }
+
+    private static <K1, K2, V> Map<K2, V> map(Map<K1, V> input, Function<K1, K2> mapper)
+    {
+        return input.entrySet()
+                .stream()
+                .collect(toImmutableMap(entry -> mapper.apply(entry.getKey()), Map.Entry::getValue));
+    }
+
+    public static class Builder<T>
+    {
+        private final ImmutableMap.Builder<T, String> grouping = ImmutableMap.builder();
+        private final ImmutableMap.Builder<T, TableStatisticType> tableStatistics = ImmutableMap.builder();
+        private final ImmutableMap.Builder<T, ColumnStatisticMetadata> columnStatistics = ImmutableMap.builder();
+
+        public void addGrouping(T key, String column)
+        {
+            grouping.put(key, column);
+        }
+
+        public void addTableStatistic(T key, TableStatisticType type)
+        {
+            tableStatistics.put(key, type);
+        }
+
+        public void addColumnStatistic(T key, ColumnStatisticMetadata statisticMetadata)
+        {
+            columnStatistics.put(key, statisticMetadata);
+        }
+
+        public StatisticAggregationsDescriptor<T> build()
+        {
+            return new StatisticAggregationsDescriptor<>(grouping.build(), tableStatistics.build(), columnStatistics.build());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregationsDescriptor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregationsDescriptor.java
@@ -31,6 +31,11 @@ public class StatisticAggregationsDescriptor<T>
     private final Map<T, TableStatisticType> tableStatistics;
     private final Map<T, ColumnStatisticMetadata> columnStatistics;
 
+    public static <T> StatisticAggregationsDescriptor<T> empty()
+    {
+        return StatisticAggregationsDescriptor.<T>builder().build();
+    }
+
     @JsonCreator
     public StatisticAggregationsDescriptor(
             @JsonProperty("grouping") Map<T, String> grouping,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
@@ -47,6 +47,7 @@ public class TableWriterNode
     private final List<String> columnNames;
     private final Optional<PartitioningScheme> partitioningScheme;
     private final Optional<StatisticAggregations> statisticsAggregation;
+    private final Optional<StatisticAggregationsDescriptor<Symbol>> statisticsAggregationDescriptor;
 
     @JsonCreator
     public TableWriterNode(
@@ -57,7 +58,8 @@ public class TableWriterNode
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("outputs") List<Symbol> outputs,
             @JsonProperty("partitioningScheme") Optional<PartitioningScheme> partitioningScheme,
-            @JsonProperty("statisticsAggregation") Optional<StatisticAggregations> statisticsAggregation)
+            @JsonProperty("statisticsAggregation") Optional<StatisticAggregations> statisticsAggregation,
+            @JsonProperty("statisticsAggregationDescriptor") Optional<StatisticAggregationsDescriptor<Symbol>> statisticsAggregationDescriptor)
     {
         super(id);
 
@@ -72,6 +74,8 @@ public class TableWriterNode
         this.outputs = ImmutableList.copyOf(requireNonNull(outputs, "outputs is null"));
         this.partitioningScheme = requireNonNull(partitioningScheme, "partitioningScheme is null");
         this.statisticsAggregation = requireNonNull(statisticsAggregation, "statisticsAggregation is null");
+        this.statisticsAggregationDescriptor = requireNonNull(statisticsAggregationDescriptor, "statisticsAggregationDescriptor is null");
+        checkArgument(statisticsAggregation.isPresent() == statisticsAggregationDescriptor.isPresent(), "statisticsAggregation and statisticsAggregationDescriptor must be either present or absent");
     }
 
     @JsonProperty
@@ -117,6 +121,12 @@ public class TableWriterNode
         return statisticsAggregation;
     }
 
+    @JsonProperty
+    public Optional<StatisticAggregationsDescriptor<Symbol>> getStatisticsAggregationDescriptor()
+    {
+        return statisticsAggregationDescriptor;
+    }
+
     @Override
     public List<PlanNode> getSources()
     {
@@ -132,7 +142,7 @@ public class TableWriterNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new TableWriterNode(getId(), Iterables.getOnlyElement(newChildren), target, columns, columnNames, outputs, partitioningScheme, statisticsAggregation);
+        return new TableWriterNode(getId(), Iterables.getOnlyElement(newChildren), target, columns, columnNames, outputs, partitioningScheme, statisticsAggregation, statisticsAggregationDescriptor);
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
@@ -46,6 +46,7 @@ public class TableWriterNode
     private final List<Symbol> columns;
     private final List<String> columnNames;
     private final Optional<PartitioningScheme> partitioningScheme;
+    private final Optional<StatisticAggregations> statisticsAggregation;
 
     @JsonCreator
     public TableWriterNode(
@@ -55,7 +56,8 @@ public class TableWriterNode
             @JsonProperty("columns") List<Symbol> columns,
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("outputs") List<Symbol> outputs,
-            @JsonProperty("partitioningScheme") Optional<PartitioningScheme> partitioningScheme)
+            @JsonProperty("partitioningScheme") Optional<PartitioningScheme> partitioningScheme,
+            @JsonProperty("statisticsAggregation") Optional<StatisticAggregations> statisticsAggregation)
     {
         super(id);
 
@@ -69,6 +71,7 @@ public class TableWriterNode
         this.columnNames = ImmutableList.copyOf(columnNames);
         this.outputs = ImmutableList.copyOf(requireNonNull(outputs, "outputs is null"));
         this.partitioningScheme = requireNonNull(partitioningScheme, "partitioningScheme is null");
+        this.statisticsAggregation = requireNonNull(statisticsAggregation, "statisticsAggregation is null");
     }
 
     @JsonProperty
@@ -108,6 +111,12 @@ public class TableWriterNode
         return partitioningScheme;
     }
 
+    @JsonProperty
+    public Optional<StatisticAggregations> getStatisticsAggregation()
+    {
+        return statisticsAggregation;
+    }
+
     @Override
     public List<PlanNode> getSources()
     {
@@ -123,7 +132,7 @@ public class TableWriterNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new TableWriterNode(getId(), Iterables.getOnlyElement(newChildren), target, columns, columnNames, outputs, partitioningScheme);
+        return new TableWriterNode(getId(), Iterables.getOnlyElement(newChildren), target, columns, columnNames, outputs, partitioningScheme, statisticsAggregation);
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.ViewNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -231,7 +232,7 @@ public class TestingMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         return Optional.empty();
     }
@@ -243,7 +244,7 @@ public class TestingMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         return Optional.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/util/AutoCloseableCloser.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/AutoCloseableCloser.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import static com.google.common.base.Throwables.propagateIfPossible;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class is inspired by com.google.common.io.Closer
+ */
+public final class AutoCloseableCloser
+        implements AutoCloseable
+{
+    private final Deque<AutoCloseable> stack = new ArrayDeque<>(4);
+
+    private AutoCloseableCloser() {}
+
+    public static AutoCloseableCloser create()
+    {
+        return new AutoCloseableCloser();
+    }
+
+    public <C extends AutoCloseable> C register(C closeable)
+    {
+        requireNonNull(closeable, "closeable is null");
+        stack.addFirst(closeable);
+        return closeable;
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        Throwable rootCause = null;
+        while (!stack.isEmpty()) {
+            AutoCloseable closeable = stack.removeFirst();
+            try {
+                closeable.close();
+            }
+            catch (Throwable t) {
+                if (rootCause == null) {
+                    rootCause = t;
+                }
+                else if (rootCause != t) {
+                    // Self-suppression not permitted
+                    rootCause.addSuppressed(t);
+                }
+            }
+        }
+        if (rootCause != null) {
+            propagateIfPossible(rootCause, Exception.class);
+            // not possible
+            throw new AssertionError(rootCause);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -26,7 +26,9 @@ import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -217,13 +219,19 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Optional<NewTableLayout> getInsertLayout(Session session, TableHandle target)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadata(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
     {
         throw new UnsupportedOperationException();
     }
@@ -247,7 +255,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -673,6 +673,7 @@ public class PlanBuilder
                 columnNames,
                 ImmutableList.of(symbol("partialrows", BIGINT), symbol("fragment", VARBINARY)),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -420,7 +420,9 @@ public class PlanBuilder
                         .addInputsSet(deleteRowId)
                         .singleDistributionPartitioningScheme(deleteRowId)),
                 deleteHandle,
-                ImmutableList.of(deleteRowId));
+                ImmutableList.of(deleteRowId),
+                Optional.empty(),
+                Optional.empty());
     }
 
     public ExchangeNode gatheringExchange(ExchangeNode.Scope scope, PlanNode child)
@@ -670,6 +672,7 @@ public class PlanBuilder
                 columns,
                 columnNames,
                 ImmutableList.of(symbol("partialrows", BIGINT), symbol("fragment", VARBINARY)),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/util/TestAutoCloseableCloser.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestAutoCloseableCloser.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import org.testng.annotations.Test;
+
+import static com.google.common.base.Throwables.propagateIfPossible;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestAutoCloseableCloser
+{
+    @Test
+    public void testEmpty()
+            throws Exception
+    {
+        AutoCloseableCloser closer = AutoCloseableCloser.create();
+        closer.close();
+    }
+
+    @Test
+    public void testAllClosed()
+    {
+        assertAllClosed(succeedingCloseable(), succeedingCloseable());
+        assertAllClosed(failingCloseable(new RuntimeException()), failingCloseable(new RuntimeException()));
+        assertAllClosed(failingCloseable(new Exception()), failingCloseable(new Exception()));
+        assertAllClosed(failingCloseable(new Error()), failingCloseable(new Error()));
+        assertAllClosed(failingCloseable(new Throwable()), failingCloseable(new Throwable()));
+        assertAllClosed(failingCloseable(new Throwable()), failingCloseable(new Throwable()), failingCloseable(new Throwable()));
+    }
+
+    @Test
+    public void testSuppressedException()
+    {
+        RuntimeException runtimeException = new RuntimeException();
+        Exception exception = new Exception();
+        Error error = new Error();
+
+        AutoCloseableCloser closer = AutoCloseableCloser.create();
+        // add twice to test self suppression handling
+        closer.register(failingCloseable(error));
+        closer.register(failingCloseable(error));
+        closer.register(failingCloseable(exception));
+        closer.register(failingCloseable(exception));
+        closer.register(failingCloseable(runtimeException));
+        closer.register(failingCloseable(runtimeException));
+
+        try {
+            closer.close();
+            fail("expected to fail");
+        }
+        catch (Throwable t) {
+            assertSame(t, runtimeException);
+            assertSame(t.getSuppressed()[0], exception);
+            assertSame(t.getSuppressed()[1], exception);
+            assertSame(t.getSuppressed()[2], error);
+            assertSame(t.getSuppressed()[3], error);
+        }
+    }
+
+    private static void assertAllClosed(TestAutoCloseable... closeables)
+    {
+        AutoCloseableCloser closer = AutoCloseableCloser.create();
+        for (AutoCloseable closeable : closeables) {
+            closer.register(closeable);
+        }
+        try {
+            closer.close();
+        }
+        catch (Throwable ignored) {
+        }
+        for (TestAutoCloseable closeable : closeables) {
+            assertTrue(closeable.isClosed());
+        }
+    }
+
+    private static TestAutoCloseable succeedingCloseable()
+    {
+        return new TestAutoCloseable(null);
+    }
+
+    private static TestAutoCloseable failingCloseable(Throwable t)
+    {
+        return new TestAutoCloseable(t);
+    }
+
+    private static class TestAutoCloseable
+            implements AutoCloseable
+    {
+        private final Throwable failure;
+        private boolean closed;
+
+        private TestAutoCloseable(Throwable failure)
+        {
+            this.failure = failure;
+        }
+
+        public boolean isClosed()
+        {
+            return closed;
+        }
+
+        @Override
+        public void close()
+                throws Exception
+        {
+            closed = true;
+            if (failure != null) {
+                propagateIfPossible(failure, Exception.class);
+                // not possible
+                throw new AssertionError(failure);
+            }
+        }
+    }
+}

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
@@ -37,6 +37,7 @@ import com.facebook.presto.spi.ViewNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
@@ -204,7 +205,7 @@ public class MemoryMetadata
     public synchronized void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
     {
         ConnectorOutputTableHandle outputTableHandle = beginCreateTable(session, tableMetadata, Optional.empty());
-        finishCreateTable(session, outputTableHandle, ImmutableList.of());
+        finishCreateTable(session, outputTableHandle, ImmutableList.of(), ImmutableList.of());
     }
 
     @Override
@@ -247,7 +248,7 @@ public class MemoryMetadata
     }
 
     @Override
-    public synchronized Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    public synchronized Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         requireNonNull(tableHandle, "tableHandle is null");
         MemoryOutputTableHandle memoryOutputHandle = (MemoryOutputTableHandle) tableHandle;
@@ -264,7 +265,7 @@ public class MemoryMetadata
     }
 
     @Override
-    public synchronized Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    public synchronized Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         requireNonNull(insertHandle, "insertHandle is null");
         MemoryInsertTableHandle memoryInsertHandle = (MemoryInsertTableHandle) insertHandle;

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
@@ -69,7 +69,7 @@ public class TestMemoryMetadata
                 new ConnectorTableMetadata(schemaTableName, ImmutableList.of(), ImmutableMap.of()),
                 Optional.empty());
 
-        metadata.finishCreateTable(SESSION, table, ImmutableList.of());
+        metadata.finishCreateTable(SESSION, table, ImmutableList.of(), ImmutableList.of());
 
         List<SchemaTableName> tables = metadata.listTables(SESSION, Optional.empty());
         assertTrue(tables.size() == 1, "Expected only one table");
@@ -154,7 +154,7 @@ public class TestMemoryMetadata
         assertTrue(tableLayoutHandle instanceof MemoryTableLayoutHandle);
         assertTrue(((MemoryTableLayoutHandle) tableLayoutHandle).getDataFragments().isEmpty(), "Data fragments should be empty");
 
-        metadata.finishCreateTable(SESSION, table, ImmutableList.of());
+        metadata.finishCreateTable(SESSION, table, ImmutableList.of(), ImmutableList.of());
     }
 
     @Test
@@ -311,7 +311,7 @@ public class TestMemoryMetadata
                 SESSION,
                 new ConnectorTableMetadata(tableName, ImmutableList.of(), ImmutableMap.of()),
                 Optional.empty());
-        metadata.finishCreateTable(SESSION, table, ImmutableList.of());
+        metadata.finishCreateTable(SESSION, table, ImmutableList.of(), ImmutableList.of());
 
         // rename table to schema which does not exist
         SchemaTableName invalidSchemaTableName = new SchemaTableName("test_schema_not_exist", "test_table_renamed");

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
@@ -229,7 +230,7 @@ public class MongoMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         clearRollback();
         return Optional.empty();
@@ -247,7 +248,7 @@ public class MongoMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         return Optional.empty();
     }

--- a/presto-product-tests/conf/presto/etc/catalog/hive.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/hive.properties
@@ -16,3 +16,4 @@ hive.allow-rename-table=true
 hive.metastore-cache-ttl=0s
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
+hive.collect-column-statistics-on-write=true

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-hdfs-impersonation/hive.properties
@@ -18,3 +18,4 @@ hive.hdfs.authentication.type=NONE
 hive.hdfs.impersonation.enabled=true
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
+hive.collect-column-statistics-on-write=true

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -9,6 +9,7 @@ connector.name=hive-hadoop2
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.metastore.thrift.client.socks-proxy=hadoop-master:1180
 hive.metastore-cache-ttl=0s
+hive.collect-column-statistics-on-write=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/presto-product-tests/conf/presto/etc/environment-specific-catalogs/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -14,6 +14,7 @@ hive.metastore-cache-ttl=0s
 hive.allow-add-column=true
 hive.allow-drop-column=true
 hive.allow-rename-column=true
+hive.collect-column-statistics-on-write=true
 
 hive.metastore.authentication.type=KERBEROS
 hive.metastore.service.principal=hive/hadoop-master@LABS.TERADATA.COM

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -13,17 +13,21 @@
  */
 package com.facebook.presto.tests.hive;
 
+import com.google.common.collect.ImmutableList;
 import io.prestodb.tempto.ProductTest;
 import io.prestodb.tempto.Requirement;
 import io.prestodb.tempto.Requirements;
 import io.prestodb.tempto.RequirementsProvider;
 import io.prestodb.tempto.Requires;
+import io.prestodb.tempto.assertions.QueryAssert.Row;
 import io.prestodb.tempto.configuration.Configuration;
 import io.prestodb.tempto.fulfillment.table.MutableTableRequirement;
 import io.prestodb.tempto.fulfillment.table.hive.HiveTableDefinition;
 import io.prestodb.tempto.fulfillment.table.hive.InlineDataSource;
 import io.prestodb.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.SKIP_ON_CDH;
@@ -37,6 +41,7 @@ import static io.prestodb.tempto.fulfillment.table.MutableTablesState.mutableTab
 import static io.prestodb.tempto.fulfillment.table.TableRequirements.mutableTable;
 import static io.prestodb.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
 import static io.prestodb.tempto.query.QueryExecutor.query;
+import static java.lang.String.format;
 
 public class TestHiveTableStatistics
         extends ProductTest
@@ -69,6 +74,7 @@ public class TestHiveTableStatistics
 
     private static final String ALL_TYPES_TABLE_NAME = "all_types";
     private static final String EMPTY_ALL_TYPES_TABLE_NAME = "empty_all_types";
+    private static final String ALL_TYPES_ALL_NULL_TABLE_NAME = "all_types_all_null";
 
     private static final HiveTableDefinition ALL_TYPES_TABLE = HiveTableDefinition.like(ALL_HIVE_SIMPLE_TYPES_TEXTFILE)
             .setDataSource(InlineDataSource.createStringDataSource(
@@ -78,6 +84,67 @@ public class TestHiveTableStatistics
                             "127|32767|2147483647|9223372036854775807|123.345|235.567|345.678|345.678|2015-05-10 12:15:35.123456|2015-06-10|ala ma kota|ala ma kot|ala ma    |true|a290IGJpbmFybnk=|\n"))
             .build();
 
+    private static final HiveTableDefinition ALL_TYPES_ALL_NULL_TABLE = HiveTableDefinition.like(ALL_HIVE_SIMPLE_TYPES_TEXTFILE)
+            .setDataSource(InlineDataSource.createStringDataSource(
+                    "all_analyzable_types_all_null",
+                    "",
+                    "\\N|\\N|\\N|\\N|\\N|\\N|\\N|\\N|\\N|\\N|\\N|\\N|\\N|\\N|\\N|\n"))
+            .build();
+
+    private static final List<Row> ALL_TYPES_TABLE_STATISTICS = ImmutableList.of(
+            row("c_tinyint", null, 2.0, 0.0, null, "121", "127"),
+            row("c_smallint", null, 2.0, 0.0, null, "32761", "32767"),
+            row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647"),
+            row("c_bigint", null, 2.0, 0.0, null, "9223372036854775801", "9223372036854775807"),
+            row("c_float", null, 2.0, 0.0, null, "123.341", "123.345"),
+            row("c_double", null, 2.0, 0.0, null, "234.561", "235.567"),
+            row("c_decimal", null, 2.0, 0.0, null, "345", "346"),
+            row("c_decimal_w_params", null, 2.0, 0.0, null, "345.67100", "345.67800"),
+            row("c_timestamp", null, 2.0, 0.0, null, "2015-05-10 12:15:31.000", "2015-05-10 12:15:35.000"),
+            row("c_date", null, 2.0, 0.0, null, "2015-05-09", "2015-06-10"),
+            row("c_string", null, 2.0, 0.0, null, null, null),
+            row("c_varchar", null, 2.0, 0.0, null, null, null),
+            row("c_char", null, 2.0, 0.0, null, null, null),
+            row("c_boolean", null, 2.0, 0.0, null, null, null),
+            row("c_binary", null, null, 0.0, null, null, null),
+            row(null, null, null, null, 2.0, null, null));
+
+    private static final List<Row> ALL_TYPES_ALL_NULL_TABLE_STATISTICS = ImmutableList.of(
+            row("c_tinyint", null, 0.0, 1.0, null, null, null),
+            row("c_smallint", null, 0.0, 1.0, null, null, null),
+            row("c_int", null, 0.0, 1.0, null, null, null),
+            row("c_bigint", null, 0.0, 1.0, null, null, null),
+            row("c_float", null, 0.0, 1.0, null, null, null),
+            row("c_double", null, 0.0, 1.0, null, null, null),
+            row("c_decimal", null, 0.0, 1.0, null, null, null),
+            row("c_decimal_w_params", null, 0.0, 1.0, null, null, null),
+            row("c_timestamp", null, 0.0, 1.0, null, null, null),
+            row("c_date", null, 0.0, 1.0, null, null, null),
+            row("c_string", null, 0.0, 1.0, null, null, null),
+            row("c_varchar", null, 0.0, 1.0, null, null, null),
+            row("c_char", null, 0.0, 1.0, null, null, null),
+            row("c_boolean", null, 0.0, 1.0, null, null, null),
+            row("c_binary", null, null, 1.0, null, null, null),
+            row(null, null, null, null, 1.0, null, null));
+
+    private static final List<Row> ALL_TYPES_EMPTY_TABLE_STATISTICS = ImmutableList.of(
+            row("c_tinyint", null, 0.0, 0.0, null, null, null),
+            row("c_smallint", null, 0.0, 0.0, null, null, null),
+            row("c_int", null, 0.0, 0.0, null, null, null),
+            row("c_bigint", null, 0.0, 0.0, null, null, null),
+            row("c_float", null, 0.0, 0.0, null, null, null),
+            row("c_double", null, 0.0, 0.0, null, null, null),
+            row("c_decimal", null, 0.0, 0.0, null, null, null),
+            row("c_decimal_w_params", null, 0.0, 0.0, null, null, null),
+            row("c_timestamp", null, 0.0, 0.0, null, null, null),
+            row("c_date", null, 0.0, 0.0, null, null, null),
+            row("c_string", null, 0.0, 0.0, null, null, null),
+            row("c_varchar", null, 0.0, 0.0, null, null, null),
+            row("c_char", null, 0.0, 0.0, null, null, null),
+            row("c_boolean", null, 0.0, 0.0, null, null, null),
+            row("c_binary", null, null, 0.0, null, null, null),
+            row(null, null, null, null, 0.0, null, null));
+
     private static final class AllTypesTable
             implements RequirementsProvider
     {
@@ -86,6 +153,7 @@ public class TestHiveTableStatistics
         {
             return Requirements.compose(
                     mutableTable(ALL_TYPES_TABLE, ALL_TYPES_TABLE_NAME, MutableTableRequirement.State.LOADED),
+                    mutableTable(ALL_TYPES_ALL_NULL_TABLE, ALL_TYPES_ALL_NULL_TABLE_NAME, MutableTableRequirement.State.LOADED),
                     mutableTable(ALL_TYPES_TABLE, EMPTY_ALL_TYPES_TABLE_NAME, MutableTableRequirement.State.CREATED));
         }
     }
@@ -399,6 +467,354 @@ public class TestHiveTableStatistics
                 row("c_boolean", null, 0.0, 1.0, null, null, null),
                 row("c_binary", null, null, 1.0, null, null, null),
                 row(null, null, null, null, 1.0, null, null));
+    }
+
+    @Test
+    @Requires(AllTypesTable.class)
+    public void testComputeTableStatisticsOnCreateTable()
+    {
+        String allTypesTable = mutableTablesState().get(ALL_TYPES_TABLE_NAME).getNameInDatabase();
+        String emptyAllTypesTable = mutableTablesState().get(EMPTY_ALL_TYPES_TABLE_NAME).getNameInDatabase();
+        String allTypesAllNullTable = mutableTablesState().get(ALL_TYPES_ALL_NULL_TABLE_NAME).getNameInDatabase();
+
+        assertComputeTableStatisticsOnCreateTable(allTypesTable, ALL_TYPES_TABLE_STATISTICS);
+        assertComputeTableStatisticsOnCreateTable(emptyAllTypesTable, ALL_TYPES_EMPTY_TABLE_STATISTICS);
+        assertComputeTableStatisticsOnCreateTable(allTypesAllNullTable, ALL_TYPES_ALL_NULL_TABLE_STATISTICS);
+    }
+
+    @Test
+    @Requires(AllTypesTable.class)
+    public void testComputeTableStatisticsOnInsert()
+    {
+        String allTypesTable = mutableTablesState().get(ALL_TYPES_TABLE_NAME).getNameInDatabase();
+        String emptyAllTypesTable = mutableTablesState().get(EMPTY_ALL_TYPES_TABLE_NAME).getNameInDatabase();
+        String allTypesAllNullTable = mutableTablesState().get(ALL_TYPES_ALL_NULL_TABLE_NAME).getNameInDatabase();
+
+        assertComputeTableStatisticsOnInsert(allTypesTable, ALL_TYPES_TABLE_STATISTICS);
+        assertComputeTableStatisticsOnInsert(emptyAllTypesTable, ALL_TYPES_EMPTY_TABLE_STATISTICS);
+        assertComputeTableStatisticsOnInsert(allTypesAllNullTable, ALL_TYPES_ALL_NULL_TABLE_STATISTICS);
+
+        String tableName = "test_update_table_statistics";
+        query(format("DROP TABLE IF EXISTS %s", tableName));
+        try {
+            query(format("CREATE TABLE %s AS SELECT * FROM %s WITH NO DATA", tableName, allTypesTable));
+            query(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesTable));
+            query(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesAllNullTable));
+            query(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesAllNullTable));
+            assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
+                    row("c_tinyint", null, 2.0, 0.5, null, "121", "127"),
+                    row("c_smallint", null, 2.0, 0.5, null, "32761", "32767"),
+                    row("c_int", null, 2.0, 0.5, null, "2147483641", "2147483647"),
+                    row("c_bigint", null, 2.0, 0.5, null, "9223372036854775801", "9223372036854775807"),
+                    row("c_float", null, 2.0, 0.5, null, "123.341", "123.345"),
+                    row("c_double", null, 2.0, 0.5, null, "234.561", "235.567"),
+                    row("c_decimal", null, 2.0, 0.5, null, "345", "346"),
+                    row("c_decimal_w_params", null, 2.0, 0.5, null, "345.67100", "345.67800"),
+                    row("c_timestamp", null, 2.0, 0.5, null, "2015-05-10 12:15:31.000", "2015-05-10 12:15:35.000"),
+                    row("c_date", null, 2.0, 0.5, null, "2015-05-09", "2015-06-10"),
+                    row("c_string", null, 2.0, 0.5, null, null, null),
+                    row("c_varchar", null, 2.0, 0.5, null, null, null),
+                    row("c_char", null, 2.0, 0.5, null, null, null),
+                    row("c_boolean", null, 2.0, 0.5, null, null, null),
+                    row("c_binary", null, null, 0.5, null, null, null),
+                    row(null, null, null, null, 4.0, null, null));
+
+            query(format("INSERT INTO %s VALUES( " +
+                    "TINYINT '120', " +
+                    "SMALLINT '32760', " +
+                    "INTEGER '2147483640', " +
+                    "BIGINT '9223372036854775800', " +
+                    "REAL '123.340', " +
+                    "DOUBLE '234.560', " +
+                    "CAST(343.0 AS DECIMAL(10, 0)), " +
+                    "CAST(345.670 AS DECIMAL(10, 5)), " +
+                    "TIMESTAMP '2015-05-10 12:15:30', " +
+                    "DATE '2015-05-08', " +
+                    "CAST('ela ma kot' AS VARCHAR), " +
+                    "CAST('ela ma ko' AS VARCHAR(10)), " +
+                    "CAST('ela m     ' AS CHAR(10)), " +
+                    "false, " +
+                    "CAST('cGllcyBiaW5hcm54' as VARBINARY))", tableName));
+
+            assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(ImmutableList.of(
+                    row("c_tinyint", null, 2.0, 0.4, null, "120", "127"),
+                    row("c_smallint", null, 2.0, 0.4, null, "32760", "32767"),
+                    row("c_int", null, 2.0, 0.4, null, "2147483640", "2147483647"),
+                    row("c_bigint", null, 2.0, 0.4, null, "9223372036854775800", "9223372036854775807"),
+                    row("c_float", null, 2.0, 0.4, null, "123.34", "123.345"),
+                    row("c_double", null, 2.0, 0.4, null, "234.56", "235.567"),
+                    row("c_decimal", null, 2.0, 0.4, null, "343", "346"),
+                    row("c_decimal_w_params", null, 2.0, 0.4, null, "345.67000", "345.67800"),
+                    row("c_timestamp", null, 2.0, 0.4, null, "2015-05-10 12:15:30.000", "2015-05-10 12:15:35.000"),
+                    row("c_date", null, 2.0, 0.4, null, "2015-05-08", "2015-06-10"),
+                    row("c_string", null, 2.0, 0.4, null, null, null),
+                    row("c_varchar", null, 2.0, 0.4, null, null, null),
+                    row("c_char", null, 2.0, 0.4, null, null, null),
+                    row("c_boolean", null, 2.0, 0.4, null, null, null),
+                    row("c_binary", null, null, 0.4, null, null, null),
+                    row(null, null, null, null, 5.0, null, null)));
+        }
+        finally {
+            query(format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test
+    @Requires(AllTypesTable.class)
+    public void testComputePartitionStatisticsOnCreateTable()
+    {
+        String tableName = "test_compute_partition_statistics_on_create_table";
+        query(format("DROP TABLE IF EXISTS %s", tableName));
+        try {
+            query(format("CREATE TABLE %s WITH ( " +
+                    " partitioned_by = ARRAY['p_bigint', 'p_varchar']" +
+                    ") AS " +
+                    "SELECT * FROM ( " +
+                    "    VALUES " +
+                    "        (" +
+                    "           TINYINT '120', " +
+                    "           SMALLINT '32760', " +
+                    "           INTEGER '2147483640', " +
+                    "           BIGINT '9223372036854775800', " +
+                    "           REAL '123.340', DOUBLE '234.560', " +
+                    "           CAST(343.0 AS DECIMAL(10, 0)), " +
+                    "           CAST(345.670 AS DECIMAL(10, 5)), " +
+                    "           TIMESTAMP '2015-05-10 12:15:30', " +
+                    "           DATE '2015-05-08', " +
+                    "           CAST('p1 varchar' AS VARCHAR), " +
+                    "           CAST('p1 varchar10' AS VARCHAR(10)), " +
+                    "           CAST('p1 char10' AS CHAR(10)), false, " +
+                    "           CAST('p1 binary' as VARBINARY), " +
+                    "           BIGINT '1', " +
+                    "           CAST('partition1' AS VARCHAR)" +
+                    "        ), " +
+                    "        (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '1', 'partition1'), " +
+                    "        (" +
+                    "           TINYINT '99', " +
+                    "           SMALLINT '333'," +
+                    "           INTEGER '444', " +
+                    "           BIGINT '555', " +
+                    "           REAL '666.340', " +
+                    "           DOUBLE '777.560', " +
+                    "           CAST(888.0 AS DECIMAL(10, 0)), " +
+                    "           CAST(999.670 AS DECIMAL(10, 5)), " +
+                    "           TIMESTAMP '2015-05-10 12:45:30', " +
+                    "           DATE '2015-05-09', " +
+                    "           CAST('p2 varchar' AS VARCHAR), " +
+                    "           CAST('p2 varchar10' AS VARCHAR(10)), " +
+                    "           CAST('p2 char10' AS CHAR(10)), " +
+                    "           true, " +
+                    "           CAST('p2 binary' as VARBINARY), " +
+                    "           BIGINT '2', " +
+                    "           CAST('partition2' AS VARCHAR)" +
+                    "        ), " +
+                    "        (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '2', 'partition2') " +
+                    "" +
+                    ") AS t (c_tinyint, c_smallint, c_int, c_bigint, c_float, c_double, c_decimal, c_decimal_w_params, c_timestamp, c_date, c_string, c_varchar, c_char, c_boolean, c_binary, p_bigint, p_varchar)", tableName));
+
+            assertThat(query(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 1 AND p_varchar = 'partition1')", tableName))).containsOnly(ImmutableList.of(
+                    row("c_tinyint", null, 1.0, 0.5, null, "120", "120"),
+                    row("c_smallint", null, 1.0, 0.5, null, "32760", "32760"),
+                    row("c_int", null, 1.0, 0.5, null, "2147483640", "2147483640"),
+                    row("c_bigint", null, 1.0, 0.5, null, "9223372036854775800", "9223372036854775800"),
+                    row("c_float", null, 1.0, 0.5, null, "123.34", "123.34"),
+                    row("c_double", null, 1.0, 0.5, null, "234.56", "234.56"),
+                    row("c_decimal", null, 1.0, 0.5, null, "343", "343"),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "345.67000", "345.67000"),
+                    row("c_timestamp", null, 1.0, 0.5, null, "2015-05-10 12:15:30.000", "2015-05-10 12:15:30.000"),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-08", "2015-05-08"),
+                    row("c_string", null, 1.0, 0.5, null, null, null),
+                    row("c_varchar", null, 1.0, 0.5, null, null, null),
+                    row("c_char", null, 1.0, 0.5, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null),
+                    row("c_binary", null, null, 0.5, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "1", "1"),
+                    row("p_varchar", null, 1.0, 0.0, null, null, null),
+                    row(null, null, null, null, 2.0, null, null)));
+
+            assertThat(query(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 2 AND p_varchar = 'partition2')", tableName))).containsOnly(ImmutableList.of(
+                    row("c_tinyint", null, 1.0, 0.5, null, "99", "99"),
+                    row("c_smallint", null, 1.0, 0.5, null, "333", "333"),
+                    row("c_int", null, 1.0, 0.5, null, "444", "444"),
+                    row("c_bigint", null, 1.0, 0.5, null, "555", "555"),
+                    row("c_float", null, 1.0, 0.5, null, "666.34", "666.34"),
+                    row("c_double", null, 1.0, 0.5, null, "777.56", "777.56"),
+                    row("c_decimal", null, 1.0, 0.5, null, "888", "888"),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "999.67000", "999.67000"),
+                    row("c_timestamp", null, 1.0, 0.5, null, "2015-05-10 12:45:30.000", "2015-05-10 12:45:30.000"),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-09", "2015-05-09"),
+                    row("c_string", null, 1.0, 0.5, null, null, null),
+                    row("c_varchar", null, 1.0, 0.5, null, null, null),
+                    row("c_char", null, 1.0, 0.5, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null),
+                    row("c_binary", null, null, 0.5, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "2", "2"),
+                    row("p_varchar", null, 1.0, 0.0, null, null, null),
+                    row(null, null, null, null, 2.0, null, null)));
+        }
+        finally {
+            query(format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    @Test
+    @Requires(AllTypesTable.class)
+    public void testComputePartitionStatisticsOnInsert()
+    {
+        String tableName = "test_compute_partition_statistics_on_insert";
+
+        query(format("DROP TABLE IF EXISTS %s", tableName));
+        try {
+            query(format("CREATE TABLE %s(" +
+                    "c_tinyint            TINYINT, " +
+                    "c_smallint           SMALLINT, " +
+                    "c_int                INT, " +
+                    "c_bigint             BIGINT, " +
+                    "c_float              REAL, " +
+                    "c_double             DOUBLE, " +
+                    "c_decimal            DECIMAL(10,0), " +
+                    "c_decimal_w_params   DECIMAL(10,5), " +
+                    "c_timestamp          TIMESTAMP, " +
+                    "c_date               DATE, " +
+                    "c_string             VARCHAR, " +
+                    "c_varchar            VARCHAR(10), " +
+                    "c_char               CHAR(10), " +
+                    "c_boolean            BOOLEAN, " +
+                    "c_binary             VARBINARY, " +
+                    "p_bigint             BIGINT, " +
+                    "p_varchar            VARCHAR " +
+                    ") WITH ( " +
+                    " partitioned_by = ARRAY['p_bigint', 'p_varchar']" +
+                    ")", tableName));
+
+            query(format("INSERT INTO %s VALUES " +
+                    "(TINYINT '120', SMALLINT '32760', INTEGER '2147483640', BIGINT '9223372036854775800', REAL '123.340', DOUBLE '234.560', CAST(343.0 AS DECIMAL(10, 0)), CAST(345.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:15:30', DATE '2015-05-08', 'p1 varchar', CAST('p1 varchar10' AS VARCHAR(10)), CAST('p1 char10' AS CHAR(10)), false, CAST('p1 binary' as VARBINARY), BIGINT '1', 'partition1')," +
+                    "(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '1', 'partition1')", tableName));
+
+            query(format("INSERT INTO %s VALUES " +
+                    "(TINYINT '99', SMALLINT '333', INTEGER '444', BIGINT '555', REAL '666.340', DOUBLE '777.560', CAST(888.0 AS DECIMAL(10, 0)), CAST(999.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:45:30', DATE '2015-05-09', 'p2 varchar', CAST('p2 varchar10' AS VARCHAR(10)), CAST('p2 char10' AS CHAR(10)), true, CAST('p2 binary' as VARBINARY), BIGINT '2', 'partition2')," +
+                    "(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '2', 'partition2')", tableName));
+
+            String showStatsPartitionOne = format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 1 AND p_varchar = 'partition1')", tableName);
+            String showStatsPartitionTwo = format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 2 AND p_varchar = 'partition2')", tableName);
+
+            assertThat(query(showStatsPartitionOne)).containsOnly(ImmutableList.of(
+                    row("c_tinyint", null, 1.0, 0.5, null, "120", "120"),
+                    row("c_smallint", null, 1.0, 0.5, null, "32760", "32760"),
+                    row("c_int", null, 1.0, 0.5, null, "2147483640", "2147483640"),
+                    row("c_bigint", null, 1.0, 0.5, null, "9223372036854775800", "9223372036854775800"),
+                    row("c_float", null, 1.0, 0.5, null, "123.34", "123.34"),
+                    row("c_double", null, 1.0, 0.5, null, "234.56", "234.56"),
+                    row("c_decimal", null, 1.0, 0.5, null, "343", "343"),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "345.67000", "345.67000"),
+                    row("c_timestamp", null, 1.0, 0.5, null, "2015-05-10 12:15:30.000", "2015-05-10 12:15:30.000"),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-08", "2015-05-08"),
+                    row("c_string", null, 1.0, 0.5, null, null, null),
+                    row("c_varchar", null, 1.0, 0.5, null, null, null),
+                    row("c_char", null, 1.0, 0.5, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null),
+                    row("c_binary", null, null, 0.5, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "1", "1"),
+                    row("p_varchar", null, 1.0, 0.0, null, null, null),
+                    row(null, null, null, null, 2.0, null, null)));
+
+            assertThat(query(showStatsPartitionTwo)).containsOnly(ImmutableList.of(
+                    row("c_tinyint", null, 1.0, 0.5, null, "99", "99"),
+                    row("c_smallint", null, 1.0, 0.5, null, "333", "333"),
+                    row("c_int", null, 1.0, 0.5, null, "444", "444"),
+                    row("c_bigint", null, 1.0, 0.5, null, "555", "555"),
+                    row("c_float", null, 1.0, 0.5, null, "666.34", "666.34"),
+                    row("c_double", null, 1.0, 0.5, null, "777.56", "777.56"),
+                    row("c_decimal", null, 1.0, 0.5, null, "888", "888"),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "999.67000", "999.67000"),
+                    row("c_timestamp", null, 1.0, 0.5, null, "2015-05-10 12:45:30.000", "2015-05-10 12:45:30.000"),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-09", "2015-05-09"),
+                    row("c_string", null, 1.0, 0.5, null, null, null),
+                    row("c_varchar", null, 1.0, 0.5, null, null, null),
+                    row("c_char", null, 1.0, 0.5, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null),
+                    row("c_binary", null, null, 0.5, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "2", "2"),
+                    row("p_varchar", null, 1.0, 0.0, null, null, null),
+                    row(null, null, null, null, 2.0, null, null)));
+
+            query(format("INSERT INTO %s VALUES( TINYINT '119', SMALLINT '32759', INTEGER '2147483639', BIGINT '9223372036854775799', REAL '122.340', DOUBLE '233.560', CAST(342.0 AS DECIMAL(10, 0)), CAST(344.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:15:29', DATE '2015-05-07', 'p1 varchar', CAST('p1 varchar10' AS VARCHAR(10)), CAST('p1 char10' AS CHAR(10)), true, CAST('p1 binary' as VARBINARY), BIGINT '1', 'partition1')", tableName));
+            query(format("INSERT INTO %s VALUES( null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '1', 'partition1')", tableName));
+
+            assertThat(query(showStatsPartitionOne)).containsOnly(ImmutableList.of(
+                    row("c_tinyint", null, 1.0, 0.5, null, "119", "120"),
+                    row("c_smallint", null, 1.0, 0.5, null, "32759", "32760"),
+                    row("c_int", null, 1.0, 0.5, null, "2147483639", "2147483640"),
+                    row("c_bigint", null, 1.0, 0.5, null, "9223372036854775799", "9223372036854775800"),
+                    row("c_float", null, 1.0, 0.5, null, "122.34", "123.34"),
+                    row("c_double", null, 1.0, 0.5, null, "233.56", "234.56"),
+                    row("c_decimal", null, 1.0, 0.5, null, "342", "343"),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "344.67000", "345.67000"),
+                    row("c_timestamp", null, 1.0, 0.5, null, "2015-05-10 12:15:29.000", "2015-05-10 12:15:30.000"),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-07", "2015-05-08"),
+                    row("c_string", null, 1.0, 0.5, null, null, null),
+                    row("c_varchar", null, 1.0, 0.5, null, null, null),
+                    row("c_char", null, 1.0, 0.5, null, null, null),
+                    row("c_boolean", null, 2.0, 0.5, null, null, null),
+                    row("c_binary", null, null, 0.5, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "1", "1"),
+                    row("p_varchar", null, 1.0, 0.0, null, null, null),
+                    row(null, null, null, null, 4.0, null, null)));
+
+            query(format("INSERT INTO %s VALUES( TINYINT '100', SMALLINT '334', INTEGER '445', BIGINT '556', REAL '667.340', DOUBLE '778.560', CAST(889.0 AS DECIMAL(10, 0)), CAST(1000.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:45:31', DATE '2015-05-10', CAST('p2 varchar' AS VARCHAR), CAST('p2 varchar10' AS VARCHAR(10)), CAST('p2 char10' AS CHAR(10)), true, CAST('p2 binary' as VARBINARY), BIGINT '2', 'partition2')", tableName));
+            query(format("INSERT INTO %s VALUES( null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '2', 'partition2')", tableName));
+
+            assertThat(query(showStatsPartitionTwo)).containsOnly(ImmutableList.of(
+                    row("c_tinyint", null, 1.0, 0.5, null, "99", "100"),
+                    row("c_smallint", null, 1.0, 0.5, null, "333", "334"),
+                    row("c_int", null, 1.0, 0.5, null, "444", "445"),
+                    row("c_bigint", null, 1.0, 0.5, null, "555", "556"),
+                    row("c_float", null, 1.0, 0.5, null, "666.34", "667.34"),
+                    row("c_double", null, 1.0, 0.5, null, "777.56", "778.56"),
+                    row("c_decimal", null, 1.0, 0.5, null, "888", "889"),
+                    row("c_decimal_w_params", null, 1.0, 0.5, null, "999.67000", "1000.67000"),
+                    row("c_timestamp", null, 1.0, 0.5, null, "2015-05-10 12:45:30.000", "2015-05-10 12:45:31.000"),
+                    row("c_date", null, 1.0, 0.5, null, "2015-05-09", "2015-05-10"),
+                    row("c_string", null, 1.0, 0.5, null, null, null),
+                    row("c_varchar", null, 1.0, 0.5, null, null, null),
+                    row("c_char", null, 1.0, 0.5, null, null, null),
+                    row("c_boolean", null, 1.0, 0.5, null, null, null),
+                    row("c_binary", null, null, 0.5, null, null, null),
+                    row("p_bigint", null, 1.0, 0.0, null, "2", "2"),
+                    row("p_varchar", null, 1.0, 0.0, null, null, null),
+                    row(null, null, null, null, 4.0, null, null)));
+        }
+        finally {
+            query(format("DROP TABLE IF EXISTS %s", tableName));
+        }
+    }
+
+    private static void assertComputeTableStatisticsOnCreateTable(String sourceTableName, List<Row> expectedStatistics)
+    {
+        String copiedTableName = "assert_compute_table_statistics_on_create_table_" + sourceTableName;
+        query(format("DROP TABLE IF EXISTS %s", copiedTableName));
+        try {
+            query(format("CREATE TABLE %s AS SELECT * FROM %s", copiedTableName, sourceTableName));
+            assertThat(query("SHOW STATS FOR " + copiedTableName)).containsOnly(expectedStatistics);
+        }
+        finally {
+            query(format("DROP TABLE IF EXISTS %s", copiedTableName));
+        }
+    }
+
+    private static void assertComputeTableStatisticsOnInsert(String sourceTableName, List<Row> expectedStatistics)
+    {
+        String copiedTableName = "assert_compute_table_statistics_on_insert_" + sourceTableName;
+        query(format("DROP TABLE IF EXISTS %s", copiedTableName));
+        try {
+            query(format("CREATE TABLE %s AS SELECT * FROM %s WITH NO DATA", copiedTableName, sourceTableName));
+            assertThat(query("SHOW STATS FOR " + copiedTableName)).containsOnly(ALL_TYPES_EMPTY_TABLE_STATISTICS);
+            query(format("INSERT INTO %s SELECT * FROM %s", copiedTableName, sourceTableName));
+            assertThat(query("SHOW STATS FOR " + copiedTableName)).containsOnly(expectedStatistics);
+        }
+        finally {
+            query(format("DROP TABLE IF EXISTS %s", copiedTableName));
+        }
     }
 
     private static QueryExecutor onHive()

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
@@ -45,6 +45,7 @@ import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -423,7 +424,7 @@ public class RaptorMetadata
     public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
     {
         Optional<ConnectorNewTableLayout> layout = getNewTableLayout(session, tableMetadata);
-        finishCreateTable(session, beginCreateTable(session, tableMetadata, layout), ImmutableList.of());
+        finishCreateTable(session, beginCreateTable(session, tableMetadata, layout), ImmutableList.of(), ImmutableList.of());
     }
 
     @Override
@@ -625,7 +626,7 @@ public class RaptorMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         RaptorOutputTableHandle table = (RaptorOutputTableHandle) outputTableHandle;
         long transactionId = table.getTransactionId();
@@ -728,7 +729,7 @@ public class RaptorMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         RaptorInsertTableHandle handle = (RaptorInsertTableHandle) insertHandle;
         long transactionId = handle.getTransactionId();

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
@@ -385,7 +385,7 @@ public class TestRaptorMetadata
         assertEquals(partitioning.getDistributionId(), 1);
 
         ConnectorOutputTableHandle outputHandle = metadata.beginCreateTable(SESSION, ordersTable, Optional.of(layout));
-        metadata.finishCreateTable(SESSION, outputHandle, ImmutableList.of());
+        metadata.finishCreateTable(SESSION, outputHandle, ImmutableList.of(), ImmutableList.of());
 
         ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS);
         assertInstanceOf(tableHandle, RaptorTableHandle.class);
@@ -667,7 +667,7 @@ public class TestRaptorMetadata
         assertNull(transactionSuccessful(transactionId));
 
         // commit table creation
-        metadata.finishCreateTable(SESSION, outputHandle, ImmutableList.of());
+        metadata.finishCreateTable(SESSION, outputHandle, ImmutableList.of(), ImmutableList.of());
         assertTrue(transactionExists(transactionId));
         assertTrue(transactionSuccessful(transactionId));
     }
@@ -690,7 +690,7 @@ public class TestRaptorMetadata
         assertNull(transactionSuccessful(transactionId));
 
         // commit insert
-        metadata.finishInsert(SESSION, insertHandle, ImmutableList.of());
+        metadata.finishInsert(SESSION, insertHandle, ImmutableList.of(), ImmutableList.of());
         assertTrue(transactionExists(transactionId));
         assertTrue(transactionSuccessful(transactionId));
     }
@@ -755,7 +755,7 @@ public class TestRaptorMetadata
 
         // commit table creation
         try {
-            metadata.finishCreateTable(SESSION, outputHandle, ImmutableList.of());
+            metadata.finishCreateTable(SESSION, outputHandle, ImmutableList.of(), ImmutableList.of());
             fail("expected exception");
         }
         catch (PrestoException e) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -34,7 +34,9 @@ import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
 import io.airlift.slice.Slice;
 
 import java.util.Collection;
@@ -276,6 +278,14 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Describes statistics that must be collected during a write.
+     */
+    default TableStatisticsMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        return TableStatisticsMetadata.empty();
+    }
+
+    /**
      * Begin the atomic creation of a table with data.
      */
     default ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
@@ -286,7 +296,7 @@ public interface ConnectorMetadata
     /**
      * Finish a table creation with data after the data is written.
      */
-    default Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    default Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         throw new PrestoException(GENERIC_INTERNAL_ERROR, "ConnectorMetadata beginCreateTable() is implemented without finishCreateTable()");
     }
@@ -313,7 +323,7 @@ public interface ConnectorMetadata
     /**
      * Finish insert query
      */
-    default Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    default Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         throw new PrestoException(GENERIC_INTERNAL_ERROR, "ConnectorMetadata beginInsert() is implemented without finishInsert()");
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -36,7 +36,9 @@ import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
 import io.airlift.slice.Slice;
 
 import java.util.Collection;
@@ -93,6 +95,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getInsertLayout(session, tableHandle);
+        }
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getStatisticsCollectionMetadata(session, tableMetadata);
         }
     }
 
@@ -273,10 +283,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.finishCreateTable(session, tableHandle, fragments);
+            return delegate.finishCreateTable(session, tableHandle, fragments, computedStatistics);
         }
     }
 
@@ -305,10 +315,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.finishInsert(session, insertHandle, fragments);
+            return delegate.finishInsert(session, insertHandle, fragments, computedStatistics);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticMetadata.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class ColumnStatisticMetadata
+{
+    private final String columnName;
+    private final ColumnStatisticType statisticType;
+
+    @JsonCreator
+    public ColumnStatisticMetadata(
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("statisticType") ColumnStatisticType statisticType)
+    {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.statisticType = requireNonNull(statisticType, "statisticType is null");
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @JsonProperty
+    public ColumnStatisticType getStatisticType()
+    {
+        return statisticType;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ColumnStatisticMetadata that = (ColumnStatisticMetadata) o;
+        return Objects.equals(columnName, that.columnName) &&
+                statisticType == that.statisticType;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnName, statisticType);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ColumnStatisticMetadata{" +
+                "columnName='" + columnName + '\'' +
+                ", statisticType=" + statisticType +
+                '}';
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatisticType.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+public enum ColumnStatisticType
+{
+    MIN_VALUE,
+    MAX_VALUE,
+    NUMBER_OF_DISTINCT_VALUES,
+    NUMBER_OF_NON_NULL_VALUES,
+    NUMBER_OF_TRUE_VALUES,
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ComputedStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ComputedStatistics.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+import com.facebook.presto.spi.block.Block;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Objects.requireNonNull;
+
+public class ComputedStatistics
+{
+    private final List<String> groupingColumns;
+    private final List<Block> groupingValues;
+    private final Map<TableStatisticType, Block> tableStatistics;
+    private final Map<ColumnStatisticMetadata, Block> columnStatistics;
+
+    private ComputedStatistics(
+            List<String> groupingColumns,
+            List<Block> groupingValues,
+            Map<TableStatisticType, Block> tableStatistics,
+            Map<ColumnStatisticMetadata, Block> columnStatistics)
+    {
+        this.groupingColumns = unmodifiableList(new ArrayList<>(requireNonNull(groupingColumns, "groupingColumns is null")));
+        this.groupingValues = unmodifiableList(new ArrayList<>(requireNonNull(groupingValues, "groupingValues is null")));
+        if (!groupingValues.stream().allMatch(ComputedStatistics::isSingleValueBlock)) {
+            throw new IllegalArgumentException("grouping value blocks are expected to be single value blocks");
+        }
+        this.tableStatistics = unmodifiableMap(new HashMap<>(requireNonNull(tableStatistics, "tableStatistics is null")));
+        if (!tableStatistics.values().stream().allMatch(ComputedStatistics::isSingleValueBlock)) {
+            throw new IllegalArgumentException("computed table statistics blocks are expected to be single value blocks");
+        }
+        this.columnStatistics = unmodifiableMap(new HashMap<>(requireNonNull(columnStatistics, "columnStatistics is null")));
+        if (!columnStatistics.values().stream().allMatch(ComputedStatistics::isSingleValueBlock)) {
+            throw new IllegalArgumentException("computed column statistics blocks are expected to be single value blocks");
+        }
+    }
+
+    private static boolean isSingleValueBlock(Block block)
+    {
+        return block.getPositionCount() == 1;
+    }
+
+    public List<String> getGroupingColumns()
+    {
+        return groupingColumns;
+    }
+
+    public List<Block> getGroupingValues()
+    {
+        return groupingValues;
+    }
+
+    public Map<TableStatisticType, Block> getTableStatistics()
+    {
+        return tableStatistics;
+    }
+
+    public Map<ColumnStatisticMetadata, Block> getColumnStatistics()
+    {
+        return columnStatistics;
+    }
+
+    public static Builder builder(List<String> groupingColumns, List<Block> groupingValues)
+    {
+        return new Builder(groupingColumns, groupingValues);
+    }
+
+    public static class Builder
+    {
+        private final List<String> groupingColumns;
+        private final List<Block> groupingValues;
+        private final Map<TableStatisticType, Block> tableStatistics = new HashMap<>();
+        private final Map<ColumnStatisticMetadata, Block> columnStatistics = new HashMap<>();
+
+        private Builder(List<String> groupingColumns, List<Block> groupingValues)
+        {
+            this.groupingColumns = requireNonNull(groupingColumns, "groupingColumns is null");
+            this.groupingValues = requireNonNull(groupingValues, "groupingValues is null");
+        }
+
+        public void addTableStatistic(TableStatisticType type, Block value)
+        {
+            tableStatistics.put(type, value);
+        }
+
+        public void addColumnStatistic(ColumnStatisticMetadata columnStatisticMetadata, Block value)
+        {
+            columnStatistics.put(columnStatisticMetadata, value);
+        }
+
+        public ComputedStatistics build()
+        {
+            return new ComputedStatistics(groupingColumns, groupingValues, tableStatistics, columnStatistics);
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatisticType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatisticType.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+public enum TableStatisticType
+{
+    ROW_COUNT,
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatisticsMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatisticsMetadata.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.Objects.requireNonNull;
+
+public class TableStatisticsMetadata
+{
+    private static final TableStatisticsMetadata EMPTY_STATISTICS_METADATA = new TableStatisticsMetadata(emptySet(), emptySet(), emptyList());
+
+    private final Set<ColumnStatisticMetadata> columnStatistics;
+    private final Set<TableStatisticType> tableStatistics;
+    private final List<String> groupingColumns;
+
+    public static TableStatisticsMetadata empty()
+    {
+        return EMPTY_STATISTICS_METADATA;
+    }
+
+    public TableStatisticsMetadata(
+            Set<ColumnStatisticMetadata> columnStatistics,
+            Set<TableStatisticType> tableStatistics,
+            List<String> groupingColumns)
+    {
+        this.columnStatistics = unmodifiableSet(new HashSet<>(requireNonNull(columnStatistics, "columnStatistics is null")));
+        this.tableStatistics = unmodifiableSet(new HashSet<>(requireNonNull(tableStatistics, "tableStatistics is null")));
+        this.groupingColumns = unmodifiableList(new ArrayList<>(requireNonNull(groupingColumns, "groupingColumns is null")));
+    }
+
+    public Set<ColumnStatisticMetadata> getColumnStatistics()
+    {
+        return columnStatistics;
+    }
+
+    public Set<TableStatisticType> getTableStatistics()
+    {
+        return tableStatistics;
+    }
+
+    public List<String> getGroupingColumns()
+    {
+        return groupingColumns;
+    }
+
+    public boolean isEmpty()
+    {
+        return tableStatistics.isEmpty() && columnStatistics.isEmpty();
+    }
+}


### PR DESCRIPTION
Important changes since the version 1:

- Commits from `Return HiveColumnStatistics from the HiveMetastore interface` to `Move createPartitionValues method to a utility class ` were extracted into a separate PR and merged: #10972
- Added `Implement AutoCloseableCloser` commit.
- SPI bits extracted to `Collect column statistics on table write: SPI`
- `getInsertStatisticsMetadata ` and `getNewTableStatisticsMetadata ` method were merged into the single `getStatisticsCollectionMetadata ` method
- `AggregationOperator` integration with the `TableWriterOperator` has changed
- `ExtendedHiveMetastore#isColumnStatistitcsSupported()` replaced with the `ExtendedHiveMetastore#getSupportedColumnStatistics`. That eliminates a need of `CollectibleStatisticsProvider`. Commit: `Replace supportsColumnStatistics with getSupportedColumnStatistics`
- `ENABLED_FOR_MARKED_TABLES ` option has been removed as well as a related table property.
- `Migrate column statistics on drop and rename column` commit has been dropped
- Added `Collect column statistics on table write: Smoke Tests` commit