### PR TITLE
Clear update count on getMoreResults method call

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
@@ -317,9 +317,7 @@ public class PrestoStatement
     public boolean getMoreResults()
             throws SQLException
     {
-        checkOpen();
-        closeResultSet();
-        return false;
+        return getMoreResults(CLOSE_CURRENT_RESULT);
     }
 
     @Override
@@ -413,6 +411,7 @@ public class PrestoStatement
     {
         checkOpen();
 
+        currentUpdateCount.set(-1);
         if (current == CLOSE_CURRENT_RESULT) {
             closeResultSet();
             return false;

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -1237,6 +1237,25 @@ public class TestPrestoDriver
     }
 
     @Test
+    public void testGetMoreResultsClearsUpdateCount()
+            throws Exception
+    {
+        try (Connection connection = createConnection("blackhole", "default")) {
+            try (Statement statement = connection.createStatement()) {
+                assertFalse(statement.execute("CREATE TABLE test_more_results_clears_update_count(id BIGINT)"));
+                assertEquals(statement.getUpdateCount(), 0);
+                assertFalse(statement.getMoreResults());
+                assertEquals(statement.getUpdateCount(), -1);
+            }
+            finally {
+                try (Statement statement = connection.createStatement()) {
+                    statement.execute("DROP TABLE test_more_results_clears_update_count");
+                }
+            }
+        }
+    }
+
+    @Test
     public void testSetTimeZoneId()
             throws Exception
     {


### PR DESCRIPTION
Original issue: https://youtrack.jetbrains.com/issue/DBE-6421

According to the JDBC documentation the getMoreResults method has to move statement to the next "result" and the "result" in this case means not only the ResultSet object. Also it affects the main condition which determines that there is a result or not (getMoreResults() || getUpdateCount() != -1). This condition is also from JDBC specification.

So getMoreResults has to advance current results including update count.