### PR TITLE
Add internal aggregations over estimated in-memory data size for stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -43,6 +43,7 @@ import com.facebook.presto.operator.aggregation.IntervalDayToSecondSumAggregatio
 import com.facebook.presto.operator.aggregation.IntervalYearToMonthAverageAggregation;
 import com.facebook.presto.operator.aggregation.IntervalYearToMonthSumAggregation;
 import com.facebook.presto.operator.aggregation.LongSumAggregation;
+import com.facebook.presto.operator.aggregation.MaxDataSizeForStats;
 import com.facebook.presto.operator.aggregation.MergeHyperLogLogAggregation;
 import com.facebook.presto.operator.aggregation.RealAverageAggregation;
 import com.facebook.presto.operator.aggregation.RealCorrelationAggregation;
@@ -51,6 +52,7 @@ import com.facebook.presto.operator.aggregation.RealGeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.RealHistogramAggregation;
 import com.facebook.presto.operator.aggregation.RealRegressionAggregation;
 import com.facebook.presto.operator.aggregation.RealSumAggregation;
+import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggregationFunction;
 import com.facebook.presto.operator.aggregation.histogram.Histogram;
@@ -417,6 +419,8 @@ public class FunctionRegistry
                 .window(LeadFunction.class)
                 .aggregate(ApproximateCountDistinctAggregation.class)
                 .aggregate(DefaultApproximateCountDistinctAggregation.class)
