### PR TITLE
Optimizing DependenciesChecker for TableScanNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -426,8 +426,7 @@ public final class ValidateDependenciesChecker
         @Override
         public Void visitTableScan(TableScanNode node, Set<Symbol> boundSymbols)
         {
-            checkArgument(node.getAssignments().keySet().containsAll(node.getOutputSymbols()), "Assignments must contain mappings for output symbols");
-
+            //We don't have to do a check here as TableScanNode has no dependencies.
             return null;
         }
 


### PR DESCRIPTION
This PR skips the dependencies check performed for a `TableScanNode` , because `TableScanNode` has no dependencies. 