### PR TITLE
Fix memory leaks in tests from the presto-tests module

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestBeginQuery.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestBeginQuery.java
@@ -38,8 +38,9 @@ import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -80,10 +81,17 @@ public class TestBeginQuery
         getQueryRunner().createCatalog("tpch", "tpch", ImmutableMap.of());
     }
 
-    @BeforeMethod
-    public void beforeMethod()
+    @AfterMethod
+    public void afterMethod()
     {
         metadata.clear();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        metadata.clear();
+        metadata = null;
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryAwareExecution.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryAwareExecution.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Key;
 import io.airlift.units.DataSize;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,6 +42,7 @@ import static io.airlift.units.DataSize.succinctBytes;
 @Test(singleThreaded = true)
 public class TestMemoryAwareExecution
 {
+    private TestingPrestoServer server;
     private QueryManager queryManager;
     private long totalAvailableMemory;
     private long queryMaxMemoryBytes;
@@ -48,7 +51,7 @@ public class TestMemoryAwareExecution
     public void setUp()
             throws Exception
     {
-        TestingPrestoServer server = new TestingPrestoServer(
+        server = new TestingPrestoServer(
                 true,
                 ImmutableMap.of("experimental.preallocate-memory-threshold", "1B"),
                 null,
@@ -66,6 +69,27 @@ public class TestMemoryAwareExecution
             Thread.sleep(1000);
         }
         totalAvailableMemory = localMemoryManager.getPool(LocalMemoryManager.GENERAL_POOL).getMaxBytes();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    private void afterMethod()
+            throws Exception
+    {
+        for (QueryInfo info : queryManager.getAllQueryInfo()) {
+            if (!info.getState().isDone()) {
+                queryManager.cancelQuery(info.getQueryId());
+                waitForState(info.getQueryId(), FAILED);
+            }
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void tearDown()
+            throws Exception
+    {
+        server.close();
+        server = null;
+        queryManager = null;
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -25,6 +25,7 @@ import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -67,7 +68,20 @@ public class TestMemoryManager
             .setSchema("tiny")
             .build();
 
-    private final ExecutorService executor = newCachedThreadPool();
+    private ExecutorService executor;
+
+    @BeforeClass
+    public void setUp()
+    {
+        executor = newCachedThreadPool();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void shutdown()
+    {
+        executor.shutdownNow();
+        executor = null;
+    }
 
     @Test(timeOut = 240_000)
     public void testResourceOverCommit()
@@ -331,12 +345,6 @@ public class TestMemoryManager
         try (QueryRunner queryRunner = createQueryRunner(SESSION, properties)) {
             queryRunner.execute(SESSION, "SELECT COUNT(*), repeat(orderstatus, 1000) FROM orders GROUP BY 2");
         }
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void shutdown()
-    {
-        executor.shutdownNow();
     }
 
     public static DistributedQueryRunner createQueryRunner(Session session, Map<String, String> properties)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestGracefulShutdown.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestGracefulShutdown.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -47,7 +48,19 @@ public class TestGracefulShutdown
             .setSchema("tiny")
             .build();
 
-    private final ListeningExecutorService executor = MoreExecutors.listeningDecorator(newCachedThreadPool());
+    private ListeningExecutorService executor;
+
+    @BeforeClass
+    public void setUp()
+    {
+        executor = MoreExecutors.listeningDecorator(newCachedThreadPool());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void shutdown()
+    {
+        executor.shutdownNow();
+    }
 
     @Test(timeOut = SHUTDOWN_TIMEOUT_MILLIS)
     public void testShutdown()
@@ -90,12 +103,6 @@ public class TestGracefulShutdown
             shutdownAction.waitForShutdownComplete(SHUTDOWN_TIMEOUT_MILLIS);
             assertTrue(shutdownAction.isWorkerShutdown());
         }
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void shutdown()
-    {
-        executor.shutdownNow();
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -77,6 +77,7 @@ public class TestMetadataManager
     {
         queryRunner.close();
         queryRunner = null;
+        metadataManager = null;
     }
 
     @Test


### PR DESCRIPTION
Close query runners after test classes are done