### PR TITLE
Revert "Make sure to free output buffer memory allocations"

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
@@ -19,7 +19,6 @@ import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.ClientBuffer.PagesSupplier;
 import com.facebook.presto.memory.context.LocalMemoryContext;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
@@ -325,12 +324,6 @@ public class ArbitraryOutputBuffer
         return memoryManager.getPeakMemoryUsage();
     }
 
-    @Override
-    public void forceFreeMemory()
-    {
-        memoryManager.close();
-    }
-
     private synchronized ClientBuffer getBuffer(OutputBufferId id)
     {
         ClientBuffer buffer = buffers.get(id);
@@ -471,11 +464,5 @@ public class ArbitraryOutputBuffer
                     .add("bufferedPages", bufferedPages.get())
                     .toString();
         }
-    }
-
-    @VisibleForTesting
-    OutputBufferMemoryManager getMemoryManager()
-    {
-        return memoryManager;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
@@ -315,12 +315,6 @@ public class BroadcastOutputBuffer
         return memoryManager.getPeakMemoryUsage();
     }
 
-    @Override
-    public void forceFreeMemory()
-    {
-        memoryManager.close();
-    }
-
     private synchronized ClientBuffer getBuffer(OutputBufferId id)
     {
         ClientBuffer buffer = buffers.get(id);

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
@@ -337,12 +337,6 @@ public class LazyOutputBuffer
         return 0;
     }
 
-    @Override
-    public synchronized void forceFreeMemory()
-    {
-        delegate.forceFreeMemory();
-    }
-
     private static class PendingRead
     {
         private final OutputBufferId bufferId;

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffer.java
@@ -112,9 +112,4 @@ public interface OutputBuffer
      * @return the peak memory usage of this output buffer.
      */
     long getPeakMemoryUsage();
-
-    /**
-     * Force free the memory allocated by this output buffer.
-     */
-    void forceFreeMemory();
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
@@ -18,7 +18,6 @@ import com.facebook.presto.OutputBuffers.OutputBufferId;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.memory.context.LocalMemoryContext;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
@@ -265,12 +264,6 @@ public class PartitionedOutputBuffer
         return memoryManager.getPeakMemoryUsage();
     }
 
