### PR TITLE
Add the geometry_union_agg spatial aggregation function

### DIFF
--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -38,6 +38,11 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-array</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -64,6 +69,11 @@
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
         </dependency>
 
         <!-- for testing -->
@@ -112,12 +122,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>it.unimi.dsi</groupId>
-            <artifactId>fastutil</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoPlugin.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoPlugin.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.geospatial;
 
 import com.facebook.presto.plugin.geospatial.BingTileFunctions.BingTileCoordinatesFunction;
+import com.facebook.presto.plugin.geospatial.aggregation.GeometryUnionAgg;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
@@ -41,6 +42,7 @@ public class GeoPlugin
                 .add(BingTileOperators.class)
                 .add(BingTileFunctions.class)
                 .add(BingTileCoordinatesFunction.class)
+                .add(GeometryUnionAgg.class)
                 .build();
     }
 }

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryState.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryState.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+@AccumulatorStateMetadata(stateSerializerClass = GeometryStateSerializer.class, stateFactoryClass = GeometryStateFactory.class)
+public interface GeometryState
+        extends AccumulatorState
+{
+    OGCGeometry getGeometry();
+
+    void setGeometry(OGCGeometry geometry);
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryStateFactory.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryStateFactory.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.spi.function.GroupedAccumulatorState;
+import org.openjdk.jol.info.ClassLayout;
+
+public class GeometryStateFactory
+        implements AccumulatorStateFactory<GeometryState>
+{
+    private static final long OGC_GEOMETRY_BASE_INSTANCE_SIZE = ClassLayout.parseClass(OGCGeometry.class).instanceSize();
+
+    @Override
+    public GeometryState createSingleState()
+    {
+        return new SingleGeometryState();
+    }
+
+    @Override
+    public Class<? extends GeometryState> getSingleStateClass()
+    {
+        return SingleGeometryState.class;
+    }
+
+    @Override
+    public GeometryState createGroupedState()
+    {
+        return new GroupedGeometryState();
+    }
+
+    @Override
+    public Class<? extends GeometryState> getGroupedStateClass()
+    {
+        return GroupedGeometryState.class;
+    }
+
+    public static class GroupedGeometryState
+            implements GeometryState, GroupedAccumulatorState
+    {
+        private long groupId;
+        private ObjectBigArray<OGCGeometry> geometries = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public OGCGeometry getGeometry()
+        {
+            return geometries.get(groupId);
+        }
+
+        @Override
+        public void setGeometry(OGCGeometry geometry)
+        {
+            OGCGeometry previousValue = this.geometries.get(groupId);
+            size -= getGeometryMemorySize(previousValue);
+            size += getGeometryMemorySize(geometry);
+            this.geometries.set(groupId, geometry);
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            geometries.ensureCapacity(size);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + geometries.sizeOf();
+        }
+
+        @Override
+        public final void setGroupId(long groupId)
+        {
+            this.groupId = groupId;
+        }
+    }
+
+    // Do a best-effort attempt to estimate the memory size
+    private static long getGeometryMemorySize(OGCGeometry geometry)
+    {
+        if (geometry == null) {
+            return 0;
+        }
+        // Due to the following issue:
+        // https://github.com/Esri/geometry-api-java/issues/192
+        // We must check if the geometry is empty before calculating its size.  Once the issue is resolved
+        // and we bring the fix into our codebase, we can remove this check.
+        if (geometry.isEmpty()) {
+            return OGC_GEOMETRY_BASE_INSTANCE_SIZE;
+        }
+        return geometry.estimateMemorySize();
+    }
+
+    public static class SingleGeometryState
+            implements GeometryState
+    {
+        private OGCGeometry geometry;
+
+        @Override
+        public OGCGeometry getGeometry()
+        {
+            return geometry;
+        }
+
+        @Override
+        public void setGeometry(OGCGeometry geometry)
+        {
+            this.geometry = geometry;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return getGeometryMemorySize(geometry);
+        }
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryStateSerializer.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryStateSerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.facebook.presto.geospatial.serde.GeometrySerde;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+
+import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY;
+
+public class GeometryStateSerializer
+        implements AccumulatorStateSerializer<GeometryState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return GEOMETRY;
+    }
+
+    @Override
+    public void serialize(GeometryState state, BlockBuilder out)
+    {
+        if (state.getGeometry() == null) {
+            out.appendNull();
+        }
+        else {
+            GEOMETRY.writeSlice(out, GeometrySerde.serialize(state.getGeometry()));
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, GeometryState state)
+    {
+        state.setGeometry(GeometrySerde.deserialize(GEOMETRY.getSlice(block, index)));
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryUnionAgg.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryUnionAgg.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.geospatial.serde.GeometrySerde;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY;
+import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY_TYPE_NAME;
+
+/**
+ * Aggregate form of ST_Union which takes a set of geometries and unions them into a single geometry, resulting in no intersecting
+ * regions.  The output may be a multi-geometry, a single geometry or a geometry collection.
+ */
+@Description("Returns a geometry that represents the point set union of the input geometries.")
+@AggregationFunction("geometry_union_agg")
+public class GeometryUnionAgg
+{
+    private GeometryUnionAgg() {}
+
+    @InputFunction
+    public static void input(@AggregationState GeometryState state, @SqlType(GEOMETRY_TYPE_NAME) Slice input)
+    {
+        OGCGeometry geometry = GeometrySerde.deserialize(input);
+        if (state.getGeometry() == null) {
+            state.setGeometry(geometry);
+        }
+        else if (!geometry.isEmpty()) {
+            state.setGeometry(state.getGeometry().union(geometry));
+        }
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState GeometryState state, @AggregationState GeometryState otherState)
+    {
+        if (state.getGeometry() == null) {
+            state.setGeometry(otherState.getGeometry());
+        }
+        else if (otherState.getGeometry() != null && !otherState.getGeometry().isEmpty()) {
+            state.setGeometry(state.getGeometry().union(otherState.getGeometry()));
+        }
+    }
+
+    @OutputFunction(GEOMETRY_TYPE_NAME)
+    public static void output(@AggregationState GeometryState state, BlockBuilder out)
+    {
+        if (state.getGeometry() == null) {
+            out.appendNull();
+        }
+        else {
+            GEOMETRY.writeSlice(out, GeometrySerde.serialize(state.getGeometry()));
+        }
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryStateFactory.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryStateFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestGeometryStateFactory
+{
+    private GeometryStateFactory factory;
+
+    @BeforeMethod
+    public void init()
+    {
+        factory = new GeometryStateFactory();
+    }
+    @Test
+    public void testCreateSingleStateEmpty()
+    {
+        GeometryState state = factory.createSingleState();
+        assertNull(state.getGeometry());
+        assertEquals(0, state.getEstimatedSize());
+    }
+
+    @Test
+    public void testCreateSingleStatePresent()
+    {
+        GeometryState state = factory.createSingleState();
+        state.setGeometry(OGCGeometry.fromText("POINT (1 2)"));
+        assertEquals(OGCGeometry.fromText("POINT (1 2)"), state.getGeometry());
+        assertTrue(state.getEstimatedSize() > 0, String.format("Estimated memory size was %d", state.getEstimatedSize()));
+    }
+
+    @Test
+    public void testCreateGroupedStateEmpty()
+    {
+        GeometryState state = factory.createGroupedState();
+        assertNull(state.getGeometry());
+        assertTrue(state.getEstimatedSize() > 0, String.format("Estimated memory size was %d", state.getEstimatedSize()));
+    }
+
+    @Test
+    public void testCreateGroupedStatePresent()
+    {
+        GeometryState state = factory.createGroupedState();
+        assertNull(state.getGeometry());
+        assertTrue(state instanceof GeometryStateFactory.GroupedGeometryState);
+        GeometryStateFactory.GroupedGeometryState groupedState = (GeometryStateFactory.GroupedGeometryState) state;
+
+        groupedState.setGroupId(1);
+        assertNull(state.getGeometry());
+        groupedState.setGeometry(OGCGeometry.fromText("POINT (1 2)"));
+        assertEquals(state.getGeometry(), OGCGeometry.fromText("POINT (1 2)"));
+
+        groupedState.setGroupId(2);
+        assertNull(state.getGeometry());
+        groupedState.setGeometry(OGCGeometry.fromText("POINT (3 4)"));
+        assertEquals(state.getGeometry(), OGCGeometry.fromText("POINT (3 4)"));
+
+        groupedState.setGroupId(1);
+        assertNotNull(state.getGeometry());
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryStateSerializer.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryStateSerializer.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.operator.aggregation.state.StateCompiler;
+import com.facebook.presto.plugin.geospatial.GeometryType;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.plugin.geospatial.aggregation.GeometryStateFactory.GroupedGeometryState;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestGeometryStateSerializer
+{
+    @Test
+    public void testSerializeDeserialize()
+    {
+        AccumulatorStateFactory<GeometryState> factory = StateCompiler.generateStateFactory(GeometryState.class);
+        AccumulatorStateSerializer<GeometryState> serializer = StateCompiler.generateStateSerializer(GeometryState.class);
+        GeometryState state = factory.createSingleState();
+
+        state.setGeometry(OGCGeometry.fromText("POINT (1 2)"));
+
+        BlockBuilder builder = GeometryType.GEOMETRY.createBlockBuilder(null, 1);
+        serializer.serialize(state, builder);
+        Block block = builder.build();
+
+        assertEquals(GeometryType.GEOMETRY.getObjectValue(null, block, 0), "POINT (1 2)");
+
+        state.setGeometry(null);
+        serializer.deserialize(block, 0, state);
+
+        assertEquals(state.getGeometry().asText(), "POINT (1 2)");
+    }
+    @Test
+    public void testSerializeDeserializeGrouped()
+    {
+        AccumulatorStateFactory<GeometryState> factory = StateCompiler.generateStateFactory(GeometryState.class);
+        AccumulatorStateSerializer<GeometryState> serializer = StateCompiler.generateStateSerializer(GeometryState.class);
+        GroupedGeometryState state = (GroupedGeometryState) factory.createGroupedState();
+
+        // Add state to group 1
+        state.setGroupId(1);
+        state.setGeometry(OGCGeometry.fromText("POINT (1 2)"));
+        // Add another state to group 2, to show that this doesn't affect the group under test (group 1)
+        state.setGroupId(2);
+        state.setGeometry(OGCGeometry.fromText("POINT (2 3)"));
+        // Return to group 1
+        state.setGroupId(1);
+
+        BlockBuilder builder = GeometryType.GEOMETRY.createBlockBuilder(null, 1);
+        serializer.serialize(state, builder);
+        Block block = builder.build();
+
+        assertEquals(GeometryType.GEOMETRY.getObjectValue(null, block, 0), "POINT (1 2)");
+
+        state.setGeometry(null);
+        serializer.deserialize(block, 0, state);
+
+        // Assert the state of group 1
+        assertEquals(state.getGeometry().asText(), "POINT (1 2)");
+        // Verify nothing changed in group 2
+        state.setGroupId(2);
+        assertEquals(state.getGeometry().asText(), "POINT (2 3)");
+        // Groups we did not touch are null
+        state.setGroupId(3);
+        assertNull(state.getGeometry());
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryUnionAgg.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryUnionAgg.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.block.BlockAssertions;
+import com.facebook.presto.geospatial.serde.GeometrySerde;
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.plugin.geospatial.GeoPlugin;
+import com.facebook.presto.plugin.geospatial.GeometryType;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeSignature;
+import io.airlift.slice.Slice;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.metadata.FunctionExtractor.extractFunctions;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+
+public class TestGeometryUnionAgg
+        extends AbstractTestFunctions
+{
+    @DataProvider(name = "point")
+    public Object[][] point()
+    {
+        return new Object[][] {
+                {
+                        "identity",
+                        "POINT (1 2)",
+                        new String[] {"POINT (1 2)", "POINT (1 2)", "POINT (1 2)"},
+                },
+                {
+                        "no input yields null",
+                        null,
+                        new String[] {},
+                },
+                {
+                        "null before value yields the value",
+                        "POINT (1 2)",
+                        new String[] {null, "POINT (1 2)"},
+                },
+                {
+                        "empty with non-empty",
+                        "POINT (1 2)",
+                        new String[] {"POINT EMPTY", "POINT (1 2)"},
+                },
+                {
+                        "disjoint returns multipoint",
+                        "MULTIPOINT ((1 2), (3 4))",
+                        new String[] {"POINT (1 2)", "POINT (3 4)"},
+                },
+        };
+    }
+
+    @DataProvider(name = "linestring")
+    public Object[][] linestring()
+    {
+        return new Object[][] {
+                {
+                        "identity",
+                        "LINESTRING (1 1, 2 2)",
+                        new String[] {"LINESTRING (1 1, 2 2)", "LINESTRING (1 1, 2 2)", "LINESTRING (1 1, 2 2)"},
+                },
+                {
+                        "empty with non-empty",
+                        "LINESTRING (1 1, 2 2)",
+                        new String[] {"LINESTRING EMPTY", "LINESTRING (1 1, 2 2)"},
+                },
+                {
+                        "overlap",
+                        "LINESTRING (1 1, 2 2, 3 3, 4 4)",
+                        new String[] {"LINESTRING (1 1, 2 2, 3 3)", "LINESTRING (2 2, 3 3, 4 4)"},
+                },
+                {
+                        "disjoint returns multistring",
+                        "MULTILINESTRING ((1 1, 2 2, 3 3), (1 2, 2 3, 3 4))",
+                        new String[] {"LINESTRING (1 1, 2 2, 3 3)", "LINESTRING (1 2, 2 3, 3 4)"},
+                },
+                {
+                        "cut through returns multistring",
+                        "MULTILINESTRING ((1 1, 2 2), (3 1, 2 2), (2 2, 3 3), (2 2, 1 3))",
+                        new String[] {"LINESTRING (1 1, 3 3)", "LINESTRING (3 1, 1 3)"},
+                },
+        };
+    }
+
+    @DataProvider(name = "polygon")
+    public Object[][] polygon()
+    {
+        return new Object[][] {
+                {
+                        "identity",
+                        "POLYGON ((2 2, 1 1, 3 1, 2 2))",
+                        new String[] {"POLYGON ((2 2, 1 1, 3 1, 2 2))", "POLYGON ((2 2, 1 1, 3 1, 2 2))", "POLYGON ((2 2, 1 1, 3 1, 2 2))"},
+                },
+                {
+                        "empty with non-empty",
+                        "POLYGON ((2 2, 1 1, 3 1, 2 2))",
+                        new String[] {"POLYGON EMPTY)", "POLYGON ((2 2, 1 1, 3 1, 2 2))"},
+                },
+                {
+                        "three overlapping triangles",
+                        "POLYGON ((1 1, 2 1, 3 1, 4 1, 5 1, 4 2, 3.5 1.5, 3 2, 2.5 1.5, 2 2, 1 1))",
+                        new String[] {"POLYGON ((2 2, 3 1, 1 1, 2 2))", "POLYGON ((3 2, 4 1, 2 1, 3 2))", "POLYGON ((4 2, 5 1, 3 1, 4 2))"},
+                },
+                {
+                        "two triangles touching at 3 1 returns multipolygon",
+                        "MULTIPOLYGON (((1 1, 3 1, 2 2, 1 1)), ((3 1, 5 1, 4 2, 3 1)))",
+                        new String[] {"POLYGON ((2 2, 3 1, 1 1, 2 2))", "POLYGON ((4 2, 5 1, 3 1, 4 2))"},
+                },
+                {
+                        "two disjoint triangles returns multipolygon",
+                        "MULTIPOLYGON (((1 1, 3 1, 2 2, 1 1)), ((4 1, 6 1, 5 2, 4 1)))",
+                        new String[] {"POLYGON ((2 2, 3 1, 1 1, 2 2))", "POLYGON ((5 2, 6 1, 4 1, 5 2))"},
+                },
+                {
+                        "polygon with hole that is filled is simplified",
+                        "POLYGON ((1 1, 6 1, 6 6, 1 6, 1 1))",
+                        new String[] {"POLYGON ((1 1, 6 1, 6 6, 1 6, 1 1), (3 3, 4 3, 4 4, 3 4, 3 3))", "POLYGON ((3 3, 4 3, 4 4, 3 4, 3 3))"},
+                },
+                {
+                        "polygon with hole with shape larger than hole is simplified",
+                        "POLYGON ((1 1, 6 1, 6 6, 1 6, 1 1))",
+                        new String[] {"POLYGON ((1 1, 6 1, 6 6, 1 6, 1 1), (3 3, 4 3, 4 4, 3 4, 3 3))", "POLYGON ((2 2, 5 2, 5 5, 2 5, 2 2))"},
+                },
+                {
+                        "polygon with hole with shape smaller than hole becomes multipolygon",
+                        "MULTIPOLYGON (((1 1, 6 1, 6 6, 1 6, 1 1), (3 3, 3 4, 4 4, 4 3, 3 3)), ((3.25 3.25, 3.75 3.25, 3.75 3.75, 3.25 3.75, 3.25 3.25)))",
+                        new String[] {"POLYGON ((1 1, 6 1, 6 6, 1 6, 1 1), (3 3, 4 3, 4 4, 3 4, 3 3))", "POLYGON ((3.25 3.25, 3.75 3.25, 3.75 3.75, 3.25 3.75, 3.25 3.25))"},
+                },
+                {
+                        "polygon with hole with several smaller pieces which fill hole simplify into polygon",
+                        "POLYGON ((1 1, 6 1, 6 6, 1 6, 1 1))",
+                        new String[] {"POLYGON ((1 1, 6 1, 6 6, 1 6, 1 1), (3 3, 4 3, 4 4, 3 4, 3 3))", "POLYGON ((3 3, 3 3.5, 3.5 3.5, 3.5 3, 3 3))",
+                                "POLYGON ((3.5 3.5, 3.5 4, 4 4, 4 3.5, 3.5 3.5))", "POLYGON ((3 3.5, 3 4, 3.5 4, 3.5 3.5, 3 3.5))",
+                                "POLYGON ((3.5 3, 3.5 3.5, 4 3.5, 4 3, 3.5 3))"},
+                },
+                {
+                        "two overlapping rectangles becomes cross",
+                        "POLYGON ((3 1, 4 1, 4 3, 6 3, 6 4, 4 4, 4 6, 3 6, 3 4, 1 4, 1 3, 3 3, 3 1))",
+                        new String[] {"POLYGON ((1 3, 1 4, 6 4, 6 3, 1 3))", "POLYGON ((3 1, 4 1, 4 6, 3 6, 3 1))"},
+                },
+                {
+                        "touching squares become single cross",
+                        "POLYGON ((3 1, 4 1, 4 3, 6 3, 6 4, 4 4, 4 6, 3 6, 3 4, 1 4, 1 3, 3 3, 3 1))",
+                        new String[] {"POLYGON ((1 3, 1 4, 3 4, 3 3, 1 3))", "POLYGON ((3 3, 3 4, 4 4, 4 3, 3 3))", "POLYGON ((4 3, 4 4, 6 4, 6 3, 4 3))",
+                                "POLYGON ((3 1, 4 1, 4 3, 3 3, 3 1))", "POLYGON ((3 4, 3 6, 4 6, 4 4, 3 4))"},
+                },
+                {
+                        "square with touching point becomes simplified polygon",
+                        "POLYGON ((1 1, 3 1, 3 2, 3 3, 1 3, 1 1))",
+                        new String[] {"POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))", "POINT (3 2)"},
+                },
+        };
+    }
+
+    @DataProvider(name = "multipoint")
+    public Object[][] multipoint()
+    {
+        return new Object[][] {
+                {
+                        "identity",
+                        "MULTIPOINT ((1 2), (2 4), (3 6), (4 8))",
+                        new String[] {"MULTIPOINT ((1 2), (2 4), (3 6), (4 8))", "MULTIPOINT ((1 2), (2 4), (3 6), (4 8))", "MULTIPOINT ((1 2), (2 4), (3 6), (4 8))"},
+                },
+                {
+                        "empty with non-empty",
+                        "MULTIPOINT ((1 2), (2 4), (3 6), (4 8))",
+                        new String[] {"MULTIPOINT EMPTY", "MULTIPOINT ((1 2), (2 4), (3 6), (4 8))"},
+                },
+                {
+                        "disjoint",
+                        "MULTIPOINT ((1 2), (2 4), (3 6), (4 8))",
+                        new String[] {"MULTIPOINT ((1 2), (2 4))", "MULTIPOINT ((3 6), (4 8))"},
+                },
+                {
+                        "overlap",
+                        "MULTIPOINT ((1 2), (2 4), (3 6), (4 8))",
+                        new String[] {"MULTIPOINT ((1 2), (2 4))", "MULTIPOINT ((2 4), (3 6))", "MULTIPOINT ((3 6), (4 8))"},
+                },
+        };
+    }
+
+    @DataProvider(name = "multilinestring")
+    public Object[][] multilinestring()
+    {
+        return new Object[][] {
+                {
+                        "identity",
+                        "MULTILINESTRING ((1 5, 4 1), (2 5, 5 1))",
+                        new String[] {"MULTILINESTRING ((1 5, 4 1), (2 5, 5 1))", "MULTILINESTRING ((1 5, 4 1), (2 5, 5 1))", "MULTILINESTRING ((1 5, 4 1), (2 5, 5 1))"},
+                },
+                {
+                        "empty with non-empty",
+                        "MULTILINESTRING ((1 5, 4 1), (2 5, 5 1))",
+                        new String[] {"MULTILINESTRING EMPTY", "MULTILINESTRING ((1 5, 4 1), (2 5, 5 1))"},
+                },
+                {
+                        "disjoint",
+                        "MULTILINESTRING ((1 5, 4 1), (2 5, 5 1), (3 5, 6 1), (4 5, 7 1))",
+                        new String[] {"MULTILINESTRING ((1 5, 4 1), (3 5, 6 1))", "MULTILINESTRING ((2 5, 5 1), (4 5, 7 1))"},
+                },
+                {
+                        "disjoint aggregates with cut through",
+                        "MULTILINESTRING ((2.5 3, 4 1), (3.5 3, 5 1), (4.5 3, 6 1), (5.5 3, 7 1), (1 3, 2.5 3), (2.5 3, 3.5 3), (1 5, 2.5 3), (3.5 3, 4.5 3), (2 5, 3.5 3), (4.5 3, 5.5 3), (3 5, 4.5 3), (5.5 3, 8 3), (4 5, 5.5 3))",
+                        new String[] {"MULTILINESTRING ((1 5, 4 1), (3 5, 6 1))", "MULTILINESTRING ((2 5, 5 1), (4 5, 7 1))", "LINESTRING (1 3, 8 3)"},
+                },
+        };
+    }
+
+    @DataProvider(name = "multipolygon")
+    public Object[][] multipolygon()
+    {
+        return new Object[][] {
+                {
+                        "identity",
+                        "MULTIPOLYGON(((4 2, 5 1, 3 1, 4 2)))",
+                        new String[] {"MULTIPOLYGON(((4 2, 5 1, 3 1, 4 2)))", "MULTIPOLYGON(((4 2, 5 1, 3 1, 4 2)))", "MULTIPOLYGON(((4 2, 5 1, 3 1, 4 2)))"},
+                },
+                {
+                        "empty with non-empty",
+                        "MULTIPOLYGON(((4 2, 5 1, 3 1, 4 2)))",
+                        new String[] {"MULTIPOLYGON EMPTY", "MULTIPOLYGON(((4 2, 5 1, 3 1, 4 2)))"},
+                },
+                {
+                        "disjoint",
+                        "MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((3 0, 5 0, 5 2, 3 2, 3 0)), ((0 3, 2 3, 2 5, 0 5, 0 3)), ((3 3, 5 3, 5 5, 3 5, 3 3)))",
+                        new String[] {"MULTIPOLYGON ((( 0 0, 0 2, 2 2, 2 0, 0 0 )), (( 0 3, 0 5, 2 5, 2 3, 0 3 )))",
+                                "MULTIPOLYGON ((( 3 0, 3 2, 5 2, 5 0, 3 0 )), (( 3 3, 3 5, 5 5, 5 3, 3 3 )))"},
+                },
+                {
+                        "overlapping multipolygons are simplified",
+                        "POLYGON ((2 2, 1 1, 2 1, 3 1, 4 1, 5 1, 4 2, 3.5 1.5, 3 2, 2.5 1.5, 2 2))",
+                        new String[] {"MULTIPOLYGON (((2 2, 3 1, 1 1, 2 2)), ((3 2, 4 1, 2 1, 3 2)))", "MULTIPOLYGON(((4 2, 5 1, 3 1, 4 2)))"},
+                },
+                {
+                        "overlapping multipolygons become single cross",
+                        "POLYGON ((3 1, 4 1, 4 3, 6 3, 6 4, 4 4, 4 6, 3 6, 3 4, 1 4, 1 3, 3 3, 3 1))",
+                        new String[] {"MULTIPOLYGON (((1 3, 1 4, 3 4, 3 3, 1 3)), ((3 3, 3 4, 4 4, 4 3, 3 3)), ((4 3, 4 4, 6 4, 6 3, 4 3)))",
+                                "MULTIPOLYGON (((3 1, 4 1, 4 3, 3 3, 3 1)), ((3 4, 3 6, 4 6, 4 4, 3 4)))"},
+                },
+        };
+    }
+
+    @DataProvider(name = "geometrycollection")
+    public Object[][] geometryCollection()
+    {
+        return new Object[][] {
+                {
+                        "identity",
+                        "MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((3 0, 5 0, 5 2, 3 2, 3 0)))",
+                        new String[] {"MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((3 0, 5 0, 5 2, 3 2, 3 0)))",
+                                "GEOMETRYCOLLECTION ( POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0)), POLYGON ((3 0, 5 0, 5 2, 3 2, 3 0)))",
+                                "GEOMETRYCOLLECTION ( POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0)), POLYGON ((3 0, 5 0, 5 2, 3 2, 3 0)))"},
+                },
+                {
+                        "empty with non-empty",
+                        "MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((3 0, 5 0, 5 2, 3 2, 3 0)))",
+                        new String[] {"GEOMETRYCOLLECTION EMPTY",
+                                "GEOMETRYCOLLECTION ( POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0)), POLYGON ((3 0, 5 0, 5 2, 3 2, 3 0)))"},
+                },
+                {
+                        "overlapping geometry collections are simplified",
+                        "POLYGON ((1 1, 2 1, 3 1, 4 1, 5 1, 4 2, 3.5 1.5, 3 2, 2.5 1.5, 2 2, 1 1))",
+                        new String[] {"GEOMETRYCOLLECTION ( POLYGON ((2 2, 3 1, 1 1, 2 2)), POLYGON ((3 2, 4 1, 2 1, 3 2)) )",
+                                "GEOMETRYCOLLECTION ( POLYGON ((4 2, 5 1, 3 1, 4 2)) )"},
+                },
+                {
+                        "disjoint geometry collection of polygons becomes multipolygon",
+                        "MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((3 0, 5 0, 5 2, 3 2, 3 0)), ((0 3, 2 3, 2 5, 0 5, 0 3)), ((3 3, 5 3, 5 5, 3 5, 3 3)))",
+                        new String[] {"GEOMETRYCOLLECTION ( POLYGON (( 0 0, 0 2, 2 2, 2 0, 0 0 )), POLYGON (( 0 3, 0 5, 2 5, 2 3, 0 3 )) )",
+                                "GEOMETRYCOLLECTION ( POLYGON (( 3 0, 3 2, 5 2, 5 0, 3 0 )), POLYGON (( 3 3, 3 5, 5 5, 5 3, 3 3 )) )"},
+                },
+                {
+                        "square with a line crossed becomes geometry collection",
+                        "GEOMETRYCOLLECTION (MULTILINESTRING ((0 2, 1 2), (3 2, 5 2)), POLYGON ((1 1, 3 1, 3 2, 3 3, 1 3, 1 2, 1 1)))",
+                        new String[] {"POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))", "LINESTRING (0 2, 5 2)"},
+                },
+                {
+                        "square with adjacent line becomes geometry collection",
+                        "GEOMETRYCOLLECTION (LINESTRING (0 5, 5 5), POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1)))",
+                        new String[] {"POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))", "LINESTRING (0 5, 5 5)"},
+                },
+                {
+                        "square with adjacent point becomes geometry collection",
+                        "GEOMETRYCOLLECTION (POINT (5 2), POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1)))",
+                        new String[] {"POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))", "POINT (5 2)"},
+                },
+        };
+    }
+
+    private InternalAggregationFunction function;
+
+    @BeforeClass
+    public void registerFunctions()
+    {
+        GeoPlugin plugin = new GeoPlugin();
+        for (Type type : plugin.getTypes()) {
+            functionAssertions.getTypeRegistry().addType(type);
+        }
+        functionAssertions.getMetadata().addFunctions(extractFunctions(plugin.getFunctions()));
+
+        function = functionAssertions.getMetadata().getFunctionRegistry().getAggregateFunctionImplementation(new Signature(
+                "geometry_union_agg",
+                FunctionKind.AGGREGATE,
+                TypeSignature.parseTypeSignature(GeometryType.GEOMETRY_TYPE_NAME),
+                TypeSignature.parseTypeSignature(GeometryType.GEOMETRY_TYPE_NAME)));
+    }
+
+    @Test(dataProvider = "point")
+    public void testPoint(String testDescription, String expectedWkt, String... wkts)
+    {
+        assertAggregatedGeometries(testDescription, expectedWkt, wkts);
+    }
+
+    @Test(dataProvider = "linestring")
+    public void testLineString(String testDescription, String expectedWkt, String... wkts)
+    {
+        assertAggregatedGeometries(testDescription, expectedWkt, wkts);
+    }
+
+    @Test(dataProvider = "polygon")
+    public void testPolygon(String testDescription, String expectedWkt, String... wkts)
+    {
+        assertAggregatedGeometries(testDescription, expectedWkt, wkts);
+    }
+
+    @Test(dataProvider = "multipoint")
+    public void testMultiPoint(String testDescription, String expectedWkt, String... wkts)
+    {
+        assertAggregatedGeometries(testDescription, expectedWkt, wkts);
+    }
+
+    @Test(dataProvider = "multilinestring")
+    public void testMultiLineString(String testDescription, String expectedWkt, String... wkts)
+    {
+        assertAggregatedGeometries(testDescription, expectedWkt, wkts);
+    }
+
+    @Test(dataProvider = "multipolygon")
+    public void testMultiPolygon(String testDescription, String expectedWkt, String... wkts)
+    {
+        assertAggregatedGeometries(testDescription, expectedWkt, wkts);
+    }
+
+    @Test(dataProvider = "geometrycollection")
+    public void testGeometryCollection(String testDescription, String expectedWkt, String... wkts)
+    {
+        assertAggregatedGeometries(testDescription, expectedWkt, wkts);
+    }
+
+    private void assertAggregatedGeometries(String testDescription, String expectedWkt, String... wkts)
+    {
+        List<Slice> geometrySlices = Arrays.stream(wkts)
+                .map(text -> text == null ? null : OGCGeometry.fromText(text))
+                .map(input -> input == null ? null : GeometrySerde.serialize(input))
+                .collect(Collectors.toList());
+
+        // Add a custom equality assertion because the resulting geometry may have its constituent points in a different order
+        BiFunction<Object, Object, Boolean> equalityFunction = (left, right) -> {
+            if (left == null && right == null) {
+                return true;
+            }
+            if (left == null || right == null) {
+                return false;
+            }
+            OGCGeometry leftGeometry = OGCGeometry.fromText(left.toString());
+            OGCGeometry rightGeometry = OGCGeometry.fromText(right.toString());
+            // Check for equality by getting the difference
+            return leftGeometry.difference(rightGeometry).isEmpty() && rightGeometry.difference(leftGeometry).isEmpty();
+        };
+        // Test in forward and reverse order to verify that ordering doesn't affect the output
+        assertAggregation(function, equalityFunction, testDescription, new Page(BlockAssertions.createSlicesBlock(geometrySlices)), expectedWkt);
+        Collections.reverse(geometrySlices);
+        assertAggregation(function, equalityFunction, testDescription, new Page(BlockAssertions.createSlicesBlock(geometrySlices)), expectedWkt);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
@@ -20,15 +20,18 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.google.common.primitives.Ints;
+import org.apache.commons.math3.util.Precision;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 public final class AggregationTestUtils
 {
@@ -43,21 +46,37 @@ public final class AggregationTestUtils
 
     public static void assertAggregation(InternalAggregationFunction function, Object expectedValue, Page page)
     {
+        BiFunction<Object, Object, Boolean> equalAssertion;
+        if (expectedValue instanceof Double && !expectedValue.equals(Double.NaN)) {
+            equalAssertion = (actual, expected) -> Precision.equals((double) actual, (double) expected, 1e-10);
+        }
+        else if (expectedValue instanceof Float && !expectedValue.equals(Float.NaN)) {
+            equalAssertion = (actual, expected) -> Precision.equals((float) actual, (float) expected, 1e-10f);
+        }
+        else {
+            equalAssertion = Objects::equals;
+        }
+
+        assertAggregation(function, equalAssertion, null, page, expectedValue);
+    }
+
+    public static void assertAggregation(InternalAggregationFunction function, BiFunction<Object, Object, Boolean> equalAssertion, String testDescription, Page page, Object expectedValue)
+    {
         int positions = page.getPositionCount();
         for (int i = 1; i < page.getChannelCount(); i++) {
             assertEquals(positions, page.getBlock(i).getPositionCount(), "input blocks provided are not equal in position count");
         }
         if (positions == 0) {
-            assertAggregationInternal(function, expectedValue, new Page[] {});
+            assertAggregationInternal(function, equalAssertion, testDescription, expectedValue, new Page[] {});
         }
         else if (positions == 1) {
-            assertAggregationInternal(function, expectedValue, page);
+            assertAggregationInternal(function, equalAssertion, testDescription, expectedValue, page);
         }
         else {
             int split = positions / 2; // [0, split - 1] goes to first list of blocks; [split, positions - 1] goes to second list of blocks.
             Page page1 = page.getRegion(0, split);
             Page page2 = page.getRegion(split, positions - split);
-            assertAggregationInternal(function, expectedValue, page1, page2);
+            assertAggregationInternal(function, equalAssertion, testDescription, expectedValue, page1, page2);
         }
     }
 
@@ -89,26 +108,28 @@ public final class AggregationTestUtils
         return blockBuilder.build();
     }
 
-    private static void assertAggregationInternal(InternalAggregationFunction function, Object expectedValue, Page... pages)
+    private static void assertAggregationInternal(InternalAggregationFunction function, BiFunction<Object, Object, Boolean> isEqual, String testDescription, Object expectedValue, Page... pages)
     {
-        BiConsumer<Object, Object> equalAssertion = (actual, expected) -> {
-            assertEquals(actual, expected);
-        };
-        if (expectedValue instanceof Double && !expectedValue.equals(Double.NaN)) {
-            equalAssertion = (actual, expected) -> assertEquals((double) actual, (double) expected, 1e-10);
-        }
-        if (expectedValue instanceof Float && !expectedValue.equals(Float.NaN)) {
-            equalAssertion = (actual, expected) -> assertEquals((float) actual, (float) expected, 1e-10f);
-        }
-
         // This assertAggregation does not try to split up the page to test the correctness of combine function.
         // Do not use this directly. Always use the other assertAggregation.
-        equalAssertion.accept(aggregation(function, pages), expectedValue);
-        equalAssertion.accept(partialAggregation(function, pages), expectedValue);
+        assertFunctionEquals(isEqual, testDescription, aggregation(function, pages), expectedValue);
+        assertFunctionEquals(isEqual, testDescription, partialAggregation(function, pages), expectedValue);
         if (pages.length > 0) {
-            equalAssertion.accept(groupedAggregation(function, pages), expectedValue);
-            equalAssertion.accept(groupedPartialAggregation(function, pages), expectedValue);
-            equalAssertion.accept(distinctAggregation(function, pages), expectedValue);
+            assertFunctionEquals(isEqual, testDescription, groupedAggregation(isEqual, function, pages), expectedValue);
+            assertFunctionEquals(isEqual, testDescription, groupedPartialAggregation(isEqual, function, pages), expectedValue);
+            assertFunctionEquals(isEqual, testDescription, distinctAggregation(function, pages), expectedValue);
+        }
+    }
+
+    private static void assertFunctionEquals(BiFunction<Object, Object, Boolean> isEqual, String testDescription, Object expectedValue, Object actualValue)
+    {
+        if (!isEqual.apply(actualValue, expectedValue)) {
+            StringBuilder sb = new StringBuilder();
+            if (testDescription != null) {
+                sb.append(String.format("Test: %s, ", testDescription));
+            }
+            sb.append(String.format("Expected: %s, actual: %s", expectedValue, actualValue));
+            fail(sb.toString());
         }
     }
 
@@ -222,18 +243,23 @@ public final class AggregationTestUtils
 
     public static Object groupedAggregation(InternalAggregationFunction function, Page... pages)
     {
+        return groupedAggregation(Objects::equals, function, pages);
+    }
+
+    public static Object groupedAggregation(BiFunction<Object, Object, Boolean> isEqual, InternalAggregationFunction function, Page... pages)
+    {
         // execute with args in positions: arg0, arg1, arg2
         Object aggregation = groupedAggregation(function, createArgs(function), pages);
 
         // execute with args in reverse order: arg2, arg1, arg0
         if (function.getParameterTypes().size() > 1) {
             Object aggregationWithOffset = groupedAggregation(function, reverseArgs(function), reverseColumns(pages));
-            assertEquals(aggregationWithOffset, aggregation, "Inconsistent results with reversed channels");
+            assertFunctionEquals(isEqual, "Inconsistent results with reversed channels", aggregationWithOffset, aggregation);
         }
 
         // execute with args at an offset (and possibly reversed): null, null, null, arg2, arg1, arg0
         Object aggregationWithOffset = groupedAggregation(function, offsetArgs(function, 3), offsetColumns(pages, 3));
-        assertEquals(aggregationWithOffset, aggregation, "Inconsistent results with channel offset");
+        assertFunctionEquals(isEqual, "Consistent results with channel offset", aggregationWithOffset, aggregation);
 
         return aggregation;
     }
@@ -255,7 +281,7 @@ public final class AggregationTestUtils
         return groupValue;
     }
 
-    public static Object groupedPartialAggregation(InternalAggregationFunction function, Page... pages)
+    public static Object groupedPartialAggregation(BiFunction<Object, Object, Boolean> isEqual, InternalAggregationFunction function, Page... pages)
     {
         // execute with args in positions: arg0, arg1, arg2
         Object aggregation = groupedPartialAggregation(function, createArgs(function), pages);
@@ -263,12 +289,12 @@ public final class AggregationTestUtils
         // execute with args in reverse order: arg2, arg1, arg0
         if (function.getParameterTypes().size() > 1) {
             Object aggregationWithOffset = groupedPartialAggregation(function, reverseArgs(function), reverseColumns(pages));
-            assertEquals(aggregationWithOffset, aggregation, "Inconsistent results with reversed channels");
+            assertFunctionEquals(isEqual, "Consistent results with reversed channels", aggregationWithOffset, aggregation);
         }
 
         // execute with args at an offset (and possibly reversed): null, null, null, arg2, arg1, arg0
         Object aggregationWithOffset = groupedPartialAggregation(function, offsetArgs(function, 3), offsetColumns(pages, 3));
-        assertEquals(aggregationWithOffset, aggregation, "Inconsistent results with channel offset");
+        assertFunctionEquals(isEqual, "Consistent results with channel offset", aggregationWithOffset, aggregation);
 
         return aggregation;
     }


### PR DESCRIPTION
This change will add aggregated form of scalar ST_Union, which will iteratively union the input geometries.  For single geometries it will not simplify collections or multi types.

This change is marked as WIP to allow for early feedback, however it has a dependency on #11157 to allow for safe unions of geometry collections, and other bug fixes.