### PR TITLE
Allow PrestoS3FileSystem to support skipping Glacier files

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -257,6 +257,7 @@ Property Name                                Description
 
 ``hive.s3.upload-acl-type``                  Canned ACL to use while uploading files to S3 (defaults
                                              to ``Private``).
+``hive.s3.skip-glacier-objects``             Skip Glacier objects when listing the objects in a path (defaults to ``true``).
 ============================================ =================================================================
 
 S3 Credentials

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Config.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Config.java
@@ -57,6 +57,7 @@ public class HiveS3Config
     private boolean pinS3ClientToCurrentRegion;
     private String s3UserAgentPrefix = "";
     private PrestoS3AclType s3AclType = PrestoS3AclType.PRIVATE;
+    private boolean skipGlacierObjects = true;
 
     public String getS3AwsAccessKey()
     {
@@ -387,6 +388,18 @@ public class HiveS3Config
     public HiveS3Config setS3AclType(PrestoS3AclType s3AclType)
     {
         this.s3AclType = s3AclType;
+        return this;
+    }
+
+    public boolean isSkipGlacierObjects()
+    {
+        return skipGlacierObjects;
+    }
+
+    @Config("hive.s3.skip-glacier-objects")
+    public HiveS3Config setSkipGlacierObjects(boolean skipGlacierObjects)
+    {
+        this.skipGlacierObjects = skipGlacierObjects;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3ConfigurationUpdater.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3ConfigurationUpdater.java
@@ -49,6 +49,7 @@ public class PrestoS3ConfigurationUpdater
     private final boolean pinClientToCurrentRegion;
     private final String userAgentPrefix;
     private final PrestoS3AclType aclType;
+    private boolean skipGlacierObjects;
 
     @Inject
     public PrestoS3ConfigurationUpdater(HiveS3Config config)
@@ -78,6 +79,7 @@ public class PrestoS3ConfigurationUpdater
         this.pinClientToCurrentRegion = config.isPinS3ClientToCurrentRegion();
         this.userAgentPrefix = config.getS3UserAgentPrefix();
         this.aclType = config.getS3AclType();
+        this.skipGlacierObjects = config.isSkipGlacierObjects();
     }
 
     @Override
@@ -127,5 +129,6 @@ public class PrestoS3ConfigurationUpdater
         config.setBoolean(S3_PIN_CLIENT_TO_CURRENT_REGION, pinClientToCurrentRegion);
         config.set(S3_USER_AGENT_PREFIX, userAgentPrefix);
         config.set(S3_ACL_TYPE, aclType.name());
+        config.setBoolean(S3_SKIP_GLACIER_OBJECTS, skipGlacierObjects);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -92,6 +92,7 @@ import java.util.Optional;
 import static com.amazonaws.regions.Regions.US_EAST_1;
 import static com.amazonaws.services.s3.Headers.SERVER_SIDE_ENCRYPTION;
 import static com.amazonaws.services.s3.Headers.UNENCRYPTED_CONTENT_LENGTH;
+import static com.amazonaws.services.s3.model.StorageClass.Glacier;
 import static com.facebook.presto.hive.RetryDriver.retry;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ACCESS_KEY;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ACL_TYPE;
@@ -111,6 +112,7 @@ import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_PATH_STYLE_A
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_PIN_CLIENT_TO_CURRENT_REGION;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SECRET_KEY;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SIGNER_TYPE;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SKIP_GLACIER_OBJECTS;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SOCKET_TIMEOUT;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SSE_ENABLED;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_SSE_KMS_KEY_ID;
@@ -172,6 +174,7 @@ public class PrestoS3FileSystem
     private long multiPartUploadMinFileSize;
     private long multiPartUploadMinPartSize;
     private PrestoS3AclType s3AclType;
+    private boolean skipGlacierObjects;
 
     @Override
     public void initialize(URI uri, Configuration conf)
@@ -207,6 +210,7 @@ public class PrestoS3FileSystem
         this.sseKmsKeyId = conf.get(S3_SSE_KMS_KEY_ID, defaults.getS3SseKmsKeyId());
         this.s3AclType = PrestoS3AclType.valueOf(conf.get(S3_ACL_TYPE, defaults.getS3AclType().name()));
         String userAgentPrefix = conf.get(S3_USER_AGENT_PREFIX, defaults.getS3UserAgentPrefix());
+        this.skipGlacierObjects = conf.getBoolean(S3_SKIP_GLACIER_OBJECTS, defaults.isSkipGlacierObjects());
 
         ClientConfiguration configuration = new ClientConfiguration()
                 .withMaxErrorRetry(maxErrorRetries)
@@ -523,6 +527,7 @@ public class PrestoS3FileSystem
         // user metadata, and in this case it doesn't matter.
         return objects.stream()
                 .filter(object -> !object.getKey().endsWith(PATH_SEPARATOR))
+                .filter(object -> !skipGlacierObjects || !isGlacierObject(object))
                 .map(object -> new FileStatus(
                         object.getSize(),
                         false,
@@ -532,6 +537,11 @@ public class PrestoS3FileSystem
                         qualifiedPath(new Path(PATH_SEPARATOR + object.getKey()))))
                 .map(this::createLocatedFileStatus)
                 .iterator();
+    }
+
+    private boolean isGlacierObject(S3ObjectSummary object)
+    {
+        return Glacier.toString().equals(object.getStorageClass());
     }
 
     /**

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/S3ConfigurationUpdater.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/S3ConfigurationUpdater.java
@@ -44,6 +44,7 @@ public interface S3ConfigurationUpdater
     String S3_SECRET_KEY = "presto.s3.secret-key";
     String S3_ACCESS_KEY = "presto.s3.access-key";
     String S3_ACL_TYPE = "presto.s3.upload-acl-type";
+    String S3_SKIP_GLACIER_OBJECTS = "presto.s3.skip-glacier-objects";
 
     void updateConfiguration(Configuration config);
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/MockAmazonS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/MockAmazonS3.java
@@ -18,20 +18,30 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.services.s3.model.StorageClass;
+
+import java.util.Date;
 
 import static org.apache.http.HttpStatus.SC_OK;
 
 public class MockAmazonS3
         extends AbstractAmazonS3
 {
+    private static final String STANDARD_OBJECT_KEY = "test/standard";
+    private static final String GLACIER_OBJECT_KEY = "test/glacier";
+
     private int getObjectHttpCode = SC_OK;
     private int getObjectMetadataHttpCode = SC_OK;
     private GetObjectMetadataRequest getObjectMetadataRequest;
     private CannedAccessControlList acl;
+    private boolean hasGlacierObjects;
 
     public void setGetObjectHttpErrorCode(int getObjectHttpErrorCode)
     {
@@ -46,6 +56,11 @@ public class MockAmazonS3
     public CannedAccessControlList getAcl()
     {
         return this.acl;
+    }
+
+    public void setHasGlacierObjects(boolean hasGlacierObjects)
+    {
+        this.hasGlacierObjects = hasGlacierObjects;
     }
 
     public GetObjectMetadataRequest getGetObjectMetadataRequest()
@@ -87,6 +102,28 @@ public class MockAmazonS3
     public PutObjectResult putObject(String bucketName, String key, String content)
     {
         return new PutObjectResult();
+    }
+
+    @Override
+    public ObjectListing listObjects(ListObjectsRequest listObjectsRequest)
+    {
+        ObjectListing listing = new ObjectListing();
+
+        S3ObjectSummary standard = new S3ObjectSummary();
+        standard.setStorageClass(StorageClass.Standard.toString());
+        standard.setKey(STANDARD_OBJECT_KEY);
+        standard.setLastModified(new Date());
+        listing.getObjectSummaries().add(standard);
+
+        if (hasGlacierObjects) {
+            S3ObjectSummary glacier = new S3ObjectSummary();
+            glacier.setStorageClass(StorageClass.Glacier.toString());
+            glacier.setKey(GLACIER_OBJECT_KEY);
+            glacier.setLastModified(new Date());
+            listing.getObjectSummaries().add(glacier);
+        }
+
+        return listing;
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestHiveS3Config.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestHiveS3Config.java
@@ -58,7 +58,8 @@ public class TestHiveS3Config
                 .setS3StagingDirectory(new File(StandardSystemProperty.JAVA_IO_TMPDIR.value()))
                 .setPinS3ClientToCurrentRegion(false)
                 .setS3UserAgentPrefix("")
-                .setS3AclType(PrestoS3AclType.PRIVATE));
+                .setS3AclType(PrestoS3AclType.PRIVATE)
+                .setSkipGlacierObjects(true));
     }
 
     @Test
@@ -90,6 +91,7 @@ public class TestHiveS3Config
                 .put("hive.s3.pin-client-to-current-region", "true")
                 .put("hive.s3.user-agent-prefix", "user-agent-prefix")
                 .put("hive.s3.upload-acl-type", "PUBLIC_READ")
+                .put("hive.s3.skip-glacier-objects", "false")
                 .build();
 
         HiveS3Config expected = new HiveS3Config()
@@ -117,7 +119,8 @@ public class TestHiveS3Config
                 .setS3StagingDirectory(new File("/s3-staging"))
                 .setPinS3ClientToCurrentRegion(true)
                 .setS3UserAgentPrefix("user-agent-prefix")
-                .setS3AclType(PrestoS3AclType.PUBLIC_READ);
+                .setS3AclType(PrestoS3AclType.PUBLIC_READ)
+                .setSkipGlacierObjects(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Right now, PrestoS3FileSystem aborts the query when hitting a Glacier object.

It means if you are doing something normal, like configure s3 lifecycle policy to move objects to glacier at 30 days, and deleting after 60 days, you cannot use Presto.

When S3 object transitions to GLACIER storage class, it still remains in S3 bucket. When PrestoS3FileSystem tries to call get object request to this object, it will throw exception like 
```
"com.amazonaws.services.s3.model.AmazonS3Exception: 
The operation is not valid for the object's storage class 
(Service: Amazon S3; Status Code: 403 ..."
```

This PR aims to allow Presto to skip Glacier files in S3 bucket.
