### PR TITLE
Optimizing DomainTranslator for translating InPredicate

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -910,6 +910,14 @@ public class TestDomainTranslator
     }
 
     @Test
+    public void testFromInPredicateWithFunctions()
+    {
+        assertUnsupportedPredicate(equal(
+                function("date", C_TIMESTAMP.toSymbolReference()),
+                toExpression(DATE_VALUE, DATE)));
+    }
+
+    @Test
     public void testFromBetweenPredicate()
     {
         assertPredicateTranslates(


### PR DESCRIPTION
When we convert a filter expression with a **IN** predicate to a **TupleDomain**, we first translate **IN** to a set of **OR** expressions and then process those **OR** expressions. But when we have a filter expression like  

`date(columnA) in (date '2018-11-10', date '2018-11-09') `

We will convert it to 

` date(columnA) = date '2018-11-10' or date(columnA) = date '2018-11-09'`

then when we process this **OR** expressions the TupleDomain which we get is `TupleDomain.all()` since TupleDomain doesn't support functions.

This patch checks InPredicate#getValue is an instance of Cast or SymbolReference or Literal expression , if not we will directly gives a `TupleDomain.all()` so we don't have to process the **OR** expressions created.