### PR TITLE
Move tagged memory allocations on memory pool update

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -58,6 +58,7 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -253,6 +254,29 @@ public class TestMemoryPools
         // free all for test_tag2
         testPool.free(testQuery, Optional.of("test_tag2"), 20);
         assertEquals(testPool.getTaggedMemoryAllocations().size(), 0);
+    }
+
+    @Test
+    public void testMoveQuery()
+    {
+        QueryId testQuery = new QueryId("test_query");
+        MemoryPool pool1 = new MemoryPool(new MemoryPoolId("test"), new DataSize(1000, BYTE));
+        MemoryPool pool2 = new MemoryPool(new MemoryPoolId("test"), new DataSize(1000, BYTE));
+        pool1.reserve(testQuery, Optional.of("test_tag"), 10);
+
+        Map<String, Long> allocations = pool1.getTaggedMemoryAllocations().get(testQuery);
+        assertEquals(allocations, ImmutableMap.of("test_tag", 10L));
+
+        pool1.moveQuery(testQuery, pool2);
+        assertNull(pool1.getTaggedMemoryAllocations().get(testQuery));
+        allocations = pool2.getTaggedMemoryAllocations().get(testQuery);
+        assertEquals(allocations, ImmutableMap.of("test_tag", 10L));
+
+        assertEquals(pool1.getFreeBytes(), 1000);
+        assertEquals(pool2.getFreeBytes(), 990);
+
+        pool2.free(testQuery, 10);
+        assertEquals(pool2.getFreeBytes(), 1000);
     }
 
     private long runDriversUntilBlocked(Predicate<OperatorContext> reason)


### PR DESCRIPTION
When a query is moved from one pool to another we need to also move
the tagged memory allocations properly to the new memory pool.

Follow up for #11011