### PR TITLE
Preserve the name of column after unnest

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -700,8 +700,8 @@ class StatementAnalyzer
                 if (expressionType instanceof ArrayType) {
                     Type elementType = ((ArrayType) expressionType).getElementType();
                     if (!SystemSessionProperties.isLegacyUnnest(session) && elementType instanceof RowType) {
-                        elementType.getTypeParameters().stream()
-                                .map(type -> Field.newUnqualified(Optional.empty(), type))
+                        ((RowType) elementType).getFields().stream()
+                                .map(field -> Field.newUnqualified(field.getName(), field.getType()))
                                 .forEach(outputFields::add);
                     }
                     else {

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestUnnest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestUnnest.java
@@ -13,23 +13,116 @@
  */
 package com.facebook.presto.sql.query;
 
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class TestUnnest
 {
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
     @Test
     public void testUnnestArrayRows()
     {
-        try (QueryAssertions assertions = new QueryAssertions()) {
-            assertions.assertQuery(
-                    "SELECT * FROM UNNEST(ARRAY[ROW(1, 1.1), ROW(3, 3.3)], ARRAY[ROW('a', true), ROW('b', false)])",
-                    "VALUES (1, 1.1, 'a', true), (3, 3.3, 'b', false)");
-            assertions.assertQuery(
-                    "SELECT x, y FROM (VALUES (ARRAY[ROW(1.0, 2), ROW(3, 4.123)])) AS t(a) CROSS JOIN UNNEST(a) t(x, y)",
-                    "VALUES (1.0, 2), (3, 4.123)");
-            assertions.assertQuery(
-                    "SELECT x, y, z FROM (VALUES (ARRAY[ROW(1, 2), ROW(3, 4)])) t(a) CROSS JOIN (VALUES (1), (2)) s(z) CROSS JOIN UNNEST(a) t(x, y)",
-                    "VALUES (1, 2, 1), (1, 2, 2), (3, 4, 1), (3, 4, 2)");
-        }
+        assertions.assertQuery(
+                "SELECT * FROM UNNEST(ARRAY[ROW(1, 1.1), ROW(3, 3.3)], ARRAY[ROW('a', true), ROW('b', false)])",
+                "VALUES (1, 1.1, 'a', true), (3, 3.3, 'b', false)");
+        assertions.assertQuery(
+                "SELECT x, y FROM (VALUES (ARRAY[ROW(1.0, 2), ROW(3, 4.123)])) AS t(a) CROSS JOIN UNNEST(a) t(x, y)",
+                "VALUES (1.0, 2), (3, 4.123)");
+        assertions.assertQuery(
+                "SELECT x, y, z FROM (VALUES (ARRAY[ROW(1, 2), ROW(3, 4)])) t(a) CROSS JOIN (VALUES (1), (2)) s(z) CROSS JOIN UNNEST(a) t(x, y)",
+                "VALUES (1, 2, 1), (1, 2, 2), (3, 4, 1), (3, 4, 2)");
+    }
+
+    @Test
+    public void testUnnestPreserveColumnName()
+    {
+        assertions.assertQuery(
+                "SELECT x FROM UNNEST(array[" +
+                        "  CAST(ROW(1, 'a') AS ROW(x int, y varchar))," +
+                        "  CAST(ROW(2, 'b') AS ROW(x int, y varchar))" +
+                        "])",
+                "VALUES (1), (2)");
+
+        assertions.assertFails(
+                "SELECT x FROM" +
+                        "(VALUES (3)) AS t(x)" +
+                        "CROSS JOIN UNNEST(array[" +
+                        "  CAST(ROW(1, 'a') AS ROW(x int, y varchar))," +
+                        "  CAST(ROW(2, 'b') AS ROW(x int, y varchar))" +
+                        "])",
+                ".*Column 'x' is ambiguous.*");
+
+        assertions.assertQuery(
+                "SELECT t.x FROM" +
+                        "(VALUES (3)) AS t(x)" +
+                        "CROSS JOIN UNNEST(array[" +
+                        "  CAST(ROW(1, 'a') AS ROW(x int, y varchar))," +
+                        "  CAST(ROW(2, 'b') AS ROW(x int, y varchar))" +
+                        "])",
+                "VALUES (3), (3)");
+
+        assertions.assertQuery(
+                "SELECT u.x FROM" +
+                        "(VALUES (3)) AS t(x)" +
+                        "CROSS JOIN UNNEST(array[" +
+                        "  CAST(ROW(1, 'a') AS ROW(x int, y varchar))," +
+                        "  CAST(ROW(2, 'b') AS ROW(x int, y varchar))" +
+                        "]) u",
+                "VALUES (1), (2)");
+    }
+
+    @Test
+    public void testUnnestMultiExpr()
+    {
+        assertions.assertFails(
+                "SELECT x" +
+                        "  FROM UNNEST(array[" +
+                        "    CAST(ROW(1, 'a') AS ROW(x int, y varchar))," +
+                        "    CAST(ROW(2, 'b') AS ROW(x int, y varchar))" +
+                        "  ]," +
+                        "  array[" +
+                        "    CAST(ROW(3, 'c') AS ROW(x int, y varchar))," +
+                        "    CAST(ROW(4, 'd') AS ROW(x int, y varchar))" +
+                        "  ])",
+                ".*Column 'x' is ambiguous.*");
+
+        assertions.assertQuery(
+                "SELECT t3" +
+                        "  FROM UNNEST(array[" +
+                        "    CAST(ROW(1, 'a') AS ROW(x int, y varchar))," +
+                        "    CAST(ROW(2, 'b') AS ROW(x int, y varchar))" +
+                        "  ]," +
+                        "  array[" +
+                        "    CAST(ROW(3, 'c') AS ROW(x int, y varchar))," +
+                        "    CAST(ROW(4, 'd') AS ROW(x int, y varchar))" +
+                        "  ]) t(t1,t2,t3,t4)",
+                "VALUES (3), (4)");
+
+        assertions.assertQuery(
+                "SELECT x" +
+                        "  FROM UNNEST(array[" +
+                        "    CAST(ROW(1, 'a') AS ROW(a int, b varchar))," +
+                        "    CAST(ROW(2, 'b') AS ROW(a int, b varchar))" +
+                        "  ]," +
+                        "  array[" +
+                        "    CAST(ROW(3, 'c') AS ROW(x int, y varchar))," +
+                        "    CAST(ROW(4, 'd') AS ROW(x int, y varchar))" +
+                        "  ])",
+                "VALUES (3), (4)");
     }
 }


### PR DESCRIPTION
### Motivation
Before #10883, we were able to do the following selection:
`SELECT a.field1, a.field2 FROM UNNEST(...) t(a)`

After the patch, this kind of query become impossible. The name of the fields becomes `_col0, _col1`. Column aliases is required in order to select the needed columns. We could rewrite it in this way:
`SELECT field1, field2 FROM UNNEST(...) t(field1, field2)`

However, it is infeasible to use column aliases to refer to a row with a lot of fields. I think we should preserve the name of the columns so that we can refer to the column easily, as below:
```
# Hard to use column aliases for complicated row (after #10883):
SELECT field1, field100 FROM UNNEST(...) t(field1, field2, field3, ..., field100)

# Preserve the name of the columns will allow this:
SELECT field1, field100 FROM UNNEST(...) t
````

---
### What changes were proposed in this pull request
Before:
```sql
presto> SELECT * FROM UNNEST(array[
     ->     CAST(ROW('a', 1) AS ROW(x varchar, y int)),
     ->     CAST(ROW('a', 1) AS ROW(x varchar, y int))
     -> ]);
 _col0 | _col1
-------+-------
 a     |     1
 a     |     1
(2 rows)
```

After:
```sql
presto> SELECT * FROM UNNEST(array[
     ->     CAST(ROW('a', 1) AS ROW(x varchar, y int)),
     ->     CAST(ROW('a', 1) AS ROW(x varchar, y int))
     -> ]);
 x | y
---+---
 a | 1
 a | 1
(2 rows)
```
