### PR TITLE
Fix NPE in MemoryPool::getInfo()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -82,11 +83,13 @@ public class MemoryPool
     public synchronized MemoryPoolInfo getInfo()
     {
         Map<QueryId, List<MemoryAllocation>> memoryAllocations = new HashMap<>();
-        taggedMemoryAllocations.forEach((queryId, allocationMap) -> {
+        for (Entry<QueryId, Map<String, Long>> entry : taggedMemoryAllocations.entrySet()) {
             List<MemoryAllocation> allocations = new ArrayList<>();
-            allocationMap.forEach((tag, allocation) -> allocations.add(new MemoryAllocation(tag, allocation)));
-            memoryAllocations.put(queryId, allocations);
-        });
+            if (entry.getValue() != null) {
+                entry.getValue().forEach((tag, allocation) -> allocations.add(new MemoryAllocation(tag, allocation)));
+            }
+            memoryAllocations.put(entry.getKey(), allocations);
+        }
         return new MemoryPoolInfo(maxBytes, reservedBytes, reservedRevocableBytes, queryMemoryReservations, memoryAllocations, queryMemoryRevocableReservations);
     }
 


### PR DESCRIPTION
```
java.lang.NullPointerException
        at com.facebook.presto.memory.MemoryPool.lambda$getInfo$1(MemoryPool.java:87)
        at java.base/java.util.HashMap.forEach(HashMap.java:1341)
        at com.facebook.presto.memory.MemoryPool.getInfo(MemoryPool.java:85)
        at com.facebook.presto.memory.LocalMemoryManager.getInfo(LocalMemoryManager.java:109)
        at com.facebook.presto.memory.MemoryResource.getMemoryInfo(MemoryResource.java:54)
        at jdk.internal.reflect.GeneratedMethodAccessor248.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```