### PR TITLE
Use names to map struct field to underlying data in ORC

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
@@ -22,6 +22,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.RowBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.io.Closer;
 import org.joda.time.DateTimeZone;
@@ -34,12 +35,16 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.StreamReaders.createStreamReader;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 public class StructStreamReader
@@ -49,7 +54,7 @@ public class StructStreamReader
 
     private final StreamDescriptor streamDescriptor;
 
-    private final StreamReader[] structFields;
+    private final Map<String, StreamReader> structFields;
 
     private int readOffset;
     private int nextBatchSize;
@@ -61,16 +66,11 @@ public class StructStreamReader
 
     private boolean rowGroupOpen;
 
-    public StructStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryContext)
+    StructStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-
-        List<StreamDescriptor> nestedStreams = streamDescriptor.getNestedStreams();
-        this.structFields = new StreamReader[nestedStreams.size()];
-        for (int i = 0; i < nestedStreams.size(); i++) {
-            StreamDescriptor nestedStream = nestedStreams.get(i);
-            this.structFields[i] = createStreamReader(nestedStream, hiveStorageTimeZone, systemMemoryContext);
-        }
+        this.structFields = streamDescriptor.getNestedStreams().stream()
+                .collect(toImmutableMap(stream -> stream.getFieldName().toLowerCase(Locale.ENGLISH), stream -> createStreamReader(stream, hiveStorageTimeZone, systemMemoryContext)));
     }
 
     @Override
@@ -94,42 +94,25 @@ public class StructStreamReader
                 // and use this as the skip size for the field readers
                 readOffset = presentStream.countBitsSet(readOffset);
             }
-            for (StreamReader structField : structFields) {
+            for (StreamReader structField : structFields.values()) {
                 structField.prepareNextRead(readOffset);
             }
         }
 
-        List<Type> typeParameters = type.getTypeParameters();
-
         boolean[] nullVector = new boolean[nextBatchSize];
