### PR TITLE
Compute covariance, etc in numerically stable manner

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/CorrelationState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/CorrelationState.java
@@ -16,11 +16,11 @@ package com.facebook.presto.operator.aggregation.state;
 public interface CorrelationState
         extends CovarianceState
 {
-    double getSumXSquare();
+    double getM2X();
 
-    void setSumXSquare(double value);
+    void setM2X(double value);
 
-    double getSumYSquare();
+    double getM2Y();
 
-    void setSumYSquare(double value);
+    void setM2Y(double value);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/CovarianceState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/CovarianceState.java
@@ -22,15 +22,15 @@ public interface CovarianceState
 
     void setCount(long value);
 
-    double getSumXY();
+    double getMeanX();
 
-    void setSumXY(double value);
+    void setMeanX(double value);
 
-    double getSumX();
+    double getMeanY();
 
-    void setSumX(double value);
+    void setMeanY(double value);
 
-    double getSumY();
+    double getC2();
 
-    void setSumY(double value);
+    void setC2(double value);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/RegressionState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/RegressionState.java
@@ -16,7 +16,7 @@ package com.facebook.presto.operator.aggregation.state;
 public interface RegressionState
         extends CovarianceState
 {
-    double getSumXSquare();
+    double getM2X();
 
-    void setSumXSquare(double value);
+    void setM2X(double value);
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestNumericalStability.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestNumericalStability.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.query;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestNumericalStability
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testVariance()
+    {
+        assertions.assertQuery(
+                "SELECT CAST(VAR_SAMP(x + exp(30))/VAR_SAMP(x) AS DECIMAL(3,2)) " +
+                        "FROM (VALUES 1.0, 2.0, 3.0, 4.0, 5.0) AS X(x)",
+                "VALUES 1.00");
+    }
+
+    @Test
+    public void testCovariance()
+    {
+        assertions.assertQuery(
+                "SELECT CAST(COVAR_SAMP(x + exp(30), x + exp(30))/VAR_SAMP(x) AS DECIMAL(3,2)) " +
+                        "FROM (VALUES 1.0, 2.0, 3.0, 4.0, 5.0) AS X(x)",
+                "VALUES 1.00");
+    }
+
+    @Test
+    public void testCorrelation()
+    {
+        assertions.assertQuery(
+                "SELECT CAST(CORR(x + exp(30), x + exp(30)) AS DECIMAL(3,2)) " +
+                        "FROM (VALUES 1.0, 2.0, 3.0, 4.0, 5.0) AS X(x)",
+                "VALUES 1.00");
+    }
+
+    @Test
+    public void testRegressionSlope()
+    {
+        assertions.assertQuery(
+                "SELECT CAST(REGR_SLOPE((x + exp(30)) * 5 + 8, x + exp(30)) AS DECIMAL(3,2)) " +
+                        "FROM (VALUES 1.0, 2.0, 3.0, 4.0, 5.0) AS X(x)",
+                "VALUES 5.00");
+    }
+
+    @Test
+    public void testRegressionIntercept()
+    {
+        assertions.assertQuery(
+                "SELECT CAST(REGR_INTERCEPT((x + exp(20)) * 5 + 8, x + exp(20)) AS DECIMAL(3,2)) " +
+                        "FROM (VALUES 1.0, 2.0, 3.0, 4.0, 5.0) AS X(x)",
+                "VALUES 8.00");
+    }
+}


### PR DESCRIPTION
This commit updates methods to compute covariance, correlation, and
simple linear regression in numerically robust manner, i.e.
Welford-style, single-pass and distributed algorithms.

This Wikipedia page gives a nice overview of the problem:
https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance. In short,
the standard way to compute variance, covariance, etc can break down
easily when confronted with large numbers, due to overflow issues; and
so there are more sophisticated methods recommended. While variance
was already computed correctly (per the "online algorithm" by Welford),
covariance and other related metrics -- correlation and parameters from
simple linear regression -- were computed in the naive fashion. I
updated covariance to be computed using the method described in
"Numerically Stable, Single-Pass, Parallel Statistics Algorithms" by
Bennett et al; all other metrics derive from covariance and variance,
and were rewritten as such.

It is important to stress that overflow issues cannot be totally eliminated.
However, this makes the algorithms more robust, and they can tolerate
much larger numbers without breaking down. Consider some examples,
using the following query over some values of n, where exp(n) is a
constant that shifts numbers but shouldn't change any results:

```
use tpch.tiny;

select var_samp(totalprice + exp(n)), covar_samp(totalprice + exp(n),
totalprice + exp(n)), corr(totalprice + exp(n), totalprice + exp(n)),
regr_slope((totalprice + exp(n)) * 5 + 10, totalprice + exp(n)),
regr_intercept((totalprice + exp(n)) * 5 + 10, totalprice + exp(n))
from orders;

```

First, consider the pre-change Presto, where n = 0. This is correct.

```
        _col0        |        _col1        | _col2 |       _col3       |       _col4
---------------------+---------------------+-------+-------------------+-------------------
 6.847211712330258E9 | 6.847211712330251E9 |   1.0 | 4.999999999999999 | 9.999999999986496

```

Now, consider the pre-change Presto, where n = 20. Intercept becomes
inaccurate.

```
        _col0        |        _col1        | _col2 |      _col3       |       _col4
---------------------+---------------------+-------+------------------+-------------------
 6.847211712329458E9 | 6.847212046098006E9 |   1.0 | 4.99999984387209 | 83.82053346542646

```

Finally, consider the pre-change Presto, where n = 30. Everything but
variance (which was already computed correctly) goes wildly wrong.
Moreover, on repeated runs, different answers emerge.

```
        _col0        |         _col1         | _col2 |       _col3        |         _col4
---------------------+-----------------------+-------+--------------------+-----------------------
 6.847211708267411E9 | -5.629874859203734E10 | NULL  | 2.6666666666666665 | 1.1728124029610666E13

        _col0        |         _col1         | _col2 | _col3 |        _col4
---------------------+-----------------------+-------+-------+----------------------
 6.847211712030038E9 | -9.383124765339555E10 | NULL  |   5.6 | -1.40737488355328E13

        _col0        |         _col1         | _col2 | _col3 | _col4
---------------------+-----------------------+-------+-------+-------
 6.847211710953991E9 | -3.753249906135822E10 | NULL  |   4.0 |  -0.0

```

Now, consider post-change Presto. First, set n = 0. This is correct.

```
        _col0        |        _col1        | _col2 |       _col3       |       _col4
---------------------+---------------------+-------+-------------------+--------------------
 6.847211712330259E9 | 6.847211712330259E9 |   1.0 | 4.999999999999997 | 10.000000000582077

```

Next, set n = 20. This is still correct, including for regression intercept,
which pre-change Presto got wrong.

```
       _col0        |        _col1        | _col2 |       _col3       |       _col4
--------------------+---------------------+-------+-------------------+-------------------
 6.84721171232945E9 | 6.847211712329576E9 |   1.0 | 5.000000000000442 | 9.999785900115967

```

Next, set n = 30. Everything but regression intercept is still computed
correctly, and this is even true on repeated runs of the query.

```
        _col0        |        _col1        |       _col2        |       _col3       |    _col4
---------------------+---------------------+--------------------+-------------------+--------------
 6.847211713557989E9 | 6.847211714293242E9 | 1.0000000000000002 | 5.000000000895967 | -9564.734375

        _col0        |        _col1        | _col2 |       _col3       |    _col4
---------------------+---------------------+-------+-------------------+-------------
 6.847211715025226E9 | 6.847211716113671E9 |   1.0 | 4.999999999632765 | 3934.453125

        _col0        |        _col1        | _col2 |      _col3       |    _col4
---------------------+---------------------+-------+------------------+-------------
 6.847211716725054E9 | 6.847211716385307E9 |   1.0 | 5.00000000056445 | -6021.96875

```

In fact, this is even true when n = 40 (except the intercept again).

```
        _col0        |        _col1        | _col2 |       _col3       |       _col4
---------------------+---------------------+-------+-------------------+--------------------
 6.847197940885167E9 | 6.847226624911631E9 |   1.0 | 4.999855871210612 | 3.3925793548544E13

```

Again, as the regression intercept case shows, this algorithm is not
immune to overflow issues (and this indeed starts to break down
more generally as n approaches 50). Indeed, you may notice the
small rise in floating point error as n gets large even in the cases
above. But regardless, this represents an improvement in robustness.