### PR TITLE
Expose debug port for Hadoop processes in product tests

### DIFF
--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -14,6 +14,7 @@ services:
     hostname: hadoop-master
     ports:
       - '${HIVE_PROXY_PORT}:1180'
+      - '5006:5006'
       - '8020:8020'
       - '8042:8042'
       - '8088:8088'


### PR DESCRIPTION
Expose debug port for Hadoop processes in product tests

Thanks to this change it is a bit easier (one place less to change) when
enabling debugging for any process running on hadoop-master container.

Notice that we already expose 5005 on presto-master to debug Presto
server.
