### PR TITLE
Add a cluster memory leak detector

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryLeakDetector.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryLeakDetector.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.QueryState;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import org.joda.time.DateTime;
+import org.weakref.jmx.Managed;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.joda.time.Seconds.secondsBetween;
+
+public class ClusterMemoryLeakDetector
+{
+    private static final Logger log = Logger.get(ClusterMemoryLeakDetector.class);
+
+    // It may take some time to remove a query's memory reservations from the worker nodes,
+    // that's why we check to see whether some time has passed after the query end time to claim that
+    // a query is leaked.
+    private static final long DEFAULT_LEAK_CLAIM_DELTA_SECONDS = 60;
+
+    private final ClusterMemoryManager clusterMemoryManager;
+    private final QueryManager queryManager;
+    private final AtomicInteger numberOfLeakedQueries = new AtomicInteger();
+    private final ScheduledExecutorService leakDetectorScheduler = newSingleThreadScheduledExecutor(daemonThreadsNamed("cluster-leak-detector"));
+
+    @Inject
+    public ClusterMemoryLeakDetector(ClusterMemoryManager clusterMemoryManager, QueryManager queryManager)
+    {
+        this.clusterMemoryManager = requireNonNull(clusterMemoryManager, "clusterMemoryManager is null");
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        leakDetectorScheduler.scheduleWithFixedDelay(this::run, 0, 60, SECONDS);
+    }
+
+    private void run()
+    {
+        try {
+            checkForMemoryLeaks(DEFAULT_LEAK_CLAIM_DELTA_SECONDS);
+        }
+        catch (Throwable e) {
+            log.error(e, "Error checking for memory leaks");
+        }
+    }
+
+    @PreDestroy
+    public void shutdown()
+    {
+        leakDetectorScheduler.shutdownNow();
+    }
+
+    @VisibleForTesting
+    void checkForMemoryLeaks(long leakClaimDeltaSeconds)
+    {
+        // A query is considered leaked if it has a memory reservation on some worker and it is currently not running.
+        ClusterMemoryPool generalPool = clusterMemoryManager.getPools().get(GENERAL_POOL);
+        Map<QueryId, Long> queryMemoryReservations = generalPool.getQueryMemoryReservations();
+        ImmutableMap.Builder<QueryId, Long> leakedQueriesBuilder = ImmutableMap.builder();
+        for (Entry<QueryId, Long> reservation : queryMemoryReservations.entrySet()) {
+            if (isQueryLeaked(reservation.getKey(), leakClaimDeltaSeconds)) {
+                leakedQueriesBuilder.put(reservation.getKey(), reservation.getValue());
+            }
+        }
+        Map<QueryId, Long> leakedQueries = leakedQueriesBuilder.build();
+        numberOfLeakedQueries.set(leakedQueries.size());
+        if (!leakedQueries.isEmpty()) {
+            log.warn("Memory leak detected. The following queries have already finished, but they still have memory reservations on some worker node(s): %s", leakedQueries);
+        }
+    }
+
+    private boolean isQueryLeaked(QueryId queryId, long leakClaimDeltaSeconds)
+    {
+        List<QueryInfo> allQueries = queryManager.getAllQueryInfo();
+        boolean queryExists = false;
+        QueryState queryState = null;
+        DateTime queryEndTime = null;
+        for (QueryInfo queryInfo : allQueries) {
+            if (queryInfo.getQueryId().equals(queryId)) {
+                queryExists = true;
+                queryState = queryInfo.getState();
+                queryEndTime = queryInfo.getQueryStats().getEndTime();
+            }
+        }
+
+        // If the query doesn't exist anymore on the coordinator we just claim that it's leaked.
+        if (!queryExists) {
+            return true;
+        }
+
+        // If the query is still running it's not leaked.
+        if (queryState.equals(RUNNING)) {
+            return false;
+        }
+
+        // If the query exists and it's not running anymore we check the query end time.
+        if (secondsBetween(queryEndTime, DateTime.now()).getSeconds() >= leakClaimDeltaSeconds) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * When a query is completed it may take some time for the query to be removed from all the worker
+     * memory reservations, so what really matters is the steady state value of this counter.
+     */
+    @Managed
+    public int getNumberOfLeakedQueries()
+    {
+        return numberOfLeakedQueries.get();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -25,7 +25,6 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.memory.MemoryPoolInfo;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -360,7 +359,6 @@ public class ClusterMemoryManager
         }
     }
 
-    @VisibleForTesting
     synchronized Map<MemoryPoolId, ClusterMemoryPool> getPools()
     {
         return ImmutableMap.copyOf(pools);

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -54,6 +54,7 @@ import com.facebook.presto.execution.scheduler.AllAtOnceExecutionPolicy;
 import com.facebook.presto.execution.scheduler.ExecutionPolicy;
 import com.facebook.presto.execution.scheduler.PhasedExecutionPolicy;
 import com.facebook.presto.execution.scheduler.SplitSchedulerStats;
+import com.facebook.presto.memory.ClusterMemoryLeakDetector;
 import com.facebook.presto.memory.ClusterMemoryManager;
 import com.facebook.presto.memory.ForMemoryManager;
 import com.facebook.presto.memory.LowMemoryKiller;
@@ -174,6 +175,10 @@ public class CoordinatorModule
         bindLowMemoryKiller(LowMemoryKillerPolicy.TOTAL_RESERVATION, TotalReservationLowMemoryKiller.class);
         bindLowMemoryKiller(LowMemoryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES, TotalReservationOnBlockedNodesLowMemoryKiller.class);
         newExporter(binder).export(ClusterMemoryManager.class).withGeneratedName();
+
+        // cluster leak detector
+        binder.bind(ClusterMemoryLeakDetector.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(ClusterMemoryLeakDetector.class).withGeneratedName();
 
         // cluster statistics
         jaxrsBinder(binder).bind(ClusterStatsResource.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -21,6 +21,7 @@ import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.TaskManager;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.memory.ClusterMemoryLeakDetector;
 import com.facebook.presto.memory.ClusterMemoryManager;
 import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.metadata.AllNodes;
@@ -115,6 +116,7 @@ public class TestingPrestoServer
     private final SplitManager splitManager;
     private final NodePartitioningManager nodePartitioningManager;
     private final ClusterMemoryManager clusterMemoryManager;
+    private final ClusterMemoryLeakDetector clusterMemoryLeakDetector;
     private final LocalMemoryManager localMemoryManager;
     private final InternalNodeManager nodeManager;
     private final ServiceSelectorManager serviceSelectorManager;
@@ -264,11 +266,13 @@ public class TestingPrestoServer
             resourceGroupManager = Optional.of((InternalResourceGroupManager) injector.getInstance(ResourceGroupManager.class));
             nodePartitioningManager = injector.getInstance(NodePartitioningManager.class);
             clusterMemoryManager = injector.getInstance(ClusterMemoryManager.class);
+            clusterMemoryLeakDetector = injector.getInstance(ClusterMemoryLeakDetector.class);
         }
         else {
             resourceGroupManager = Optional.empty();
             nodePartitioningManager = null;
             clusterMemoryManager = null;
+            clusterMemoryLeakDetector = null;
         }
         localMemoryManager = injector.getInstance(LocalMemoryManager.class);
         nodeManager = injector.getInstance(InternalNodeManager.class);
@@ -405,6 +409,12 @@ public class TestingPrestoServer
     {
         checkState(coordinator, "not a coordinator");
         return clusterMemoryManager;
+    }
+
+    public ClusterMemoryLeakDetector getClusterMemoryLeakDetector()
+    {
+        checkState(coordinator, "not a coordinator");
+        return clusterMemoryLeakDetector;
     }
 
     public GracefulShutdownHandler getGracefulShutdownHandler()

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.TestQueryRunnerUtil;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.SettableFuture;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static com.facebook.presto.execution.QueryState.FAILED;
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.cancelQuery;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.createQuery;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.waitForQueryState;
+import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestClusterMemoryLeakDetector
+{
+    @Test(timeOut = 30_000)
+    public void testLeakDetector()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = TestQueryRunnerUtil.createQueryRunner()) {
+            TestingPrestoServer worker = queryRunner.getServers().get(0);
+            MemoryPool generalPool = worker.getLocalMemoryManager().getPool(LocalMemoryManager.GENERAL_POOL);
+            ClusterMemoryLeakDetector leakDetector = queryRunner.getCoordinator().getClusterMemoryLeakDetector();
+
+            Session testSession = testSessionBuilder()
+                    .setCatalog("tpch")
+                    .setSchema("sf100000")
+                    .setSource("test")
+                    .setClientTags(ImmutableSet.of())
+                    .setResourceEstimates(null)
+                    .build();
+
+            // start a long running query
+            QueryId queryId = createQuery(queryRunner, testSession, "SELECT COUNT(*) FROM lineitem");
+
+            // reserve some memory, the query won't be able to release it so effectively this is a leak
+            generalPool.reserve(queryId, 1L);
+
+            // wait for the query to start
+            waitForQueryState(queryRunner, queryId, RUNNING);
+
+            // wait until the cluster-level memory pools are updated
+            waitUntilQueryMemoryReservationIsObserved(queryRunner, queryId);
+
+            // at this point the leak detector should report no leaked queries as the query is still running
+            leakDetector.checkForMemoryLeaks(0L);
+            assertEquals(leakDetector.getNumberOfLeakedQueries(), 0);
+
+            // kill the query
+            cancelQuery(queryRunner, queryId);
+            waitForQueryState(queryRunner, queryId, FAILED);
+
+            // at this point the leak detector should report exactly one leaked query
+            leakDetector.checkForMemoryLeaks(0L);
+            assertEquals(leakDetector.getNumberOfLeakedQueries(), 1);
+
+            // free the leaked memory
+            generalPool.free(queryId, 1L);
+
+            // wait until the cluster-level memory pools observe the previous free operation
+            waitUntilAllMemoryReservationsAreFreed(queryRunner);
+
+            // at this point the leak detector should report no leaked queries
+            leakDetector.checkForMemoryLeaks(0L);
+            assertEquals(leakDetector.getNumberOfLeakedQueries(), 0);
+        }
+    }
+
+    private void waitUntilQueryMemoryReservationIsObserved(DistributedQueryRunner queryRunner, QueryId queryId)
+            throws InterruptedException, ExecutionException
+    {
+        SettableFuture<Void> clusterMemoryPoolsUpdated = SettableFuture.create();
+        ClusterMemoryManager clusterMemoryManager = queryRunner.getCoordinator().getClusterMemoryManager();
+        clusterMemoryManager.addChangeListener(GENERAL_POOL, (memoryPoolInfo) -> {
+            if (memoryPoolInfo.getQueryMemoryReservations().containsKey(queryId)) {
+                clusterMemoryPoolsUpdated.set(null);
+            }
+        });
+        clusterMemoryPoolsUpdated.get();
+    }
+
+    private void waitUntilAllMemoryReservationsAreFreed(DistributedQueryRunner queryRunner)
+            throws InterruptedException, ExecutionException
+    {
+        SettableFuture<Void> clusterMemoryPoolsUpdated = SettableFuture.create();
+        ClusterMemoryManager clusterMemoryManager = queryRunner.getCoordinator().getClusterMemoryManager();
+        clusterMemoryManager.addChangeListener(GENERAL_POOL, (memoryPoolInfo) -> {
+            if (memoryPoolInfo.getQueryMemoryReservations().size() == 0) {
+                clusterMemoryPoolsUpdated.set(null);
+            }
+        });
+        clusterMemoryPoolsUpdated.get();
+    }
+}


### PR DESCRIPTION
A query is reported as leaked if it doesn't exist in the list
of queries that the coordinator knows about, or if it exists and 
60s has passed since the query finished. The leak detector prints 
the ID and the memory reservation of the leaked queries, and also 
exposes a JMX counter for the number of leaked queries.