### PR TITLE
ViewFs Temp Directory

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -17,6 +17,8 @@ import com.facebook.presto.hive.s3.S3FileSystemType;
 import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
@@ -33,10 +35,13 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.Iterables.transform;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 @DefunctConfig({
@@ -137,6 +142,8 @@ public class HiveClientConfig
     private boolean tableStatisticsEnabled = true;
     private int partitionStatisticsSampleSize = 100;
     private boolean collectColumnStatisticsOnWrite;
+
+    private Map<String, String> viewFsTempDirMapping = Collections.emptyMap();
 
     public int getMaxInitialSplits()
     {
@@ -1087,5 +1094,22 @@ public class HiveClientConfig
     {
         this.collectColumnStatisticsOnWrite = collectColumnStatisticsOnWrite;
         return this;
+    }
+
+    @Config("hive.hdfs.viewfs.tmpdirs")
+    @ConfigDescription("HDFS Viewfs temp directories mapping")
+    public HiveClientConfig setViewFsTempDirMapping(String mapping)
+    {
+        this.viewFsTempDirMapping = ImmutableMap.copyOf(transform(SPLITTER.split(mapping), (s) -> {
+            String[] item = s.split("#");
+            return Maps.immutableEntry(item[0], item[1]);
+        }));
+        return this;
+    }
+
+    @NotNull
+    public Map<String, String> getViewFsTempDirMapping()
+    {
+        return viewFsTempDirMapping;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.fs.Path;
 
 import javax.inject.Inject;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PATH_ALREADY_EXISTS;
@@ -41,11 +43,13 @@ public class HiveLocationService
         implements LocationService
 {
     private final HdfsEnvironment hdfsEnvironment;
+    private final Map<String, String> viewFsTempDirMapping;
 
     @Inject
-    public HiveLocationService(HdfsEnvironment hdfsEnvironment)
+    public HiveLocationService(HdfsEnvironment hdfsEnvironment, HiveClientConfig config)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.viewFsTempDirMapping = requireNonNull(config.getViewFsTempDirMapping(), "HiveClientConfig is null");
     }
 
     @Override
@@ -60,7 +64,7 @@ public class HiveLocationService
         }
 
         if (shouldUseTemporaryDirectory(context, targetPath)) {
-            Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
+            Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath, viewFsTempDirMapping);
             return new LocationHandle(targetPath, writePath, false, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
         else {
@@ -75,7 +79,7 @@ public class HiveLocationService
         Path targetPath = new Path(table.getStorage().getLocation());
 
         if (shouldUseTemporaryDirectory(context, targetPath)) {
-            Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath);
+            Path writePath = createTemporaryPath(context, hdfsEnvironment, targetPath, Collections.emptyMap());
             return new LocationHandle(targetPath, writePath, true, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
         else {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -541,7 +541,7 @@ public final class HiveWriteUtils
         }
     }
 
-    public static Path createTemporaryPath(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path targetPath)
+    public static Path createTemporaryPath(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path targetPath, Map<String, String> viewFsTempDirMapping)
     {
         // use a per-user temporary directory to avoid permission problems
         String temporaryPrefix = "/tmp/presto-" + context.getIdentity().getUser();
@@ -549,6 +549,12 @@ public final class HiveWriteUtils
         // use relative temporary directory on ViewFS
         if (isViewFileSystem(context, hdfsEnvironment, targetPath)) {
             temporaryPrefix = ".hive-staging";
+            for (String key : viewFsTempDirMapping.keySet()) {
+                if (targetPath.toString().startsWith(key)) {
+                    temporaryPrefix = viewFsTempDirMapping.get(key);
+                    break;
+                }
+            }
         }
 
         // create a temporary directory on the same filesystem

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -727,7 +727,7 @@ public abstract class AbstractTestHiveClient
         metastoreClient = hiveMetastore;
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig));
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
-        locationService = new HiveLocationService(hdfsEnvironment);
+        locationService = new HiveLocationService(hdfsEnvironment, hiveClientConfig);
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
         metadataFactory = new HiveMetadataFactory(
                 metastoreClient,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -165,7 +165,7 @@ public abstract class AbstractTestHiveFileSystem
                 config,
                 getBasePath(),
                 hdfsEnvironment);
-        locationService = new HiveLocationService(hdfsEnvironment);
+        locationService = new HiveLocationService(hdfsEnvironment, config);
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
         metadataFactory = new HiveMetadataFactory(
                 config,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -258,7 +258,7 @@ public class TestHivePageSink
                 new GroupByHashPageIndexerFactory(new JoinCompiler(MetadataManager.createTestMetadataManager(), new FeaturesConfig())),
                 TYPE_MANAGER,
                 config,
-                new HiveLocationService(hdfsEnvironment),
+                new HiveLocationService(hdfsEnvironment, config),
                 partitionUpdateCodec,
                 new TestingNodeManager("fake-environment"),
                 new HiveEventClient(),


### PR DESCRIPTION
This commit makes the temp dir during DDL configurable,
in viewFs based hdfs environment, make temp dir inside the
current targetpath will make hdfs rename fail during CREATE/ALTER
TABLE/PARTITION