### PR TITLE
Add MockConnectorFactory.Builder to simplify construction

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/connector/informationschema/BenchmarkInformationSchema.java
+++ b/presto-tests/src/test/java/com/facebook/presto/connector/informationschema/BenchmarkInformationSchema.java
@@ -126,7 +126,13 @@ public class BenchmarkInformationSchema
                             .boxed()
                             .map(i -> "column_" + i)
                             .collect(toImmutableMap(column -> column, column -> new TpchColumnHandle(column, createUnboundedVarcharType()) {}));
-                    return ImmutableList.of(new MockConnectorFactory(listSchemaNames, listTables, (session, prefix) -> ImmutableMap.of(), getColumnHandles));
+                    MockConnectorFactory connectorFactory = MockConnectorFactory.builder()
+                            .withListSchemaNames(listSchemaNames)
+                            .withListTables(listTables)
+                            .withGetViews((session, prefix) -> ImmutableMap.of())
+                            .withGetColumnHandles(getColumnHandles)
+                            .build();
+                    return ImmutableList.of(connectorFactory);
                 }
             });
             queryRunner.createCatalog("test_catalog", "mock", ImmutableMap.of());

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -59,15 +59,17 @@ public class TestMetadataManager
             @Override
             public Iterable<ConnectorFactory> getConnectorFactories()
             {
-                return ImmutableList.of(new MockConnectorFactory(
-                        session -> ImmutableList.of("UPPER_CASE_SCHEMA"),
-                        (session, schemaNameOrNull) -> {
+                MockConnectorFactory connectorFactory = MockConnectorFactory.builder()
+                        .withListSchemaNames(session -> ImmutableList.of("UPPER_CASE_SCHEMA"))
+                        .withListTables((session, schemaNameOrNull) -> {
                             throw new UnsupportedOperationException();
-                        },
-                        (session, prefix) -> ImmutableMap.of(),
-                        (session, tableHandle) -> {
+                        })
+                        .withGetViews((session, prefix) -> ImmutableMap.of())
+                        .withGetColumnHandles((session, tableHandle) -> {
                             throw new UnsupportedOperationException();
-                        }));
+                        })
+                        .build();
+                return ImmutableList.of(connectorFactory);
             }
         });
         queryRunner.createCatalog("upper_case_schema_catalog", "mock");


### PR DESCRIPTION
This is a minor followup for https://github.com/prestodb/presto/pull/11234