-    @Override
-    public void forceFreeMemory()
-    {
-        memoryManager.close();
-    }
-
     private void checkFlushComplete()
     {
         if (state.get() != FLUSHING && state.get() != NO_MORE_BUFFERS) {
@@ -280,11 +273,5 @@ public class PartitionedOutputBuffer
         if (partitions.stream().allMatch(ClientBuffer::isDestroyed)) {
             destroy();
         }
-    }
-
-    @VisibleForTesting
-    OutputBufferMemoryManager getMemoryManager()
-    {
-        return memoryManager;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
@@ -190,7 +190,6 @@ public class PartitionedOutputOperator
     private final OperatorContext operatorContext;
     private final Function<Page, Page> pagePreprocessor;
     private final PagePartitioner partitionFunction;
-    private final OutputBuffer outputBuffer;
     private final LocalMemoryContext systemMemoryContext;
     private final long partitionsInitialRetainedSize;
     private boolean finished;
@@ -210,7 +209,6 @@ public class PartitionedOutputOperator
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
-        this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
         this.partitionFunction = new PagePartitioner(
                 partitionFunction,
                 partitionChannels,
@@ -244,7 +242,6 @@ public class PartitionedOutputOperator
     {
         finished = true;
         partitionFunction.flush(true);
-        outputBuffer.forceFreeMemory();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskOutputOperator.java
@@ -111,7 +111,6 @@ public class TaskOutputOperator
     public void finish()
     {
         finished = true;
-        outputBuffer.forceFreeMemory();
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -925,24 +925,6 @@ public class TestArbitraryOutputBuffer
         assertBufferResultEquals(TYPES, getBufferResult(buffer, SECOND, 0, sizeOfPages(1), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));
     }
 
-    @Test
-    public void testForceFreeMemory()
-            throws Throwable
-    {
-        ArbitraryOutputBuffer buffer = createArbitraryBuffer(createInitialEmptyOutputBuffers(ARBITRARY), sizeOfPages(10));
-        for (int i = 0; i < 3; i++) {
-            addPage(buffer, createPage(i));
-        }
-        OutputBufferMemoryManager memoryManager = buffer.getMemoryManager();
-        assertTrue(memoryManager.getBufferedBytes() > 0);
-        buffer.forceFreeMemory();
-        assertEquals(memoryManager.getBufferedBytes(), 0);
-        // adding another page after buffer.forceFreeMemory()
-        // should have no effect in terms of memory usage
-        addPage(buffer, createPage(1));
-        assertEquals(memoryManager.getBufferedBytes(), 0);
-    }
-
     private static BufferResult getBufferResult(OutputBuffer buffer, OutputBufferId bufferId, long sequenceId, DataSize maxSize, Duration maxWait)
     {
         ListenableFuture<BufferResult> future = buffer.get(bufferId, sequenceId, maxSize);

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -1120,28 +1120,6 @@ public class TestBroadcastOutputBuffer
         assertTrue(buffer.isFinished());
     }
 
-    @Test
-    public void testForceFreeMemory()
-            throws Throwable
-    {
-        BroadcastOutputBuffer buffer = createBroadcastBuffer(
-                createInitialEmptyOutputBuffers(BROADCAST)
-                        .withBuffer(FIRST, BROADCAST_PARTITION_ID)
-                        .withNoMoreBufferIds(),
-                sizeOfPages(5));
-        for (int i = 0; i < 3; i++) {
-            addPage(buffer, createPage(1), 0);
-        }
-        OutputBufferMemoryManager memoryManager = buffer.getMemoryManager();
-        assertTrue(memoryManager.getBufferedBytes() > 0);
-        buffer.forceFreeMemory();
-        assertEquals(memoryManager.getBufferedBytes(), 0);
-        // adding another page after buffer.forceFreeMemory()
-        // should have no effect in terms of memory usage
-        addPage(buffer, createPage(1));
-        assertEquals(memoryManager.getBufferedBytes(), 0);
-    }
-
     private BroadcastOutputBuffer createBroadcastBuffer(OutputBuffers outputBuffers, DataSize dataSize)
     {
         BroadcastOutputBuffer buffer = new BroadcastOutputBuffer(

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
@@ -817,28 +817,6 @@ public class TestPartitionedOutputBuffer
         }
     }
 
-    @Test
-    public void testForceFreeMemory()
-            throws Throwable
-    {
-        PartitionedOutputBuffer buffer = createPartitionedBuffer(
-                createInitialEmptyOutputBuffers(PARTITIONED)
-                        .withBuffer(FIRST, 0)
-                        .withNoMoreBufferIds(),
-                sizeOfPages(10));
-        for (int i = 0; i < 5; i++) {
-            addPage(buffer, createPage(1), 0);
-        }
-        OutputBufferMemoryManager memoryManager = buffer.getMemoryManager();
-        assertTrue(memoryManager.getBufferedBytes() > 0);
-        buffer.forceFreeMemory();
-        assertEquals(memoryManager.getBufferedBytes(), 0);
-        // adding another page after buffer.forceFreeMemory()
-        // should have no effect in terms of memory usage
-        addPage(buffer, createPage(1));
-        assertEquals(memoryManager.getBufferedBytes(), 0);
-    }
-
     private PartitionedOutputBuffer createPartitionedBuffer(OutputBuffers buffers, DataSize dataSize)
     {
         return new PartitionedOutputBuffer(

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryAwareExecution.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryAwareExecution.java
@@ -120,7 +120,8 @@ public class TestMemoryAwareExecution
             throws Exception
     {
         // Invoke multiple times to make sure that pre-allocation state resets properly and that there aren't weird data races
-        ResourceEstimates estimate = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.of(succinctBytes(totalAvailableMemory)));
+        // TODO: Remove subtraction of 156 * invocationCount * 2 when memory leak in PartitionedOutputBuffer is fixed
+        ResourceEstimates estimate = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.of(succinctBytes(totalAvailableMemory - (156 * 5 * 2))));
 
         QueryId highMemoryQuery1 = queryWithResourceEstimate(estimate, queryManager);
         assertState(highMemoryQuery1, RUNNING);


### PR DESCRIPTION
This change is broken, because an output buffer and the associated
output buffer memory manager are shared by multiple PartitionedOutputOperator
instances, and when *any* of these instances finish and call
outputBuffer.forceFreeMemory(), the other PartitionedOutputOperators'
allocations will never block after that instant (as the buffer is
closed) resulting in significant amount of memory allocation by these
operators, and eventually full GCs and OOMs.