### PR TITLE
Fix memory leak in MemoryAwareQueryExecution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -107,7 +107,10 @@ public class ClusterMemoryManager
     private final AtomicLong clusterMemoryBytes = new AtomicLong();
     private final AtomicLong queriesKilledDueToOutOfMemory = new AtomicLong();
 
-    private final Map<QueryId, Long> preAllocations = new HashMap<>();
+    @GuardedBy("this")
+    public final Map<QueryId, Long> preAllocations = new HashMap<>();
+
+    @GuardedBy("this")
     private final Map<QueryId, Long> preAllocationsConsumed = new HashMap<>();
 
     @GuardedBy("this")


### PR DESCRIPTION
Previously, we would add a listener for state change *on* every state
change. This could also cause listeners to be added in a loop in
between failed state transitions. Fixes #10812.