+                .aggregate(SumDataSizeForStats.class)
+                .aggregate(MaxDataSizeForStats.class)
                 .aggregates(CountAggregation.class)
                 .aggregates(VarianceAggregation.class)
                 .aggregates(CentralMomentsAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlAggregationFunction.java
@@ -30,6 +30,7 @@ public abstract class SqlAggregationFunction
         implements SqlFunction
 {
     private final Signature signature;
+    private final boolean hidden;
 
     public static List<SqlAggregationFunction> createFunctionByAnnotations(Class<?> aggregationDefinition)
     {
@@ -42,12 +43,6 @@ public abstract class SqlAggregationFunction
                 .stream()
                 .map(x -> (SqlAggregationFunction) x)
                 .collect(toImmutableList());
-    }
-
-    protected SqlAggregationFunction(Signature signature)
-    {
-        requireNonNull(signature, "signature is null");
-        this.signature = signature;
     }
 
     protected SqlAggregationFunction(
@@ -68,13 +63,30 @@ public abstract class SqlAggregationFunction
             List<TypeSignature> argumentTypes,
             FunctionKind kind)
     {
+        this(createSignature(name, typeVariableConstraints, longVariableConstraints, returnType, argumentTypes, kind), false);
+    }
+
+    protected SqlAggregationFunction(Signature signature, boolean hidden)
+    {
+        this.signature = requireNonNull(signature, "signature is null");
+        this.hidden = hidden;
+    }
+
+    private static Signature createSignature(
+            String name,
+            List<TypeVariableConstraint> typeVariableConstraints,
+            List<LongVariableConstraint> longVariableConstraints,
+            TypeSignature returnType,
+            List<TypeSignature> argumentTypes,
+            FunctionKind kind)
+    {
         requireNonNull(name, "name is null");
         requireNonNull(typeVariableConstraints, "typeVariableConstraints is null");
         requireNonNull(longVariableConstraints, "longVariableConstraints is null");
         requireNonNull(returnType, "returnType is null");
         requireNonNull(argumentTypes, "argumentTypes is null");
         checkArgument(kind == AGGREGATE, "kind must be an aggregate");
-        this.signature = new Signature(
+        return new Signature(
                 name,
                 kind,
                 ImmutableList.copyOf(typeVariableConstraints),
@@ -93,7 +105,7 @@ public abstract class SqlAggregationFunction
     @Override
     public boolean isHidden()
     {
-        return false;
+        return hidden;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -182,6 +182,12 @@ public class GroupByIdBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return block.getEstimatedDataSizeForStats(position);
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(block, block.getRetainedSizeInBytes());

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
@@ -131,7 +131,12 @@ public class AggregationFromAnnotationsParser
     {
         AggregationFunction aggregationAnnotation = aggregationDefinition.getAnnotation(AggregationFunction.class);
         requireNonNull(aggregationAnnotation, "aggregationAnnotation is null");
-        return new AggregationHeader(aggregationAnnotation.value(), parseDescription(aggregationDefinition), aggregationAnnotation.decomposable(), aggregationAnnotation.isOrderSensitive());
+        return new AggregationHeader(
+                aggregationAnnotation.value(),
+                parseDescription(aggregationDefinition),
+                aggregationAnnotation.decomposable(),
+                aggregationAnnotation.isOrderSensitive(),
+                aggregationAnnotation.hidden());
     }
 
     private static List<AggregationHeader> parseHeaders(AnnotatedElement aggregationDefinition, AnnotatedElement toParse)
@@ -144,7 +149,8 @@ public class AggregationFromAnnotationsParser
                                 name,
                                 parseDescription(aggregationDefinition, toParse),
                                 aggregationAnnotation.decomposable(),
-                                aggregationAnnotation.isOrderSensitive()))
+                                aggregationAnnotation.isOrderSensitive(),
+                                aggregationAnnotation.hidden()))
                 .collect(toImmutableList());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationHeader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationHeader.java
@@ -23,13 +23,15 @@ public class AggregationHeader
     private final Optional<String> description;
     private final boolean decomposable;
     private final boolean orderSensitive;
+    private final boolean hidden;
 
-    public AggregationHeader(String name, Optional<String> description, boolean decomposable, boolean orderSensitive)
+    public AggregationHeader(String name, Optional<String> description, boolean decomposable, boolean orderSensitive, boolean hidden)
     {
         this.name = requireNonNull(name, "name cannot be null");
         this.description = requireNonNull(description, "description cannot be null");
         this.decomposable = decomposable;
         this.orderSensitive = orderSensitive;
+        this.hidden = hidden;
     }
 
     public String getName()
@@ -50,5 +52,10 @@ public class AggregationHeader
     public boolean isOrderSensitive()
     {
         return orderSensitive;
+    }
+
+    public boolean isHidden()
+    {
+        return hidden;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MaxDataSizeForStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MaxDataSizeForStats.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.NullableLongState;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.StandardTypes;
+
+import static java.lang.Math.max;
+
+@AggregationFunction(value = "$internal$max_data_size_for_stats", hidden = true)
+public final class MaxDataSizeForStats
+{
+    private MaxDataSizeForStats() {}
+
+    @InputFunction
+    @TypeParameter(value = "T")
+    public static void input(@AggregationState NullableLongState state, @BlockPosition @SqlType("T") Block block, @BlockIndex int index)
+    {
+        update(state, block.getEstimatedDataSizeForStats(index));
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState NullableLongState state, @AggregationState NullableLongState otherState)
+    {
+        update(state, otherState.getLong());
+    }
+
+    private static void update(NullableLongState state, long size)
+    {
+        if (state.isNull()) {
+            state.setNull(false);
+            state.setLong(size);
+        }
+        else {
+            state.setLong(max(state.getLong(), size));
+        }
+    }
+
+    @OutputFunction(StandardTypes.BIGINT)
+    public static void output(@AggregationState NullableLongState state, BlockBuilder out)
+    {
+        NullableLongState.write(BigintType.BIGINT, state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public class ParametricAggregation
         extends SqlAggregationFunction
@@ -51,13 +52,14 @@ public class ParametricAggregation
     AggregationHeader details;
     ParametricImplementationsGroup<AggregationImplementation> implementations;
 
-    public ParametricAggregation(Signature signature,
+    public ParametricAggregation(
+            Signature signature,
             AggregationHeader details,
-            ParametricImplementationsGroup implementations)
+            ParametricImplementationsGroup<AggregationImplementation> implementations)
     {
-        super(signature);
-        this.details = details;
-        this.implementations = implementations;
+        super(signature, details.isHidden());
+        this.details = requireNonNull(details, "details is null");
+        this.implementations = requireNonNull(implementations, "implementations is null");
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/SumDataSizeForStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/SumDataSizeForStats.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.NullableLongState;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.StandardTypes;
+
+@AggregationFunction(value = "$internal$sum_data_size_for_stats", hidden = true)
+public final class SumDataSizeForStats
+{
+    private SumDataSizeForStats() {}
+
+    @InputFunction
+    @TypeParameter(value = "T")
+    public static void input(@AggregationState NullableLongState state, @BlockPosition @SqlType("T") Block block, @BlockIndex int index)
+    {
+        update(state, block.getEstimatedDataSizeForStats(index));
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState NullableLongState state, @AggregationState NullableLongState otherState)
+    {
+        update(state, otherState.getLong());
+    }
+
+    private static void update(NullableLongState state, long size)
+    {
+        if (state.isNull()) {
+            state.setNull(false);
+            state.setLong(size);
+        }
+        else {
+            state.setLong(state.getLong() + size);
+        }
+    }
+
+    @OutputFunction(StandardTypes.BIGINT)
+    public static void output(@AggregationState NullableLongState state, BlockBuilder out)
+    {
+        NullableLongState.write(BigintType.BIGINT, state, out);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -465,4 +465,19 @@ public abstract class AbstractTestBlock
         }
         return expectedValues;
     }
+
+    protected static void assertEstimatedDataSizeForStats(BlockBuilder blockBuilder, Slice[] expectedSliceValues)
+    {
+        Block block = blockBuilder.build();
+        assertEquals(block.getPositionCount(), expectedSliceValues.length);
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            int expectedSize = expectedSliceValues[i] == null ? 0 : expectedSliceValues[i].length();
+            assertEquals(blockBuilder.getEstimatedDataSizeForStats(i), expectedSize);
+            assertEquals(block.getEstimatedDataSizeForStats(i), expectedSize);
+        }
+
+        BlockBuilder nullValueBlockBuilder = blockBuilder.newBlockBuilderLike(null).appendNull();
+        assertEquals(nullValueBlockBuilder.getEstimatedDataSizeForStats(0), 0);
+        assertEquals(nullValueBlockBuilder.build().getEstimatedDataSizeForStats(0), 0);
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestByteArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestByteArrayBlock.java
@@ -60,6 +60,13 @@ public class TestByteArrayBlock
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
 
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        Slice[] expectedValues = createTestValue(100);
+        assertEstimatedDataSizeForStats(createBlockBuilderWithValues(expectedValues), expectedValues);
+    }
+
     private void assertFixedWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
@@ -253,6 +253,18 @@ public class TestDictionaryBlock
         assertTrue(block.isCompact());
     }
 
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        int positionCount = 10;
+        int dictionaryPositionCount = 100;
+        Slice[] expectedValues = createExpectedValues(positionCount);
+        DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, dictionaryPositionCount);
+        for (int position = 0; position < dictionaryPositionCount; position++) {
+            assertEquals(dictionaryBlock.getEstimatedDataSizeForStats(position), expectedValues[position % positionCount].length());
+        }
+    }
+
     private static DictionaryBlock createDictionaryBlockWithUnreferencedKeys(Slice[] expectedValues, int positionCount)
     {
         // adds references to 0 and all odd indexes

--- a/presto-main/src/test/java/com/facebook/presto/block/TestFixedWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestFixedWidthBlock.java
@@ -65,6 +65,17 @@ public class TestFixedWidthBlock
         }
     }
 
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        for (int fixedSize = 0; fixedSize < 20; fixedSize++) {
+            Slice[] expectedValues = (Slice[]) alternatingNullValues(createExpectedValues(17, fixedSize));
+            BlockBuilder blockBuilder = new FixedWidthBlockBuilder(fixedSize, null, expectedValues.length);
+            writeValues(expectedValues, blockBuilder);
+            assertEstimatedDataSizeForStats(blockBuilder, expectedValues);
+        }
+    }
+
     private void assertFixedWithValues(Slice[] expectedValues, int fixedSize)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues, fixedSize);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestIntArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestIntArrayBlock.java
