### PR TITLE
Migrate TransformCorrelatedSingleRowSubqueryToProject to rule and allow it to work with multiple projections

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -324,6 +324,8 @@ public class PlanOptimizers
                         ImmutableList.of(
                                 new com.facebook.presto.sql.planner.optimizations.TransformCorrelatedSingleRowSubqueryToProject()),
                         ImmutableSet.of(
+                                new InlineProjections(),
+                                new RemoveRedundantIdentityProjections(),
                                 new TransformCorrelatedSingleRowSubqueryToProject())),
                 new CheckSubqueryNodesAreRewritten(),
                 predicatePushDown,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -89,6 +89,7 @@ import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedInPredi
 import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedLateralJoinToJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedScalarAggregationToJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedScalarSubquery;
+import com.facebook.presto.sql.planner.iterative.rule.TransformCorrelatedSingleRowSubqueryToProject;
 import com.facebook.presto.sql.planner.iterative.rule.TransformExistsApplyToLateralNode;
 import com.facebook.presto.sql.planner.iterative.rule.TransformSpatialPredicates;
 import com.facebook.presto.sql.planner.iterative.rule.TransformUncorrelatedInPredicateSubqueryToSemiJoin;
@@ -110,7 +111,6 @@ import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.StatsRecordingPlanOptimizer;
-import com.facebook.presto.sql.planner.optimizations.TransformCorrelatedSingleRowSubqueryToProject;
 import com.facebook.presto.sql.planner.optimizations.TransformQuantifiedComparisonApplyToLateralJoin;
 import com.facebook.presto.sql.planner.optimizations.UnaliasSymbolReferences;
 import com.facebook.presto.sql.planner.optimizations.WindowFilterPushDown;
@@ -317,7 +317,14 @@ public class PlanOptimizers
                                 new TransformCorrelatedScalarSubquery(), // must be run after TransformCorrelatedScalarAggregationToJoin
                                 new TransformCorrelatedLateralJoinToJoin(),
                                 new ImplementFilteredAggregations())),
