### PR TITLE
Expose resource group information

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/system/ResourceGroupInfoSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/ResourceGroupInfoSystemTable.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.server.ResourceGroupInfo;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.InMemoryRecordSet;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.ArrayType;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+import static com.facebook.presto.connector.system.QuerySystemTable.resourceGroupIdToBlock;
+import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
+import static com.facebook.presto.spi.SystemTable.Distribution.ALL_COORDINATORS;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.util.Objects.requireNonNull;
+
+public class ResourceGroupInfoSystemTable
+        implements SystemTable
+{
+    public static final SchemaTableName RESOURCE_GROUP_INFO_TABLE_NAME = new SchemaTableName("runtime", "resource_group_info");
+
+    public static final ConnectorTableMetadata RESOURCE_GROUP_INFO_TABLE = tableMetadataBuilder(RESOURCE_GROUP_INFO_TABLE_NAME)
+            .column("resource_group_id", new ArrayType(createUnboundedVarcharType()))
+            .column("resource_group_state", createUnboundedVarcharType())
+            .column("scheduling_policy", createUnboundedVarcharType())
+            .column("scheduling_weight", BIGINT)
+            .column("soft_memory_limit_bytes", BIGINT)
+            .column("soft_concurrency_limit", BIGINT)
+            .column("hard_concurrency_limit", BIGINT)
+            .column("max_queued_queries", BIGINT)
+            .column("running_time_limit", BIGINT)
+            .column("queued_time_limit", BIGINT)
+            .column("memory_usage_bytes", BIGINT)
+            .column("queued_queries", BIGINT)
+            .column("running_queries", BIGINT)
+            .column("eligible_subgroups", BIGINT)
+            .build();
+
+    private final ResourceGroupManager<?> resourceGroupManager;
+
+    @Inject
+    public ResourceGroupInfoSystemTable(ResourceGroupManager resourceGroupManager)
+    {
+        this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return ALL_COORDINATORS;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return RESOURCE_GROUP_INFO_TABLE;
+    }
+
+    @Override
+    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        InMemoryRecordSet.Builder table = InMemoryRecordSet.builder(RESOURCE_GROUP_INFO_TABLE);
+        for (ResourceGroupInfo resourceGroupInfo : resourceGroupManager.getAllResourceGroupInfos()) {
+            table.addRow(
+                    resourceGroupIdToBlock(resourceGroupInfo.getId()),
+                    resourceGroupInfo.getState().toString(),
+                    resourceGroupInfo.getSchedulingPolicy().toString(),
+                    resourceGroupInfo.getSchedulingWeight(),
+                    toBytes(resourceGroupInfo.getSoftMemoryLimit()),
+                    resourceGroupInfo.getSoftConcurrencyLimit(),
+                    resourceGroupInfo.getHardConcurrencyLimit(),
+                    resourceGroupInfo.getMaxQueuedQueries(),
+                    Optional.ofNullable(resourceGroupInfo.getRunningTimeLimit()).map(Duration::toMillis).orElse(null),
+                    Optional.ofNullable(resourceGroupInfo.getQueuedTimeLimit()).map(Duration::toMillis).orElse(null),
+                    toBytes(resourceGroupInfo.getMemoryUsage()),
+                    resourceGroupInfo.getNumQueuedQueries(),
+                    resourceGroupInfo.getNumRunningQueries(),
+                    resourceGroupInfo.getNumEligibleSubGroups());
+        }
+        return table.build().cursor();
+    }
+
+    static Long toBytes(DataSize datasize)
+    {
+        if (datasize == null) {
+            return null;
+        }
+        return datasize.toBytes();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorModule.java
@@ -50,6 +50,7 @@ public class SystemConnectorModule
         Multibinder<SystemTable> globalTableBinder = Multibinder.newSetBinder(binder, SystemTable.class);
         globalTableBinder.addBinding().to(NodeSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(QuerySystemTable.class).in(Scopes.SINGLETON);
+        globalTableBinder.addBinding().to(ResourceGroupInfoSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TaskSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(CatalogSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(SchemaPropertiesSystemTable.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -995,6 +996,20 @@ public class InternalResourceGroup
             if (elapsedSeconds > 0) {
                 internalGenerateCpuQuota(elapsedSeconds);
             }
+        }
+
+        public synchronized List<ResourceGroupInfo> getAllResourceGroupInfo()
+        {
+            ImmutableList.Builder<ResourceGroupInfo> builder = ImmutableList.builder();
+            builder.add(super.getSummaryInfo());
+            LinkedList<InternalResourceGroup> queue = new LinkedList<>();
+            queue.addAll(super.subGroups());
+            while (!queue.isEmpty()) {
+                InternalResourceGroup group = queue.poll();
+                builder.add(group.getSummaryInfo());
+                queue.addAll(group.subGroups());
+            }
+            return builder.build();
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -58,6 +58,7 @@ import static com.facebook.presto.util.PropertiesUtil.loadProperties;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -97,6 +98,14 @@ public final class InternalResourceGroupManager<C>
     {
         checkArgument(groups.containsKey(id), "Group %s does not exist", id);
         return groups.get(id).getFullInfo();
+    }
+
+    @Override
+    public List<ResourceGroupInfo> getAllResourceGroupInfos()
+    {
+        return rootGroups.stream()
+                .flatMap(rootGroup -> rootGroup.getAllResourceGroupInfo().stream())
+                .collect(toImmutableList());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/NoOpResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/NoOpResourceGroupManager.java
@@ -43,6 +43,12 @@ public final class NoOpResourceGroupManager
     }
 
     @Override
+    public List<ResourceGroupInfo> getAllResourceGroupInfos()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<ResourceGroupInfo> getPathToRoot(ResourceGroupId id)
     {
         throw new UnsupportedOperationException();

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
@@ -39,6 +39,8 @@ public interface ResourceGroupManager<C>
 
     ResourceGroupInfo getResourceGroupInfo(ResourceGroupId id);
 
+    List<ResourceGroupInfo> getAllResourceGroupInfos();
+
     List<ResourceGroupInfo> getPathToRoot(ResourceGroupId id);
 
     void addConfigurationManagerFactory(ResourceGroupConfigurationManagerFactory factory);

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupInfo.java
@@ -23,7 +23,9 @@ import io.airlift.units.Duration;
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 /*
@@ -211,5 +213,76 @@ public class ResourceGroupInfo
     public List<ResourceGroupInfo> getSubGroups()
     {
         return subGroups;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof ResourceGroupInfo)) {
+            return false;
+        }
+        ResourceGroupInfo that = (ResourceGroupInfo) other;
+        return id.equals(that.id) &&
+                state == that.state &&
+                schedulingPolicy == that.schedulingPolicy &&
+                schedulingWeight == that.schedulingWeight &&
+                softMemoryLimit.toBytes() == that.softMemoryLimit.toBytes() &&
+                softConcurrencyLimit == that.softConcurrencyLimit &&
+                hardConcurrencyLimit == that.hardConcurrencyLimit &&
+                maxQueuedQueries == that.maxQueuedQueries &&
+                runningTimeLimit.toMillis() == that.runningTimeLimit.toMillis() &&
+                queuedTimeLimit.toMillis() == that.queuedTimeLimit.toMillis() &&
+                memoryUsage.toBytes() == that.memoryUsage.toBytes() &&
+                numQueuedQueries == that.numQueuedQueries &&
+                numRunningQueries == that.numRunningQueries &&
+                numEligibleSubGroups == that.numEligibleSubGroups &&
+                (subGroups == null ? that.subGroups == null : subGroups.equals(that.subGroups)) &&
+                (runningQueries == null ? that.runningQueries == null : runningQueries.equals(that.runningQueries));
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(id,
+                state,
+                schedulingPolicy,
+                schedulingWeight,
+                softMemoryLimit.toBytes(),
+                softConcurrencyLimit,
+                hardConcurrencyLimit,
+                maxQueuedQueries,
+                runningTimeLimit.toMillis(),
+                queuedTimeLimit.toMillis(),
+                memoryUsage.toBytes(),
+                numQueuedQueries,
+                numRunningQueries,
+                numEligibleSubGroups,
+                subGroups,
+                runningQueries);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("id", id)
+                .add("state", state)
+                .add("schedulingPolicy", schedulingPolicy)
+                .add("softMemoryLimit", softMemoryLimit)
+                .add("softConcurrencyLimit", softConcurrencyLimit)
+                .add("hardConcurrencyLimit", hardConcurrencyLimit)
+                .add("maxQueuedQueries", maxQueuedQueries)
+                .add("runningTimeLimit", runningTimeLimit)
+                .add("queuedTimeLimit", queuedTimeLimit)
+                .add("memoryUsage", memoryUsage)
+                .add("numQueuedQueries", numQueuedQueries)
+                .add("numRunningQueries", numRunningQueries)
+                .add("numEligibleSubGroups", numEligibleSubGroups)
+                .add("subGroups", subGroups)
+                .add("runningQueries", runningQueries)
+                .toString();
     }
 }

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -56,6 +56,7 @@ system| runtime| queries| user| varchar| YES| null| null|
 system| runtime| queries| source| varchar| YES| null| null|
 system| runtime| queries| query| varchar| YES| null| null|
 system| runtime| queries| resource_group_id| array(varchar)| YES| null| null|
+system| runtime| queries| session_properties| map(varchar, varchar)| YES| null| null|
 system| runtime| queries| queued_time_ms| bigint| YES| null| null|
 system| runtime| queries| analysis_time_ms| bigint| YES| null| null|
 system| runtime| queries| distributed_planning_time_ms| bigint| YES| null| null|
@@ -63,6 +64,20 @@ system| runtime| queries| created| timestamp| YES| null| null|
 system| runtime| queries| started| timestamp| YES| null| null|
 system| runtime| queries| last_heartbeat| timestamp| YES| null| null|
 system| runtime| queries| end| timestamp| YES| null| null|
+system| runtime| resource_group_info| resource_group_id| array(varchar)| YES| null| null|
+system| runtime| resource_group_info| resource_group_state| varchar| YES| null| null|
+system| runtime| resource_group_info| scheduling_policy| varchar| YES| null| null|
+system| runtime| resource_group_info| scheduling_weight| bigint| YES| null| null|
+system| runtime| resource_group_info| soft_memory_limit_bytes| bigint| YES| null| null|
+system| runtime| resource_group_info| soft_concurrency_limit| bigint| YES| null| null|
+system| runtime| resource_group_info| hard_concurrency_limit| bigint| YES| null| null|
+system| runtime| resource_group_info| max_queued_queries| bigint| YES| null| null|
+system| runtime| resource_group_info| running_time_limit| bigint| YES| null| null|
+system| runtime| resource_group_info| queued_time_limit| bigint| YES| null| null|
+system| runtime| resource_group_info| memory_usage_bytes| bigint| YES| null| null|
+system| runtime| resource_group_info| queued_queries| bigint| YES| null| null|
+system| runtime| resource_group_info| running_queries| bigint| YES| null| null|
+system| runtime| resource_group_info| eligible_subgroups| bigint| YES| null| null|
 system| runtime| tasks| node_id| varchar| YES| null| null|
 system| runtime| tasks| task_id| varchar| YES| null| null|
 system| runtime| tasks| stage_id| varchar| YES| null| null|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemRuntime.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemRuntime.result
@@ -1,5 +1,6 @@
 -- delimiter: |; ignoreOrder: true;
 nodes|
 queries|
+resource_group_info|
 tasks|
 transactions|

--- a/presto-spi/src/main/java/com/facebook/presto/spi/InMemoryRecordSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/InMemoryRecordSet.java
@@ -235,6 +235,10 @@ public class InMemoryRecordSet
                     checkArgument(value instanceof Block,
                             "Expected value %d to be an instance of Block, but is a %s", i, value.getClass().getSimpleName());
                 }
+                else if (type.getTypeSignature().getBase().equals("map")) {
+                    checkArgument(value instanceof Block,
+                            "Expected value %d to be an instance of Block, but is a %s", i, value.getClass().getSimpleName());
+                }
                 else {
                     throw new IllegalStateException("Unsupported column type " + types.get(i));
                 }

--- a/presto-tests/src/test/java/com/facebook/presto/connector/system/TestQuerySystemTable.java
+++ b/presto-tests/src/test/java/com/facebook/presto/connector/system/TestQuerySystemTable.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
+import com.facebook.presto.resourceGroups.ResourceGroupManagerPlugin;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.execution.QueryState.FAILED;
+import static com.facebook.presto.execution.QueryState.RUNNING;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.cancelQuery;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.createQuery;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.waitForQueryState;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestQuerySystemTable
+{
+    private static final String LONG_LASTING_QUERY = "SELECT COUNT(*) FROM lineitem";
+
+    @Test(timeOut = 60_000)
+    public void testQuerySystemTableSessionProperties()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().build()) {
+            queryRunner.installPlugin(new ResourceGroupManagerPlugin());
+            InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+            manager.setConfigurationManager("file", ImmutableMap.of(
+                    "resource-groups.config-file", this.getClass().getClassLoader().getResource("resource_group_config_all_parameters.json").getPath()));
+            QueryId queryId = createQuery(queryRunner, testSessionBuilder().setCatalog("tpch").setSchema("sf100000").setSource("dashboard").build(), LONG_LASTING_QUERY);
+            waitForQueryState(queryRunner, queryId, RUNNING);
+            MaterializedResult result = queryRunner.execute("SELECT session_properties FROM system.runtime.queries WHERE source = 'dashboard'");
+            assertTrue(((Map<String, String>) result.getOnlyValue()).isEmpty());
+            cancelQuery(queryRunner, queryId);
+            waitForQueryState(queryRunner, queryId, FAILED);
+            Session dashBoardSession = testSessionBuilder()
+                    .setCatalog("tpch")
+                    .setSchema("sf100000")
+                    .setSource("dashboard")
+                    .setSystemProperty("query_priority", "12")
+                    .build();
+            queryId = createQuery(queryRunner, dashBoardSession, LONG_LASTING_QUERY);
+            waitForQueryState(queryRunner, queryId, RUNNING);
+
+            result = queryRunner.execute("SELECT session_properties FROM system.runtime.queries WHERE query_id = '" + queryId.toString() + "'");
+            Map<String, String> sessionProperties = (Map<String, String>) result.getOnlyValue();
+            assertEquals(sessionProperties.size(), 1);
+            assertEquals(sessionProperties.get("query_priority"), "12");
+            cancelQuery(queryRunner, queryId);
+            waitForQueryState(queryRunner, queryId, FAILED);
+        }
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestResourceGroupSystemTable.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestResourceGroupSystemTable.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.resourceGroups.db;
+
+import com.facebook.presto.resourceGroups.db.H2ResourceGroupsDao;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.createQueryRunner;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDao;
+import static com.facebook.presto.execution.resourceGroups.db.H2TestUtil.getDbConfigUrl;
+
+// run single threaded to avoid creating multiple query runners at once
+@Test(singleThreaded = true)
+public class TestResourceGroupSystemTable
+{
+    // Copy of TestQueues with tests for db reconfiguration of resource groups
+    private static final String LONG_LASTING_QUERY = "SELECT COUNT(*) FROM lineitem";
+    private DistributedQueryRunner queryRunner;
+    private H2ResourceGroupsDao dao;
+
+    @BeforeMethod
+    public void setup()
+            throws Exception
+    {
+        String dbConfigUrl = getDbConfigUrl();
+        dao = getDao(dbConfigUrl);
+        queryRunner = createQueryRunner(dbConfigUrl, dao);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
+    }
+}

--- a/presto-tests/src/test/resources/resource_group_config_all_parameters.json
+++ b/presto-tests/src/test/resources/resource_group_config_all_parameters.json
@@ -1,0 +1,88 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "softMemoryLimit": "1MB",
+      "softConcurrencyLimit": 99,
+      "hardConcurrencyLimit": 100,
+      "maxQueued": 1000,
+      "schedulingPolicy": "fair",
+      "jmxExport": true,
+      "softCpuLimit": "1h",
+      "hardCpuLimit": "2h",
+      "queuedTimeLimit": "3h",
+      "runningTimeLimit": "1h",
+      "subGroups": [
+        {
+          "name": "user-${USER}",
+          "softMemoryLimit": "1MB",
+          "softConcurrencyLimit": 3,
+          "hardConcurrencyLimit": 4,
+          "maxQueued": 3,
+          "schedulingPolicy": "query_priority",
+          "jmxExport": true,
+          "softCpuLimit": "1h",
+          "hardCpuLimit": "2h",
+          "queuedTimeLimit": "3h",
+          "runningTimeLimit": "1h",
+          "subGroups": [
+            {
+              "name": "adhoc-${USER}",
+              "softMemoryLimit": "1MB",
+              "softConcurrencyLimit": 2,
+              "hardConcurrencyLimit": 3,
+              "maxQueued": 3,
+              "schedulingPolicy": "query_priority",
+              "jmxExport": true,
+              "softCpuLimit": "1h",
+              "hardCpuLimit": "2h",
+              "queuedTimeLimit": "3h",
+              "runningTimeLimit": "1h"
+            },
+            {
+              "name": "dashboard-${USER}",
+              "softMemoryLimit": "1MB",
+              "softConcurrencyLimit": 1,
+              "hardConcurrencyLimit": 2,
+              "maxQueued": 4,
+              "schedulingPolicy": "query_priority",
+              "jmxExport": true,
+              "softCpuLimit": "1h",
+              "hardCpuLimit": "2h",
+              "queuedTimeLimit": "3h",
+              "runningTimeLimit": "1h"
+            }
+          ]
+        },
+        {
+          "name": "test",
+          "softMemoryLimit": "1MB",
+          "softConcurrencyLimit": 2,
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 3,
+          "schedulingPolicy": "fair",
+          "jmxExport": true,
+          "softCpuLimit": "1h",
+          "hardCpuLimit": "2h",
+          "queuedTimeLimit": "3h",
+          "runningTimeLimit": "1h"
+        }
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "source": "(?i).*dashboard.*",
+      "group": "global.user-${USER}.dashboard-${USER}"
+    },
+    {
+      "source": "(?i).*adhoc.*",
+      "group": "global.user-${USER}.adhoc-${USER}"
+    },
+    {
+      "source": "test",
+      "group": "global.test"
+    }
+  ],
+  "cpuQuotaPeriod": "1h"
+}


### PR DESCRIPTION
Expose resource group information so that it can be used by an external system to reconstruct the query queues and determine an approximate order in which queries will be dequeued.