@@ -60,6 +60,13 @@ public class TestIntArrayBlock
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
 
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        Slice[] expectedValues = createTestValue(100);
+        assertEstimatedDataSizeForStats(createBlockBuilderWithValues(expectedValues), expectedValues);
+    }
+
     private void assertFixedWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestLongArrayBlock.java
@@ -61,6 +61,13 @@ public class TestLongArrayBlock
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
 
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        Slice[] expectedValues = createTestValue(100);
+        assertEstimatedDataSizeForStats(createBlockBuilderWithValues(expectedValues), expectedValues);
+    }
+
     private void assertFixedWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
@@ -225,4 +225,31 @@ public class TestMapBlock
         }
         mapBlockBuilder.closeEntryStrict();
     }
+
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        Map<String, Long>[] expectedValues = (Map<String, Long>[]) alternatingNullValues(createTestMap(9, 3, 4, 0, 8, 0, 6, 5));
+        BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
+        Block block = blockBuilder.build();
+        assertEquals(block.getPositionCount(), expectedValues.length);
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            int expectedSize = getExpectedEstimatedDataSize(expectedValues[i]);
+            assertEquals(blockBuilder.getEstimatedDataSizeForStats(i), expectedSize);
+            assertEquals(block.getEstimatedDataSizeForStats(i), expectedSize);
+        }
+    }
+
+    private static int getExpectedEstimatedDataSize(Map<String, Long> map)
+    {
+        if (map == null) {
+            return 0;
+        }
+        int size = 0;
+        for (Map.Entry<String, Long> entry : map.entrySet()) {
+            size += entry.getKey().length();
+            size += entry.getValue() == null ? 0 : Long.BYTES;
+        }
+        return size;
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
@@ -49,6 +49,32 @@ public class TestRowBlock
         testWith(fieldTypes, (List<Object>[]) alternatingNullValues(testRows));
     }
 
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        List<Type> fieldTypes = ImmutableList.of(VARCHAR, BIGINT);
+        List<Object>[] expectedValues = (List<Object>[]) alternatingNullValues(generateTestRows(fieldTypes, 100));
+        BlockBuilder blockBuilder = createBlockBuilderWithValues(fieldTypes, expectedValues);
+        Block block = blockBuilder.build();
+        assertEquals(block.getPositionCount(), expectedValues.length);
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            int expectedSize = getExpectedEstimatedDataSize(expectedValues[i]);
+            assertEquals(blockBuilder.getEstimatedDataSizeForStats(i), expectedSize);
+            assertEquals(block.getEstimatedDataSizeForStats(i), expectedSize);
+        }
+    }
+
+    private int getExpectedEstimatedDataSize(List<Object> row)
+    {
+        if (row == null) {
+            return 0;
+        }
+        int size = 0;
+        size += row.get(0) == null ? 0 : ((String) row.get(0)).length();
+        size += row.get(1) == null ? 0 : Long.BYTES;
+        return size;
+    }
+
     private void testWith(List<Type> fieldTypes, List<Object>[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(fieldTypes, expectedValues);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
@@ -93,6 +93,17 @@ public class TestRunLengthEncodedBlock
         assertEquals(blockBuilder.build().getEncodingName(), RunLengthBlockEncoding.NAME);
     }
 
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        int positionCount = 10;
+        Slice expectedValue = createExpectedValue(5);
+        Block block = new RunLengthEncodedBlock(createSingleValueBlock(expectedValue), positionCount);
+        for (int postition = 0; postition < positionCount; postition++) {
+            assertEquals(block.getEstimatedDataSizeForStats(postition), expectedValue.length());
+        }
+    }
+
     private void populateNullValues(BlockBuilder blockBuilder, int positionCount)
     {
         for (int i = 0; i < positionCount; i++) {

--- a/presto-main/src/test/java/com/facebook/presto/block/TestShortArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestShortArrayBlock.java
@@ -60,6 +60,13 @@ public class TestShortArrayBlock
         assertEquals(blockBuilder.getRetainedSizeInBytes(), emptyBlockBuilder.getRetainedSizeInBytes());
     }
 
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        Slice[] expectedValues = createTestValue(100);
+        assertEstimatedDataSizeForStats(createBlockBuilderWithValues(expectedValues), expectedValues);
+    }
+
     private void assertFixedWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestVariableWidthBlock.java
