### PR TITLE
Remove unused statement resource thread pools from workers

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -359,12 +359,16 @@ public class CoordinatorModule
 
         @Inject
         public ExecutorCleanup(
+                @ForStatementResource ExecutorService statementResponseExecutor,
+                @ForStatementResource ScheduledExecutorService statementTimeoutExecutor,
                 @ForQueryExecution ExecutorService queryExecutionExecutor,
                 @ForScheduler ScheduledExecutorService schedulerExecutor,
                 @ForTransactionManager ExecutorService transactionFinishingExecutor,
                 @ForTransactionManager ScheduledExecutorService transactionIdleExecutor)
         {
             executors = ImmutableList.<ExecutorService>builder()
+                    .add(statementResponseExecutor)
+                    .add(statementTimeoutExecutor)
                     .add(queryExecutionExecutor)
                     .add(schedulerExecutor)
                     .add(transactionFinishingExecutor)

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -126,6 +126,7 @@ import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.transaction.ForTransactionManager;
 import com.facebook.presto.transaction.NoOpTransactionManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.transaction.TransactionManagerConfig;
@@ -319,8 +320,6 @@ public class ServerMainModule
         configBinder(binder).bindConfig(TaskManagerConfig.class);
         binder.bind(IndexJoinLookupStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(IndexJoinLookupStats.class).withGeneratedName();
-        binder.bind(StatementHttpExecutionMBean.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(StatementHttpExecutionMBean.class).withGeneratedName();
         binder.bind(AsyncHttpExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(AsyncHttpExecutionMBean.class).withGeneratedName();
         binder.bind(JoinFilterFunctionCompiler.class).in(Scopes.SINGLETON);
@@ -510,30 +509,6 @@ public class ServerMainModule
     public static ScheduledExecutorService createAsyncHttpTimeoutExecutor(TaskManagerConfig config)
     {
         return newScheduledThreadPool(config.getHttpTimeoutThreads(), daemonThreadsNamed("async-http-timeout-%s"));
-    }
-
-    @Provides
-    @Singleton
-    @ForStatementResource
-    public static ExecutorService createStatementResponseCoreExecutor()
-    {
-        return newCachedThreadPool(daemonThreadsNamed("statement-response-%s"));
-    }
-
-    @Provides
-    @Singleton
-    @ForStatementResource
-    public static BoundedExecutor createStatementResponseExecutor(@ForStatementResource ExecutorService coreExecutor, TaskManagerConfig config)
-    {
-        return new BoundedExecutor(coreExecutor, config.getHttpResponseThreads());
-    }
-
-    @Provides
-    @Singleton
-    @ForStatementResource
-    public static ScheduledExecutorService createStatementTimeoutExecutor(TaskManagerConfig config)
-    {
-        return newScheduledThreadPool(config.getHttpTimeoutThreads(), daemonThreadsNamed("statement-timeout-%s"));
     }
 
     private static void bindFailureDetector(Binder binder, boolean coordinator)


### PR DESCRIPTION
The statement resource is only bound on the coordinator.