### PR TITLE
Revert "Make sure to release task-level memory on completion"

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -26,7 +26,6 @@ import com.facebook.presto.operator.PipelineContext;
 import com.facebook.presto.operator.PipelineStatus;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskStats;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.base.Function;
@@ -112,55 +111,46 @@ public class SqlTask
                 // because we haven't created the task context that holds the the memory context yet.
                 () -> queryContext.getTaskContextByTaskId(taskId).localSystemMemoryContext());
         taskStateMachine = new TaskStateMachine(taskId, taskNotificationExecutor);
-        taskStateMachine.addStateChangeListener(taskState -> cleanupTask(taskState, onDone));
-    }
+        taskStateMachine.addStateChangeListener(new StateChangeListener<TaskState>()
+        {
+            @Override
+            public void stateChanged(TaskState newState)
+            {
+                if (!newState.isDone()) {
+                    return;
+                }
 
-    private void cleanupTask(TaskState newState, Function<SqlTask, ?> onDone)
-    {
-        if (!newState.isDone()) {
-            return;
-        }
+                // store final task info
+                while (true) {
+                    TaskHolder taskHolder = taskHolderReference.get();
+                    if (taskHolder.isFinished()) {
+                        // another concurrent worker already set the final state
+                        return;
+                    }
 
-        // release all task-level allocated memory
-        SqlTaskExecution taskExecution = taskHolderReference.get().getTaskExecution();
-        if (taskExecution != null) {
-            try {
-                taskExecution.getTaskContext().destroy();
+                    if (taskHolderReference.compareAndSet(taskHolder, new TaskHolder(createTaskInfo(taskHolder), taskHolder.getIoStats()))) {
+                        break;
+                    }
+                }
+
+                // make sure buffers are cleaned up
+                if (newState == TaskState.FAILED || newState == TaskState.ABORTED) {
+                    // don't close buffers for a failed query
+                    // closed buffers signal to upstream tasks that everything finished cleanly
+                    outputBuffer.fail();
+                }
+                else {
+                    outputBuffer.destroy();
+                }
+
+                try {
+                    onDone.apply(SqlTask.this);
+                }
+                catch (Exception e) {
+                    log.warn(e, "Error running task cleanup callback %s", SqlTask.this.taskId);
+                }
             }
-            catch (PrestoException e) {
-                log.warn(e, "Error destroying task context");
-            }
-        }
-
-        // store final task info
-        while (true) {
-            TaskHolder taskHolder = taskHolderReference.get();
-            if (taskHolder.isFinished()) {
-                // another concurrent worker already set the final state
-                return;
-            }
-
-            if (taskHolderReference.compareAndSet(taskHolder, new TaskHolder(createTaskInfo(taskHolder), taskHolder.getIoStats()))) {
-                break;
-            }
-        }
-
-        // make sure buffers are cleaned up
-        if (newState == TaskState.FAILED || newState == TaskState.ABORTED) {
-            // don't close buffers for a failed query
-            // closed buffers signal to upstream tasks that everything finished cleanly
-            outputBuffer.fail();
-        }
-        else {
-            outputBuffer.destroy();
-        }
-
-        try {
-            onDone.apply(SqlTask.this);
-        }
-        catch (Exception e) {
-            log.warn(e, "Error running task cleanup callback %s", SqlTask.this.taskId);
-        }
+        });
     }
 
     public boolean isOutputBufferOverutilized()

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -22,7 +22,6 @@ import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.memory.QueryContextVisitor;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.memory.context.MemoryTrackingContext;
-import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -46,8 +45,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.transform;
@@ -56,7 +53,6 @@ import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -521,31 +517,6 @@ public class TaskContext
         return pipelineContexts.stream()
                 .map(pipelineContext -> pipelineContext.accept(visitor, context))
                 .collect(toList());
-    }
-
-    public void destroy()
-    {
-        taskMemoryContext.close();
-
-        if (taskMemoryContext.getSystemMemory() != 0) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, format("Task %s has non-zero system memory (%d bytes) after destroy()", this, taskMemoryContext.getSystemMemory()));
-        }
-
-        if (taskMemoryContext.getUserMemory() != 0) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, format("Task %s has non-zero user memory (%d bytes) after destroy()", this, taskMemoryContext.getUserMemory()));
-        }
-
-        if (taskMemoryContext.getRevocableMemory() != 0) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, format("Task %s has non-zero revocable memory (%d bytes) after destroy()", this, taskMemoryContext.getRevocableMemory()));
-        }
-    }
-
-    @Override
-    public String toString()
-    {
-        return toStringHelper(this)
-                .add("taskId", getTaskId())
-                .toString();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
This change introduces a race where the task context destroys the
aggregated memory context, and a thread does a localContext.setBytes()
after that resulting in an IllegalArgumentException:
```
Caused by: java.lang.IllegalArgumentException: tried to free more memory than is reserved by query
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:135)
	at com.facebook.presto.memory.MemoryPool.free(MemoryPool.java:178)
	at com.facebook.presto.memory.DefaultQueryContext.updateUserMemory(DefaultQueryContext.java:137)
	at com.facebook.presto.memory.DefaultQueryContext$QueryMemoryReservationHandler.reserveMemory(DefaultQueryContext.java:310)
	at com.facebook.presto.memory.context.RootAggregatedMemoryContext.updateBytes(RootAggregatedMemoryContext.java:35)
	at com.facebook.presto.memory.context.ChildAggregatedMemoryContext.updateBytes(ChildAggregatedMemoryContext.java:36)
	at com.facebook.presto.memory.context.ChildAggregatedMemoryContext.updateBytes(ChildAggregatedMemoryContext.java:36)
	at com.facebook.presto.memory.context.ChildAggregatedMemoryContext.updateBytes(ChildAggregatedMemoryContext.java:36)
	at com.facebook.presto.memory.context.ChildAggregatedMemoryContext.updateBytes(ChildAggregatedMemoryContext.java:36)
	at com.facebook.presto.memory.context.SimpleLocalMemoryContext.setBytes(SimpleLocalMemoryContext.java:63)
	at com.facebook.presto.operator.OperatorContext$InternalLocalMemoryContext.setBytes(OperatorContext.java:626)
	at com.facebook.presto.operator.HashBuilderOperator.lambda$close$10(HashBuilderOperator.java:628)
	at com.google.common.io.Closer.close(Closer.java:214)
	at com.facebook.presto.operator.HashBuilderOperator.close(HashBuilderOperator.java:630)
	at com.facebook.presto.operator.HashBuilderOperator.finish(HashBuilderOperator.java:432)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:355)
	at com.facebook.presto.operator.Driver.lambda$processFor$8(Driver.java:282)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:672)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:276)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:973)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:162)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:477)
	... 3 more