### PR TITLE
Fix the race between close and destroy in the Driver

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -688,7 +688,10 @@ public class Driver
         // If there are more source updates available, attempt to reacquire the lock and process them.
         // This can happen if new sources are added while we're holding the lock here doing work.
         // NOTE: this is separate duplicate code to make debugging lock reacquisition easier
-        while (pendingTaskSourceUpdates.get() != null && state.get() == State.ALIVE && exclusiveLock.tryLock()) {
+        // The first condition is for processing the pending updates if this driver is still ALIVE
+        // The second condition is to destroy the driver if the state is NEED_DESTRUCTION
+        while (((pendingTaskSourceUpdates.get() != null && state.get() == State.ALIVE) || state.get() == State.NEED_DESTRUCTION)
+                && exclusiveLock.tryLock()) {
             try {
                 try {
                     processNewSources();


### PR DESCRIPTION
There is a race condition where a driver thread may not destroy the
operators even though it's closed. This is not desirable as there are
parts of the code that rely on the operators to be destroyed by the
driver, e.g., memory tracking related code.

The race occurs when a driver thread T1 is in the tryWithLock method and
holds the exclusiveLock, and it has already called the
destroyIfNecessary() method. At this point T1 hasn't destroyed the operators
yet as the driver hasn't been closed. Now if the task owning those splits
gets aborted (say due to a LIMIT query), another thread T2 will call
driver.close(), and in close() it will try to acquire the lock to destroy the
operators, but T1 still holds that lock. Then, T1 releases the lock and checks
the condition `while (pendingTaskSourceUpdates.get() != null
&& state.get() == State.ALIVE && exclusiveLock.tryLock())`, and this condition
is false as the state is NEED_DESTRUCTION (as the driver is closed by T2). At this
point T1 just exits without destroying the operators.