### PR TITLE
Add extension points for JDBC-to-Presto type mappings

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -387,6 +387,12 @@ public class BaseJdbcClient
     }
 
     @Override
+    public JdbcPageSink getPageSink(JdbcOutputTableHandle tableHandle)
+    {
+        return new JdbcPageSink(tableHandle, this);
+    }
+
+    @Override
     public void dropTable(JdbcTableHandle handle)
     {
         StringBuilder sql = new StringBuilder()

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -299,6 +299,9 @@ public class BaseJdbcClient
             String catalog = connection.getCatalog();
 
             String temporaryName = generateTemporaryTableName();
+            if (uppercase) {
+                temporaryName = temporaryName.toUpperCase();
+            }
             StringBuilder sql = new StringBuilder()
                     .append("CREATE TABLE ")
                     .append(quoted(catalog, schema, temporaryName))

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -67,6 +67,8 @@ public interface JdbcClient
 
     void finishInsertTable(JdbcOutputTableHandle handle);
 
+    JdbcPageSink getPageSink(JdbcOutputTableHandle tableHandle);
+
     void dropTable(JdbcTableHandle jdbcTableHandle);
 
     void rollbackCreateTable(JdbcOutputTableHandle handle);

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcPageSink.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcPageSink.java
@@ -46,6 +46,10 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
@@ -111,56 +115,69 @@ public class JdbcPageSink
         return NOT_BLOCKED;
     }
 
-    private void appendColumn(Page page, int position, int channel)
+    public void appendColumn(Page page, int position, int channel)
             throws SQLException
     {
         Block block = page.getBlock(channel);
         int parameter = channel + 1;
+        Type type = columnTypes.get(channel);
 
         if (block.isNull(position)) {
-            statement.setObject(parameter, null);
-            return;
+            setNull(type, parameter, block, position);
         }
-
-        Type type = columnTypes.get(channel);
-        if (BOOLEAN.equals(type)) {
-            statement.setBoolean(parameter, type.getBoolean(block, position));
+        else if (BOOLEAN.equals(type)) {
+            setBoolean(type, parameter, block, position);
         }
         else if (BIGINT.equals(type)) {
-            statement.setLong(parameter, type.getLong(block, position));
+            setBigint(type, parameter, block, position);
         }
         else if (INTEGER.equals(type)) {
-            statement.setInt(parameter, toIntExact(type.getLong(block, position)));
+            setInteger(type, parameter, block, position);
         }
         else if (SMALLINT.equals(type)) {
-            statement.setShort(parameter, Shorts.checkedCast(type.getLong(block, position)));
+            setSmallint(type, parameter, block, position);
         }
         else if (TINYINT.equals(type)) {
-            statement.setByte(parameter, SignedBytes.checkedCast(type.getLong(block, position)));
+            setTinyint(type, parameter, block, position);
         }
         else if (DOUBLE.equals(type)) {
-            statement.setDouble(parameter, type.getDouble(block, position));
+            setDouble(type, parameter, block, position);
         }
         else if (REAL.equals(type)) {
-            statement.setFloat(parameter, intBitsToFloat(toIntExact(type.getLong(block, position))));
+            setReal(type, parameter, block, position);
         }
         else if (type instanceof DecimalType) {
-            statement.setBigDecimal(parameter, readBigDecimal((DecimalType) type, block, position));
+            setDecimal(type, parameter, block, position);
         }
-        else if (isVarcharType(type) || isCharType(type)) {
-            statement.setString(parameter, type.getSlice(block, position).toStringUtf8());
+        else if (isVarcharType(type)) {
+            setVarchar(type, parameter, block, position);
+        }
+        else if (isCharType(type)) {
+            setChar(type, parameter, block, position);
         }
         else if (VARBINARY.equals(type)) {
-            statement.setBytes(parameter, type.getSlice(block, position).getBytes());
+            setVarbinary(type, parameter, block, position);
         }
         else if (DATE.equals(type)) {
-            // convert to midnight in default time zone
-            long utcMillis = DAYS.toMillis(type.getLong(block, position));
-            long localMillis = getInstanceUTC().getZone().getMillisKeepLocal(DateTimeZone.getDefault(), utcMillis);
-            statement.setDate(parameter, new Date(localMillis));
+            setDate(type, parameter, block, position);
+        }
+        else if (TIME.equals(type)) {
+            setTime(type, parameter, block, position);
+        }
+        else if (TIME_WITH_TIME_ZONE.equals(type)) {
+            setTimeWithTimeZone(type, parameter, block, position);
+        }
+        else if (TIMESTAMP.equals(type)) {
+            setTimestamp(type, parameter, block, position);
+        }
+        else if (TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
+            setTimestampWithTimeZone(type, parameter, block, position);
+        }
+        else if (isOtherType(type)) {
+            setOtherType(type, parameter, block, position);
         }
         else {
-            throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
+            throw unsupportedType(type);
         }
     }
 
@@ -211,5 +228,139 @@ public class JdbcPageSink
                 throwable.addSuppressed(t);
             }
         }
