### PR TITLE
Merge partition preference when adding exchange nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -20,6 +20,7 @@ import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialMergePushdownStrategy;
@@ -135,6 +136,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZE_FULL_OUTER_JOIN_WITH_COALESCE = "optimize_full_outer_join_with_coalesce";
     public static final String INDEX_LOADER_TIMEOUT = "index_loader_timeout";
     public static final String OPTIMIZED_REPARTITIONING_ENABLED = "optimized_repartitioning";
+    public static final String AGGREGATION_PARTITIONING_MERGING_STRATEGY = "aggregation_partitioning_merging_strategy";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -664,7 +666,19 @@ public final class SystemSessionProperties
                         OPTIMIZED_REPARTITIONING_ENABLED,
                         "Experimental: Use optimized repartitioning",
                         featuresConfig.isOptimizedRepartitioningEnabled(),
-                        false));
+                        false),
+                new PropertyMetadata<>(
+                        AGGREGATION_PARTITIONING_MERGING_STRATEGY,
+                        format("Strategy to merge partition preference in aggregation node. Options are %s",
+                                Stream.of(AggregationPartitioningMergingStrategy.values())
+                                        .map(AggregationPartitioningMergingStrategy::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        AggregationPartitioningMergingStrategy.class,
+                        featuresConfig.getAggregationPartitioningMergingStrategy(),
+                        false,
+                        value -> AggregationPartitioningMergingStrategy.valueOf(((String) value).toUpperCase()),
+                        AggregationPartitioningMergingStrategy::name));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1133,5 +1147,10 @@ public final class SystemSessionProperties
     public static boolean isOptimizedRepartitioningEnabled(Session session)
     {
         return session.getSystemProperty(OPTIMIZED_REPARTITIONING_ENABLED, Boolean.class);
+    }
+
+    public static AggregationPartitioningMergingStrategy getAggregationPartitioningMergingStrategy(Session session)
+    {
+        return session.getSystemProperty(AGGREGATION_PARTITIONING_MERGING_STRATEGY, AggregationPartitioningMergingStrategy.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy.LEGACY;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.PARTITIONED;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
@@ -132,6 +133,7 @@ public class FeaturesConfig
     private int filterAndProjectMinOutputPageRowCount = 256;
     private int maxGroupingSets = 2048;
     private boolean legacyUnnestArrayRows;
+    private AggregationPartitioningMergingStrategy aggregationPartitioningMergingStrategy = LEGACY;
 
     private boolean jsonSerdeCodeGenerationEnabled;
     private int maxConcurrentMaterializations = 3;
@@ -171,6 +173,23 @@ public class FeaturesConfig
     {
         NONE,
         PUSH_THROUGH_LOW_MEMORY_OPERATORS
+    }
+
+    public enum AggregationPartitioningMergingStrategy
+    {
+        LEGACY, // merge partition preference with parent but apply current partition preference
+        TOP_DOWN, // merge partition preference with parent and apply the merged partition preference
+        BOTTOM_UP; // don't merge partition preference and apply current partition preference only
+
+        public boolean isMergingWithParent()
+        {
+            return this == LEGACY || this == TOP_DOWN;
+        }
+
+        public boolean isAdoptingMergedPreference()
+        {
+            return this == TOP_DOWN;
+        }
     }
 
     public double getCpuCostWeight()
@@ -484,6 +503,18 @@ public class FeaturesConfig
     public FeaturesConfig setMaxReorderedJoins(int maxReorderedJoins)
     {
         this.maxReorderedJoins = maxReorderedJoins;
+        return this;
+    }
+
+    public AggregationPartitioningMergingStrategy getAggregationPartitioningMergingStrategy()
+    {
+        return aggregationPartitioningMergingStrategy;
+    }
+
+    @Config("optimizer.aggregation-partition-merging")
+    public FeaturesConfig setAggregationPartitioningMergingStrategy(AggregationPartitioningMergingStrategy aggregationPartitioningMergingStrategy)
+    {
+        this.aggregationPartitioningMergingStrategy = requireNonNull(aggregationPartitioningMergingStrategy, "aggregationPartitioningMergingStrategy is null");
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -59,7 +59,7 @@ public final class Partitioning
         this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
     }
 
-    public static <T extends RowExpression> Partitioning create(PartitioningHandle handle, List<T> columns)
+    public static <T extends RowExpression> Partitioning create(PartitioningHandle handle, Collection<T> columns)
     {
         return new Partitioning(handle, columns.stream()
                 .map(RowExpression.class::cast)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
@@ -130,7 +130,7 @@ class PreferredProperties
         return localProperties;
     }
 
-    public PreferredProperties mergeWithParent(PreferredProperties parent)
+    public PreferredProperties mergeWithParent(PreferredProperties parent, boolean mergePartitionPreference)
     {
         List<LocalProperty<VariableReferenceExpression>> newLocal = ImmutableList.<LocalProperty<VariableReferenceExpression>>builder()
                 .addAll(localProperties)
@@ -143,7 +143,7 @@ class PreferredProperties
         if (globalProperties.isPresent()) {
             Global currentGlobal = globalProperties.get();
             Global newGlobal = parent.getGlobalProperties()
-                    .map(currentGlobal::mergeWithParent)
+                    .map(global -> currentGlobal.mergeWithParent(global, mergePartitionPreference))
                     .orElse(currentGlobal);
             builder.global(newGlobal);
         }
@@ -249,7 +249,7 @@ class PreferredProperties
             return partitioningProperties;
         }
 
-        public Global mergeWithParent(Global parent)
+        public Global mergeWithParent(Global parent, boolean mergePartitionPreference)
         {
             if (distributed != parent.distributed) {
                 return this;
@@ -257,7 +257,7 @@ class PreferredProperties
             if (!partitioningProperties.isPresent()) {
                 return parent;
             }
-            if (!parent.partitioningProperties.isPresent()) {
+            if (!parent.partitioningProperties.isPresent() || !mergePartitionPreference) {
                 return this;
             }
             return new Global(distributed, Optional.of(partitioningProperties.get().mergeWithParent(parent.partitioningProperties.get())));

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -27,6 +27,8 @@ import java.util.Map;
 
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy.LEGACY;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy.TOP_DOWN;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.PARTITIONED;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
@@ -73,6 +75,7 @@ public class TestFeaturesConfig
                 .setOptimizeHashGeneration(true)
                 .setPushTableWriteThroughUnion(true)
                 .setDictionaryAggregation(false)
+                .setAggregationPartitioningMergingStrategy(LEGACY)
                 .setLegacyArrayAgg(false)
                 .setGroupByUsesEqualTo(false)
                 .setLegacyMapSubscript(false)
@@ -167,6 +170,7 @@ public class TestFeaturesConfig
                 .put("optimizer.push-table-write-through-union", "false")
                 .put("optimizer.dictionary-aggregation", "true")
                 .put("optimizer.push-aggregation-through-join", "false")
+                .put("optimizer.aggregation-partition-merging", "top_down")
                 .put("regex-library", "RE2J")
                 .put("re2j.dfa-states-limit", "42")
                 .put("re2j.dfa-retries", "42")
@@ -236,6 +240,7 @@ public class TestFeaturesConfig
                 .setOptimizeMixedDistinctAggregations(true)
                 .setPushTableWriteThroughUnion(false)
                 .setDictionaryAggregation(true)
+                .setAggregationPartitioningMergingStrategy(TOP_DOWN)
                 .setPushAggregationThroughJoin(false)
                 .setLegacyArrayAgg(true)
                 .setGroupByUsesEqualTo(true)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -14,21 +14,34 @@
 
 package com.facebook.presto.sql.planner.optimizations;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.function.BiConsumer;
+
+import static com.facebook.presto.SystemSessionProperties.AGGREGATION_PARTITIONING_MERGING_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.TASK_CONCURRENCY;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static org.testng.Assert.assertEquals;
 
 /**
  * These are plan tests similar to what we have for other optimizers (e.g. {@link com.facebook.presto.sql.planner.TestPredicatePushdown})
@@ -100,5 +113,71 @@ public class TestAddExchangesPlans
                                         exchange(REMOTE_STREAMING, REPARTITION,
                                                 anyTree(
                                                         tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))));
+    }
+
+    private void assertPlanWithMergePartitionStrategy(
+            String sql,
+            String partitionMergingStrategy,
+            int remoteRepartitionExchangeCount,
+            PlanMatchPattern pattern)
+    {
+        Session session = Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(AGGREGATION_PARTITIONING_MERGING_STRATEGY, partitionMergingStrategy)
+                .setSystemProperty(TASK_CONCURRENCY, "2")
+                .build();
+        BiConsumer<Plan, Integer> validateMultipleRemoteRepartitionExchange = (plan, count) -> assertEquals(
+                searchFrom(plan.getRoot()).where(node -> node instanceof ExchangeNode && ((ExchangeNode) node).getScope() == REMOTE_STREAMING && ((ExchangeNode) node).getType() == REPARTITION).count(),
+                count.intValue());
+
+        assertPlanWithSession(sql, session, false, pattern, plan -> validateMultipleRemoteRepartitionExchange.accept(plan, remoteRepartitionExchangeCount));
+    }
+
+    @Test
+    public void testMergePartitionWithGroupingSets()
+    {
+        String sql = "SELECT orderkey, count(distinct(custkey)) FROM orders GROUP BY GROUPING SETS((orderkey), ())";
+
+        assertPlanWithMergePartitionStrategy(sql, "bottom_up", 2,
+                anyTree(node(AggregationNode.class,
+                        anyTree(exchange(REMOTE_STREAMING, REPARTITION,
+                                node(AggregationNode.class,
+                                        anyTree(node(AggregationNode.class,
+                                                anyTree(exchange(REMOTE_STREAMING, REPARTITION,
+                                                        node(AggregationNode.class,
+                                                                anyTree(node(GroupIdNode.class,
+                                                                        tableScan("orders"))))))))))))));
+        assertPlanWithMergePartitionStrategy(sql, "top_down", 2,
+                anyTree(node(AggregationNode.class,
+                        anyTree(exchange(REMOTE_STREAMING, REPARTITION,
+                                node(AggregationNode.class,
+                                        anyTree(node(AggregationNode.class,
+                                                anyTree(exchange(REMOTE_STREAMING, REPARTITION,
+                                                        node(AggregationNode.class,
+                                                                anyTree(node(GroupIdNode.class,
+                                                                        tableScan("orders"))))))))))))));
+    }
+
+    @Test
+    public void testMergePartitionWithAggregation()
+    {
+        String sql = "SELECT count(orderdate), custkey FROM (SELECT orderdate, custkey FROM orders GROUP BY orderdate, custkey) GROUP BY custkey";
+
+        // disable merging partition preference
+        assertPlanWithMergePartitionStrategy(sql, "bottom_up", 2,
+                anyTree(node(AggregationNode.class,
+                        anyTree(exchange(REMOTE_STREAMING, REPARTITION,
+                                anyTree(node(AggregationNode.class,
+                                        node(AggregationNode.class,
+                                                anyTree(exchange(REMOTE_STREAMING, REPARTITION,
+                                                        node(AggregationNode.class,
+                                                                anyTree(tableScan("orders")))))))))))));
+
+        // enable merging partition preference
+        assertPlanWithMergePartitionStrategy(sql, "top_down", 1,
+                anyTree(node(AggregationNode.class,
+                        node(AggregationNode.class,
+                                anyTree(exchange(REMOTE_STREAMING, REPARTITION,
+                                        anyTree(node(AggregationNode.class,
+                                                anyTree(tableScan("orders"))))))))));
     }
 }


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Add new session property "aggregation_partitioning_merging_strategy" to control merging partitioning preference when adding repartition remote exchange around aggregation node. Default option is `LEGACY` and can be overwritten to `TOP_DOWN` or `BOTTOM_UP`.
```
---
Previously we only used merged partition preference when adding exchange for union. This commit allow us to merge partitioning preference when adding exchange for aggregation, window function and index join.

By merging partition preference we have chance to reduce data repartitions but may also result in increased skewness. We add a session property to control this behavior. 

---
## Current `AddExchange` behavior
When planning `Aggregation`, `MarkDistinct`, `RowNumber` and `TopNRowNumber` nodes, the current logic do the following:
1. Calculate a `PreferredProperties` which merge the partition preference of the current node and its parent. (e.g. parent requires partitioning on `(col_A)`, current node requires partitioning on `(col_A, col_B)` --> merged result is partitioning on `(col_A)`). 
2. Recursively call rewriter on child node, with the merged `PreferredProperties` (partition on `(col_A)`).
3. Check if the returned partitioning property from child plan. If it's not what the current node requires (`(col_A, col_B)`), add a remote exchange on the current requirement (`(col_A, col_B)`). 

This can result in adding extra remote exchange for certain query shape. For example:

> Take the following aggregation query as an example:
> 
> ```
> SELECT COUNT(orderdate), custkey 
> FROM (
>     SELECT orderdate, custkey 
>     FROM orders 
>     GROUP BY orderdate, custkey
> )
> GROUP BY custkey
> ```
> 
> The previous plan has 2 repartition exchanges, partitioning on group by columns of the inner query and the outer query respectively:
> 
> ```
> OutputNode
>     Aggregation (final, group by custkey)
>         Exchange (repartition on custkey)        // Second exchange on custkey
>             Aggregation (partial, group by custkey)
>                 Aggregation (final, group by custkey, orderdate)               
>                    Exchange (repartition on custkey, orderdate)        // First exchange on custkey and orderdate
>                         Aggregation (partial, group by custkey, orderdate)
>                             TableScan (orders)
> ```

## What this PR changes
The major confusion is between (1) passing the merged preference when planning child and (2) add exchange to the child plan based on unmerged preference. This PR added a session property to control this behavior. 
- With `partition_merging_strategy` set to `LEGACY`, we preserve the previous behavior where we (1) pass the merged preference when planning child and (2) add exchange based on local preference.
- With `partition_merging_strategy` set to `TOP_DOWN`, we (1) pass the merged preference when planning child and (2) add exchange based on the merged preference.
- With `partition_merging_strategy` set to `BOTTOM_UP`, we (1) don't merge preference and (2) add exchange based on local preference. 

For example, with `partition_merging_strategy` set to `TOP_DOWN`, the plan of the above example only has 1 remote exchange:

> ```
> OutputNode
>     Aggregation (single, group by custkey)
>         Aggregation (final, group by custkey, orderdate)               
>             Exchange (repartition on custkey)        // Here is the merged exchange
>                 Aggregation (partial, group by custkey, orderdate)
>                     TableScan (orders)
> ```

Note that less remote exchange is not necessary always the optimal, it depends on the cardinality of partition columns. 

## Open discussions
- ~~With the current approach, we don't have an option to return to our previous behavior. Maybe we should add 2 flag, one is for using merged partition preference when planning child, the other one is for using merged partition preference when adding exchange for current node.~~ 
  - update: Added an enum property to control the partition preference merging strategy. There are currently 3 options: `LEGACY`, `TOP_DOWN` and `BOTTOM_UP`. 

- ~~Open discussion before about controlling merging other properties and also top-down vs bottom-up partition preference (https://github.com/prestodb/presto/pull/11262#issuecomment-413796437).~~

- `IndexJoin` and `Union` is handled differently in the current logic. They handle parent partition preference on their own.

## Todo
- Add detail commit message before merging. 