### PR TITLE
Fix information schema predicate pushdown for views

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaMetadata.java
@@ -238,7 +238,7 @@ public class InformationSchemaMetadata
 
     private boolean isTablesEnumeratingTable(SchemaTableName schemaTableName)
     {
-        return ImmutableSet.of(TABLE_COLUMNS, TABLE_TABLES, TABLE_TABLES, TABLE_TABLE_PRIVILEGES).contains(schemaTableName);
+        return ImmutableSet.of(TABLE_COLUMNS, TABLE_VIEWS, TABLE_TABLES, TABLE_TABLES, TABLE_TABLE_PRIVILEGES).contains(schemaTableName);
     }
 
     private Set<QualifiedTablePrefix> calculatePrefixesWithSchemaName(

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestInformationSchemaMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestInformationSchemaMetadata.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.client.ClientCapabilities;
+import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.connector.MockConnectorFactory;
+import com.facebook.presto.connector.informationSchema.InformationSchemaColumnHandle;
+import com.facebook.presto.connector.informationSchema.InformationSchemaMetadata;
+import com.facebook.presto.connector.informationSchema.InformationSchemaTableHandle;
+import com.facebook.presto.connector.informationSchema.InformationSchemaTableLayoutHandle;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorViewDefinition;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.NullableValue;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.testing.TestingConnectorContext;
+import com.facebook.presto.transaction.TransactionId;
+import com.facebook.presto.transaction.TransactionManager;
+import com.facebook.presto.type.TypeRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.connector.ConnectorId.createInformationSchemaConnectorId;
+import static com.facebook.presto.connector.ConnectorId.createSystemTablesConnectorId;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Arrays.stream;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestInformationSchemaMetadata
+{
+    private static final JsonCodec<ViewDefinition> VIEW_DEFINITION_JSON_CODEC = JsonCodec.jsonCodec(ViewDefinition.class);
+
+    private final TransactionManager transactionManager;
+    private final Metadata metadata;
+
+    public TestInformationSchemaMetadata()
+    {
+        MockConnectorFactory mockConnectorFactory = new MockConnectorFactory(
+                connectorSession -> ImmutableList.of("test_schema"),
+                (connectorSession, schemaNameOrNull) ->
+                        ImmutableList.of(
+                                new SchemaTableName("test_schema", "test_view"),
+                                new SchemaTableName("test_schema", "another_table")),
+                (connectorSession, prefix) -> {
+                    String viewJson = VIEW_DEFINITION_JSON_CODEC.toJson(new ViewDefinition("select 1", Optional.of("test_catalog"), Optional.of("test_schema"), ImmutableList.of(), Optional.empty()));
+                    SchemaTableName viewName = new SchemaTableName("test_schema", "test_view");
+                    return ImmutableMap.of(viewName, new ConnectorViewDefinition(viewName, Optional.empty(), viewJson));
+                },
+                (connectorSession, tableHandle) -> {
+                    throw new UnsupportedOperationException();
+                });
+
+        Connector testConnector = mockConnectorFactory.create("test", ImmutableMap.of(), new TestingConnectorContext());
+        CatalogManager catalogManager = new CatalogManager();
+        String catalogName = "test_catalog";
+        ConnectorId connectorId = new ConnectorId(catalogName);
+        catalogManager.registerCatalog(new Catalog(
+                catalogName,
+                connectorId,
+                testConnector,
+                createInformationSchemaConnectorId(connectorId),
+                testConnector,
+                createSystemTablesConnectorId(connectorId),
+                testConnector));
+        transactionManager = createTestTransactionManager(catalogManager);
+        metadata = new MetadataManager(
+                new FeaturesConfig(),
+                new TypeRegistry(),
+                new BlockEncodingManager(new TypeRegistry()),
+                new SessionPropertyManager(),
+                new SchemaPropertyManager(),
+                new TablePropertyManager(),
+                new ColumnPropertyManager(),
+                transactionManager);
+    }
+
+    /**
+     * Tests information schema predicate pushdown when both schema and table name are specified.
+     */
+    @Test
+    public void testInformationSchemaPredicatePushdown()
+    {
+        TransactionId transactionId = transactionManager.beginTransaction(false);
+
+        ImmutableMap.Builder<ColumnHandle, Domain> domains = new ImmutableMap.Builder<>();
+        domains.put(new InformationSchemaColumnHandle("table_schema"), Domain.singleValue(VARCHAR, Slices.utf8Slice("test_schema")));
+        domains.put(new InformationSchemaColumnHandle("table_name"), Domain.singleValue(VARCHAR, Slices.utf8Slice("test_view")));
+        Constraint<ColumnHandle> constraint = new Constraint<>(TupleDomain.withColumnDomains(domains.build()));
+
+        InformationSchemaMetadata informationSchemaMetadata = new InformationSchemaMetadata("test_catalog", metadata);
+        List<ConnectorTableLayoutResult> layoutResults = informationSchemaMetadata.getTableLayouts(
+                createNewSession(transactionId),
+                new InformationSchemaTableHandle("test_catalog", "information_schema", "views"),
+                constraint,
+                Optional.empty());
+
+        assertEquals(layoutResults.size(), 1);
+        ConnectorTableLayoutHandle handle = layoutResults.get(0).getTableLayout().getHandle();
+        assertTrue(handle instanceof InformationSchemaTableLayoutHandle);
+        InformationSchemaTableLayoutHandle tableHandle = (InformationSchemaTableLayoutHandle) handle;
+        assertEquals(tableHandle.getPrefixes(), ImmutableSet.of(new QualifiedTablePrefix("test_catalog", "test_schema", "test_view")));
+    }
+
+    @Test
+    public void testInformationSchemaPredicatePushdownWithConstraintPredicate()
+    {
+        TransactionId transactionId = transactionManager.beginTransaction(false);
+        Constraint<ColumnHandle> constraint = new Constraint<>(
+                TupleDomain.all(),
+                // test_schema has a table named "another_table" and we filter that out in this predicate
+                bindings -> {
+                    NullableValue catalog = bindings.get(new InformationSchemaColumnHandle("table_catalog"));
+                    NullableValue schema = bindings.get(new InformationSchemaColumnHandle("table_schema"));
+                    NullableValue table = bindings.get(new InformationSchemaColumnHandle("table_name"));
+                    boolean isValid = true;
+                    if (catalog != null) {
+                        isValid = ((Slice) catalog.getValue()).toStringUtf8().equals("test_catalog");
+                    }
+                    if (schema != null) {
+                        isValid &= ((Slice) schema.getValue()).toStringUtf8().equals("test_schema");
+                    }
+                    if (table != null) {
+                        isValid &= ((Slice) table.getValue()).toStringUtf8().equals("test_view");
+                    }
+                    return isValid;
+                });
+
+        InformationSchemaMetadata informationSchemaMetadata = new InformationSchemaMetadata("test_catalog", metadata);
+        List<ConnectorTableLayoutResult> layoutResults = informationSchemaMetadata.getTableLayouts(
+                createNewSession(transactionId),
+                new InformationSchemaTableHandle("test_catalog", "information_schema", "views"),
+                constraint,
+                Optional.empty());
+
+        assertEquals(layoutResults.size(), 1);
+        ConnectorTableLayoutHandle handle = layoutResults.get(0).getTableLayout().getHandle();
+        assertTrue(handle instanceof InformationSchemaTableLayoutHandle);
+        InformationSchemaTableLayoutHandle tableHandle = (InformationSchemaTableLayoutHandle) handle;
+        assertEquals(tableHandle.getPrefixes(), ImmutableSet.of(new QualifiedTablePrefix("test_catalog", "test_schema", "test_view")));
+    }
+
+    private ConnectorSession createNewSession(TransactionId transactionId)
+    {
+        return testSessionBuilder()
+                    .setCatalog("test_catalog")
+                    .setSchema("information_schema")
+                    .setClientCapabilities(stream(ClientCapabilities.values())
+                            .map(ClientCapabilities::toString)
+                            .collect(toImmutableSet()))
+                    .setTransactionId(transactionId)
+                    .build()
+                .toConnectorSession();
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/connector/informationschema/BenchmarkInformationSchema.java
+++ b/presto-tests/src/test/java/com/facebook/presto/connector/informationschema/BenchmarkInformationSchema.java
@@ -126,7 +126,7 @@ public class BenchmarkInformationSchema
                             .boxed()
                             .map(i -> "column_" + i)
                             .collect(toImmutableMap(column -> column, column -> new TpchColumnHandle(column, createUnboundedVarcharType()) {}));
-                    return ImmutableList.of(new MockConnectorFactory(listSchemaNames, listTables, getColumnHandles));
+                    return ImmutableList.of(new MockConnectorFactory(listSchemaNames, listTables, (session, prefix) -> ImmutableMap.of(), getColumnHandles));
                 }
             });
             queryRunner.createCatalog("test_catalog", "mock", ImmutableMap.of());

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
 import com.facebook.presto.transaction.TransactionBuilder;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -63,6 +64,7 @@ public class TestMetadataManager
                         (session, schemaNameOrNull) -> {
                             throw new UnsupportedOperationException();
                         },
+                        (session, prefix) -> ImmutableMap.of(),
                         (session, tableHandle) -> {
                             throw new UnsupportedOperationException();
                         }));


### PR DESCRIPTION
For queries of the form:

```
SELECT view_definition
FROM information_schema.views
WHERE table_catalog = 'catalog' AND
table_schema = 'schema_name'
AND table_name = 'view_name';
```

that specifies both the schema name and view name, the current
implementation calculates the prefix "schema_name.*" to get
all the views under the given schema. However, it should calculate the
prefix "schema_name.view_name" to get only the specified view.
This change fixes that.

@kokosing `isTablesEnumeratingTable()` method returns false when we query the `views` table. Is there a reason why we don't include `views` in that method? That contradicts with the `calculatePrefixesWithTableName` method where we also call `metadata.getView()`. Including the `views` table in that method fixes the problem.