### PR TITLE
Fix approx_distinct(NULL)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregation.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.operator.aggregation.state.HyperLogLogState;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.AggregationState;
@@ -43,6 +44,16 @@ public final class ApproximateCountDistinctAggregation
     private static final double HIGHEST_MAX_STANDARD_ERROR = 0.26000;
 
     private ApproximateCountDistinctAggregation() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState HyperLogLogState state,
+            @BlockPosition @SqlType("unknown") Block block,
+            @BlockIndex int index,
+            @SqlType(StandardTypes.DOUBLE) double maxStandardError)
+    {
+        // do nothing
+    }
 
     @InputFunction
     @TypeParameter("T")

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.aggregation;
 
 import com.facebook.presto.operator.aggregation.state.HyperLogLogState;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.AggregationState;
@@ -36,6 +37,15 @@ public final class DefaultApproximateCountDistinctAggregation
     private static final double DEFAULT_STANDARD_ERROR = 0.023;
 
     private DefaultApproximateCountDistinctAggregation() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState HyperLogLogState state,
+            @BlockPosition @SqlType("unknown") Block block,
+            @BlockIndex int index)
+    {
+        // do nothing
+    }
 
     @InputFunction
     @TypeParameter("T")

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -660,6 +660,10 @@ public abstract class AbstractTestAggregations
     @Test
     public void testApproximateCountDistinct()
     {
+        // test NULL
+        assertQuery("SELECT approx_distinct(NULL)", "SELECT 0");
+        assertQuery("SELECT approx_distinct(NULL, 0.023)", "SELECT 0");
+
         // test date
         assertQuery("SELECT approx_distinct(orderdate) FROM orders", "SELECT 2443");
         assertQuery("SELECT approx_distinct(orderdate, 0.023) FROM orders", "SELECT 2443");


### PR DESCRIPTION
Explicitly support `UNKNOWN` type in approximate count distinct
implementation.