### PR TITLE
Reordering plan optimizers

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -230,6 +230,8 @@ public class PlanOptimizers
         PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser));
 
         builder.add(
+                // Clean up all other symbols or expressions which are not a part of the given query
+                new PruneUnreferencedOutputs(),
                 // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers
                 new IterativeOptimizer(
                         ruleStats,


### PR DESCRIPTION
Presto's planning time increases as the number of columns in the given table increases, so before applying other optimizers for a given query it would be better if we remove the unnecessary column.
We first apply `PruneUnreferencedOutputs` optimizer then we apply the other optimizer. We tested this order on tpch tables on query 5

**On normal TPCH table**

Benchmark                     (iterativeOptimizerEnabled)    (stage)  Mode  Cnt   Score   Error  Units
BenchmarkPlanner.planQueries                         true  optimized  avgt   20  39.222 ± 3.603  ms/op
BenchmarkPlanner.planQueries                         true    created  avgt   20   3.349 ± 0.505  ms/op
BenchmarkPlanner.planQueries                        false  optimized  avgt   20  36.918 ± 4.752  ms/op
BenchmarkPlanner.planQueries                        false    created  avgt   20   3.530 ± 0.276  ms/op


 **Number of columns in a TPCH table are increased by 100 times**

Benchmark                     (iterativeOptimizerEnabled)    (stage)  Mode  Cnt     Score     Error  Units
BenchmarkPlanner.planQueries                         true  optimized  avgt   20  1103.009 ±  53.372  ms/op
BenchmarkPlanner.planQueries                         true    created  avgt   20    25.000 ±   1.107  ms/op
BenchmarkPlanner.planQueries                        false  optimized  avgt   20  1127.392 ± 117.608  ms/op
BenchmarkPlanner.planQueries                        false    created  avgt   20    31.669 ±   9.585  ms/op

**Benchmark after we reordered the optimizers**

Benchmark                     (iterativeOptimizerEnabled)    (stage)  Mode  Cnt   Score    Error  Units
BenchmarkPlanner.planQueries                         true  optimized  avgt   20  71.519 ±  4.426  ms/op
BenchmarkPlanner.planQueries                         true    created  avgt   20  25.124 ±  0.826  ms/op
BenchmarkPlanner.planQueries                        false  optimized  avgt   20  99.174 ± 29.015  ms/op
BenchmarkPlanner.planQueries                        false    created  avgt   20  23.561 ±  0.655  ms/op


The planning time is reduced from **1103ms** to **71ms**