### PR TITLE
Fix live plan and stage kill button URL

### DIFF
--- a/presto-main/src/main/resources/webapp/assets/plan.js
+++ b/presto-main/src/main/resources/webapp/assets/plan.js
@@ -137,7 +137,7 @@ let LivePlan = React.createClass({
                         </div>
                     </td>
                     <td>
-                        <a onClick={ () => $.ajax({url: 'v1/query/' + query.queryId, type: 'DELETE'}) } className="btn btn-warning" target="_blank">
+                        <a onClick={ () => $.ajax({url: '/v1/query/' + query.queryId, type: 'DELETE'}) } className="btn btn-warning" target="_blank">
                             Kill
                         </a>
                     </td>

--- a/presto-main/src/main/resources/webapp/assets/stage.js
+++ b/presto-main/src/main/resources/webapp/assets/stage.js
@@ -536,7 +536,7 @@ let StagePerformance = React.createClass({
                         </div>
                     </td>
                     <td>
-                        <a onClick={ () => $.ajax({url: 'v1/query/' + query.queryId, type: 'DELETE'}) } className="btn btn-warning" target="_blank">
+                        <a onClick={ () => $.ajax({url: '/v1/query/' + query.queryId, type: 'DELETE'}) } className="btn btn-warning" target="_blank">
                             Kill
                         </a>
                     </td>


### PR DESCRIPTION
Finish the work started in #10799 by making the `Kill` button work on the remaining two pages it appears on. Long-term it's probably better to refactor these into one place.

Fixes: https://github.com/prestodb/presto/issues/10223