### PR TITLE
Fix memory accounting leak in AggregationOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
@@ -122,6 +122,13 @@ public class AggregationOperator
     }
 
     @Override
+    public void close()
+    {
+        userMemoryContext.setBytes(0);
+        systemMemoryContext.close();
+    }
+
+    @Override
     public boolean isFinished()
     {
         return state == State.FINISHED;

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
@@ -311,6 +311,7 @@ public class TableWriterOperator
             }
         }
         closer.register(statisticAggregationOperator);
+        closer.register(() -> pageSinkMemoryContext.close());
         closer.close();
     }
 
@@ -326,6 +327,12 @@ public class TableWriterOperator
         long pageSinkMemoryUsage = pageSink.getSystemMemoryUsage();
         pageSinkMemoryContext.setBytes(pageSinkMemoryUsage);
         pageSinkPeakMemoryUsage.accumulateAndGet(pageSinkMemoryUsage, Math::max);
+    }
+
+    @VisibleForTesting
+    Operator getStatisticAggregationOperator()
+    {
+        return statisticAggregationOperator;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
If an AggregationOperator is used inside a TableWriterOperator
for stats collection the AggregationOperator will leak, as the driver
thread will only destroy the TableWriterOperator, and operators
rely on getting destroyed by the driver threads to free up their
allocations.

This change also closes the memory context of TableWriterOperator
in close(), however that's just for testing as the memory reserved
by that context will be released when the driver thread destroys its
operator context.