### PR TITLE
Make sure to free output buffer memory on task completion

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
@@ -306,6 +306,7 @@ public class ArbitraryOutputBuffer
             safeGetBuffersSnapshot().forEach(ClientBuffer::destroy);
 
             memoryManager.setNoBlockOnFull();
+            forceFreeMemory();
         }
     }
 
@@ -315,6 +316,7 @@ public class ArbitraryOutputBuffer
         // ignore fail if the buffer already in a terminal state.
         if (state.setIf(FAILED, oldState -> !oldState.isTerminal())) {
             memoryManager.setNoBlockOnFull();
+            forceFreeMemory();
             // DO NOT destroy buffers or set no more pages.  The coordinator manages the teardown of failed queries.
         }
     }
@@ -325,8 +327,8 @@ public class ArbitraryOutputBuffer
         return memoryManager.getPeakMemoryUsage();
     }
 
-    @Override
-    public void forceFreeMemory()
+    @VisibleForTesting
+    void forceFreeMemory()
     {
         memoryManager.close();
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BroadcastOutputBuffer.java
@@ -296,6 +296,7 @@ public class BroadcastOutputBuffer
             safeGetBuffersSnapshot().forEach(ClientBuffer::destroy);
 
             memoryManager.setNoBlockOnFull();
+            forceFreeMemory();
         }
     }
 
@@ -305,6 +306,7 @@ public class BroadcastOutputBuffer
         // ignore fail if the buffer already in a terminal state.
         if (state.setIf(FAILED, oldState -> !oldState.isTerminal())) {
             memoryManager.setNoBlockOnFull();
+            forceFreeMemory();
             // DO NOT destroy buffers or set no more pages.  The coordinator manages the teardown of failed queries.
         }
     }
@@ -315,8 +317,8 @@ public class BroadcastOutputBuffer
         return memoryManager.getPeakMemoryUsage();
     }
 
-    @Override
-    public void forceFreeMemory()
+    @VisibleForTesting
+    void forceFreeMemory()
     {
         memoryManager.close();
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
@@ -337,12 +337,6 @@ public class LazyOutputBuffer
         return 0;
     }
 
-    @Override
-    public synchronized void forceFreeMemory()
-    {
-        delegate.forceFreeMemory();
-    }
-
     private static class PendingRead
     {
         private final OutputBufferId bufferId;

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffer.java
@@ -112,9 +112,4 @@ public interface OutputBuffer
      * @return the peak memory usage of this output buffer.
      */
     long getPeakMemoryUsage();
-
-    /**
-     * Force free the memory allocated by this output buffer.
-     */
-    void forceFreeMemory();
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/PartitionedOutputBuffer.java
@@ -246,6 +246,7 @@ public class PartitionedOutputBuffer
         if (state.setIf(FINISHED, oldState -> !oldState.isTerminal())) {
             partitions.forEach(ClientBuffer::destroy);
             memoryManager.setNoBlockOnFull();
+            forceFreeMemory();
         }
     }
 
@@ -255,6 +256,7 @@ public class PartitionedOutputBuffer
         // ignore fail if the buffer already in a terminal state.
         if (state.setIf(FAILED, oldState -> !oldState.isTerminal())) {
             memoryManager.setNoBlockOnFull();
+            forceFreeMemory();
             // DO NOT destroy buffers or set no more pages.  The coordinator manages the teardown of failed queries.
         }
     }
@@ -265,8 +267,8 @@ public class PartitionedOutputBuffer
         return memoryManager.getPeakMemoryUsage();
     }
 
