### PR TITLE
Clean type predicates

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSink.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloPageSink.java
@@ -25,7 +25,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeUtils;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -59,6 +58,7 @@ import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -217,7 +217,7 @@ public class AccumuloPageSink
             else if (type.equals(VARBINARY)) {
                 serializer.setVarbinary(value, field.getVarbinary());
             }
-            else if (type instanceof VarcharType) {
+            else if (isVarcharType(type)) {
                 serializer.setVarchar(value, field.getVarchar());
             }
             else {

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
@@ -20,7 +20,6 @@ import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarbinaryType;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.apache.accumulo.core.client.BatchScanner;
@@ -50,6 +49,7 @@ import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
@@ -255,7 +255,7 @@ public class AccumuloRecordCursor
     public Slice getSlice(int field)
     {
         Type type = getType(field);
-        if (type instanceof VarbinaryType) {
+        if (VARBINARY.equals(type)) {
             return Slices.wrappedBuffer(serializer.getVarbinary(fieldToColumnName[field]));
         }
         else if (isVarcharType(type)) {

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarbinaryType;
-import com.facebook.presto.spi.type.VarcharType;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.apache.accumulo.core.client.BatchScanner;
@@ -51,6 +50,7 @@ import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -258,7 +258,7 @@ public class AccumuloRecordCursor
         if (type instanceof VarbinaryType) {
             return Slices.wrappedBuffer(serializer.getVarbinary(fieldToColumnName[field]));
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             return Slices.utf8Slice(serializer.getVarchar(fieldToColumnName[field]));
         }
         else {

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Field.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Field.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.ArrayBlock;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import io.airlift.slice.Slice;
 
 import java.sql.Date;
@@ -46,6 +45,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.DAYS;
@@ -364,7 +364,7 @@ public class Field
         else if (type.equals(VARBINARY)) {
             return "CAST('" + new String((byte[]) value, UTF_8).replaceAll("'", "''") + "' AS VARBINARY)";
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             return "'" + value.toString().replaceAll("'", "''") + "'";
         }
         else {
@@ -511,7 +511,7 @@ public class Field
                 throw new PrestoException(FUNCTION_IMPLEMENTATION_ERROR, "Object is not a Slice byte[], but " + value.getClass());
             }
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             if (value instanceof Slice) {
                 return new String(((Slice) value).getBytes(), UTF_8);
             }

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Row.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Row.java
@@ -17,7 +17,6 @@ import com.facebook.presto.accumulo.Types;
 import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -48,6 +47,7 @@ import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -227,7 +227,7 @@ public class Row
         else if (type.equals(VARBINARY)) {
             return str.getBytes(UTF_8);
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             return str;
         }
         else {

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/LexicoderRowSerializer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/LexicoderRowSerializer.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeSignature;
-import com.facebook.presto.spi.type.VarcharType;
 import io.airlift.slice.Slice;
 import org.apache.accumulo.core.client.lexicoder.BytesLexicoder;
 import org.apache.accumulo.core.client.lexicoder.DoubleLexicoder;
@@ -51,6 +50,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -363,7 +363,7 @@ public class LexicoderRowSerializer
         else if (type.equals(VARBINARY) && value instanceof Slice) {
             toEncode = ((Slice) value).getBytes();
         }
-        else if (type instanceof VarcharType && value instanceof Slice) {
+        else if (isVarcharType(type) && value instanceof Slice) {
             toEncode = ((Slice) value).toStringUtf8();
         }
         else {
@@ -387,7 +387,7 @@ public class LexicoderRowSerializer
         else if (Types.isMapType(type)) {
             return getMapLexicoder(type);
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             return LEXICODER_MAP.get(VARCHAR);
         }
         else {

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -55,6 +55,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -479,7 +480,7 @@ public class BaseJdbcClient
             }
             return "char(" + ((CharType) type).getLength() + ")";
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             return format("decimal(%s, %s)", ((DecimalType) type).getPrecision(), ((DecimalType) type).getScale());
         }
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -53,6 +53,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -472,7 +473,7 @@ public class BaseJdbcClient
             }
             return "varchar(" + varcharType.getLengthSafe() + ")";
         }
-        if (type instanceof CharType) {
+        if (isCharType(type)) {
             if (((CharType) type).getLength() == CharType.MAX_LENGTH) {
                 return "char";
             }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcPageSink.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcPageSink.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Decimals.readBigDecimal;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -144,7 +145,7 @@ public class JdbcPageSink
         else if (REAL.equals(type)) {
             statement.setFloat(parameter, intBitsToFloat(toIntExact(type.getLong(block, position))));
         }
-        else if (type instanceof DecimalType) {
+        else if (isDecimalType(type)) {
             statement.setBigDecimal(parameter, readBigDecimal((DecimalType) type, block, position));
         }
         else if (isVarcharType(type) || isCharType(type)) {

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
@@ -30,7 +30,6 @@ import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.TimestampWithTimeZoneType;
 import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
@@ -46,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.facebook.presto.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -166,7 +166,7 @@ public class QueryBuilder
             else if (typeAndValue.getType().equals(TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE)) {
                 statement.setTimestamp(i + 1, new Timestamp(unpackMillisUtc((long) typeAndValue.getValue())));
             }
-            else if (typeAndValue.getType() instanceof VarcharType) {
+            else if (isVarcharType(typeAndValue.getType())) {
                 statement.setString(i + 1, ((Slice) typeAndValue.getValue()).toStringUtf8());
             }
             else {
@@ -192,7 +192,7 @@ public class QueryBuilder
                 validType.equals(TimeWithTimeZoneType.TIME_WITH_TIME_ZONE) ||
                 validType.equals(TimestampType.TIMESTAMP) ||
                 validType.equals(TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE) ||
-                validType instanceof VarcharType;
+                isVarcharType(validType);
     }
 
     private List<String> toConjuncts(List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> tupleDomain, List<TypeAndValue> accumulator)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -60,6 +60,7 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Decimals.rescale;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -495,7 +496,7 @@ class GenericHiveRecordCursor<K, V extends Writable>
         else if (TIMESTAMP.equals(type)) {
             parseLongColumn(column);
         }
-        else if (type instanceof DecimalType) {
+        else if (isDecimalType(type)) {
             parseDecimalColumn(column);
         }
         else {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionPolicy.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionPolicy.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.facebook.presto.spi.type.VarcharType;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
@@ -32,6 +31,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_SHORT;
 import static com.facebook.presto.hive.HiveUtil.extractStructFieldTypes;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
@@ -51,10 +51,10 @@ public class HiveCoercionPolicy
     {
         Type fromType = typeManager.getType(fromHiveType.getTypeSignature());
         Type toType = typeManager.getType(toHiveType.getTypeSignature());
-        if (fromType instanceof VarcharType) {
+        if (isVarcharType(fromType)) {
             return toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG);
         }
-        if (toType instanceof VarcharType) {
+        if (isVarcharType(toType)) {
             return fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG);
         }
         if (fromHiveType.equals(HIVE_BYTE)) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercionRecordCursor.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
@@ -41,6 +40,7 @@ import static com.facebook.presto.hive.HiveUtil.isArrayType;
 import static com.facebook.presto.hive.HiveUtil.isMapType;
 import static com.facebook.presto.hive.HiveUtil.isRowType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.min;
@@ -282,10 +282,10 @@ public class HiveCoercionRecordCursor
     {
         Type fromType = typeManager.getType(fromHiveType.getTypeSignature());
         Type toType = typeManager.getType(toHiveType.getTypeSignature());
-        if (toType instanceof VarcharType && (fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG))) {
+        if (isVarcharType(toType) && (fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG))) {
             return new IntegerNumberToVarcharCoercer();
         }
-        else if (fromType instanceof VarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
+        else if (isVarcharType(fromType) && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
             return new VarcharToIntegerNumberCoercer(toHiveType);
         }
         else if (fromHiveType.equals(HIVE_BYTE) && toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -33,7 +33,6 @@ import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.facebook.presto.spi.type.VarcharType;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
@@ -321,10 +320,10 @@ public class HivePageSource
     {
         Type fromType = typeManager.getType(fromHiveType.getTypeSignature());
         Type toType = typeManager.getType(toHiveType.getTypeSignature());
-        if (toType instanceof VarcharType && (fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG))) {
+        if (isVarcharType(toType) && (fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG))) {
             return new IntegerNumberToVarcharCoercer(fromType, toType);
         }
-        else if (fromType instanceof VarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
+        else if (isVarcharType(fromType) && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
             return new VarcharToIntegerNumberCoercer(fromType, toType);
         }
         else if (fromHiveType.equals(HIVE_BYTE) && toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG)) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.BooleanType;
-import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
@@ -40,7 +39,6 @@ import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -66,7 +64,9 @@ import static com.facebook.presto.hive.HiveUtil.parsePartitionValue;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.padSpaces;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.not;
 import static java.lang.String.format;
@@ -228,11 +228,11 @@ public class HivePartitionManager
                 if (value == null) {
                     filter.add(HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITION);
                 }
-                else if (type instanceof CharType) {
+                else if (isCharType(type)) {
                     Slice slice = (Slice) value;
                     filter.add(padSpaces(slice, type).toStringUtf8());
                 }
-                else if (type instanceof VarcharType) {
+                else if (isVarcharType(type)) {
                     Slice slice = (Slice) value;
                     filter.add(slice.toStringUtf8());
                 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -26,17 +26,8 @@ import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.ValueSet;
-import com.facebook.presto.spi.type.BigintType;
-import com.facebook.presto.spi.type.BooleanType;
-import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
-import com.facebook.presto.spi.type.DoubleType;
-import com.facebook.presto.spi.type.IntegerType;
-import com.facebook.presto.spi.type.RealType;
-import com.facebook.presto.spi.type.SmallintType;
-import com.facebook.presto.spi.type.TimestampType;
-import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.base.Predicates;
@@ -64,9 +55,18 @@ import static com.facebook.presto.hive.HiveUtil.parsePartitionValue;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.padSpaces;
+import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.Decimals.isDecimalType;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.not;
@@ -252,21 +252,21 @@ public class HivePartitionManager
                 else if (isDecimalType(type) && ((DecimalType) type).isShort()) {
                     filter.add(Decimals.toString((long) value, ((DecimalType) type).getScale()));
                 }
-                else if (type instanceof DateType) {
+                else if (DATE.equals(type)) {
                     DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.date().withZoneUTC();
                     filter.add(dateTimeFormatter.print(TimeUnit.DAYS.toMillis((long) value)));
                 }
-                else if (type instanceof TimestampType) {
+                else if (TIMESTAMP.equals(type)) {
                     // we don't have time zone info, so just add a wildcard
                     filter.add(PARTITION_VALUE_WILDCARD);
                 }
-                else if (type instanceof TinyintType
-                        || type instanceof SmallintType
-                        || type instanceof IntegerType
-                        || type instanceof BigintType
-                        || type instanceof DoubleType
-                        || type instanceof RealType
-                        || type instanceof BooleanType) {
+                else if (TINYINT.equals(type)
+                        || SMALLINT.equals(type)
+                        || INTEGER.equals(type)
+                        || BIGINT.equals(type)
+                        || DOUBLE.equals(type)
+                        || REAL.equals(type)
+                        || BOOLEAN.equals(type)) {
                     filter.add(value.toString());
                 }
                 else {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -66,6 +66,7 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.padSpaces;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.not;
@@ -244,11 +245,11 @@ public class HivePartitionManager
                 else if (!assumeCanonicalPartitionKeys) {
                     filter.add(PARTITION_VALUE_WILDCARD);
                 }
-                else if (type instanceof DecimalType && !((DecimalType) type).isShort()) {
+                else if (isDecimalType(type) && !((DecimalType) type).isShort()) {
                     Slice slice = (Slice) value;
                     filter.add(Decimals.toString(slice, ((DecimalType) type).getScale()));
                 }
-                else if (type instanceof DecimalType && ((DecimalType) type).isShort()) {
+                else if (isDecimalType(type) && ((DecimalType) type).isShort()) {
                     filter.add(Decimals.toString((long) value, ((DecimalType) type).getScale()));
                 }
                 else if (type instanceof DateType) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -120,7 +121,7 @@ public class HiveTypeTranslator
         if (TIMESTAMP.equals(type)) {
             return HIVE_TIMESTAMP.getTypeInfo();
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale());
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.hive.HiveUtil.isRowType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -51,6 +52,7 @@ import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getCharTypeInfo;
@@ -86,7 +88,7 @@ public class HiveTypeTranslator
         if (DOUBLE.equals(type)) {
             return HIVE_DOUBLE.getTypeInfo();
         }
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             VarcharType varcharType = (VarcharType) type;
             int varcharLength = varcharType.getLength();
             if (varcharLength <= HiveVarchar.MAX_VARCHAR_LENGTH) {
@@ -100,7 +102,7 @@ public class HiveTypeTranslator
                         type, HiveVarchar.MAX_VARCHAR_LENGTH));
             }
         }
-        if (type instanceof CharType) {
+        if (isCharType(type)) {
             CharType charType = (CharType) type;
             int charLength = charType.getLength();
             if (charLength <= HiveChar.MAX_CHAR_LENGTH) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -106,6 +106,7 @@ import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.trimTrailingSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -412,7 +413,7 @@ public final class HiveUtil
 
     private static boolean isValidPartitionType(Type type)
     {
-        return type instanceof DecimalType ||
+        return isDecimalType(type) ||
                 BOOLEAN.equals(type) ||
                 TINYINT.equals(type) ||
                 SMALLINT.equals(type) ||
@@ -432,7 +433,7 @@ public final class HiveUtil
 
         boolean isNull = HIVE_DEFAULT_DYNAMIC_PARTITION.equals(value);
 
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             if (isNull) {
                 return NullableValue.asNull(decimalType);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -122,6 +122,7 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.Chars.isCharType;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Strings.padEnd;
 import static com.google.common.io.BaseEncoding.base16;
@@ -287,7 +288,7 @@ public final class HiveWriteUtils
         else if (type.equals(TimestampType.TIMESTAMP)) {
             return javaTimestampObjectInspector;
         }
-        else if (type instanceof DecimalType) {
+        else if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return getPrimitiveJavaObjectInspector(new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale()));
         }
@@ -376,7 +377,7 @@ public final class HiveWriteUtils
             long millisUtc = type.getLong(block, position);
             return new Timestamp(millisUtc);
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return getHiveDecimal(decimalType, block, position);
         }
@@ -701,7 +702,7 @@ public final class HiveWriteUtils
             return writableTimestampObjectInspector;
         }
 
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return getPrimitiveWritableObjectInspector(new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale()));
         }
@@ -763,7 +764,7 @@ public final class HiveWriteUtils
             return new TimestampFieldSetter(rowInspector, row, field);
         }
 
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return new DecimalFieldSetter(rowInspector, row, field, decimalType);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -122,6 +122,7 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.Chars.isCharType;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Strings.padEnd;
 import static com.google.common.io.BaseEncoding.base16;
 import static java.lang.Float.intBitsToFloat;
@@ -271,10 +272,10 @@ public final class HiveWriteUtils
         else if (type.equals(DoubleType.DOUBLE)) {
             return javaDoubleObjectInspector;
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             return writableStringObjectInspector;
         }
-        else if (type instanceof CharType) {
+        else if (isCharType(type)) {
             return writableHiveCharObjectInspector;
         }
         else if (type.equals(VarbinaryType.VARBINARY)) {
@@ -357,10 +358,10 @@ public final class HiveWriteUtils
         if (DoubleType.DOUBLE.equals(type)) {
             return type.getDouble(block, position);
         }
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             return new Text(type.getSlice(block, position).getBytes());
         }
-        if (type instanceof CharType) {
+        if (isCharType(type)) {
             CharType charType = (CharType) type;
             return new Text(padEnd(type.getSlice(block, position).toStringUtf8(), charType.getLength(), ' '));
         }
@@ -668,7 +669,7 @@ public final class HiveWriteUtils
             return writableDoubleObjectInspector;
         }
 
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             VarcharType varcharType = (VarcharType) type;
             int varcharLength = varcharType.getLength();
             // VARCHAR columns with the length less than or equal to 65535 are supported natively by Hive
@@ -742,11 +743,11 @@ public final class HiveWriteUtils
             return new DoubleFieldSetter(rowInspector, row, field);
         }
 
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             return new VarcharFieldSetter(rowInspector, row, field, type);
         }
 
-        if (type instanceof CharType) {
+        if (isCharType(type)) {
             return new CharFieldSetter(rowInspector, row, field, type);
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -29,7 +29,6 @@ import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
 import com.facebook.presto.spi.type.ArrayType;
-import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
@@ -90,6 +89,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -670,7 +670,6 @@ public final class ThriftMetastoreUtil
     private static boolean isNumericType(Type type)
     {
         return type.equals(BIGINT) || type.equals(INTEGER) || type.equals(SMALLINT) || type.equals(TINYINT) ||
-                type.equals(DOUBLE) || type.equals(REAL) ||
-                type instanceof DecimalType;
+                type.equals(DOUBLE) || type.equals(REAL) || isDecimalType(type);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
@@ -182,20 +182,15 @@ public class MetastoreHiveStatisticsProvider
 
     private boolean isLowHighSupportedForType(Type type)
     {
-        if (isDecimalType(type)) {
-            return true;
-        }
-        if (type.equals(TINYINT)
+        return isDecimalType(type)
+                || type.equals(TINYINT)
                 || type.equals(SMALLINT)
                 || type.equals(INTEGER)
                 || type.equals(BIGINT)
                 || type.equals(REAL)
                 || type.equals(DOUBLE)
                 || type.equals(DATE)
-                || type.equals(TIMESTAMP)) {
-            return true;
-        }
-        return false;
+                || type.equals(TIMESTAMP);
     }
 
     private OptionalDouble calculateRowsPerPartition(Map<String, PartitionStatistics> statisticsSample)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
@@ -31,7 +31,6 @@ import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.RangeColumnStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
-import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.annotations.VisibleForTesting;
@@ -60,6 +59,7 @@ import static com.facebook.presto.hive.util.Statistics.getMinMaxAsPrestoNativeVa
 import static com.facebook.presto.spi.predicate.Utils.nativeValueToBlock;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -182,7 +182,7 @@ public class MetastoreHiveStatisticsProvider
 
     private boolean isLowHighSupportedForType(Type type)
     {
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             return true;
         }
         if (type.equals(TINYINT)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/Statistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/Statistics.java
@@ -61,6 +61,7 @@ import static com.facebook.presto.spi.statistics.ColumnStatisticType.NUMBER_OF_T
 import static com.facebook.presto.spi.statistics.ColumnStatisticType.TOTAL_SIZE_IN_BYTES;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -297,7 +298,7 @@ public final class Statistics
                     boxed(integerStatistics.getMax()).map(value -> convertLocalToUtc(timeZone, value))))
                     .orElse(Range.empty());
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             return statistics.getDecimalStatistics().map(decimalStatistics -> Range.create(
                     decimalStatistics.getMin().map(value -> encodeDecimal(type, value)),
                     decimalStatistics.getMax().map(value -> encodeDecimal(type, value))))
@@ -428,7 +429,7 @@ public final class Statistics
         else if (type.equals(TIMESTAMP)) {
             result.setIntegerStatistics(new IntegerStatistics(getTimestampValue(timeZone, min), getTimestampValue(timeZone, max)));
         }
-        else if (type instanceof DecimalType) {
+        else if (isDecimalType(type)) {
             result.setDecimalStatistics(new DecimalStatistics(getDecimalValue(session, type, min), getDecimalValue(session, type, max)));
         }
         else {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -99,6 +99,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.CharType.createCharType;
 import static com.facebook.presto.spi.type.Chars.isCharType;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -657,7 +658,7 @@ public abstract class AbstractTestHiveFileFormats
         else if (isStructuralType(type)) {
             return cursor.getObject(field);
         }
-        else if (type instanceof DecimalType) {
+        else if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             if (decimalType.isShort()) {
                 return BigInteger.valueOf(cursor.getLong(field));
@@ -681,7 +682,7 @@ public abstract class AbstractTestHiveFileFormats
                 if (fieldFromCursor == null) {
                     assertEquals(null, testColumn.getExpectedValue(), String.format("Expected null for column %s", testColumn.getName()));
                 }
-                else if (type instanceof DecimalType) {
+                else if (isDecimalType(type)) {
                     DecimalType decimalType = (DecimalType) type;
                     fieldFromCursor = new BigDecimal((BigInteger) fieldFromCursor, decimalType.getScale());
                     assertEquals(fieldFromCursor, testColumn.getExpectedValue(), String.format("Wrong value for column %s", testColumn.getName()));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -86,6 +86,7 @@ import static com.facebook.presto.hive.HiveUtil.isArrayType;
 import static com.facebook.presto.hive.HiveUtil.isMapType;
 import static com.facebook.presto.hive.HiveUtil.isRowType;
 import static com.facebook.presto.hive.HiveUtil.isStructuralType;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
@@ -360,7 +361,7 @@ public class ParquetTester
                 return toRowValue(block, type.getTypeParameters());
             }
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return new SqlDecimal((BigInteger) fieldFromCursor, decimalType.getPrecision(), decimalType.getScale());
         }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
@@ -29,7 +29,6 @@ import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.testing.TestingNodeManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -49,6 +48,7 @@ import static com.facebook.presto.connector.jmx.JmxMetadata.HISTORY_SCHEMA_NAME;
 import static com.facebook.presto.connector.jmx.JmxMetadata.JMX_SCHEMA_NAME;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -183,7 +183,7 @@ public class TestJmxSplitManager
                 if (cursor.isNull(0)) {
                     return result.build();
                 }
-                assertTrue(recordSet.getColumnTypes().get(0) instanceof TimestampType);
+                assertTrue(TIMESTAMP.equals(recordSet.getColumnTypes().get(0)));
                 result.add(cursor.getLong(0));
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/jdbc/ColumnJdbcTable.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -189,7 +190,7 @@ public class ColumnJdbcTable
         if (type.equals(DOUBLE)) {
             return Types.DOUBLE;
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             return Types.DECIMAL;
         }
         if (isVarcharType(type)) {
@@ -236,7 +237,7 @@ public class ColumnJdbcTable
         if (type.equals(TINYINT)) {
             return 3;   // 2**7-1
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             return ((DecimalType) type).getPrecision();
         }
         if (type.equals(REAL)) {
@@ -275,7 +276,7 @@ public class ColumnJdbcTable
     // DECIMAL_DIGITS is the number of fractional digits
     private static Integer decimalDigits(Type type)
     {
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             return ((DecimalType) type).getScale();
         }
         return null;
@@ -301,7 +302,7 @@ public class ColumnJdbcTable
                 type.equals(INTEGER) ||
                 type.equals(SMALLINT) ||
                 type.equals(TINYINT) ||
-                (type instanceof DecimalType)) {
+                (isDecimalType(type))) {
             return 10;
         }
         if (type.equals(REAL) || type.equals(DOUBLE)) {

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsNormalizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsNormalizer.java
@@ -32,6 +32,7 @@ import java.util.function.Predicate;
 
 import static com.facebook.presto.cost.SymbolStatsEstimate.UNKNOWN_STATS;
 import static com.facebook.presto.cost.SymbolStatsEstimate.ZERO_STATS;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static java.lang.Double.NaN;
 import static java.lang.Double.isNaN;
 import static java.lang.Math.floor;
@@ -140,7 +141,7 @@ public class StatsNormalizer
             return NaN;
         }
 
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             length *= pow(10, ((DecimalType) type).getScale());
         }
         return floor(length + 1);
@@ -154,6 +155,6 @@ public class StatsNormalizer
                 type.equals(TinyintType.TINYINT) ||
                 type.equals(BooleanType.BOOLEAN) ||
                 type.equals(DateType.DATE) ||
-                type instanceof DecimalType;
+                isDecimalType(type);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.DateType;
-import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.IntegerType;
 import com.facebook.presto.spi.type.RealType;
@@ -32,6 +31,7 @@ import com.facebook.presto.sql.FunctionInvoker;
 
 import java.util.OptionalDouble;
 
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static java.util.Collections.singletonList;
 
 final class StatsUtil
@@ -60,7 +60,7 @@ final class StatsUtil
 
     private static boolean convertibleToDoubleWithCast(Type type)
     {
-        return type instanceof DecimalType
+        return isDecimalType(type)
                 || DoubleType.DOUBLE.equals(type)
                 || RealType.REAL.equals(type)
                 || BigintType.BIGINT.equals(type)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -146,7 +146,6 @@ import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -291,6 +290,7 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.type.DecimalCasts.BIGINT_TO_DECIMAL_CAST;
@@ -1098,7 +1098,7 @@ public class FunctionRegistry
             return DOUBLE;
         }
         if (!clazz.isPrimitive()) {
-            if (type instanceof VarcharType) {
+            if (isVarcharType(type)) {
                 return type;
             }
             else {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalAverageAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalAverageAggregation.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Decimals.writeBigDecimal;
 import static com.facebook.presto.spi.type.Decimals.writeShortDecimal;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -95,7 +96,7 @@ public class DecimalAverageAggregation
 
     private static InternalAggregationFunction generateAggregation(Type type)
     {
-        checkArgument(type instanceof DecimalType, "type must be Decimal");
+        checkArgument(isDecimalType(type), "type must be Decimal");
         DynamicClassLoader classLoader = new DynamicClassLoader(DecimalAverageAggregation.class.getClassLoader());
         List<Type> inputTypes = ImmutableList.of(type);
         MethodHandle inputFunction;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalSumAggregation.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.operator.aggregation.AggregationMetadata.Param
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.throwIfOverflows;
 import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.throwOverflowException;
@@ -89,7 +90,7 @@ public class DecimalSumAggregation
 
     private static InternalAggregationFunction generateAggregation(Type inputType, Type outputType)
     {
-        checkArgument(inputType instanceof DecimalType, "type must be Decimal");
+        checkArgument(isDecimalType(inputType), "type must be Decimal");
         DynamicClassLoader classLoader = new DynamicClassLoader(DecimalSumAggregation.class.getClassLoader());
         List<Type> inputTypes = ImmutableList.of(inputType);
         MethodHandle inputFunction;

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -119,6 +119,7 @@ import static com.facebook.presto.SystemSessionProperties.isLegacyRowFieldOrdina
 import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -132,6 +133,7 @@ import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
 import static com.facebook.presto.sql.analyzer.Analyzer.verifyNoAggregateWindowOrGroupingFunctions;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.EXPRESSION_NOT_CONSTANT;
@@ -617,7 +619,7 @@ public class ExpressionAnalyzer
         protected Type visitLikePredicate(LikePredicate node, StackableAstVisitorContext<Context> context)
         {
             Type valueType = process(node.getValue(), context);
-            if (!(valueType instanceof CharType) && !(valueType instanceof VarcharType)) {
+            if (!isCharType(valueType) && !isVarcharType(valueType)) {
                 coerceType(context, node.getValue(), VARCHAR, "Left side of LIKE expression");
             }
 
@@ -635,7 +637,7 @@ public class ExpressionAnalyzer
         private Type getVarcharType(Expression value, StackableAstVisitorContext<Context> context)
         {
             Type type = process(value, context);
-            if (!(type instanceof VarcharType)) {
+            if (!isVarcharType(type)) {
                 return VARCHAR;
             }
             return type;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/InCodeGenerator.java
@@ -16,9 +16,6 @@ package com.facebook.presto.sql.gen;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
-import com.facebook.presto.spi.type.BigintType;
-import com.facebook.presto.spi.type.DateType;
-import com.facebook.presto.spi.type.IntegerType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.relational.ConstantExpression;
 import com.facebook.presto.sql.relational.RowExpression;
@@ -46,6 +43,8 @@ import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.sql.gen.BytecodeUtils.ifWasNullPopAndGoto;
 import static com.facebook.presto.sql.gen.BytecodeUtils.invoke;
 import static com.facebook.presto.sql.gen.BytecodeUtils.loadConstant;
@@ -84,7 +83,7 @@ public class InCodeGenerator
             return SwitchGenerationCase.SET_CONTAINS;
         }
 
-        if (!(type instanceof IntegerType || type instanceof BigintType || type instanceof DateType)) {
+        if (!(INTEGER.equals(type) || BIGINT.equals(type) || DATE.equals(type))) {
             return SwitchGenerationCase.HASH_SWITCH;
         }
         for (RowExpression expression : values) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -34,7 +34,6 @@ import com.facebook.presto.spi.type.RowType.Field;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.FunctionInvoker;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
 import com.facebook.presto.sql.analyzer.Scope;
@@ -114,9 +113,11 @@ import java.util.stream.Stream;
 import static com.facebook.presto.SystemSessionProperties.isLegacyRowFieldOrdinalAccessEnabled;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.RETURN_NULL_ON_NULL;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.sql.analyzer.ConstantExpressionVerifier.verifyExpressionIsConstant;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.createConstantAnalyzer;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
@@ -1039,12 +1040,12 @@ public class ExpressionInterpreter
 
         private boolean evaluateLikePredicate(LikePredicate node, Slice value, Regex regex)
         {
-            if (type(node.getValue()) instanceof VarcharType) {
+            if (isVarcharType(type(node.getValue()))) {
                 return LikeFunctions.likeVarchar(value, regex);
             }
 
             Type type = type(node.getValue());
-            checkState(type instanceof CharType, "LIKE value is neither VARCHAR or CHAR");
+            checkState(isCharType(type), "LIKE value is neither VARCHAR or CHAR");
             return LikeFunctions.likeChar((long) ((CharType) type).getLength(), value, regex);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralEncoder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralEncoder.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -146,7 +147,7 @@ public final class LiteralEncoder
             return new GenericLiteral("REAL", value.toString());
         }
 
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             String string;
             if (isShortDecimal(type)) {
                 string = Decimals.toString((long) object, ((DecimalType) type).getScale());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralEncoder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralEncoder.java
@@ -19,7 +19,6 @@ import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.operator.scalar.VarbinaryFunctions;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
-import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.SqlDate;
@@ -49,11 +48,13 @@ import java.util.List;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Float.intBitsToFloat;
@@ -156,7 +157,7 @@ public final class LiteralEncoder
             return new Cast(new DecimalLiteral(string), type.getDisplayName());
         }
 
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             VarcharType varcharType = (VarcharType) type;
             Slice value = (Slice) object;
             StringLiteral stringLiteral = new StringLiteral(value.toStringUtf8());
@@ -167,7 +168,7 @@ public final class LiteralEncoder
             return new Cast(stringLiteral, type.getDisplayName(), false, true);
         }
 
-        if (type instanceof CharType) {
+        if (isCharType(type)) {
             StringLiteral stringLiteral = new StringLiteral(((Slice) object).toStringUtf8());
             return new Cast(stringLiteral, type.getDisplayName(), false, true);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/Signatures.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/Signatures.java
@@ -16,7 +16,6 @@ package com.facebook.presto.sql.relational;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.BigintType;
-import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
@@ -35,6 +34,7 @@ import static com.facebook.presto.metadata.FunctionRegistry.mangleOperatorName;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.Signature.internalScalarFunction;
 import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.tree.ArrayConstructor.ARRAY_CONSTRUCTOR;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -77,7 +77,7 @@ public final class Signatures
 
     public static Signature likeCharSignature(Type valueType)
     {
-        checkArgument(valueType instanceof CharType, "Expected CHAR value type");
+        checkArgument(isCharType(valueType), "Expected CHAR value type");
         return internalScalarFunction("LIKE", parseTypeSignature(StandardTypes.BOOLEAN), valueType.getTypeSignature(), parseTypeSignature(LikePatternType.NAME));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -18,7 +18,6 @@ import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.metadata.FunctionKind;
 import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.Signature;
-import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalParseResult;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.RowType;
@@ -27,7 +26,6 @@ import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.relational.optimizer.ExpressionOptimizer;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
@@ -88,6 +86,7 @@ import static com.facebook.presto.metadata.FunctionKind.SCALAR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.CharType.createCharType;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
@@ -95,6 +94,7 @@ import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.constantNull;
@@ -711,11 +711,11 @@ public final class SqlToRowExpressionTranslator
 
         private RowExpression likeFunctionCall(RowExpression value, RowExpression pattern)
         {
-            if (value.getType() instanceof VarcharType) {
+            if (isVarcharType(value.getType())) {
                 return call(likeVarcharSignature(), BOOLEAN, value, pattern);
             }
 
-            checkState(value.getType() instanceof CharType, "LIKE value type is neither VARCHAR or CHAR");
+            checkState(isCharType(value.getType()), "LIKE value type is neither VARCHAR or CHAR");
             return call(likeCharSignature(value.getType()), BOOLEAN, value, pattern);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.ArrayType;
-import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.SqlDate;
@@ -32,7 +31,6 @@ import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.spi.type.SqlTimestampWithTimeZone;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -60,6 +58,7 @@ import java.util.stream.Stream;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -74,6 +73,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -261,10 +261,10 @@ public class MaterializedResult
         else if (BOOLEAN.equals(type)) {
             type.writeBoolean(blockBuilder, (Boolean) value);
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             type.writeSlice(blockBuilder, Slices.utf8Slice((String) value));
         }
-        else if (type instanceof CharType) {
+        else if (isCharType(type)) {
             type.writeSlice(blockBuilder, Slices.utf8Slice((String) value));
         }
         else if (VARBINARY.equals(type)) {

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -56,6 +56,7 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.CharType.createCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -233,7 +234,7 @@ public final class TypeRegistry
             return true;
         }
 
-        if (source instanceof DecimalType && result instanceof DecimalType) {
+        if (isDecimalType(source) && isDecimalType(result)) {
             DecimalType sourceDecimal = (DecimalType) source;
             DecimalType resultDecimal = (DecimalType) result;
             boolean sameDecimalSubtype = (sourceDecimal.isShort() && resultDecimal.isShort())

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -71,6 +71,7 @@ import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.type.ArrayParametricType.ARRAY;
 import static com.facebook.presto.type.CodePointsType.CODE_POINTS;
 import static com.facebook.presto.type.ColorType.COLOR;
@@ -228,7 +229,7 @@ public final class TypeRegistry
             return false;
         }
 
-        if (source instanceof VarcharType && result instanceof VarcharType) {
+        if (isVarcharType(source) && isVarcharType(result)) {
             return true;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/SequencePageBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/SequencePageBuilder.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 
 import java.util.List;
 
@@ -31,6 +30,7 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 
 public final class SequencePageBuilder
 {
@@ -59,7 +59,7 @@ public final class SequencePageBuilder
             else if (type.equals(DOUBLE)) {
                 blocks[i] = BlockAssertions.createDoubleSequenceBlock(initialValue, initialValue + length);
             }
-            else if (type instanceof VarcharType) {
+            else if (isVarcharType(type)) {
                 blocks[i] = BlockAssertions.createStringSequenceBlock(initialValue, initialValue + length);
             }
             else if (type.equals(BOOLEAN)) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDomainTranslator.java
@@ -64,6 +64,7 @@ import static com.facebook.presto.spi.type.CharType.createCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -1560,7 +1561,7 @@ public class TestDomainTranslator
 
         public boolean isFractional()
         {
-            return type == DOUBLE || type == REAL || (type instanceof DecimalType && ((DecimalType) type).getScale() > 0);
+            return type == DOUBLE || type == REAL || (isDecimalType(type) && ((DecimalType) type).getScale() > 0);
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
@@ -19,9 +19,7 @@ import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.DecimalType;
-import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
@@ -618,13 +616,13 @@ public class BenchmarkDecimalOperators
 
         private Object generateRandomValue(Type type)
         {
-            if (type instanceof DoubleType) {
+            if (DOUBLE.equals(type)) {
                 return random.nextDouble() * (2L * doubleMaxValue) - doubleMaxValue;
             }
             else if (isDecimalType(type)) {
                 return randomDecimal((DecimalType) type);
             }
-            else if (type instanceof BigintType) {
+            else if (BIGINT.equals(type)) {
                 int randomInt = random.nextInt();
                 return randomInt == 0 ? 1 : randomInt;
             }

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
@@ -67,6 +67,7 @@ import static com.facebook.presto.metadata.MetadataManager.createTestMetadataMan
 import static com.facebook.presto.operator.scalar.FunctionAssertions.createExpression;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypesFromInput;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
@@ -620,7 +621,7 @@ public class BenchmarkDecimalOperators
             if (type instanceof DoubleType) {
                 return random.nextDouble() * (2L * doubleMaxValue) - doubleMaxValue;
             }
-            else if (type instanceof DecimalType) {
+            else if (isDecimalType(type)) {
                 return randomDecimal((DecimalType) type);
             }
             else if (type instanceof BigintType) {

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoPageSink.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoPageSink.java
@@ -62,6 +62,7 @@ import static com.facebook.presto.mongodb.TypeUtils.isMapType;
 import static com.facebook.presto.mongodb.TypeUtils.isRowType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
@@ -162,7 +163,7 @@ public class MongoPageSink
             long millisUtc = unpackMillisUtc(type.getLong(block, position));
             return new Date(millisUtc);
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             // TODO: decimal type might not support yet
             // TODO: this code is likely wrong and should switch to Decimals.readBigDecimal()
             DecimalType decimalType = (DecimalType) type;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -71,6 +71,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -678,7 +679,7 @@ public class OrcWriteValidation
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
-            else if (type instanceof DecimalType) {
+            else if (isDecimalType(type)) {
                 DecimalType decimalType = (DecimalType) type;
                 if (decimalType.isShort()) {
                     statisticsBuilder = new ShortDecimalStatisticsBuilder((decimalType).getScale());

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -37,11 +37,9 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.ColumnarMap;
 import com.facebook.presto.spi.block.ColumnarRow;
 import com.facebook.presto.spi.type.AbstractLongType;
-import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
@@ -71,6 +69,7 @@ import static com.facebook.presto.spi.block.ColumnarArray.toColumnarArray;
 import static com.facebook.presto.spi.block.ColumnarMap.toColumnarMap;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -82,6 +81,7 @@ import static com.facebook.presto.spi.type.StandardTypes.ROW;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -653,12 +653,12 @@ public class OrcWriteValidation
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
-            else if (type instanceof VarcharType) {
+            else if (isVarcharType(type)) {
                 statisticsBuilder = new StringStatisticsBuilder(stringStatisticsLimitInBytes);
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
-            else if (type instanceof CharType) {
+            else if (isCharType(type)) {
                 statisticsBuilder = new StringStatisticsBuilder(stringStatisticsLimitInBytes);
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarbinaryType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
@@ -49,6 +48,7 @@ import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -169,7 +169,7 @@ public class TupleDomainOrcPredicate<C>
             return bloomFilter.testDouble((Double) predicateValue);
         }
 
-        if (isVarcharType(sqlType) || sqlType instanceof VarbinaryType) {
+        if (isVarcharType(sqlType) || sqlType == VARBINARY) {
             return bloomFilter.test(((Slice) predicateValue).getBytes());
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
@@ -25,7 +25,6 @@ import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarbinaryType;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
@@ -170,7 +169,7 @@ public class TupleDomainOrcPredicate<C>
             return bloomFilter.testDouble((Double) predicateValue);
         }
 
-        if (sqlType instanceof VarcharType || sqlType instanceof VarbinaryType) {
+        if (isVarcharType(sqlType) || sqlType instanceof VarbinaryType) {
             return bloomFilter.test(((Slice) predicateValue).getBytes());
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
@@ -30,6 +30,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -216,7 +217,7 @@ public class OrcType
         if (TIMESTAMP.equals(type)) {
             return ImmutableList.of(new OrcType(OrcTypeKind.TIMESTAMP));
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return ImmutableList.of(new OrcType(OrcTypeKind.DECIMAL, decimalType.getPrecision(), decimalType.getScale()));
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -39,6 +40,7 @@ import static com.facebook.presto.spi.type.StandardTypes.ROW;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
@@ -195,14 +197,14 @@ public class OrcType
         if (REAL.equals(type)) {
             return ImmutableList.of(new OrcType(OrcTypeKind.FLOAT));
         }
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             VarcharType varcharType = (VarcharType) type;
             if (varcharType.isUnbounded()) {
                 return ImmutableList.of(new OrcType(OrcTypeKind.STRING));
             }
             return ImmutableList.of(new OrcType(OrcTypeKind.VARCHAR, varcharType.getLengthSafe()));
         }
-        if (type instanceof CharType) {
+        if (isCharType(type)) {
             return ImmutableList.of(new OrcType(OrcTypeKind.CHAR, ((CharType) type).getLength()));
         }
         if (VARBINARY.equals(type)) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -122,6 +122,7 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Decimals.rescale;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -1036,7 +1037,7 @@ public class OrcTester
         if (type.equals(TIMESTAMP)) {
             return javaTimestampObjectInspector;
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return getPrimitiveJavaObjectInspector(new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale()));
         }
@@ -1111,7 +1112,7 @@ public class OrcTester
             long millisUtc = (int) ((SqlTimestamp) value).getMillisUtc();
             return new Timestamp(millisUtc);
         }
-        else if (type instanceof DecimalType) {
+        else if (isDecimalType(type)) {
             return HiveDecimal.create(((SqlDecimal) value).toBigDecimal());
         }
         else if (type.getTypeSignature().getBase().equals(StandardTypes.ARRAY)) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -35,7 +35,6 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.facebook.presto.spi.type.VarbinaryType;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.AbstractIterator;
@@ -120,6 +119,7 @@ import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.Decimals.rescale;
@@ -130,6 +130,7 @@ import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.spi.type.Varchars.truncateToLength;
 import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
@@ -700,11 +701,11 @@ public class OrcTester
                 float floatValue = ((Number) value).floatValue();
                 type.writeLong(blockBuilder, Float.floatToIntBits(floatValue));
             }
-            else if (type instanceof VarcharType) {
+            else if (isVarcharType(type)) {
                 Slice slice = truncateToLength(utf8Slice((String) value), type);
                 type.writeSlice(blockBuilder, slice);
             }
-            else if (type instanceof CharType) {
+            else if (isCharType(type)) {
                 Slice slice = truncateToLengthAndTrimSpaces(utf8Slice((String) value), type);
                 type.writeSlice(blockBuilder, slice);
             }
@@ -1019,10 +1020,10 @@ public class OrcTester
         if (type.equals(DOUBLE)) {
             return javaDoubleObjectInspector;
         }
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             return javaStringObjectInspector;
         }
-        if (type instanceof CharType) {
+        if (isCharType(type)) {
             int charLength = ((CharType) type).getLength();
             return new JavaHiveCharObjectInspector(getCharTypeInfo(charLength));
         }
@@ -1086,10 +1087,10 @@ public class OrcTester
         else if (type.equals(DOUBLE)) {
             return ((Number) value).doubleValue();
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             return value;
         }
-        else if (type instanceof CharType) {
+        else if (isCharType(type)) {
             return new HiveChar((String) value, ((CharType) type).getLength());
         }
         else if (type.equals(VARBINARY)) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -34,7 +34,6 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
-import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.AbstractIterator;
@@ -1028,7 +1027,7 @@ public class OrcTester
             int charLength = ((CharType) type).getLength();
             return new JavaHiveCharObjectInspector(getCharTypeInfo(charLength));
         }
-        if (type instanceof VarbinaryType) {
+        if (type.equals(VARBINARY)) {
             return javaByteArrayObjectInspector;
         }
         if (type.equals(DATE)) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -15,7 +15,6 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.OrcTester.Format;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
-import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDate;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.facebook.presto.spi.type.SqlTimestamp;
@@ -37,6 +36,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -109,7 +109,7 @@ public final class TestingOrcPredicate
         if (isCharType(type)) {
             return new CharOrcPredicate(expectedValues, format == DWRF);
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             return new DecimalOrcPredicate(expectedValues, format == DWRF);
         }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.type.SqlDate;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarbinaryType;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import io.airlift.slice.Slice;
@@ -46,6 +45,7 @@ import static com.facebook.presto.spi.type.StandardTypes.MAP;
 import static com.facebook.presto.spi.type.StandardTypes.ROW;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.notNull;
@@ -99,7 +99,7 @@ public final class TestingOrcPredicate
                             .collect(toList()),
                     format == DWRF);
         }
-        if (type instanceof VarbinaryType) {
+        if (VARBINARY.equals(type)) {
             // binary does not have stats
             return new BasicOrcPredicate<>(expectedValues, Object.class, format == DWRF);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -15,14 +15,12 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.OrcTester.Format;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
-import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.SqlDate;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarbinaryType;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import io.airlift.slice.Slice;
@@ -37,6 +35,7 @@ import java.util.Objects;
 import static com.facebook.presto.orc.OrcTester.Format.DWRF;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -47,6 +46,7 @@ import static com.facebook.presto.spi.type.StandardTypes.MAP;
 import static com.facebook.presto.spi.type.StandardTypes.ROW;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.notNull;
 import static com.google.common.collect.Iterables.filter;
@@ -103,10 +103,10 @@ public final class TestingOrcPredicate
             // binary does not have stats
             return new BasicOrcPredicate<>(expectedValues, Object.class, format == DWRF);
         }
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             return new StringOrcPredicate(expectedValues, format, isHiveWriter);
         }
-        if (type instanceof CharType) {
+        if (isCharType(type)) {
             return new CharOrcPredicate(expectedValues, format == DWRF);
         }
         if (type instanceof DecimalType) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ColumnIndexStatsUtils.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ColumnIndexStatsUtils.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.raptor.storage;
 
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 
 import java.sql.JDBCType;
 
@@ -24,6 +23,7 @@ import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 
 public class ColumnIndexStatsUtils
 {
@@ -46,7 +46,7 @@ public class ColumnIndexStatsUtils
         if (type.equals(DATE)) {
             return JDBCType.INTEGER;
         }
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             return JDBCType.VARBINARY;
         }
         return null;

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
@@ -62,6 +62,7 @@ import static com.facebook.presto.raptor.util.Types.isArrayType;
 import static com.facebook.presto.raptor.util.Types.isMapType;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Functions.toStringFunction;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -293,7 +294,7 @@ public class OrcFileWriter
 
     private static StorageType toStorageType(Type type)
     {
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return StorageType.decimal(decimalType.getPrecision(), decimalType.getScale());
         }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
@@ -21,7 +21,6 @@ import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.spi.type.VarbinaryType;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -63,6 +62,7 @@ import static com.facebook.presto.raptor.util.Types.isArrayType;
 import static com.facebook.presto.raptor.util.Types.isMapType;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Functions.toStringFunction;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.transform;
@@ -308,7 +308,7 @@ public class OrcFileWriter
             return StorageType.DOUBLE;
         }
         if (javaType == Slice.class) {
-            if (type instanceof VarcharType) {
+            if (isVarcharType(type)) {
                 return StorageType.STRING;
             }
             if (type.equals(VarbinaryType.VARBINARY)) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/Row.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/Row.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import static com.facebook.presto.raptor.util.Types.isArrayType;
 import static com.facebook.presto.raptor.util.Types.isMapType;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
@@ -130,7 +131,7 @@ public class Row
         if (nativeValue == null) {
             return null;
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             BigInteger unscaledValue;
             DecimalType decimalType = (DecimalType) type;
             if (decimalType.isShort()) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/Row.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/Row.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import io.airlift.slice.Slice;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 
@@ -32,6 +31,7 @@ import java.util.Map;
 import static com.facebook.presto.raptor.util.Types.isArrayType;
 import static com.facebook.presto.raptor.util.Types.isMapType;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
@@ -152,7 +152,7 @@ public class Row
         }
         if (type.getJavaType() == Slice.class) {
             Slice slice = (Slice) nativeValue;
-            return type instanceof VarcharType ? slice.toStringUtf8() : slice.getBytes();
+            return isVarcharType(type) ? slice.toStringUtf8() : slice.getBytes();
         }
         if (isArrayType(type)) {
             Block arrayBlock = (Block) nativeValue;

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
@@ -25,7 +25,6 @@ import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 
@@ -36,6 +35,7 @@ import java.util.Optional;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 import static org.joda.time.DateTimeZone.UTC;
@@ -80,7 +80,7 @@ public final class ShardStats
         if (type.equals(DoubleType.DOUBLE)) {
             return indexDouble(type, reader, columnIndex, columnId);
         }
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             return indexString(type, reader, columnIndex, columnId);
         }
         return null;

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileDecoderUtils.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileDecoderUtils.java
@@ -23,6 +23,8 @@ import io.airlift.slice.Slices;
 
 import java.io.IOException;
 
+import static com.facebook.presto.spi.type.Chars.isCharType;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
@@ -234,10 +236,10 @@ public final class RcFileDecoderUtils
     public static int calculateTruncationLength(Type type, Slice slice, int offset, int length)
     {
         requireNonNull(type, "type is null");
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             return calculateTruncationLength(((VarcharType) type).getLength(), slice, offset, length);
         }
-        if (type instanceof CharType) {
+        if (isCharType(type)) {
             int truncationLength = calculateTruncationLength(((CharType) type).getLength(), slice, offset, length);
             // At run-time char(x) is represented without trailing spaces
             while (truncationLength > 0 && slice.getByte(offset + truncationLength - 1) == ' ') {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileEncoding.java
@@ -14,16 +14,15 @@
 package com.facebook.presto.rcfile;
 
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 
 import java.util.List;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -35,6 +34,7 @@ import static com.facebook.presto.spi.type.StandardTypes.ROW;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static java.util.stream.Collectors.toList;
 
 public interface RcFileEncoding
@@ -95,7 +95,7 @@ public interface RcFileEncoding
         if (DOUBLE.equals(type)) {
             return doubleEncoding(type);
         }
-        if (type instanceof VarcharType || type instanceof CharType) {
+        if (isVarcharType(type) || isCharType(type)) {
             return stringEncoding(type);
         }
         if (VARBINARY.equals(type)) {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/RcFileEncoding.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.rcfile;
 
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
@@ -24,6 +23,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -86,7 +86,7 @@ public interface RcFileEncoding
         if (BIGINT.equals(type)) {
             return longEncoding(type);
         }
-        if (type instanceof DecimalType) {
+        if (isDecimalType(type)) {
             return decimalEncoding(type);
         }
         if (REAL.equals(type)) {

--- a/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
@@ -34,7 +34,6 @@ import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.AbstractIterator;
@@ -146,6 +145,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.google.common.base.Functions.constant;
 import static com.google.common.collect.Iterables.transform;
@@ -974,7 +974,7 @@ public class RcFileTester
         else if (type.equals(DOUBLE)) {
             return javaDoubleObjectInspector;
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             return javaStringObjectInspector;
         }
         else if (type.equals(VARBINARY)) {
@@ -1037,7 +1037,7 @@ public class RcFileTester
         else if (type.equals(DOUBLE)) {
             return ((Number) value).doubleValue();
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             return value;
         }
         else if (type.equals(VARBINARY)) {

--- a/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
@@ -132,6 +132,7 @@ import static com.facebook.presto.rcfile.RcFileWriter.PRESTO_RCFILE_WRITER_VERSI
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Decimals.rescale;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -986,7 +987,7 @@ public class RcFileTester
         else if (type.equals(TIMESTAMP)) {
             return javaTimestampObjectInspector;
         }
-        else if (type instanceof DecimalType) {
+        else if (isDecimalType(type)) {
             DecimalType decimalType = (DecimalType) type;
             return getPrimitiveJavaObjectInspector(new DecimalTypeInfo(decimalType.getPrecision(), decimalType.getScale()));
         }
@@ -1058,7 +1059,7 @@ public class RcFileTester
             long millisUtc = (int) ((SqlTimestamp) value).getMillisUtc();
             return new Timestamp(millisUtc);
         }
-        else if (type instanceof DecimalType) {
+        else if (isDecimalType(type)) {
             return HiveDecimal.create(((SqlDecimal) value).toBigDecimal());
         }
         else if (type.getTypeSignature().getBase().equals(ARRAY)) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Decimals.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Decimals.java
@@ -66,6 +66,21 @@ public final class Decimals
         }
     }
 
+    public static boolean isDecimalType(Type type)
+    {
+        return type instanceof DecimalType;
+    }
+
+    public static boolean isShortDecimal(Type type)
+    {
+        return type instanceof ShortDecimalType;
+    }
+
+    public static boolean isLongDecimal(Type type)
+    {
+        return type instanceof LongDecimalType;
+    }
+
     public static long longTenToNth(int n)
     {
         return LONG_POWERS_OF_TEN[n];
@@ -297,16 +312,6 @@ public final class Decimals
             throw new IllegalArgumentException("target scale must be larger than source scale");
         }
         return value.multiply(bigIntegerTenToNth(toScale - fromScale));
-    }
-
-    public static boolean isShortDecimal(Type type)
-    {
-        return type instanceof ShortDecimalType;
-    }
-
-    public static boolean isLongDecimal(Type type)
-    {
-        return type instanceof LongDecimalType;
     }
 
     private static void checkArgument(boolean condition)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -58,6 +58,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -333,7 +334,7 @@ public class H2QueryRunner
                         checkState(resultSet.wasNull(), "Expected a null value, but got %s", objectValue);
                         row.add(null);
                     }
-                    else if (type instanceof DecimalType) {
+                    else if (isDecimalType(type)) {
                         DecimalType decimalType = (DecimalType) type;
                         BigDecimal decimalValue = resultSet.getBigDecimal(i);
                         if (resultSet.wasNull()) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.tpch.TpchMetadata;
@@ -398,7 +397,7 @@ public class H2QueryRunner
                     else if (DOUBLE.equals(type)) {
                         batch.bind(column, cursor.getDouble(column));
                     }
-                    else if (type instanceof VarcharType) {
+                    else if (isVarcharType(type)) {
                         batch.bind(column, cursor.getSlice(column).toStringUtf8());
                     }
                     else if (DATE.equals(type)) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -20,7 +20,6 @@ import com.facebook.presto.client.QueryData;
 import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.type.ArrayType;
-import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.spi.type.SqlTimestampWithTimeZone;
@@ -57,6 +56,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -246,7 +246,7 @@ public class TestingPrestoClient
                             e -> convertToRowValue(((MapType) type).getKeyType(), e.getKey(), timeZoneKey),
                             e -> convertToRowValue(((MapType) type).getValueType(), e.getValue(), timeZoneKey)));
         }
-        else if (type instanceof DecimalType) {
+        else if (isDecimalType(type)) {
             return new BigDecimal((String) value);
         }
         else if (type.getTypeSignature().getBase().equals("ObjectId")) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.spi.type.SqlTimestampWithTimeZone;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.type.SqlIntervalDayTime;
@@ -68,6 +67,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.testing.MaterializedResult.DEFAULT_PRECISION;
 import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 import static com.facebook.presto.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
@@ -199,7 +199,7 @@ public class TestingPrestoClient
         else if (REAL.equals(type)) {
             return ((Number) value).floatValue();
         }
-        else if (type instanceof VarcharType) {
+        else if (isVarcharType(type)) {
             return value;
         }
         else if (isCharType(type)) {

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
@@ -32,7 +32,6 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
-import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -97,7 +96,7 @@ public class TpcdsTableStatisticsFactory
         else if (tpcdsValue instanceof String && type.equals(DATE)) {
             return LocalDate.parse((CharSequence) tpcdsValue).toEpochDay();
         }
-        else if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(DATE) || (isDecimalType(type) && isShortDecimal(type))) {
+        else if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(DATE) || isShortDecimal(type)) {
             return ((Number) tpcdsValue).longValue();
         }
         else if (type.equals(DOUBLE)) {

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
@@ -18,11 +18,9 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
-import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.TimeType;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.tpcds.TpcdsColumnHandle;
 import com.teradata.tpcds.Table;
 import io.airlift.slice.Slices;
@@ -32,11 +30,13 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 
 public class TpcdsTableStatisticsFactory
 {
@@ -88,10 +88,10 @@ public class TpcdsTableStatisticsFactory
 
     private Object toPrestoValue(Object tpcdsValue, Type type)
     {
-        if (type instanceof VarcharType) {
+        if (isVarcharType(type)) {
             return Slices.utf8Slice((String) tpcdsValue);
         }
-        else if (type instanceof CharType) {
+        else if (isCharType(type)) {
             return truncateToLengthAndTrimSpaces(Slices.utf8Slice((String) tpcdsValue), type);
         }
         else if (tpcdsValue instanceof String && type.equals(DATE)) {

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/statistics/TpcdsTableStatisticsFactory.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
-import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.TimeType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.tpcds.TpcdsColumnHandle;
@@ -33,6 +32,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.Decimals.isDecimalType;
 import static com.facebook.presto.spi.type.Decimals.isShortDecimal;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -97,7 +97,7 @@ public class TpcdsTableStatisticsFactory
         else if (tpcdsValue instanceof String && type.equals(DATE)) {
             return LocalDate.parse((CharSequence) tpcdsValue).toEpochDay();
         }
-        else if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(DATE) || (type instanceof DecimalType && isShortDecimal(type))) {
+        else if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(DATE) || (isDecimalType(type) && isShortDecimal(type))) {
             return ((Number) tpcdsValue).longValue();
         }
         else if (type.equals(DOUBLE)) {

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -36,7 +36,6 @@ import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.tpch.statistics.ColumnStatisticsData;
 import com.facebook.presto.tpch.statistics.StatisticsEstimator;
 import com.facebook.presto.tpch.statistics.TableStatisticsData;
@@ -70,6 +69,7 @@ import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.facebook.presto.tpch.util.PredicateUtils.convertToPredicate;
 import static com.facebook.presto.tpch.util.PredicateUtils.filterOutColumnFromPredicate;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -384,7 +384,7 @@ public class TpchMetadata
 
     private Object toPrestoValue(Object tpchValue, Type columnType)
     {
-        if (columnType instanceof VarcharType) {
+        if (isVarcharType(columnType)) {
             return Slices.utf8Slice((String) tpchValue);
         }
         if (columnType.equals(BIGINT) || columnType.equals(INTEGER) || columnType.equals(DATE)) {


### PR DESCRIPTION
- Replace uses of `instanceof CharType` with `isCharType`, and the same for `Varchar`
- Replace uses of `instanceof DecimalType` with new `isDecimalType` method
- For SQL `Type`s, replace `instanceof` checks with comparisons to the singleton instance where applicable (for `Type`s that implement `equals` as `==`, more or less)

---

Not included in this PR:

- Changing `type == TYPE` and `type.equals(TYPE)` to `TYPE.equals(type)`
- `isArrayType` and `isMapType`, each of which is implemented in four places in Presto, or `isRowType`, which is implemented twice.
- `instanceof` checks for other types are not replaced. This includes `UnknownType` and interfaces such as `FixedWidthType`