### PR TITLE
Canonicalize ValuesNode as it may contain correlated symbols

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -434,6 +434,13 @@ public final class ValidateDependenciesChecker
         @Override
         public Void visitValues(ValuesNode node, Set<Symbol> boundSymbols)
         {
+            Set<Symbol> correlatedDependencies = SymbolsExtractor.extractUnique(node);
+            checkDependencies(
+                    boundSymbols,
+                    correlatedDependencies,
+                    "Invalid node. Expression correlated dependencies (%s) not satisfied by (%s)",
+                    correlatedDependencies,
+                    boundSymbols);
             return null;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
@@ -182,6 +182,14 @@ public class TestSubqueries
     }
 
     @Test
+    public void testLateralWithUnnest()
+    {
+        assertions.assertFails(
+                "SELECT * FROM (VALUES ARRAY[1]) t(x), LATERAL (SELECT * FROM UNNEST(x))",
+                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+    }
+
+    @Test
     public void testCorrelatedScalarSubquery()
     {
         assertions.assertQuery(


### PR DESCRIPTION
Canonicalize ValuesNode as it may contain correlated symbols

Fixes #11047