+    }
+
+    protected PreparedStatement statement()
+    {
+        return statement;
+    }
+
+    protected final PrestoException unsupportedType(Type type)
+    {
+        return new PrestoException(NOT_SUPPORTED,
+                "Unsupported column type: " + type.getDisplayName());
+    }
+
+    protected void setNull(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setObject(parameter, null);
+    }
+
+    protected void setBoolean(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setBoolean(parameter, BOOLEAN.getBoolean(block, position));
+    }
+
+    protected void setTinyint(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setByte(parameter, SignedBytes.checkedCast(TINYINT.getLong(block, position)));
+    }
+
+    protected void setSmallint(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setShort(parameter, Shorts.checkedCast(SMALLINT.getLong(block, position)));
+    }
+
+    protected void setInteger(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setInt(parameter, toIntExact(INTEGER.getLong(block, position)));
+    }
+
+    protected void setBigint(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setLong(parameter, BIGINT.getLong(block, position));
+    }
+
+    protected void setReal(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setFloat(parameter, intBitsToFloat(toIntExact(REAL.getLong(block, position))));
+    }
+
+    protected void setDouble(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setDouble(parameter, DOUBLE.getDouble(block, position));
+    }
+
+    protected void setDecimal(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setBigDecimal(parameter, readBigDecimal((DecimalType) type, block, position));
+    }
+
+    protected void setVarchar(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setString(parameter, type.getSlice(block, position).toStringUtf8());
+    }
+
+    protected void setChar(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setString(parameter, type.getSlice(block, position).toStringUtf8());
+    }
+
+    protected void setVarbinary(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        statement.setBytes(parameter, type.getSlice(block, position).getBytes());
+    }
+
+    protected void setDate(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        // convert to midnight in default time zone
+        long utcMillis = DAYS.toMillis(type.getLong(block, position));
+        long localMillis = getInstanceUTC().getZone()
+                .getMillisKeepLocal(DateTimeZone.getDefault(), utcMillis);
+        statement.setDate(parameter, new Date(localMillis));
+    }
+
+    protected void setTime(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        throw unsupportedType(type);
+    }
+
+    protected void setTimeWithTimeZone(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        throw unsupportedType(type);
+    }
+
+    protected void setTimestamp(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        throw unsupportedType(type);
+    }
+
+    protected void setTimestampWithTimeZone(Type type, int parameter, Block block, int position)
+            throws SQLException
+    {
+        throw unsupportedType(type);
+    }
+
+    /**
+     * @return Whether the given {@link Type} is a supported type that does not
+     * have its own setter method.
+     */
+    protected boolean isOtherType(Type type)
+    {
+        return false;
+    }
+
+    /**
+     * Set a column of a type that does not have its own setter method.
+     */
+    protected void setOtherType(Type type, int parameter, Block block, int position)
+    {
+        throw unsupportedType(type);
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcPageSinkProvider.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcPageSinkProvider.java
@@ -38,12 +38,12 @@ public class JdbcPageSinkProvider
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle tableHandle)
     {
-        return new JdbcPageSink((JdbcOutputTableHandle) tableHandle, jdbcClient);
+        return jdbcClient.getPageSink((JdbcOutputTableHandle) tableHandle);
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle tableHandle)
     {
-        return new JdbcPageSink((JdbcOutputTableHandle) tableHandle, jdbcClient);
+        return jdbcClient.getPageSink((JdbcOutputTableHandle) tableHandle);
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
@@ -34,4 +34,14 @@ public final class TestingJdbcTypeHandle
     public static final JdbcTypeHandle JDBC_DATE = new JdbcTypeHandle(Types.DATE, 8, 0);
     public static final JdbcTypeHandle JDBC_TIME = new JdbcTypeHandle(Types.TIME, 4, 0);
     public static final JdbcTypeHandle JDBC_TIMESTAMP = new JdbcTypeHandle(Types.TIMESTAMP, 8, 0);
+
+    public static final JdbcTypeHandle jdbcChar(int size)
+    {
+        return new JdbcTypeHandle(Types.CHAR, size, 0);
+    }
+
+    public static final JdbcTypeHandle jdbcDecimal(int precision, int scale)
+    {
+        return new JdbcTypeHandle(Types.DECIMAL, precision, scale);
+    }
 }


### PR DESCRIPTION
- Allow extension of `JdbcPageSink` to allow connectors to modify Presto-to-JDBC type mappings.

- Allow extension of `QueryBuilder` to allow the same during predicate pushdown.

- Conditionally capitalize the names of temporary tables created by `BaseJdbcClient` to match the capitalization of table names elsewhere in the class.