### PR TITLE
Improve Stripe Size Estimation for SliceDictionaryColumnWriter

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/ChainedSliceLoader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ChainedSliceLoader.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.ChunkedSliceInput.BufferReference;
+import io.airlift.slice.ChunkedSliceInput.SliceLoader;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.util.List;
+
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class ChainedSliceLoader
+        implements SliceLoader<BufferReference>
+{
+    private final List<Slice> slices;
+    private final long totalLength;
+
+    public ChainedSliceLoader(List<Slice> slices)
+    {
+        this.slices = ImmutableList.copyOf(requireNonNull(slices));
+        this.totalLength = slices.stream().mapToLong(Slice::length).sum();
+    }
+
+    @Override
+    public BufferReference createBuffer(int bufferSize)
+    {
+        Slice slice = Slices.allocate(bufferSize);
+        return () -> slice;
+    }
+
+    @Override
+    public long getSize()
+    {
+        return totalLength;
+    }
+
+    @Override
+    public void load(long position, BufferReference bufferReference, int length)
+    {
+        if (position < 0 || position + length > totalLength) {
+            throw new IllegalArgumentException();
+        }
+
+        int currentSliceIndex = 0;
+        long globalOffset = 0;
+        while (globalOffset + slices.get(currentSliceIndex).length() <= position) {
+            globalOffset += slices.get(currentSliceIndex).length();
+            currentSliceIndex++;
+        }
+
+        int currentSliceOffset = toIntExact(position - globalOffset);
+        Slice outputSlice = bufferReference.getSlice();
+        int outputSliceOffset = 0;
+        while (length > 0) {
+            Slice currentSlice = slices.get(currentSliceIndex);
+            int loadSize = Math.min(currentSlice.length() - currentSliceOffset, length);
+
+            currentSlice.getBytes(currentSliceOffset, outputSlice, outputSliceOffset, loadSize);
+            length -= loadSize;
+            outputSliceOffset += loadSize;
+
+            // advance to the next slice
+            currentSliceIndex++;
+            currentSliceOffset = 0;
+        }
+    }
+
+    @Override
+    public void close()
+    {
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -362,6 +363,12 @@ public class OrcOutputBuffer
     public Slice getUnderlyingSlice()
     {
         throw new UnsupportedOperationException();
+    }
+
+    public List<Slice> getCompressedSlices()
+    {
+        flushBufferToOutputStream();
+        return compressedOutputStream.getSlices();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStream.java
@@ -34,4 +34,9 @@ public interface LongOutputStream
     }
 
     void writeLong(long value);
+
+    /**
+     * Used for rewriting dictionary output ids after sorting in {@link com.facebook.presto.orc.writer.SliceDictionaryColumnWriter}
+     */
+    LongInputStream getLongInputStream();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -13,18 +13,27 @@
  */
 package com.facebook.presto.orc.stream;
 
+import com.facebook.presto.orc.ChainedSliceLoader;
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamDwrfCheckpoint;
 import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.ChunkedSliceInput;
+import io.airlift.slice.FixedLengthSliceInput;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.stream.LongDecode.writeVLong;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Math.toIntExact;
@@ -35,6 +44,8 @@ public class LongOutputStreamDwrf
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongOutputStreamDwrf.class).instanceSize();
     private final StreamKind streamKind;
+    private final CompressionKind compression;
+    private final int bufferSize;
     private final OrcOutputBuffer buffer;
     private final boolean signed;
     private final List<LongStreamDwrfCheckpoint> checkpoints = new ArrayList<>();
@@ -44,6 +55,8 @@ public class LongOutputStreamDwrf
     public LongOutputStreamDwrf(CompressionKind compression, int bufferSize, boolean signed, StreamKind streamKind)
     {
         this.streamKind = requireNonNull(streamKind, "streamKind is null");
+        this.compression = requireNonNull(compression, "compression is null");
+        this.bufferSize = bufferSize;
         this.buffer = new OrcOutputBuffer(compression, bufferSize);
         this.signed = signed;
     }
@@ -75,6 +88,30 @@ public class LongOutputStreamDwrf
     {
         checkState(closed);
         return ImmutableList.copyOf(checkpoints);
+    }
+
+    @Override
+    public LongInputStream getLongInputStream()
+    {
+        checkState(closed);
+
+        FixedLengthSliceInput sliceInput = new ChunkedSliceInput(new ChainedSliceLoader(buffer.getCompressedSlices()), 32 * 1024);
+        OrcDataSourceId orcDataSourceId = new OrcDataSourceId("LongOutputStream");
+        try {
+            return new LongInputStreamDwrf(
+                    new OrcInputStream(
+                            orcDataSourceId,
+                            sliceInput,
+                            createOrcDecompressor(orcDataSourceId, compression, bufferSize),
+                            newSimpleAggregatedMemoryContext(),
+                            sliceInput.getRetainedSize()),
+                    OrcTypeKind.LONG,
+                    signed,
+                    true);
+        }
+        catch (OrcCorruptionException e) {
+            throw new UncheckedIOException("Unable to create LongInputStream from LongOutputStream", e);
+        }
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.orc.stream;
 
+import com.facebook.presto.orc.ChainedSliceLoader;
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamV2Checkpoint;
@@ -20,13 +23,18 @@ import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.ChunkedSliceInput;
+import io.airlift.slice.FixedLengthSliceInput;
 import io.airlift.slice.SizeOf;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.stream.LongOutputStreamV2.SerializationUtils.encodeBitWidth;
 import static com.facebook.presto.orc.stream.LongOutputStreamV2.SerializationUtils.findClosestNumBits;
 import static com.facebook.presto.orc.stream.LongOutputStreamV2.SerializationUtils.getClosestAlignedFixedBits;
@@ -60,6 +68,8 @@ public class LongOutputStreamV2
     private static final int MAX_SHORT_REPEAT_LENGTH = 10;
 
     private final StreamKind streamKind;
+    private final CompressionKind compression;
+    private final int bufferSize;
     private final OrcOutputBuffer buffer;
     private final List<LongStreamCheckpoint> checkpoints = new ArrayList<>();
 
@@ -91,6 +101,8 @@ public class LongOutputStreamV2
     public LongOutputStreamV2(CompressionKind compression, int bufferSize, boolean signed, StreamKind streamKind)
     {
         this.streamKind = requireNonNull(streamKind, "streamKind is null");
+        this.compression = requireNonNull(compression, "compression is null");
+        this.bufferSize = bufferSize;
         this.buffer = new OrcOutputBuffer(compression, bufferSize);
         this.signed = signed;
     }
@@ -750,6 +762,29 @@ public class LongOutputStreamV2
     public StreamDataOutput getStreamDataOutput(int column)
     {
         return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+    }
+
+    @Override
+    public LongInputStream getLongInputStream()
+    {
+        checkState(closed);
+
+        FixedLengthSliceInput sliceInput = new ChunkedSliceInput(new ChainedSliceLoader(buffer.getCompressedSlices()), 32 * 1024);
+        OrcDataSourceId orcDataSourceId = new OrcDataSourceId("LongOutputStream");
+        try {
+            return new LongInputStreamV2(
+                    new OrcInputStream(
+                            orcDataSourceId,
+                            sliceInput,
+                            createOrcDecompressor(orcDataSourceId, compression, bufferSize),
+                            newSimpleAggregatedMemoryContext(),
+                            sliceInput.getRetainedSize()),
+                    signed,
+                    false);
+        }
+        catch (OrcCorruptionException e) {
+            throw new UncheckedIOException("Unable to create LongInputStream from LongOutputStream", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
When writing dictionary encoded columns, the ORC write estimates
the buffered size based on (1) estimated index bytes per entry,
and (2) number of entries.

However, this doesn't account for the compression, which can be
very efficient when the dictionary indices are highly skewed.
For an extreme example, thinking about dictionary has 1M entires,
yet one value appeared all the time, while all the other (1M - 1)
entires only appeared once.

We have observed written stripe size is only 10M ~ 20M when the
estimated stripe size is full at 64MB for real workloads..

This commit makes SliceDictionaryColumnWriter also writes the
dictionary index to a temporary data stream, and use the buffered
size of that stream to estimate stripe size.

Note the uncompressed dictionary IDs can be too large to store in
memory. Thus we uncompress and read the dictionary ids from the
temporary data stream.