-    @Override
-    public void forceFreeMemory()
+    @VisibleForTesting
+    void forceFreeMemory()
     {
         memoryManager.close();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
@@ -244,7 +244,6 @@ public class PartitionedOutputOperator
     {
         finished = true;
         partitionFunction.flush(true);
-        outputBuffer.forceFreeMemory();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskOutputOperator.java
@@ -111,7 +111,6 @@ public class TaskOutputOperator
     public void finish()
     {
         finished = true;
-        outputBuffer.forceFreeMemory();
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -53,6 +53,7 @@ import static com.facebook.presto.execution.TaskTestUtils.TABLE_SCAN_NODE_ID;
 import static com.facebook.presto.execution.TaskTestUtils.createTestQueryMonitor;
 import static com.facebook.presto.execution.TaskTestUtils.createTestingPlanner;
 import static com.facebook.presto.execution.TaskTestUtils.updateTask;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -300,19 +301,23 @@ public class TestSqlTask
         TaskId taskId = new TaskId("query", 0, nextTaskId.incrementAndGet());
         URI location = URI.create("fake://task/" + taskId);
 
+        DefaultQueryContext queryContext = new DefaultQueryContext(new QueryId("query"),
+                new DataSize(1, MEGABYTE),
+                new DataSize(2, MEGABYTE),
+                new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE)),
+                new TestingGcMonitor(),
+                taskNotificationExecutor,
+                driverYieldExecutor,
+                new DataSize(1, MEGABYTE),
+                new SpillSpaceTracker(new DataSize(1, GIGABYTE)));
+
+        queryContext.addTaskContext(new TaskStateMachine(taskId, taskNotificationExecutor), testSessionBuilder().build(), false, false, OptionalInt.empty());
+
         return new SqlTask(
                 taskId,
                 location,
                 "fake",
-                new DefaultQueryContext(new QueryId("query"),
-                        new DataSize(1, MEGABYTE),
-                        new DataSize(2, MEGABYTE),
-                        new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE)),
-                        new TestingGcMonitor(),
-                        taskNotificationExecutor,
-                        driverYieldExecutor,
-                        new DataSize(1, MEGABYTE),
-                        new SpillSpaceTracker(new DataSize(1, GIGABYTE))),
+                queryContext,
                 sqlTaskExecutionFactory,
                 taskNotificationExecutor,
                 Functions.identity(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -54,6 +54,8 @@ import static com.facebook.presto.execution.TaskTestUtils.SPLIT;
 import static com.facebook.presto.execution.TaskTestUtils.TABLE_SCAN_NODE_ID;
 import static com.facebook.presto.execution.TaskTestUtils.createTestQueryMonitor;
 import static com.facebook.presto.execution.TaskTestUtils.createTestingPlanner;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -261,6 +263,8 @@ public class TestSqlTaskManager
 
     private TaskInfo createTask(SqlTaskManager sqlTaskManager, TaskId taskId, OutputBuffers outputBuffers)
     {
+        sqlTaskManager.getQueryContext(taskId.getQueryId())
+                .addTaskContext(new TaskStateMachine(taskId, directExecutor()), testSessionBuilder().build(), false, false, OptionalInt.empty());
         return sqlTaskManager.updateTask(TEST_SESSION,
                 taskId,
                 Optional.of(PLAN_FRAGMENT),

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -937,8 +937,7 @@ public class TestArbitraryOutputBuffer
         assertTrue(memoryManager.getBufferedBytes() > 0);
         buffer.forceFreeMemory();
         assertEquals(memoryManager.getBufferedBytes(), 0);
-        // adding another page after buffer.forceFreeMemory()
-        // should have no effect in terms of memory usage
+        // adding a page after forceFreeMemory() should be NOOP
         addPage(buffer, createPage(1));
         assertEquals(memoryManager.getBufferedBytes(), 0);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -1136,8 +1136,7 @@ public class TestBroadcastOutputBuffer
         assertTrue(memoryManager.getBufferedBytes() > 0);
         buffer.forceFreeMemory();
         assertEquals(memoryManager.getBufferedBytes(), 0);
-        // adding another page after buffer.forceFreeMemory()
-        // should have no effect in terms of memory usage
+        // adding a page after forceFreeMemory() should be NOOP
         addPage(buffer, createPage(1));
         assertEquals(memoryManager.getBufferedBytes(), 0);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPartitionedOutputBuffer.java
@@ -833,8 +833,7 @@ public class TestPartitionedOutputBuffer
         assertTrue(memoryManager.getBufferedBytes() > 0);
         buffer.forceFreeMemory();
         assertEquals(memoryManager.getBufferedBytes(), 0);
-        // adding another page after buffer.forceFreeMemory()
-        // should have no effect in terms of memory usage
+        // adding a page after forceFreeMemory() should be NOOP
         addPage(buffer, createPage(1));
         assertEquals(memoryManager.getBufferedBytes(), 0);
     }


### PR DESCRIPTION
Follow up for https://github.com/prestodb/presto/pull/11188. We now close the output buffer memory manager on task completion, and ignore any subsequent calls.