### PR TITLE
Fix explain analyze for index join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexLoader.java
@@ -249,7 +249,7 @@ public class IndexLoader
         if (pipelineContext == null) {
             TaskContext taskContext = taskContextReference.get();
             checkState(taskContext != null, "Task context must be set before index can be built");
-            pipelineContext = taskContext.addPipelineContext(indexBuildDriverFactoryProvider.getPipelineId(), false, false);
+            pipelineContext = taskContext.addPipelineContext(indexBuildDriverFactoryProvider.getPipelineId(), true, true);
         }
         if (indexSnapshotLoader == null) {
             indexSnapshotLoader = new IndexSnapshotLoader(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -154,6 +154,9 @@ public class PlanNodeStatsSummarizer
         List<PlanNodeStats> stats = new ArrayList<>();
         for (Map.Entry<PlanNodeId, Long> entry : planNodeWallMillis.entrySet()) {
             PlanNodeId planNodeId = entry.getKey();
+            if (!planNodeInputPositions.containsKey(planNodeId)) {
+                continue;
+            }
             stats.add(new PlanNodeStats(
                     planNodeId,
                     new Duration(planNodeWallMillis.get(planNodeId), MILLISECONDS),

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
@@ -52,6 +52,19 @@ public abstract class AbstractTestIndexedQueries
     }
 
     @Test
+    public void testExplainAnalyzeIndexJoin()
+    {
+        assertQuerySucceeds(getSession(), "EXPLAIN ANALYZE " +
+                " SELECT *\n" +
+                "FROM (\n" +
+                "  SELECT *\n" +
+                "  FROM lineitem\n" +
+                "  WHERE partkey % 8 = 0) l\n" +
+                "JOIN orders o\n" +
+                "  ON l.orderkey = o.orderkey");
+    }
+
+    @Test
     public void testBasicIndexJoin()
     {
         assertQuery("" +

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -188,6 +188,11 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertUpdate(queryRunner, session, sql, OptionalLong.of(count));
     }
 
+    protected void assertQuerySucceeds(Session session, @Language("SQL") String sql)
+    {
+        QueryAssertions.assertQuerySucceeds(queryRunner, session, sql);
+    }
+
     protected void assertQueryFailsEventually(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp, Duration timeout)
     {
         QueryAssertions.assertQueryFailsEventually(queryRunner, getSession(), sql, expectedMessageRegExp, timeout);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -199,6 +199,16 @@ public final class QueryAssertions
         }
     }
 
+    protected static void assertQuerySucceeds(QueryRunner queryRunner, Session session, @Language("SQL") String sql)
+    {
+        try {
+            queryRunner.execute(session, sql);
+        }
+        catch (RuntimeException e) {
+            fail(format("Expected query to succeed: %s", sql), e);
+        }
+    }
+
     protected static void assertQueryFailsEventually(QueryRunner queryRunner, Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp, Duration timeout)
     {
         long start = System.nanoTime();


### PR DESCRIPTION
Currently if we run explain analyze on queries that uses index join, we will fail with null pointer error. IndexBuild has input/output stats populated, we just need to mark it in the PipelineContext to allow PlanNodeStatsSummarizer to pick it up. 