### PR TITLE
Remove unnecessary copies in PruneUnreferencedOutputs

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -495,15 +495,12 @@ public class PruneUnreferencedOutputs
             ImmutableSet.Builder<Symbol> expectedInputs = ImmutableSet.builder();
 
             Assignments.Builder builder = Assignments.builder();
-            for (int i = 0; i < node.getOutputSymbols().size(); i++) {
-                Symbol output = node.getOutputSymbols().get(i);
-                Expression expression = node.getAssignments().get(output);
-
-                if (context.get().contains(output)) {
+            node.getAssignments().forEach((symbol, expression) -> {
+                if (context.get().contains(symbol)) {
                     expectedInputs.addAll(SymbolsExtractor.extractUnique(expression));
-                    builder.put(output, expression);
+                    builder.put(symbol, expression);
                 }
-            }
+            });
 
             PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Assignments.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Assignments.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
@@ -167,6 +168,11 @@ public class Assignments
     public boolean isEmpty()
     {
         return size() == 0;
+    }
+
+    public void forEach(BiConsumer<Symbol, Expression> consumer)
+    {
+        assignments.forEach(consumer);
     }
 
     @Override


### PR DESCRIPTION
Currently in `PruneUnreferencedOutputs` optimizer, when we are processing a `Project` node

```
for (int i = 0; i < node.getOutputSymbols().size(); i++) {
    Symbol output = node.getOutputSymbols().get(i);
    Expression expression = node.getAssignments().get(output);
```
this can be replaced by a `Map.Entry` 