### PR TITLE
Enable history for presto-cli.sh

### DIFF
--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -48,6 +48,7 @@ services:
       - ${PRESTO_JDBC_DRIVER_JAR}:/docker/volumes/jdbc/driver.jar
       - ../../../conf/tempto/tempto-configuration-for-docker-default.yaml:/docker/volumes/tempto/tempto-configuration-local.yaml
       - ../../../target/test-reports:/docker/volumes/test-reports
+      - /tmp/presto_history_docker:/root/.presto_history
     environment:
       - PRESTO_JDBC_DRIVER_CLASS
       - TEMPTO_EXTRA_CONFIG_FILE


### PR DESCRIPTION
Enable history for presto-cli.sh

./conf/docker/<env>/compose.sh run application-runner /docker/volumes/conf/docker/files/presto-cli.sh

Above command executes presto-cli which is capable to connect to product
test Presto server in given test environment. However notice that it
always executes new docker container for that process. Because of that
it does not maintain history between sessions.

Thanks to this commit history will be saved.
