### PR TITLE
Make possible to overwrite default history path with env variable

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -52,6 +52,7 @@ import static com.facebook.presto.sql.parser.StatementSplitter.Statement;
 import static com.facebook.presto.sql.parser.StatementSplitter.isEmptyStatement;
 import static com.facebook.presto.sql.parser.StatementSplitter.squeezeStatement;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.io.ByteStreams.nullOutputStream;
 import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static java.lang.Integer.parseInt;
@@ -82,8 +83,8 @@ public class Console
     public boolean run()
     {
         ClientSession session = clientOptions.toClientSession();
-        boolean hasQuery = !Strings.isNullOrEmpty(clientOptions.execute);
-        boolean isFromFile = !Strings.isNullOrEmpty(clientOptions.file);
+        boolean hasQuery = !isNullOrEmpty(clientOptions.execute);
+        boolean isFromFile = !isNullOrEmpty(clientOptions.file);
 
         if (!hasQuery && !isFromFile) {
             AnsiConsole.systemInstall();

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Console.java
@@ -369,7 +369,15 @@ public class Console
 
     private static MemoryHistory getHistory()
     {
-        return getHistory(new File(getUserHome(), ".presto_history"));
+        String historyFilePath = System.getenv("PRESTO_HISTORY_FILE");
+        File historyFile;
+        if (isNullOrEmpty(historyFilePath)) {
+            historyFile = new File(getUserHome(), ".presto_history");
+        }
+        else {
+            historyFile = new File(historyFilePath);
+        }
+        return getHistory(historyFile);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Make possible to overwrite default history path with env variable

By setting PRESTO_CLI_HISTORY_FILE user can overwrite the path where
presto-cli history commands are stored.
