### PR TITLE
Revert "Destroy exchange sources for finished tasks on the coordinator"

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
@@ -19,14 +19,11 @@ import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.Node;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
 
-import java.util.List;
 import java.util.OptionalInt;
-import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
 
@@ -65,12 +62,6 @@ public class MemoryTrackingRemoteTaskFactory
 
         task.addStateChangeListener(new UpdatePeakMemory(stateMachine));
         return task;
-    }
-
-    @Override
-    public void destroyExchangeSources(List<ExchangeBufferLocation> locationsToDestroy, Consumer<PrestoException> onFailure)
-    {
-        remoteTaskFactory.destroyExchangeSources(locationsToDestroy, onFailure);
     }
 
     private static final class UpdatePeakMemory

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
@@ -18,17 +18,11 @@ import com.facebook.presto.Session;
 import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.Node;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
 
-import java.net.URI;
-import java.util.List;
 import java.util.OptionalInt;
-import java.util.function.Consumer;
-
-import static java.util.Objects.requireNonNull;
 
 public interface RemoteTaskFactory
 {
@@ -41,28 +35,4 @@ public interface RemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             boolean summarizeTaskInfo);
-
-    void destroyExchangeSources(List<ExchangeBufferLocation> locationsToDestroy, Consumer<PrestoException> onFailure);
-
-    final class ExchangeBufferLocation
-    {
-        private final TaskId producerTaskId;
-        private final URI bufferLocation;
-
-        public ExchangeBufferLocation(TaskId producerTaskId, URI bufferLocation)
-        {
-            this.producerTaskId = requireNonNull(producerTaskId, "producerTaskId is null");
-            this.bufferLocation = requireNonNull(bufferLocation, "bufferLocation is null");
-        }
-
-        public TaskId getProducerTaskId()
-        {
-            return producerTaskId;
-        }
-
-        public URI getBufferLocation()
-        {
-            return bufferLocation;
-        }
-    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -64,7 +64,6 @@ import com.facebook.presto.memory.TotalReservationLowMemoryKiller;
 import com.facebook.presto.memory.TotalReservationOnBlockedNodesLowMemoryKiller;
 import com.facebook.presto.operator.ForScheduler;
 import com.facebook.presto.server.protocol.StatementResource;
-import com.facebook.presto.server.remotetask.HttpRemoteTaskFactory;
 import com.facebook.presto.server.remotetask.RemoteTaskStats;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.resourceGroups.QueryType;

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRemoteTaskFactory.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.server.remotetask;
+package com.facebook.presto.server;
 
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.Session;
@@ -26,19 +26,16 @@ import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.TaskStatus;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.ForScheduler;
-import com.facebook.presto.server.TaskUpdateRequest;
+import com.facebook.presto.server.remotetask.HttpRemoteTask;
+import com.facebook.presto.server.remotetask.RemoteTaskStats;
 import com.facebook.presto.spi.Node;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
-import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.http.client.HttpClient;
-import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
-import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -46,19 +43,13 @@ import org.weakref.jmx.Nested;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
-import java.util.List;
 import java.util.OptionalInt;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.function.Consumer;
 
-import static io.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
-import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -66,8 +57,6 @@ import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 public class HttpRemoteTaskFactory
         implements RemoteTaskFactory
 {
-    private static final Logger log = Logger.get(HttpRemoteTaskFactory.class);
-
     private final HttpClient httpClient;
     private final LocationFactory locationFactory;
     private final JsonCodec<TaskStatus> taskStatusCodec;
@@ -136,8 +125,7 @@ public class HttpRemoteTaskFactory
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             boolean summarizeTaskInfo)
     {
-        return new HttpRemoteTask(
-                session,
+        return new HttpRemoteTask(session,
                 taskId,
                 node.getNodeIdentifier(),
                 locationFactory.createTaskLocation(node, taskId),
@@ -158,51 +146,5 @@ public class HttpRemoteTaskFactory
                 taskUpdateRequestCodec,
                 partitionedSplitCountTracker,
                 stats);
-    }
-
-    @Override
-    public void destroyExchangeSources(List<ExchangeBufferLocation> locationsToDestroy, Consumer<PrestoException> onFailure)
-    {
-        for (ExchangeBufferLocation exchangeBufferLocation : locationsToDestroy) {
-            Request request = prepareDelete()
-                    .setUri(exchangeBufferLocation.getBufferLocation())
-                    .build();
-            RequestErrorTracker errorTracker = new RequestErrorTracker(
-                    exchangeBufferLocation.getProducerTaskId(),
-                    exchangeBufferLocation.getBufferLocation(),
-                    maxErrorDuration,
-                    errorScheduledExecutor,
-                    "Cleanup exchange sources");
-            executeDestroyExchangeSourceRequest(errorTracker, request, onFailure);
-        }
-    }
-
-    private void executeDestroyExchangeSourceRequest(RequestErrorTracker errorTracker, Request request, Consumer<PrestoException> onFailure)
-    {
-        errorTracker.startRequest();
-        addExceptionCallback(httpClient.executeAsync(request, createFullJsonResponseHandler(taskInfoCodec)), failedReason -> {
-            if (failedReason instanceof RejectedExecutionException && httpClient.isClosed()) {
-                log.error("Unable to destroy exchange source at %s. HTTP client is closed", request.getUri());
-                return;
-            }
-
-            // record failure
-            try {
-                errorTracker.requestFailed(failedReason);
-            }
-            catch (PrestoException e) {
-                onFailure.accept(e);
-                return;
-            }
-
-            // if throttled due to error, asynchronously wait for timeout and try again
-            ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
-            if (errorRateLimit.isDone()) {
-                executeDestroyExchangeSourceRequest(errorTracker, request, onFailure);
-            }
-            else {
-                errorRateLimit.addListener(() -> executeDestroyExchangeSourceRequest(errorTracker, request, onFailure), errorScheduledExecutor);
-            }
-        });
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -27,7 +27,6 @@ import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spi.Node;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spiller.SpillSpaceTracker;
@@ -70,7 +69,6 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.OutputBuffers.BufferType.BROADCAST;
@@ -143,11 +141,6 @@ public class MockRemoteTaskFactory
             boolean summarizeTaskInfo)
     {
         return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, totalPartitions, partitionedSplitCountTracker);
-    }
-
-    @Override
-    public void destroyExchangeSources(List<ExchangeBufferLocation> locationsToDestroy, Consumer<PrestoException> onFailure)
-    {
     }
 
     public static final class MockRemoteTask

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -32,6 +32,7 @@ import com.facebook.presto.metadata.HandleJsonModule;
 import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.metadata.PrestoNode;
 import com.facebook.presto.metadata.Split;
+import com.facebook.presto.server.HttpRemoteTaskFactory;
 import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.type.Type;


### PR DESCRIPTION
This reverts commit 36a60a6f6e029ddd890d0eb10de01f339eedfebb.

It introduced too many coordinator to worker HTTP requests in a bursty manner.
This leads to communication failures due to
"Max requests queued per destination 1000 exceeded for HttpDestination",
This affects not only the query that is triggering the issue, but also
other queries running at the same time.