-        Block[] blocks = new Block[typeParameters.size()];
+        Block[] blocks;
+
         if (presentStream == null) {
-            for (int i = 0; i < typeParameters.size(); i++) {
-                if (i < structFields.length) {
-                    StreamReader structField = structFields[i];
-                    structField.prepareNextRead(nextBatchSize);
-                    blocks[i] = structField.readBlock(typeParameters.get(i));
-                }
-                else {
-                    blocks[i] = getNullBlock(typeParameters.get(i), nextBatchSize);
-                }
-            }
+            blocks = getBlocksForType(type, nextBatchSize);
         }
         else {
             int nullValues = presentStream.getUnsetBits(nextBatchSize, nullVector);
             if (nullValues != nextBatchSize) {
-                for (int i = 0; i < typeParameters.size(); i++) {
-                    if (i < structFields.length) {
-                        StreamReader structField = structFields[i];
-                        structField.prepareNextRead(nextBatchSize - nullValues);
-                        blocks[i] = structField.readBlock(typeParameters.get(i));
-                    }
-                    else {
-                        blocks[i] = getNullBlock(typeParameters.get(i), nextBatchSize - nullValues);
-                    }
-                }
+                blocks = getBlocksForType(type, nextBatchSize - nullValues);
             }
             else {
+                List<Type> typeParameters = type.getTypeParameters();
+                blocks = new Block[typeParameters.size()];
                 for (int i = 0; i < typeParameters.size(); i++) {
                     blocks[i] = typeParameters.get(i).createBlockBuilder(null, 0).build();
                 }
@@ -171,7 +154,7 @@ public class StructStreamReader
 
         rowGroupOpen = false;
 
-        for (StreamReader structField : structFields) {
+        for (StreamReader structField : structFields.values()) {
             structField.startStripe(dictionaryStreamSources, encoding);
         }
     }
@@ -189,7 +172,7 @@ public class StructStreamReader
 
         rowGroupOpen = false;
 
-        for (StreamReader structField : structFields) {
+        for (StreamReader structField : structFields.values()) {
             structField.startRowGroup(dataStreamSources);
         }
     }
@@ -200,6 +183,33 @@ public class StructStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    private Block[] getBlocksForType(Type type, int positionCount) throws IOException
+    {
+        RowType rowType = (RowType) type;
+
+        Block[] blocks = new Block[rowType.getFields().size()];
+
+        for (int i = 0; i < rowType.getFields().size(); i++) {
+            Optional<String> fieldName = rowType.getFields().get(i).getName();
+            Type fieldType = rowType.getFields().get(i).getType();
+
+            if (!fieldName.isPresent()) {
+                throw new IllegalArgumentException("Missing struct field name in type " + rowType);
+            }
+
+            String lowerCaseFieldName = fieldName.get().toLowerCase(Locale.ENGLISH);
+            StreamReader streamReader = structFields.get(lowerCaseFieldName);
+            if (streamReader != null) {
+                streamReader.prepareNextRead(positionCount);
+                blocks[i] = streamReader.readBlock(fieldType);
+            }
+            else {
+                blocks[i] = getNullBlock(fieldType, positionCount);
+            }
+        }
+        return blocks;
     }
 
     private static Block getNullBlock(Type type, int positionCount)
@@ -214,7 +224,7 @@ public class StructStreamReader
     public void close()
     {
         try (Closer closer = Closer.create()) {
-            for (StreamReader structField : structFields) {
+            for (StreamReader structField : structFields.values()) {
                 closer.register(() -> structField.close());
             }
         }
@@ -227,7 +237,7 @@ public class StructStreamReader
     public long getRetainedSizeInBytes()
     {
         long retainedSizeInBytes = INSTANCE_SIZE;
-        for (StreamReader structField : structFields) {
+        for (StreamReader structField : structFields.values()) {
             retainedSizeInBytes += structField.getRetainedSizeInBytes();
         }
         return retainedSizeInBytes;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructStreamReader.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.orc;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.RowBlock;
+import com.facebook.presto.spi.type.NamedTypeSignature;
+import com.facebook.presto.spi.type.RowFieldName;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
+import static com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
+import static com.facebook.presto.orc.TestingOrcPredicate.ORC_ROW_GROUP_SIZE;
+import static com.facebook.presto.orc.TestingOrcPredicate.ORC_STRIPE_SIZE;
+import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+@Test(singleThreaded = true)
+public class TestStructStreamReader
+{
+    private static final TypeManager TYPE_MANAGER = new TypeRegistry();
+
+    private static final Type TEST_DATA_TYPE = VARCHAR;
+
+    private static final String STRUCT_COL_NAME = "struct_col";
+
+    public static final ConnectorSession SESSION = new TestingConnectorSession(ImmutableList.of());
+
+    private TempFile tempFile;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        tempFile = new TempFile();
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException
+    {
+        tempFile.close();
+    }
+
+    /**
+     * Reader and writer have the same fields. Checks that fields are read in correctly
+     */
+    @Test
+    public void testValuesAreReadInCorrectly() throws IOException
+    {
+        List<String> readerFields = new ArrayList<>(Arrays.asList("field_a", "field_b", "field_c"));
+        List<String> writerFields = new ArrayList<>(Arrays.asList("field_a", "field_b", "field_c"));
+        List<String> writerData = new ArrayList<>(Arrays.asList("field_a_value", "field_b_value", "field_c_value"));
+        Type readerType = getType(readerFields);
+        Type writerType = getType(writerFields);
+
+        write(tempFile, writerType, writerData);
+        RowBlock readBlock = read(tempFile, readerType);
+        List actual = (List) readerType.getObjectValue(SESSION, readBlock, 0);
+
+        assertEquals(actual.size(), readerFields.size());
+        assertEquals(actual.get(0), "field_a_value");
+        assertEquals(actual.get(1), "field_b_value");
+        assertEquals(actual.get(2), "field_c_value");
+    }
+
+    /**
+     * The writer has fields with upper case characters, reader has same names downcased.
+     */
+    @Test
+    public void testReaderLowerCasesFieldNamesFromStream() throws IOException
+    {
+        List<String> readerFields = new ArrayList<>(Arrays.asList("field_a", "field_b", "field_c"));
+        List<String> writerFields = new ArrayList<>(Arrays.asList("field_A", "field_B", "field_C"));
+        List<String> writerData = new ArrayList<>(Arrays.asList("fieldAValue", "fieldBValue", "fieldCValue"));
+        Type readerType = getType(readerFields);
+        Type writerType = getType(writerFields);
+
+        write(tempFile, writerType, writerData);
+        RowBlock readBlock = read(tempFile, readerType);
+        List actual = (List) readerType.getObjectValue(SESSION, readBlock, 0);
+
+        assertEquals(actual.size(), readerFields.size());
+        assertEquals(actual.get(0), "fieldAValue");
+        assertEquals(actual.get(1), "fieldBValue");
+        assertEquals(actual.get(2), "fieldCValue");
+    }
+
+    /**
+     * Reader has fields with upper case characters, writer has same names downcased.
+     */
+    @Test
+    public void testReaderLowerCasesFieldNamesFromType() throws IOException
+    {
+        List<String> readerFields = new ArrayList<>(Arrays.asList("field_A", "field_B", "field_C"));
+        List<String> writerFields = new ArrayList<>(Arrays.asList("field_a", "field_b", "field_c"));
+        List<String> writerData = new ArrayList<>(Arrays.asList("fieldAValue", "fieldBValue", "fieldCValue"));
+        Type readerType = getType(readerFields);
+        Type writerType = getType(writerFields);
+
+        write(tempFile, writerType, writerData);
+        RowBlock readBlock = read(tempFile, readerType);
+        List actual = (List) readerType.getObjectValue(SESSION, readBlock, 0);
+
+        assertEquals(actual.size(), readerFields.size());
+        assertEquals(actual.get(0), "fieldAValue");
+        assertEquals(actual.get(1), "fieldBValue");
+        assertEquals(actual.get(2), "fieldCValue");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
+            "Missing struct field name in type row\\(varchar,varchar,varchar\\)")
+    public void testThrowsExceptionWhenFieldNameMissing() throws IOException
+    {
+        List<String> readerFields = new ArrayList<>(Arrays.asList("field_a", "field_b", "field_c"));
+        List<String> writerFields = new ArrayList<>(Arrays.asList("field_a", "field_b", "field_c"));
+        List<String> writerData = new ArrayList<>(Arrays.asList("field_a_value", "field_b_value", "field_c_value"));
+        Type readerType = getTypeNullName(readerFields.size());
+        Type writerType = getType(writerFields);
+
+        write(tempFile, writerType, writerData);
+        read(tempFile, readerType);
+    }
+
+    /**
+     * The reader has a field that is missing from the ORC file
+     */
+    @Test
+    public void testExtraFieldsInReader() throws IOException
+    {
+        List<String> readerFields = new ArrayList<>(Arrays.asList("field_a", "field_b", "field_c"));
+
+        // field_b is missing
+        List<String> writerFields = new ArrayList<>(Arrays.asList("field_a", "field_c"));
+        List<String> writerData = new ArrayList<>(Arrays.asList("field_a_value", "field_c_value"));
+        Type readerType = getType(readerFields);
+        Type writerType = getType(writerFields);
+
+        write(tempFile, writerType, writerData);
+        RowBlock readBlock = read(tempFile, readerType);
+        List actual = (List) readerType.getObjectValue(SESSION, readBlock, 0);
+
+        assertEquals(actual.size(), readerFields.size());
+        assertEquals(actual.get(0), "field_a_value");
+        assertNull(actual.get(1));
+        assertEquals(actual.get(2), "field_c_value");
+    }
+
+    /**
+     * The ORC file has a field that is missing from the reader
+     */
+    @Test
+    public void testExtraFieldsInWriter() throws IOException
+    {
+        // field_b is missing
+        List<String> readerFields = new ArrayList<>(Arrays.asList("field_a", "field_c"));
+        List<String> writerFields = new ArrayList<>(Arrays.asList("field_a", "field_b", "field_c"));
+        List<String> writerData = new ArrayList<>(Arrays.asList("field_a_value", "field_b_value", "field_c_value"));
+        Type readerType = getType(readerFields);
+        Type writerType = getType(writerFields);
+
+        write(tempFile, writerType, writerData);
+        RowBlock readBlock = read(tempFile, readerType);
+        List actual = (List) readerType.getObjectValue(SESSION, readBlock, 0);
+
+        assertEquals(actual.size(), readerFields.size());
+        assertEquals(actual.get(0), "field_a_value");
+        assertEquals(actual.get(1), "field_c_value");
+    }
+
+    private void write(TempFile tempFile, Type writerType, List<String> data) throws IOException
+    {
+        OrcWriter writer = new OrcWriter(
+                new OutputStreamOrcDataSink(
+                        new FileOutputStream(tempFile.getFile())), ImmutableList.of(STRUCT_COL_NAME), ImmutableList.of(writerType), ORC, NONE,
+                           new OrcWriterOptions().withStripeMinSize(new DataSize(0, MEGABYTE)).withStripeMaxSize(new DataSize(32, MEGABYTE)).withStripeMaxRowCount(ORC_STRIPE_SIZE)
+                                   .withRowGroupMaxRowCount(ORC_ROW_GROUP_SIZE).withDictionaryMaxMemory(new DataSize(32, MEGABYTE)),
+                ImmutableMap.of(), HIVE_STORAGE_TIME_ZONE, true, BOTH, new OrcWriterStats());
+
+        // write down some data with unsorted streams
+        Block[] fieldBlocks = new Block[data.size()];
+
+        int entries = 10;
+        boolean[] rowIsNull = new boolean[entries];
+        Arrays.fill(rowIsNull, false);
+
+        BlockBuilder blockBuilder = TEST_DATA_TYPE.createBlockBuilder(null, entries);
+        for (int i = 0; i < data.size(); i++) {
+            byte[] bytes = data.get(i).getBytes();
+            for (int j = 0; j < entries; j++) {
+                blockBuilder.writeBytes(Slices.wrappedBuffer(bytes), 0, bytes.length);
+                blockBuilder.closeEntry();
+            }
+            fieldBlocks[i] = blockBuilder.build();
+            blockBuilder = blockBuilder.newBlockBuilderLike(null);
+        }
+        Block rowBlock = RowBlock.fromFieldBlocks(rowIsNull, fieldBlocks);
+        writer.write(new Page(rowBlock));
+        writer.close();
+    }
+
+    private RowBlock read(TempFile tempFile, Type readerType) throws IOException
+    {
+        DataSize dataSize = new DataSize(1, MEGABYTE);
+        OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), dataSize, dataSize, dataSize, true);
+        OrcReader orcReader = new OrcReader(orcDataSource, ORC, dataSize, dataSize, dataSize, dataSize);
+
+        Map<Integer, Type> includedColumns = new HashMap<>();
+        includedColumns.put(0, readerType);
+
+        OrcRecordReader recordReader = orcReader.createRecordReader(includedColumns, OrcPredicate.TRUE, UTC, newSimpleAggregatedMemoryContext(), OrcReader.INITIAL_BATCH_SIZE);
+
+        recordReader.nextBatch();
+        RowBlock block = (RowBlock) recordReader.readBlock(readerType, 0);
+        recordReader.close();
+        return block;
+    }
+
+    private Type getType(List<String> fieldNames)
+    {
+        ImmutableList.Builder<TypeSignatureParameter> typeSignatureParameters = ImmutableList.builder();
+        for (String fieldName : fieldNames) {
+            typeSignatureParameters.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(fieldName, false)), TEST_DATA_TYPE.getTypeSignature())));
+        }
+        return TYPE_MANAGER.getParameterizedType(StandardTypes.ROW, typeSignatureParameters.build());
+    }
+
+    private Type getTypeNullName(int numFields)
+    {
+        ImmutableList.Builder<TypeSignatureParameter> typeSignatureParameters = ImmutableList.builder();
+
+        for (int i = 0; i < numFields; i++) {
+            typeSignatureParameters.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.empty(), TEST_DATA_TYPE.getTypeSignature())));
+        }
+        return TYPE_MANAGER.getParameterizedType(StandardTypes.ROW, typeSignatureParameters.build());
+    }
+}


### PR DESCRIPTION
Fixes #11001. A summary for completeness:

Previously, presto used the ordinal position of a struct field to map a field to its corresponding data. The method does not work if fields are removed from the struct.

Let's say we have `struct <a:string, b string, c:string>` that changes to `struct <a:string, c:string>` (Field `b` is dropped). In this case the value of `c` from the old ORC files would be incorrect. It would read in the value of `b` from the underlying ORC files and misrepresent it as the values for `c`.

With this change, the old values of `b` will be ignored. `c` will be null if it is missing from an ORC file, or it will have the right value assigned to it.
