### PR TITLE
Allow LateralJoin rewrite to work with multiple projections

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -244,6 +244,12 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testCoercionWithExplicitPrecisionInCorrelatedSubquery()
+    {
+        assertQuery("SELECT 1 FROM nation n WHERE 1 = (SELECT cast(n.nationkey as decimal(7,2)))");
+    }
+
+    @Test
     public void testLambdaInAggregationContext()
     {
         assertQuery("SELECT apply(sum(x), i -> i * i) FROM (VALUES 1, 2, 3, 4, 5) t(x)", "SELECT 225");


### PR DESCRIPTION
Currently, we do not handle a rewrite of a LateralJoin which has multiple
projections in its subquery when transforming a correlated single row subquery
to Project. This leads to failure of queries such as ones containing coercions
with explicit precisions in the subquery. This commit removes that restriction

Fixes #11026