### PR TITLE
Add FunctionManager, FunctionNamespace, and FunctionHandle

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionHandle.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public final class FunctionHandle
+{
+    private final Signature signature;
+    private final String catalog;
+    private final String schema;
+
+    @JsonCreator
+    public FunctionHandle(
+            @JsonProperty("signature") Signature signature,
+            @JsonProperty("catalog") String catalog,
+            @JsonProperty("schema") String schema)
+    {
+        this.signature = requireNonNull(signature, "signature is null");
+        this.catalog = requireNonNull(catalog, "catalog is null");
+        this.schema = requireNonNull(schema, "schema is null");
+    }
+
+    @JsonProperty
+    public Signature getSignature()
+    {
+        return signature;
+    }
+
+    @JsonProperty
+    public String getCatalog()
+    {
+        return catalog;
+    }
+
+    @JsonProperty
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(signature, catalog, schema);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        FunctionHandle other = (FunctionHandle) obj;
+        return Objects.equals(this.signature, other.signature) &&
+                Objects.equals(this.catalog, other.catalog) &&
+                Objects.equals(this.schema, other.schema);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("signature", signature)
+                .add("catalog", catalog)
+                .add("schema", schema)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
+import com.facebook.presto.operator.window.WindowFunctionSupplier;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.sql.SqlPathElement;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.metadata.FunctionUtils.createOperatorHandle;
+import static com.facebook.presto.metadata.FunctionUtils.isOperator;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class FunctionManager
+{
+    private static final String TEMP_DEFAULT_CATALOG = "system";
+    private static final String TEMP_DEFAULT_SCHEMA = "functions";
+
+    private volatile Map<String, FunctionNamespace> functionNamespaces;
+    private final FunctionNamespace operatorNamespace;
+    private final TypeManager typeManager;
+    private final BlockEncodingSerde blockEncodingSerde;
+    private final FeaturesConfig featuresConfig;
+
+    public FunctionManager(TypeManager typeManager, BlockEncodingSerde blockEncodingSerde, FeaturesConfig featuresConfig)
+    {
+        functionNamespaces = ImmutableMap.of();
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
+        this.featuresConfig = requireNonNull(featuresConfig, "featuresConfig is null");
+        operatorNamespace = new StaticFunctionNamespace(typeManager, blockEncodingSerde, featuresConfig);
+    }
+
+    public void addFunctions(List<? extends SqlFunction> functions)
+    {
+        addFunctions(TEMP_DEFAULT_CATALOG, functions);
+    }
+
+    public synchronized void addFunctions(String catalog, List<? extends SqlFunction> functions)
+    {
+        Map<Boolean, List<SqlFunction>> operatorAndFunctionMap = functions.stream()
+                .collect(Collectors.partitioningBy(function -> isOperator(function.getSignature())));
+
+        operatorNamespace.addFunctions(operatorAndFunctionMap.get(true));
+
+        if (!functionNamespaces.containsKey(catalog)) {
+            FunctionNamespace namespace = new StaticFunctionNamespace(typeManager, blockEncodingSerde, featuresConfig);
+            namespace.addFunctions(operatorAndFunctionMap.get(false));
+            functionNamespaces = ImmutableMap.<String, FunctionNamespace>builder()
+                    .putAll(functionNamespaces)
+                    .put(catalog, namespace)
+                    .build();
+        }
+        else {
+            functionNamespaces.get(catalog).addFunctions(operatorAndFunctionMap.get(false));
+        }
+    }
+
+    public List<SqlFunction> list(Session session)
+    {
+        ImmutableList.Builder<SqlFunction> builder = ImmutableList.builder();
+        builder.addAll(operatorNamespace.list());
+        for (SqlPathElement element : session.getPath().getParsedPath()) {
+            FunctionNamespace namespace = functionNamespaces.get(getCatalog(element, session));
+            if (namespace != null) {
+                builder.addAll(namespace.list());
+            }
+        }
+        return builder.build();
+    }
+
+    public FunctionHandle resolveFunction(Session session, QualifiedName name, List<TypeSignatureProvider> parameterTypes)
+    {
+        try {
+            Signature operatorSignature = operatorNamespace.resolveFunction(name, parameterTypes);
+            return createOperatorHandle(operatorSignature);
+        }
+        catch (Exception e) {
+            //do nothing and try to resolve the function using the path
+        }
+        for (SqlPathElement element : session.getPath().getParsedPath()) {
+            FunctionNamespace namespace = functionNamespaces.get(getCatalog(element, session));
+            if (namespace != null) {
+                try {
+                    Signature signature = namespace.resolveFunction(name, parameterTypes);
+                    return new FunctionHandle(signature, getCatalog(element, session), TEMP_DEFAULT_SCHEMA);
+                }
+                catch (PrestoException e) {
+                    if (!e.getErrorCode().equals(FUNCTION_NOT_FOUND.toErrorCode())) {
+                        throw e;
+                    }
+                }
+            }
+        }
+        throw new PrestoException(FUNCTION_NOT_FOUND, format("Function %s not found in path: %s", name, session.getPath()));
+    }
+
+    public WindowFunctionSupplier getWindowFunctionImplementation(FunctionHandle handle)
+    {
+        if (operatorNamespace.isRegistered(handle.getSignature())) {
+            return operatorNamespace.getWindowFunctionImplementation(handle.getSignature());
+        }
+        return functionNamespaces.get(handle.getCatalog()).getWindowFunctionImplementation(handle.getSignature());
+    }
+
+    public InternalAggregationFunction getAggregateFunctionImplementation(FunctionHandle handle)
+    {
+        if (operatorNamespace.isRegistered(handle.getSignature())) {
+            return operatorNamespace.getAggregateFunctionImplementation(handle.getSignature());
+        }
+        return functionNamespaces.get(handle.getCatalog()).getAggregateFunctionImplementation(handle.getSignature());
+    }
+
+    public ScalarFunctionImplementation getScalarFunctionImplementation(FunctionHandle handle)
+    {
+        if (operatorNamespace.isRegistered(handle.getSignature())) {
+            return operatorNamespace.getScalarFunctionImplementation(handle.getSignature());
+        }
+        return functionNamespaces.get(handle.getCatalog()).getScalarFunctionImplementation(handle.getSignature());
+    }
+
+    public boolean canResolveOperator(OperatorType operatorType, Type returnType, List<? extends Type> argumentTypes)
+    {
+        return operatorNamespace.canResolveOperator(operatorType, returnType, argumentTypes);
+    }
+
+    public boolean isRegistered(FunctionHandle handle)
+    {
+        if (operatorNamespace.isRegistered(handle.getSignature())) {
+            return true;
+        }
+        return functionNamespaces.get(handle.getCatalog()).isRegistered(handle.getSignature());
+    }
+
+    public FunctionHandle resolveOperator(OperatorType operatorType, List<? extends Type> argumentTypes)
+            throws OperatorNotFoundException
+    {
+        try {
+            Signature signature = operatorNamespace.resolveOperator(operatorType, argumentTypes);
+            return createOperatorHandle(signature);
+        }
+        catch (PrestoException e) {
+            if (!(e instanceof OperatorNotFoundException)) {
+                throw e;
+            }
+        }
+        throw new OperatorNotFoundException(
+                operatorType,
+                argumentTypes.stream()
+                        .map(Type::getTypeSignature)
+                        .collect(toImmutableList()));
+    }
+
+    public FunctionHandle getCoercion(Type fromType, Type toType)
+    {
+        return getCoercion(fromType.getTypeSignature(), toType.getTypeSignature());
+    }
+
+    public FunctionHandle getCoercion(TypeSignature fromType, TypeSignature toType)
+    {
+        try {
+            Signature signature = operatorNamespace.getCoercion(fromType, toType);
+            return createOperatorHandle(signature);
+        }
+        catch (PrestoException e) {
+            if (!(e instanceof OperatorNotFoundException)) {
+                throw e;
+            }
+        }
+        throw new OperatorNotFoundException(OperatorType.CAST, ImmutableList.of(fromType), toType);
+    }
+
+    private String getCatalog(SqlPathElement pathElement, Session session)
+    {
+        if (pathElement.getCatalog().isPresent()) {
+            return pathElement.getCatalog().get().getValue();
+        }
+        if (session.getCatalog().isPresent()) {
+            return session.getCatalog().get();
+        }
+        throw new PrestoException(NOT_FOUND, format("Catalog not found in path element %s and not set in session %s", pathElement, session));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionNamespace.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionNamespace.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
+import com.facebook.presto.operator.window.WindowFunctionSupplier;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
+import com.facebook.presto.sql.tree.QualifiedName;
+
+import java.util.List;
+
+public interface FunctionNamespace
+{
+    void addFunctions(List<? extends SqlFunction> functions);
+
+    List<SqlFunction> list();
+
+    Signature resolveFunction(QualifiedName name, List<TypeSignatureProvider> parameterTypes);
+
+    WindowFunctionSupplier getWindowFunctionImplementation(Signature signature);
+
+    InternalAggregationFunction getAggregateFunctionImplementation(Signature signature);
+
+    ScalarFunctionImplementation getScalarFunctionImplementation(Signature signature);
+
+    boolean canResolveOperator(OperatorType operatorType, Type returnType, List<? extends Type> argumentTypes);
+
+    boolean isRegistered(Signature signature);
+
+    Signature resolveOperator(OperatorType operatorType, List<? extends Type> argumentTypes)
+            throws OperatorNotFoundException;
+
+    Signature getCoercion(Type fromType, Type toType);
+
+    Signature getCoercion(TypeSignature fromType, TypeSignature toType);
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+
+public class FunctionUtils
+{
+    private static final String OPERATOR_PREFIX = "$operator$";
+
+    private FunctionUtils()
+    {
+    }
+
+    public static boolean isOperator(Signature signature)
+    {
+        return signature.getName().startsWith(OPERATOR_PREFIX);
+    }
+
+    public static FunctionHandle createOperatorHandle(Signature signature)
+    {
+        checkArgument(isOperator(signature), "signature is not an operator signature");
+        //catalog and schema values specified are not used - only specified for debugging purposes
+        return new FunctionHandle(signature, format("%scatalog", OPERATOR_PREFIX), format("%sschema", OPERATOR_PREFIX));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
+import com.facebook.presto.operator.window.WindowFunctionSupplier;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
+import com.facebook.presto.sql.tree.QualifiedName;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.List;
+
+@ThreadSafe
+public class StaticFunctionNamespace
+        implements FunctionNamespace
+{
+    private final FunctionRegistry functionRegistry;
+
+    public StaticFunctionNamespace(TypeManager typeManager, BlockEncodingSerde blockEncodingSerde, FeaturesConfig featuresConfig)
+    {
+        functionRegistry = new FunctionRegistry(typeManager, blockEncodingSerde, featuresConfig);
+    }
+
+    public void addFunctions(List<? extends SqlFunction> functions)
+    {
+        functionRegistry.addFunctions(functions);
+    }
+
+    public List<SqlFunction> list()
+    {
+        return functionRegistry.list();
+    }
+
+    public Signature resolveFunction(QualifiedName name, List<TypeSignatureProvider> parameterTypes)
+    {
+        return functionRegistry.resolveFunction(name, parameterTypes);
+    }
+
+    public WindowFunctionSupplier getWindowFunctionImplementation(Signature signature)
+    {
+        return functionRegistry.getWindowFunctionImplementation(signature);
+    }
+
+    public InternalAggregationFunction getAggregateFunctionImplementation(Signature signature)
+    {
+        return functionRegistry.getAggregateFunctionImplementation(signature);
+    }
+
+    public ScalarFunctionImplementation getScalarFunctionImplementation(Signature signature)
+    {
+        return functionRegistry.getScalarFunctionImplementation(signature);
+    }
+
+    public boolean canResolveOperator(OperatorType operatorType, Type returnType, List<? extends Type> argumentTypes)
+    {
+        return functionRegistry.canResolveOperator(operatorType, returnType, argumentTypes);
+    }
+
+    public boolean isRegistered(Signature signature)
+    {
+        return functionRegistry.isRegistered(signature);
+    }
+
+    public Signature resolveOperator(OperatorType operatorType, List<? extends Type> argumentTypes)
+            throws OperatorNotFoundException
+    {
+        return functionRegistry.resolveOperator(operatorType, argumentTypes);
+    }
+
+    public Signature getCoercion(Type fromType, Type toType)
+    {
+        return functionRegistry.getCoercion(fromType, toType);
+    }
+
+    public Signature getCoercion(TypeSignature fromType, TypeSignature toType)
+    {
+        return functionRegistry.getCoercion(fromType, toType);
+    }
+}


### PR DESCRIPTION
Some context:

These classes are the basis for changes to move away from the FunctionRegistry and onto the newly-created FunctionManager to allow for function namespaces and path-based resolution of functions. When the refactor occurs, all external references to the FunctionRegistry will instead refer to FunctionManager or FunctionUtils (which also may end up being moved into FunctionManager - pending discussion about that).

The follow-up PR to this will:
- Add a default path to SqlEnvironmentConfig (and add default catalog/schema).
- Move registration of default functions and operators from FunctionRegistry to FunctionManager.
- Refactor all references to static method calls in FunctionRegistry to FunctionUtils.
- Refactor all other references to anything in FunctionRegistry to FunctionManager.
- Rework parts of the code to store/utilize FunctionHandle instead of Signature. This won't be a total conversion until some syntax tree objects are converted to IR (outside the scope of this).
- Rework parts of the code to include the session (for path/session catalog) when making resolution calls to the FunctionRegistry.

There are several steps in the refactor that will change these classes:
- The default/built-in functions and operators which are currently registered in the FunctionRegistry will instead be registered in the FunctionManager under the default catalog and schema.
- FunctionUtils will be expanded to contain all public static methods currently present within the FunctionRegistry.
- The temporary default catalog and schema will be moved out of FunctionManager and into SqlEnvironmentConfig.

Following that, function configuration will be added. FunctionRegistry and StaticFunctionNamespace will be modified to include logic to work with schemas.