### PR TITLE
Append original error message to thrift connector remote exception

### DIFF
--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/util/ThriftExceptions.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/util/ThriftExceptions.java
@@ -37,7 +37,7 @@ public final class ThriftExceptions
             throw new PrestoException(THRIFT_SERVICE_NO_AVAILABLE_HOSTS, e);
         }
         if ((e instanceof TApplicationException) || (e instanceof PrestoThriftServiceException)) {
-            return new PrestoException(THRIFT_SERVICE_GENERIC_REMOTE_ERROR, "Exception raised by remote Thrift server", e);
+            return new PrestoException(THRIFT_SERVICE_GENERIC_REMOTE_ERROR, "Exception raised by remote Thrift server: " + e.getMessage(), e);
         }
         if (e instanceof TException) {
             return new PrestoException(THRIFT_SERVICE_CONNECTION_ERROR, "Error communicating with remote Thrift server", e);


### PR DESCRIPTION
This PR append the original error message from the remote server to the generic remote server exception thrown in the thrift connector. In some application (e.g. command line interface), it's convenient to display server side customized error message to user.

For example, remote thrift server can fail a query because it expects filters on certain column in all queries. It's not very informative by just saying "Exception raised by remote server" in the error message.