@@ -104,6 +104,13 @@ public class TestVariableWidthBlock
         assertEquals(quarter1size + quarter2size + quarter3size + quarter4size, sizeInBytes);
     }
 
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        Slice[] expectedValues = createExpectedValues(100);
+        assertEstimatedDataSizeForStats(createBlockBuilderWithValues(expectedValues), expectedValues);
+    }
+
     private void assertVariableWithValues(Slice[] expectedValues)
     {
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionRegistry.java
@@ -148,6 +148,8 @@ public class TestFunctionRegistry
         assertTrue(names.contains("stddev"), "Expected function names " + names + " to contain 'stddev'");
         assertTrue(names.contains("rank"), "Expected function names " + names + " to contain 'rank'");
         assertFalse(names.contains("like"), "Expected function names " + names + " not to contain 'like'");
+        assertFalse(names.contains("$internal$sum_data_size_for_stats"), "Expected function names " + names + " not to contain '$internal$sum_data_size_for_stats'");
+        assertFalse(names.contains("$internal$max_data_size_for_stats"), "Expected function names " + names + " not to contain '$internal$max_data_size_for_stats'");
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -157,6 +157,26 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        checkReadablePosition(position);
+
+        if (isNull(position)) {
+            return 0;
+        }
+
+        int startValueOffset = getOffset(position);
+        int endValueOffset = getOffset(position + 1);
+
+        Block rawElementBlock = getRawElementBlock();
+        long size = 0;
+        for (int i = startValueOffset; i < endValueOffset; i++) {
+            size += rawElementBlock.getEstimatedDataSizeForStats(i);
+        }
+        return size;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
@@ -166,6 +166,12 @@ public abstract class AbstractFixedWidthBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : fixedSize;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -244,6 +244,28 @@ public abstract class AbstractMapBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        checkReadablePosition(position);
+
+        if (isNull(position)) {
+            return 0;
+        }
+
+        int startValueOffset = getOffset(position);
+        int endValueOffset = getOffset(position + 1);
+
+        long size = 0;
+        Block rawKeyBlock = getRawKeyBlock();
+        Block rawValueBlock = getRawValueBlock();
+        for (int i = startValueOffset; i < endValueOffset; i++) {
+            size += rawKeyBlock.getEstimatedDataSizeForStats(i);
+            size += rawValueBlock.getEstimatedDataSizeForStats(i);
+        }
+        return size;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -167,6 +167,23 @@ public abstract class AbstractRowBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        checkReadablePosition(position);
+
+        if (isNull(position)) {
+            return 0;
+        }
+
+        Block[] rawFieldBlocks = getRawFieldBlocks();
+        long size = 0;
+        for (int i = 0; i < numFields; i++) {
+            size += rawFieldBlocks[i].getEstimatedDataSizeForStats(getFieldBlockOffset(position));
+        }
+        return size;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -140,6 +140,13 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        checkReadablePosition(position);
+        return getBlock().getEstimatedDataSizeForStats(position + start);
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
@@ -229,6 +229,18 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        position = getAbsolutePosition(position);
+        if (position % 2 == 0) {
+            return getRawKeyBlock().getEstimatedDataSizeForStats(position / 2);
+        }
+        else {
+            return getRawValueBlock().getEstimatedDataSizeForStats(position / 2);
+        }
+    }
+
+    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
@@ -148,6 +148,13 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        checkFieldIndex(position);
+        return getRawFieldBlock(position).getEstimatedDataSizeForStats(rowIndex);
+    }
+
+    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
@@ -143,6 +143,12 @@ public abstract class AbstractVariableWidthBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : getSliceLength(position);
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -180,6 +180,12 @@ public interface Block
     long getRetainedSizeInBytes();
 
     /**
+     * Returns the estimated in memory data size for stats of position.
+     * Do not use it for other purpose.
+     */
+    long getEstimatedDataSizeForStats(int position);
+
+    /**
      * {@code consumer} visits each of the internal data container and accepts the size for it.
      * This method can be helpful in cases such as memory counting for internal data structure.
      * Also, the method should be non-recursive, only visit the elements at the top level,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -88,6 +88,12 @@ public class ByteArrayBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : Byte.BYTES;
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(values, sizeOf(values));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -153,6 +153,12 @@ public class ByteArrayBlockBuilder
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : Byte.BYTES;
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(values, sizeOf(values));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -250,6 +250,12 @@ public class DictionaryBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return dictionary.getEstimatedDataSizeForStats(getId(position));
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(dictionary, dictionary.getRetainedSizeInBytes());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -88,6 +88,12 @@ public class IntArrayBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : Integer.BYTES;
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(values, sizeOf(values));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -153,6 +153,12 @@ public class IntArrayBlockBuilder
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : Integer.BYTES;
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(values, sizeOf(values));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -185,6 +185,13 @@ public class LazyBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        assureLoaded();
+        return block.getEstimatedDataSizeForStats(position);
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         assureLoaded();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -89,6 +89,12 @@ public class LongArrayBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : Long.BYTES;
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(values, sizeOf(values));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -154,6 +154,12 @@ public class LongArrayBlockBuilder
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : Long.BYTES;
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(values, sizeOf(values));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -88,6 +88,12 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return value.getEstimatedDataSizeForStats(0);
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(value, value.getRetainedSizeInBytes());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -88,6 +88,12 @@ public class ShortArrayBlock
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : Short.BYTES;
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(values, sizeOf(values));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -153,6 +153,12 @@ public class ShortArrayBlockBuilder
     }
 
     @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : Short.BYTES;
+    }
+
+    @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
         consumer.accept(values, sizeOf(values));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlock.java
@@ -55,7 +55,7 @@ public class SingleRowBlock
     {
         long sizeInBytes = 0;
         for (int i = 0; i < fieldBlocks.length; i++) {
-            sizeInBytes += getRawFieldBlock(i).getSizeInBytes();
+            sizeInBytes += getRawFieldBlock(i).getRegionSizeInBytes(rowIndex, 1);
         }
         return sizeInBytes;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunction.java
@@ -30,5 +30,7 @@ public @interface AggregationFunction
 
     boolean isOrderSensitive() default false;
 
+    boolean hidden() default false;
+
     String[] alias() default {};
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -748,6 +748,48 @@ public abstract class AbstractTestAggregations
     }
 
     @Test
+    public void testSumDataSizeForStats()
+    {
+        // varchar
+        assertQuery("SELECT \"$internal$sum_data_size_for_stats\"(comment) FROM orders", "SELECT sum(length(comment)) FROM orders");
+
+        // char
+        // Presto removes trailing whitespaces when casting to CHAR.
+        // Hard code the expected data size since there is no easy to way to compute it in H2.
+        assertQuery("SELECT \"$internal$sum_data_size_for_stats\"(CAST(comment AS CHAR(1000))) FROM orders", "SELECT 725468");
+
+        // varbinary
+        assertQuery("SELECT \"$internal$sum_data_size_for_stats\"(CAST(comment AS VARBINARY)) FROM orders", "SELECT sum(length(comment)) FROM orders");
+
+        // array
+        assertQuery("SELECT \"$internal$sum_data_size_for_stats\"(ARRAY[comment]) FROM orders", "SELECT sum(length(comment)) FROM orders");
+        assertQuery("SELECT \"$internal$sum_data_size_for_stats\"(ARRAY[comment, comment]) FROM orders", "SELECT 2 * sum(length(comment)) FROM orders");
+
+        // map
+        assertQuery("SELECT \"$internal$sum_data_size_for_stats\"(map(ARRAY[1], ARRAY[comment])) FROM orders", "SELECT 4 * count(*) + sum(length(comment)) FROM orders");
+        assertQuery("SELECT \"$internal$sum_data_size_for_stats\"(map(ARRAY[1, 2], ARRAY[comment, comment])) FROM orders", "SELECT 2 * 4 * count(*) + 2 * sum(length(comment)) FROM orders");
+
+        // row
+        assertQuery("SELECT \"$internal$sum_data_size_for_stats\"(ROW(comment)) FROM orders", "SELECT sum(length(comment)) FROM orders");
+        assertQuery("SELECT \"$internal$sum_data_size_for_stats\"(ROW(comment, comment)) FROM orders", "SELECT 2 * sum(length(comment)) FROM orders");
+    }
+
+    @Test
+    public void testMaxDataSizeForStats()
+    {
+        // varchar
+        assertQuery("SELECT \"$internal$max_data_size_for_stats\"(comment) FROM orders", "SELECT max(length(comment)) FROM orders");
+
+        // char
+        assertQuery("SELECT \"$internal$max_data_size_for_stats\"(CAST(comment AS CHAR(1000))) FROM orders", "SELECT max(length(comment)) FROM orders");
+
+        // varbinary
+        assertQuery("SELECT \"$internal$max_data_size_for_stats\"(CAST(comment AS VARBINARY)) FROM orders", "SELECT max(length(comment)) FROM orders");
+
+        // $internal$max_data_size_for_stats is not needed for array, map and row
+    }
+
+    @Test
     public void testApproximateCountDistinctGroupBy()
     {
         MaterializedResult actual = computeActual("SELECT orderstatus, approx_distinct(custkey) FROM orders GROUP BY orderstatus");


### PR DESCRIPTION
These aggregation are needed for `MAX_VALUE_SIZE` and `TOTAL_VALUES_SIZE` statistics computation. The PR that adds this 2 statistics will be opened once the #11054 and the #11107 are merged.