### PR TITLE
Fix delay in sending noMoreSplits for scan node in colocated join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -191,11 +191,16 @@ public final class SqlStageExecution
         }
 
         for (PlanNodeId partitionedSource : stateMachine.getFragment().getPartitionedSources()) {
-            for (RemoteTask task : getAllTasks()) {
-                task.noMoreSplits(partitionedSource);
-            }
-            completeSources.add(partitionedSource);
+            schedulingComplete(partitionedSource);
         }
+    }
+
+    public synchronized void schedulingComplete(PlanNodeId partitionedSource)
+    {
+        for (RemoteTask task : getAllTasks()) {
+            task.noMoreSplits(partitionedSource);
+        }
+        completeSources.add(partitionedSource);
     }
 
     public synchronized void cancel()

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -199,6 +199,7 @@ public class FixedSourcePartitionedScheduler
             driverGroupsToStart = sourcePartitionedScheduler.drainCompletedLifespans();
 
             if (schedule.isFinished()) {
+                stage.schedulingComplete(sourcePartitionedScheduler.getPlanNodeId());
                 schedulerIterator.remove();
                 sourcePartitionedScheduler.close();
             }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -117,6 +117,11 @@ public class SourcePartitionedScheduler
         this.autoDropCompletedLifespans = autoDropCompletedLifespans;
     }
 
+    public PlanNodeId getPlanNodeId()
+    {
+        return partitionedNode;
+    }
+
     /**
      * Obtains an instance of {@code SourcePartitionedScheduler} suitable for use as a
      * stage scheduler.


### PR DESCRIPTION
When a fragment/stage contains multiple scan nodes. None of the scan nodes
will receive a TaskSource where TaskSource.noMoreSplits = true until
cheduling for splits for all the scan nodes in the stage finishes.
Instead, each scan node should receive noMoreSplits indepedently.

The bug affects scheduling for fragment/stage with more than one scan nodes.
Only colocated join can create such fragment/stage at this time.

This fixes bug 1 in #11253.