-                new TransformCorrelatedSingleRowSubqueryToProject(),
+                new IterativeOptimizer(
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableList.of(
+                                new com.facebook.presto.sql.planner.optimizations.TransformCorrelatedSingleRowSubqueryToProject()),
+                        ImmutableSet.of(
+                                new TransformCorrelatedSingleRowSubqueryToProject())),
                 new CheckSubqueryNodesAreRewritten(),
                 predicatePushDown,
                 new IterativeOptimizer(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedSingleRowSubqueryToProject.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.LateralJoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.ValuesNode;
+
+import java.util.List;
+
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.plan.Patterns.lateralJoin;
+
+/**
+ * This optimizer can rewrite correlated single row subquery to projection in a way described here:
+ * From:
+ * <pre>
+ * - Lateral(with correlation list: [A, C])
+ *   - (input) plan which produces symbols: [A, B, C]
+ *   - (subquery)
+ *     - Project (A + C)
+ *       - single row VALUES()
+ * </pre>
+ * to:
+ * <pre>
+ *   - Project(A, B, C, A + C)
+ *       - (input) plan which produces symbols: [A, B, C]
+ * </pre>
+ */
+
+public class TransformCorrelatedSingleRowSubqueryToProject
+        implements Rule<LateralJoinNode>
+{
+    private static final Pattern<LateralJoinNode> PATTERN = lateralJoin();
+
+    @Override
+    public Pattern<LateralJoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(LateralJoinNode parent, Captures captures, Context context)
+    {
+        List<ValuesNode> values = searchFrom(parent.getSubquery(), context.getLookup())
+                .recurseOnlyWhen(ProjectNode.class::isInstance)
+                .where(ValuesNode.class::isInstance)
+                .findAll();
+
+        if (values.size() != 1 || !isSingleRowValuesWithNoColumns(values.get(0))) {
+            return Result.empty();
+        }
+
+        List<ProjectNode> subqueryProjections = searchFrom(parent.getSubquery(), context.getLookup())
+                .where(node -> node instanceof ProjectNode && !node.getOutputSymbols().equals(parent.getCorrelation()))
+                .findAll();
+
+        if (subqueryProjections.size() == 0) {
+            return Result.ofPlanNode(parent.getInput());
+        }
+        else if (subqueryProjections.size() == 1) {
+            Assignments assignments = Assignments.builder()
+                    .putIdentities(parent.getInput().getOutputSymbols())
+                    .putAll(subqueryProjections.get(0).getAssignments())
+                    .build();
+            return Result.ofPlanNode(projectNode(parent.getInput(), assignments, context));
+        }
+
+        return Result.empty();
+    }
+
+    private ProjectNode projectNode(PlanNode source, Assignments assignments, Context context)
+    {
+        return new ProjectNode(context.getIdAllocator().getNextId(), source, assignments);
+    }
+
+    private static boolean isSingleRowValuesWithNoColumns(ValuesNode values)
+    {
+        return values.getRows().size() == 1 && values.getRows().get(0).size() == 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformCorrelatedSingleRowSubqueryToProject.java
@@ -47,6 +47,7 @@ import static java.util.Objects.requireNonNull;
  *       - (input) plan which produces symbols: [A, B, C]
  * </pre>
  */
+@Deprecated
 public class TransformCorrelatedSingleRowSubqueryToProject
         implements PlanOptimizer
 {
@@ -88,8 +89,8 @@ public class TransformCorrelatedSingleRowSubqueryToProject
                 return rewrittenLateral;
             }
 
-            List<ProjectNode> subqueryProjections = searchFrom(lateral.getSubquery())
-                    .where(ProjectNode.class::isInstance)
+            List<ProjectNode> subqueryProjections = searchFrom(rewrittenLateral.getSubquery())
+                    .where(node -> node instanceof ProjectNode && !node.getOutputSymbols().equals(rewrittenLateral.getCorrelation()))
                     .findAll();
 
             if (subqueryProjections.size() == 0) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCALE_FACTOR;
+
+public class TestTransformCorrelatedSingleRowSubqueryToProject
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoesNotFire()
+    {
+        tester().assertThat(new TransformCorrelatedSingleRowSubqueryToProject())
+                .on(p -> p.values(p.symbol("a")))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRewrite()
+    {
+        tester().assertThat(new TransformCorrelatedSingleRowSubqueryToProject())
+                .on(p ->
+                        p.lateral(
+                                ImmutableList.of(p.symbol("l_nationkey")),
+                                p.tableScan(new TableHandle(
+                                                new ConnectorId("local"),
+                                                new TpchTableHandle("local", "nation", TINY_SCALE_FACTOR)), ImmutableList.of(p.symbol("l_nationkey")),
+                                        ImmutableMap.of(p.symbol("l_nationkey"), new TpchColumnHandle("nationkey",
+                                                BIGINT))),
+                                p.project(
+                                        Assignments.of(p.symbol("l_expr2"), expression("l_nationkey + 1")),
+                                        p.values(
+                                                ImmutableList.of(),
+                                                ImmutableList.of(
+                                                        ImmutableList.of())))))
+                .matches(project(
+                        ImmutableMap.of(
+                                ("l_expr2"), PlanMatchPattern.expression("l_nationkey + 1"),
+                                "l_nationkey", PlanMatchPattern.expression("l_nationkey")),
+                        tableScan("nation", ImmutableMap.of("l_nationkey", "nationkey"))));
+    }
+
+    @Test
+    public void testDoesNotFireWithEmptyValuesNode()
+    {
+        tester().assertThat(new TransformCorrelatedSingleRowSubqueryToProject())
+                .on(p ->
+                        p.lateral(
+                                ImmutableList.of(p.symbol("a")),
+                                p.values(p.symbol("a")),
+                                p.values(p.symbol("a"))))
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
@@ -197,6 +197,14 @@ public class TestSubqueries
                 "VALUES 2");
     }
 
+    @Test
+    public void testCorrelatedSubqueryWithExplicitCoercion()
+    {
+        assertions.assertQuery(
+                "SELECT 1 FROM (VALUES 1, 2) t1(b) WHERE 1 = (SELECT cast(b as decimal(7,2)))",
+                "VALUES 1");
+    }
+
     private void assertExistsRewrittenToAggregationBelowJoin(@Language("SQL") String actual, @Language("SQL") String expected, boolean extraAggregation)
     {
         PlanMatchPattern source = node(ValuesNode.class);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6074,9 +6074,8 @@ public abstract class AbstractTestQueries
 
         // group by
         assertQuery("SELECT max(n.regionkey), 2 * n.nationkey, (SELECT n.nationkey) FROM nation n GROUP BY n.nationkey");
-        assertQueryFails(
-                "SELECT max(l.quantity), 2 * l.orderkey FROM lineitem l GROUP BY l.orderkey HAVING max(l.quantity) < (SELECT l.orderkey)",
-                UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        assertQuery(
+                "SELECT max(l.quantity), 2 * l.orderkey FROM lineitem l GROUP BY l.orderkey HAVING max(l.quantity) < (SELECT l.orderkey)");
         assertQuery("SELECT max(l.quantity), 2 * l.orderkey FROM lineitem l GROUP BY l.orderkey, (SELECT l.orderkey)");
 
         // join


### PR DESCRIPTION
…roject

The commit adds a new rule for $subject, and removes the current optimizer
that performs the task. The new rule works in the same optimizer as InlineProjections
and can deal with duplicate identity projections, allowing subqueries with multiple
projections to work, something the previous optimizer lacked

Fixes #11026 and supersedes #11099