### PR TITLE
Make ClusterMemoryManager resilient to memory accounting leaks

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -26,6 +26,8 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.OptionalDouble;
 import java.util.Set;
@@ -276,6 +278,7 @@ public class QueryStats
         return lastHeartbeat;
     }
 
+    @Nullable
     @JsonProperty
     public DateTime getEndTime()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -595,9 +595,10 @@ public class SqlQueryManager
      */
     public void enforceMemoryLimits()
     {
-        memoryManager.process(queries.values().stream()
+        List<QueryExecution> runningQueries = queries.values().stream()
                 .filter(query -> query.getState() == RUNNING)
-                .collect(toImmutableList()));
+                .collect(toImmutableList());
+        memoryManager.process(runningQueries, () -> getAllQueryInfo());
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryLeakDetector.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryLeakDetector.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import io.airlift.log.Logger;
+import org.joda.time.DateTime;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+import static org.joda.time.DateTime.now;
+import static org.joda.time.Seconds.secondsBetween;
+
+@ThreadSafe
+public class ClusterMemoryLeakDetector
+{
+    private static final Logger log = Logger.get(ClusterMemoryLeakDetector.class);
+
+    // It may take some time to remove a query's memory reservations from the worker nodes, that's why
+    // we check to see whether some time has passed after the query finishes to claim that it is leaked.
+    private static final int DEFAULT_LEAK_CLAIM_DELTA_SEC = 60;
+
+    @GuardedBy("this")
+    private Set<QueryId> leakedQueries;
+
+    /**
+     * @param queryInfoSupplier All queries that the coordinator knows about.
+     * @param queryMemoryReservations The memory reservations of queries in the GENERAL cluster memory pool.
+     */
+    void checkForMemoryLeaks(Supplier<List<QueryInfo>> queryInfoSupplier, Map<QueryId, Long> queryMemoryReservations)
+    {
+        requireNonNull(queryInfoSupplier);
+        requireNonNull(queryMemoryReservations);
+
+        Map<QueryId, QueryInfo> queryIdToInfo = Maps.uniqueIndex(queryInfoSupplier.get(), QueryInfo::getQueryId);
+
+        Map<QueryId, Long> leakedQueryReservations = queryMemoryReservations.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() > 0)
+                .filter(entry -> isLeaked(queryIdToInfo, entry.getKey()))
+                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+
+        if (!leakedQueryReservations.isEmpty()) {
+            log.warn("Memory leak detected. The following queries are already finished, " +
+                    "but they have memory reservations on some worker node(s): %s", leakedQueryReservations);
+        }
+
+        synchronized (this) {
+            leakedQueries = ImmutableSet.copyOf(leakedQueryReservations.keySet());
+        }
+    }
+
+    private static boolean isLeaked(Map<QueryId, QueryInfo> queryIdToInfo, QueryId queryId)
+    {
+        QueryInfo queryInfo = queryIdToInfo.get(queryId);
+
+        if (queryInfo == null) {
+            return true;
+        }
+
+        DateTime queryEndTime = queryInfo.getQueryStats().getEndTime();
+
+        if (queryInfo.getState() == RUNNING || queryEndTime == null) {
+            return false;
+        }
+
+        return secondsBetween(queryEndTime, now()).getSeconds() >= DEFAULT_LEAK_CLAIM_DELTA_SEC;
+    }
+
+    synchronized boolean wasQueryPossiblyLeaked(QueryId queryId)
+    {
+        return leakedQueries.contains(queryId);
+    }
+
+    synchronized int getNumberOfLeakedQueries()
+    {
+        return leakedQueries.size();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
@@ -130,12 +130,12 @@ public class ClusterMemoryPool
 
     public synchronized Map<QueryId, Long> getQueryMemoryReservations()
     {
-        return queryMemoryReservations;
+        return ImmutableMap.copyOf(queryMemoryReservations);
     }
 
     public synchronized Map<QueryId, Long> getQueryMemoryRevocableReservations()
     {
-        return queryMemoryRevocableReservations;
+        return ImmutableMap.copyOf(queryMemoryRevocableReservations);
     }
 
     public synchronized void update(List<MemoryInfo> memoryInfos, int assignedQueries)

--- a/presto-main/src/main/java/com/facebook/presto/memory/LowMemoryKiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/LowMemoryKiller.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 public interface LowMemoryKiller
 {
-    Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> queries, List<MemoryInfo> nodes);
+    Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes);
 
     class QueryMemoryInfo
     {

--- a/presto-main/src/main/java/com/facebook/presto/memory/NoneLowMemoryKiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/NoneLowMemoryKiller.java
@@ -23,7 +23,7 @@ public class NoneLowMemoryKiller
         implements LowMemoryKiller
 {
     @Override
-    public Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> queries, List<MemoryInfo> nodes)
+    public Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes)
     {
         return Optional.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/memory/TotalReservationLowMemoryKiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/TotalReservationLowMemoryKiller.java
@@ -25,11 +25,11 @@ public class TotalReservationLowMemoryKiller
         implements LowMemoryKiller
 {
     @Override
-    public Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> queries, List<MemoryInfo> nodes)
+    public Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes)
     {
         QueryId biggestQuery = null;
         long maxMemory = 0;
-        for (QueryMemoryInfo query : queries) {
+        for (QueryMemoryInfo query : runningQueries) {
             long bytesUsed = query.getMemoryReservation();
             if (bytesUsed > maxMemory && GENERAL_POOL.equals(query.getMemoryPoolId())) {
                 biggestQuery = query.getQueryId();

--- a/presto-main/src/main/java/com/facebook/presto/memory/TotalReservationOnBlockedNodesLowMemoryKiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/TotalReservationOnBlockedNodesLowMemoryKiller.java
@@ -29,7 +29,7 @@ public class TotalReservationOnBlockedNodesLowMemoryKiller
         implements LowMemoryKiller
 {
     @Override
-    public Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> queries, List<MemoryInfo> nodes)
+    public Optional<QueryId> chooseQueryToKill(List<QueryMemoryInfo> runningQueries, List<MemoryInfo> nodes)
     {
         Map<QueryId, Long> memoryReservationOnBlockedNodes = new HashMap<>();
         for (MemoryInfo node : nodes) {

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.execution.QueryState;
+import com.facebook.presto.execution.QueryStats;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.execution.QueryState.FINISHED;
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
+import static com.facebook.presto.operator.BlockedReason.WAITING_FOR_MEMORY;
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class TestClusterMemoryLeakDetector
+{
+    @Test
+    public void testLeakDetector()
+    {
+        QueryId testQuery = new QueryId("test");
+        ClusterMemoryLeakDetector leakDetector = new ClusterMemoryLeakDetector();
+
+        leakDetector.checkForMemoryLeaks(() -> ImmutableList.of(), ImmutableMap.of());
+        assertEquals(leakDetector.getNumberOfLeakedQueries(), 0);
+
+        // the leak detector should report no leaked queries as the query is still running
+        leakDetector.checkForMemoryLeaks(() -> ImmutableList.of(createQueryInfo(testQuery.getId(), RUNNING)), ImmutableMap.of(testQuery, 1L));
+        assertEquals(leakDetector.getNumberOfLeakedQueries(), 0);
+
+        // the leak detector should report exactly one leaked query since the query is finished, and its end time is way in the past
+        leakDetector.checkForMemoryLeaks(() -> ImmutableList.of(createQueryInfo(testQuery.getId(), FINISHED)), ImmutableMap.of(testQuery, 1L));
+        assertEquals(leakDetector.getNumberOfLeakedQueries(), 1);
+
+        // the leak detector should report no leaked queries as the query doesn't have any memory reservation
+        leakDetector.checkForMemoryLeaks(() -> ImmutableList.of(createQueryInfo(testQuery.getId(), FINISHED)), ImmutableMap.of(testQuery, 0L));
+        assertEquals(leakDetector.getNumberOfLeakedQueries(), 0);
+
+        // the leak detector should report exactly one leaked query since the coordinator doesn't know of any query
+        leakDetector.checkForMemoryLeaks(() -> ImmutableList.of(), ImmutableMap.of(testQuery, 1L));
+        assertEquals(leakDetector.getNumberOfLeakedQueries(), 1);
+    }
+
+    private QueryInfo createQueryInfo(String queryId, QueryState state)
+    {
+        return new QueryInfo(
+                new QueryId(queryId),
+                TEST_SESSION.toSessionRepresentation(),
+                state,
+                GENERAL_POOL,
+                true,
+                URI.create("1"),
+                ImmutableList.of("2", "3"),
+                "",
+                new QueryStats(
+                        DateTime.parse("1991-09-06T05:00-05:30"),
+                        DateTime.parse("1991-09-06T05:01-05:30"),
+                        DateTime.parse("1991-09-06T05:02-05:30"),
+                        DateTime.parse("1991-09-06T06:00-05:30"),
+                        Duration.valueOf("8m"),
+                        Duration.valueOf("7m"),
+                        Duration.valueOf("34m"),
+                        Duration.valueOf("9m"),
+                        Duration.valueOf("10m"),
+                        Duration.valueOf("11m"),
+                        Duration.valueOf("12m"),
+                        13,
+                        14,
+                        15,
+                        100,
+                        17,
+                        18,
+                        34,
+                        19,
+                        20.0,
+                        DataSize.valueOf("21GB"),
+                        DataSize.valueOf("22GB"),
+                        DataSize.valueOf("23GB"),
+                        DataSize.valueOf("24GB"),
+                        DataSize.valueOf("25GB"),
+                        true,
+                        Duration.valueOf("23m"),
+                        Duration.valueOf("24m"),
+                        Duration.valueOf("25m"),
+                        Duration.valueOf("26m"),
+                        true,
+                        ImmutableSet.of(WAITING_FOR_MEMORY),
+                        DataSize.valueOf("27GB"),
+                        28,
+                        DataSize.valueOf("29GB"),
+                        30,
+                        DataSize.valueOf("31GB"),
+                        32,
+                        DataSize.valueOf("33GB"),
+                        ImmutableList.of(),
+                        ImmutableList.of()),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of(),
+                ImmutableSet.of(),
+                ImmutableMap.of(),
+                ImmutableSet.of(),
+                Optional.empty(),
+                false,
+                "33",
+                Optional.empty(),
+                null,
+                null,
+                ImmutableSet.of(),
+                Optional.empty(),
+                false,
+                Optional.empty());
+    }
+}


### PR DESCRIPTION
We have seen that if a finished query has non-zero memory reservation
on some worker (e.g., "leak") it will effectively disable the oom killer
as the lastKilledQuery will never be gone from the system
(isLastKilledQueryGone will return false). This change makes the
ClusterMemoryManager resilient to such memory leaks.

The change addds a ClusterMemoryLeakDetector and updates
ClusterMemoryManager to use the leak detector to determine whether the
lastKilledQuery has a leak, and if it has the ClusterMemoryManager
considers the lastKilledQuery as gone from the system, and continues
functioning as usual.