### PR TITLE
Determine grouped execution on an individual scan node basis 

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2347,6 +2347,27 @@ public class TestHiveIntegrationSmokeTest
             assertQuery(colocatedOneGroupAtATime, crossJoin, expectedCrossJoinQuery);
 
             //
+            // Bucketed and unbucketed HASH JOIN mixed
+            // =======================================
+            @Language("SQL") String bucketedAndUnbucketedJoin =
+                    "SELECT key1, value1, keyN, valueN, key2, value2, key3, value3\n" +
+                            "FROM\n" +
+                            "  test_grouped_join1\n" +
+                            "JOIN (\n" +
+                            "  SELECT *\n" +
+                            "  FROM test_grouped_joinN\n" +
+                            "  JOIN test_grouped_join2\n" +
+                            "  ON keyN = key2\n" +
+                            ")\n" +
+                            "ON key1 = keyN\n" +
+                            "JOIN test_grouped_join3\n" +
+                            "ON key1 = key3";
+            @Language("SQL") String expectedBucketedAndUnbucketedJoinQuery = "SELECT orderkey, comment, orderkey, comment, orderkey, comment, orderkey, comment from orders";
+            assertQuery(notColocated, bucketedAndUnbucketedJoin, expectedBucketedAndUnbucketedJoinQuery);
+            assertQuery(colocatedAllGroupsAtOnce, bucketedAndUnbucketedJoin, expectedBucketedAndUnbucketedJoinQuery);
+            assertQuery(colocatedOneGroupAtATime, bucketedAndUnbucketedJoin, expectedBucketedAndUnbucketedJoinQuery);
+
+            //
             // UNION ALL / GROUP BY
             // ====================
 
@@ -2496,8 +2517,8 @@ public class TestHiveIntegrationSmokeTest
             assertQuery(colocatedOneGroupAtATime, joinUngroupedWithGrouped, expectedJoinUngroupedWithGrouped);
 
             //
-            // Outer JOIN
-            // ==========
+            // Outer JOIN (that involves LookupOuterOperator)
+            // ==============================================
 
             // Chain on the probe side to test duplicating OperatorFactory
             @Language("SQL") String chainedOuterJoin =

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -27,6 +27,7 @@ import com.facebook.presto.operator.DriverFactory;
 import com.facebook.presto.operator.DriverStats;
 import com.facebook.presto.operator.PipelineContext;
 import com.facebook.presto.operator.PipelineExecutionStrategy;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
@@ -221,7 +222,7 @@ public class SqlTaskExecution
                     taskContext,
                     localExecutionPlan.getDriverFactories().stream()
                             .collect(toImmutableMap(DriverFactory::getPipelineId, DriverFactory::getPipelineExecutionStrategy)));
-            this.schedulingLifespanManager = new SchedulingLifespanManager(localExecutionPlan.getPartitionedSourceOrder(), this.status);
+            this.schedulingLifespanManager = new SchedulingLifespanManager(localExecutionPlan.getPartitionedSourceOrder(), localExecutionPlan.getStageExecutionStrategy(), this.status);
 
             checkArgument(this.driverRunnerFactoriesWithSplitLifeCycle.keySet().equals(partitionedSources),
                     "Fragment is partitioned, but not all partitioned drivers were found");
@@ -231,7 +232,7 @@ public class SqlTaskExecution
                 PlanNodeId planNodeId = entry.getKey();
                 DriverSplitRunnerFactory driverSplitRunnerFactory = entry.getValue();
                 if (driverSplitRunnerFactory.getPipelineExecutionStrategy() == UNGROUPED_EXECUTION) {
-                    schedulingLifespanManager.addLifespanIfAbsent(Lifespan.taskWide());
+                    this.schedulingLifespanManager.addLifespanIfAbsent(Lifespan.taskWide());
                     this.pendingSplitsByPlanNode.get(planNodeId).getLifespan(Lifespan.taskWide());
                 }
             }
@@ -373,63 +374,89 @@ public class SqlTaskExecution
     {
         mergeIntoPendingSplits(sourceUpdate.getPlanNodeId(), sourceUpdate.getSplits(), sourceUpdate.getNoMoreSplitsForLifespan(), sourceUpdate.isNoMoreSplits());
 
-        // SchedulingLifespanManager tracks how far each Lifespan has been scheduled. Here is an example.
-        // Let's say there are 4 source pipelines/nodes: A, B, C, and D, in scheduling order.
-        // And we're processing 3 concurrent lifespans at a time. In this case, we could have
-        //
-        // * Lifespan 10:  A   B  [C]  D; i.e. Pipeline A and B has finished scheduling (but not necessarily finished running).
-        // * Lifespan 20: [A]  B   C   D
-        // * Lifespan 30:  A  [B]  C   D
-        //
-        // To recap, SchedulingLifespanManager records the next scheduling source node for each lifespan.
-
-        Iterator<SchedulingLifespan> activeLifespans = schedulingLifespanManager.getActiveLifespans();
-
-        while (activeLifespans.hasNext()) {
-            SchedulingLifespan schedulingLifespan = activeLifespans.next();
-            Lifespan lifespan = schedulingLifespan.getLifespan();
-
-            // Continue using the example from above. Let's say the sourceUpdate adds some new splits for source node B.
+        while (true) {
+            // SchedulingLifespanManager tracks how far each Lifespan has been scheduled. Here is an example.
+            // Let's say there are 4 source pipelines/nodes: A, B, C, and D, in scheduling order.
+            // And we're processing 3 concurrent lifespans at a time. In this case, we could have
             //
-            // For lifespan 30, it could start new drivers and assign a pending split to each.
-            // Pending splits could include both pre-existing pending splits, and the new ones from sourceUpdate.
-            // If there is enough driver slots to deplete pending splits, one of the below would happen.
-            // * If it is marked that all splits for node B in lifespan 30 has been received, SchedulingLifespanManager
-            //   will be updated so that lifespan 30 now processes source node C. It will immediately start processing them.
-            // * Otherwise, processing of lifespan 30 will be shelved for now.
+            // * Lifespan 10:  A   B  [C]  D; i.e. Pipeline A and B has finished scheduling (but not necessarily finished running).
+            // * Lifespan 20: [A]  B   C   D
+            // * Lifespan 30:  A  [B]  C   D
             //
-            // It is possible that the following loop would be a no-op for a particular lifespan.
-            // It is also possible that a single lifespan can proceed through multiple source nodes in one run.
-            while (true) {
-                PlanNodeId schedulingPlanNode = schedulingLifespan.getSchedulingPlanNode();
-                DriverSplitRunnerFactory partitionedDriverRunnerFactory = driverRunnerFactoriesWithSplitLifeCycle.get(schedulingPlanNode);
-                checkLifespan(partitionedDriverRunnerFactory.getPipelineExecutionStrategy(), lifespan);
-                PendingSplits pendingSplits = pendingSplitsByPlanNode.get(schedulingPlanNode).getLifespan(lifespan);
+            // To recap, SchedulingLifespanManager records the next scheduling source node for each lifespan.
+            Iterator<SchedulingLifespan> activeLifespans = schedulingLifespanManager.getActiveLifespans();
 
-                // Enqueue driver runners with driver group lifecycle for this driver life cycle, if not already enqueued.
-                if (!schedulingLifespan.getAndSetDriversForDriverGroupLifeCycleScheduled()) {
-                    scheduleDriversForDriverGroupLifeCycle(lifespan);
-                }
+            boolean madeProgress = false;
 
-                // Enqueue driver runners with split lifecycle for this plan node and driver life cycle combination.
-                ImmutableList.Builder<DriverSplitRunner> runners = ImmutableList.builder();
-                for (ScheduledSplit scheduledSplit : pendingSplits.removeAllSplits()) {
-                    // create a new driver for the split
-                    runners.add(partitionedDriverRunnerFactory.createDriverRunner(scheduledSplit, true, lifespan));
-                }
-                enqueueDriverSplitRunner(false, runners.build());
+            while (activeLifespans.hasNext()) {
+                SchedulingLifespan schedulingLifespan = activeLifespans.next();
+                Lifespan lifespan = schedulingLifespan.getLifespan();
 
-                // If all driver runners have been enqueued for this plan node and driver life cycle combination,
-                // move on to the next plan node.
-                if (pendingSplits.getState() != NO_MORE_SPLITS) {
-                    break;
+                // Continue using the example from above. Let's say the sourceUpdate adds some new splits for source node B.
+                //
+                // For lifespan 30, it could start new drivers and assign a pending split to each.
+                // Pending splits could include both pre-existing pending splits, and the new ones from sourceUpdate.
+                // If there is enough driver slots to deplete pending splits, one of the below would happen.
+                // * If it is marked that all splits for node B in lifespan 30 has been received, SchedulingLifespanManager
+                //   will be updated so that lifespan 30 now processes source node C. It will immediately start processing them.
+                // * Otherwise, processing of lifespan 30 will be shelved for now.
+                //
+                // It is possible that the following loop would be a no-op for a particular lifespan.
+                // It is also possible that a single lifespan can proceed through multiple source nodes in one run.
+                //
+                // When different drivers in the task has different pipelineExecutionStrategy, it adds additional complexity.
+                // For example, when driver B is ungrouped and driver A, C, D is grouped, you could have something like this:
+                //     TaskWide   :     [B]
+                //     Lifespan 10:  A  [ ]  C   D
+                //     Lifespan 20: [A]      C   D
+                //     Lifespan 30:  A  [ ]  C   D
+                // In this example, Lifespan 30 cannot start executing drivers in pipeline C because pipeline B
+                // hasn't finished scheduling yet (albeit in a different lifespan).
+                // Similarly, it wouldn't make sense for TaskWide to start executing drivers in pipeline B until at least
+                // one lifespan has finished scheduling pipeline A.
+                // This is why getSchedulingPlanNode returns an Optional.
+                while (true) {
+                    Optional<PlanNodeId> optionalSchedulingPlanNode = schedulingLifespan.getSchedulingPlanNode();
+                    if (!optionalSchedulingPlanNode.isPresent()) {
+                        break;
+                    }
+                    PlanNodeId schedulingPlanNode = optionalSchedulingPlanNode.get();
+
+                    DriverSplitRunnerFactory partitionedDriverRunnerFactory = driverRunnerFactoriesWithSplitLifeCycle.get(schedulingPlanNode);
+
+                    PendingSplits pendingSplits = pendingSplitsByPlanNode.get(schedulingPlanNode).getLifespan(lifespan);
+
+                    // Enqueue driver runners with driver group lifecycle for this driver life cycle, if not already enqueued.
+                    if (!lifespan.isTaskWide() && !schedulingLifespan.getAndSetDriversForDriverGroupLifeCycleScheduled()) {
+                        scheduleDriversForDriverGroupLifeCycle(lifespan);
+                    }
+
+                    // Enqueue driver runners with split lifecycle for this plan node and driver life cycle combination.
+                    ImmutableList.Builder<DriverSplitRunner> runners = ImmutableList.builder();
+                    for (ScheduledSplit scheduledSplit : pendingSplits.removeAllSplits()) {
+                        // create a new driver for the split
+                        runners.add(partitionedDriverRunnerFactory.createDriverRunner(scheduledSplit, true, lifespan));
+                    }
+                    enqueueDriverSplitRunner(false, runners.build());
+
+                    // If all driver runners have been enqueued for this plan node and driver life cycle combination,
+                    // move on to the next plan node.
+                    if (pendingSplits.getState() != NO_MORE_SPLITS) {
+                        break;
+                    }
+                    partitionedDriverRunnerFactory.noMoreDriverRunner(ImmutableList.of(lifespan));
+                    pendingSplits.markAsCleanedUp();
+
+                    schedulingLifespan.nextPlanNode();
+                    madeProgress = true;
+                    if (schedulingLifespan.isDone()) {
+                        break;
+                    }
                 }
-                partitionedDriverRunnerFactory.noMoreDriverRunner(ImmutableList.of(lifespan));
-                pendingSplits.markAsCleanedUp();
-                schedulingLifespan.nextPlanNode();
-                if (schedulingLifespan.isDone()) {
-                    break;
-                }
+            }
+
+            if (!madeProgress) {
+                break;
             }
         }
 
@@ -716,9 +743,10 @@ public class SqlTaskExecution
     private static class SchedulingLifespanManager
     {
         // SchedulingLifespanManager only contains partitioned drivers.
-        // All the partitioned drivers in a task is guaranteed to have the same pipelineExecutionStrategy.
+        // Note that different drivers in a task may have different pipelineExecutionStrategy.
 
         private final List<PlanNodeId> sourceStartOrder;
+        private final StageExecutionStrategy stageExecutionStrategy;
         private final Status status;
 
         private final Map<Lifespan, SchedulingLifespan> lifespans = new HashMap<>();
@@ -727,10 +755,25 @@ public class SqlTaskExecution
 
         private final Set<PlanNodeId> noMoreSplits = new HashSet<>();
 
-        public SchedulingLifespanManager(List<PlanNodeId> sourceStartOrder, Status status)
+        private int maxScheduledPlanNodeOrdinal;
+
+        public SchedulingLifespanManager(List<PlanNodeId> sourceStartOrder, StageExecutionStrategy stageExecutionStrategy, Status status)
         {
             this.sourceStartOrder = ImmutableList.copyOf(sourceStartOrder);
+            this.stageExecutionStrategy = stageExecutionStrategy;
             this.status = requireNonNull(status, "status is null");
+        }
+
+        public int getMaxScheduledPlanNodeOrdinal()
+        {
+            return maxScheduledPlanNodeOrdinal;
+        }
+
+        public void updateMaxScheduledPlanNodeOrdinalIfNecessary(int scheduledPlanNodeOrdinal)
+        {
+            if (maxScheduledPlanNodeOrdinal < scheduledPlanNodeOrdinal) {
+                maxScheduledPlanNodeOrdinal = scheduledPlanNodeOrdinal;
+            }
         }
 
         public void noMoreSplits(PlanNodeId planNodeId)
@@ -753,7 +796,8 @@ public class SqlTaskExecution
                 return;
             }
             checkState(!status.isNoMoreLifespans());
-            lifespans.put(lifespan, new SchedulingLifespan(lifespan, sourceStartOrder));
+            checkState(!sourceStartOrder.isEmpty());
+            lifespans.put(lifespan, new SchedulingLifespan(lifespan, this));
         }
 
         public Iterator<SchedulingLifespan> getActiveLifespans()
@@ -788,15 +832,14 @@ public class SqlTaskExecution
     private static class SchedulingLifespan
     {
         private final Lifespan lifespan;
-        private final List<PlanNodeId> planNodeSchedulingOrder;
+        private final SchedulingLifespanManager manager;
         private int schedulingPlanNodeOrdinal;
         private boolean unpartitionedDriversScheduled;
 
-        public SchedulingLifespan(Lifespan lifespan, List<PlanNodeId> planNodeSchedulingOrder)
+        public SchedulingLifespan(Lifespan lifespan, SchedulingLifespanManager manager)
         {
             this.lifespan = requireNonNull(lifespan, "lifespan is null");
-            this.planNodeSchedulingOrder = requireNonNull(planNodeSchedulingOrder, "planNodeSchedulingOrder is null");
-            checkArgument(!planNodeSchedulingOrder.isEmpty(), "planNodeSchedulingOrder is empty");
+            this.manager = requireNonNull(manager, "manager is null");
         }
 
         public Lifespan getLifespan()
@@ -804,21 +847,42 @@ public class SqlTaskExecution
             return lifespan;
         }
 
-        public PlanNodeId getSchedulingPlanNode()
+        public Optional<PlanNodeId> getSchedulingPlanNode()
         {
             checkState(!isDone());
-            return planNodeSchedulingOrder.get(schedulingPlanNodeOrdinal);
+            while (!isDone()) {
+                // Return current plan node if this lifespan is compatible with the plan node.
+                // i.e. One of the following bullet points is true:
+                // * The execution strategy of the plan node is grouped. And lifespan represents a driver group.
+                // * The execution strategy of the plan node is ungrouped. And lifespan is task wide.
+                if (manager.stageExecutionStrategy.isGroupedExecution(manager.sourceStartOrder.get(schedulingPlanNodeOrdinal)) != lifespan.isTaskWide()) {
+                    return Optional.of(manager.sourceStartOrder.get(schedulingPlanNodeOrdinal));
+                }
+                // This lifespan is incompatible with the plan node. As a result, this method should either
+                // return empty to indicate that scheduling for this lifespan is blocked, or skip the current
+                // plan node and went on to the next one. Which one of the two happens is dependent on whether
+                // the current plan node has finished scheduling in any other lifespan.
+                // If so, the lifespan can advance to the next plan node.
+                // If not, it should not advance because doing so would violate scheduling order.
+                if (manager.getMaxScheduledPlanNodeOrdinal() == schedulingPlanNodeOrdinal) {
+                    return Optional.empty();
+                }
+                verify(manager.getMaxScheduledPlanNodeOrdinal() > schedulingPlanNodeOrdinal);
+                nextPlanNode();
+            }
+            return Optional.empty();
         }
 
         public void nextPlanNode()
         {
             checkState(!isDone());
             schedulingPlanNodeOrdinal++;
+            manager.updateMaxScheduledPlanNodeOrdinalIfNecessary(schedulingPlanNodeOrdinal);
         }
 
         public boolean isDone()
         {
-            return schedulingPlanNodeOrdinal >= planNodeSchedulingOrder.size();
+            return schedulingPlanNodeOrdinal >= manager.sourceStartOrder.size();
         }
 
         public boolean getAndSetDriversForDriverGroupLifeCycleScheduled()

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecutionFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecutionFactory.java
@@ -19,26 +19,20 @@ import com.facebook.presto.event.query.QueryMonitor;
 import com.facebook.presto.execution.buffer.OutputBuffer;
 import com.facebook.presto.execution.executor.TaskExecutor;
 import com.facebook.presto.memory.QueryContext;
-import com.facebook.presto.operator.DriverFactory;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.TypeProvider;
-import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import io.airlift.concurrent.SetThreadName;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.Executor;
 
 import static com.facebook.presto.execution.SqlTaskExecution.createSqlTaskExecution;
-import static com.facebook.presto.operator.PipelineExecutionStrategy.GROUPED_EXECUTION;
-import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
@@ -88,21 +82,9 @@ public class SqlTaskExecutionFactory
                         fragment.getRoot(),
                         TypeProvider.copyOf(fragment.getSymbols()),
                         fragment.getPartitioningScheme(),
-                        fragment.getPipelineExecutionStrategy() == GROUPED_EXECUTION,
+                        fragment.getStageExecutionStrategy(),
                         fragment.getPartitionedSources(),
                         outputBuffer);
-
-                for (DriverFactory driverFactory : localExecutionPlan.getDriverFactories()) {
-                    Optional<PlanNodeId> sourceId = driverFactory.getSourceId();
-                    if (sourceId.isPresent() && fragment.isPartitionedSources(sourceId.get())) {
-                        checkArgument(fragment.getPipelineExecutionStrategy() == driverFactory.getPipelineExecutionStrategy(),
-                                "Partitioned pipelines are expected to have the same execution strategy as the fragment");
-                    }
-                    else {
-                        checkArgument(fragment.getPipelineExecutionStrategy() != UNGROUPED_EXECUTION || driverFactory.getPipelineExecutionStrategy() == UNGROUPED_EXECUTION,
-                                "When fragment execution strategy is ungrouped, all pipelines should have ungrouped execution strategy");
-                    }
-                }
             }
             catch (Throwable e) {
                 // planning failed

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -45,9 +45,7 @@ import static com.facebook.presto.execution.scheduler.ScheduleResult.BlockedReas
 import static com.facebook.presto.execution.scheduler.ScheduleResult.BlockedReason.NO_ACTIVE_DRIVER_GROUP;
 import static com.facebook.presto.execution.scheduler.ScheduleResult.BlockedReason.SPLIT_QUEUES_FULL;
 import static com.facebook.presto.execution.scheduler.ScheduleResult.BlockedReason.WAITING_FOR_SOURCE;
-import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
-import static com.facebook.presto.util.Failures.checkCondition;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -391,22 +389,6 @@ public class SourcePartitionedScheduler
         }
 
         return result.build();
-    }
-
-    private ScheduleResult scheduleEmptySplit()
-    {
-        state = State.SPLITS_ADDED;
-
-        List<Node> nodes = splitPlacementPolicy.allNodes();
-        checkCondition(!nodes.isEmpty(), NO_NODES_AVAILABLE, "No nodes available to run query");
-        Node node = nodes.iterator().next();
-
-        Split emptySplit = new Split(
-                splitSource.getConnectorId(),
-                splitSource.getTransactionHandle(),
-                new EmptySplit(splitSource.getConnectorId()));
-        Set<RemoteTask> emptyTask = assignSplits(ImmutableMultimap.of(node, emptySplit), ImmutableMultimap.of());
-        return new ScheduleResult(false, emptyTask, 1);
     }
 
     private Set<RemoteTask> assignSplits(Multimap<Node, Split> splitAssignment, Multimap<Node, Lifespan> noMoreSplitsNotification)

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourceScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourceScheduler.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+
+import java.util.List;
+
+interface SourceScheduler
+{
+    ScheduleResult schedule();
+
+    void close();
+
+    PlanNodeId getPlanNodeId();
+
+    void startLifespan(Lifespan lifespan, ConnectorPartitionHandle partitionHandle);
+
+    List<Lifespan> drainCompletedLifespans();
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -79,7 +79,6 @@ import static com.facebook.presto.execution.StageState.FINISHED;
 import static com.facebook.presto.execution.StageState.RUNNING;
 import static com.facebook.presto.execution.StageState.SCHEDULED;
 import static com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.newSourcePartitionedSchedulerAsStageScheduler;
-import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
@@ -269,7 +268,7 @@ public class SqlQueryScheduler
             NodeSelector nodeSelector = nodeScheduler.createNodeSelector(connectorId);
             SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeSelector, stage::getAllTasks);
 
-            checkArgument(plan.getFragment().getPipelineExecutionStrategy() == UNGROUPED_EXECUTION);
+            checkArgument(!plan.getFragment().getStageExecutionStrategy().isAnyScanGroupedExecution());
             stageSchedulers.put(stageId, newSourcePartitionedSchedulerAsStageScheduler(stage, planNodeId, splitSource, placementPolicy, splitBatchSize));
             bucketToPartition = Optional.of(new int[1]);
         }
@@ -286,22 +285,18 @@ public class SqlQueryScheduler
             if (!splitSources.isEmpty()) {
                 List<PlanNodeId> schedulingOrder = plan.getFragment().getPartitionedSources();
                 List<ConnectorPartitionHandle> connectorPartitionHandles;
-                switch (plan.getFragment().getPipelineExecutionStrategy()) {
-                    case GROUPED_EXECUTION:
-                        connectorPartitionHandles = nodePartitioningManager.listPartitionHandles(session, partitioningHandle);
-                        checkState(connectorPartitionHandles.size() == nodePartitionMap.getBucketToPartition().length);
-                        checkState(!ImmutableList.of(NOT_PARTITIONED).equals(connectorPartitionHandles));
-                        break;
-                    case UNGROUPED_EXECUTION:
-                        connectorPartitionHandles = ImmutableList.of(NOT_PARTITIONED);
-                        break;
-                    default:
-                        throw new UnsupportedOperationException();
+                if (plan.getFragment().getStageExecutionStrategy().isAnyScanGroupedExecution()) {
+                    connectorPartitionHandles = nodePartitioningManager.listPartitionHandles(session, partitioningHandle);
+                    checkState(connectorPartitionHandles.size() == nodePartitionMap.getBucketToPartition().length);
+                    checkState(!ImmutableList.of(NOT_PARTITIONED).equals(connectorPartitionHandles));
+                }
+                else {
+                    connectorPartitionHandles = ImmutableList.of(NOT_PARTITIONED);
                 }
                 stageSchedulers.put(stageId, new FixedSourcePartitionedScheduler(
                         stage,
                         splitSources,
-                        plan.getFragment().getPipelineExecutionStrategy(),
+                        plan.getFragment().getStageExecutionStrategy(),
                         schedulingOrder,
                         nodePartitionMap,
                         splitBatchSize,

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -78,7 +78,7 @@ import static com.facebook.presto.execution.StageState.FAILED;
 import static com.facebook.presto.execution.StageState.FINISHED;
 import static com.facebook.presto.execution.StageState.RUNNING;
 import static com.facebook.presto.execution.StageState.SCHEDULED;
-import static com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.simpleSourcePartitionedScheduler;
+import static com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.newSourcePartitionedSchedulerAsStageScheduler;
 import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
@@ -270,7 +270,7 @@ public class SqlQueryScheduler
             SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeSelector, stage::getAllTasks);
 
             checkArgument(plan.getFragment().getPipelineExecutionStrategy() == UNGROUPED_EXECUTION);
-            stageSchedulers.put(stageId, simpleSourcePartitionedScheduler(stage, planNodeId, splitSource, placementPolicy, splitBatchSize));
+            stageSchedulers.put(stageId, newSourcePartitionedSchedulerAsStageScheduler(stage, planNodeId, splitSource, placementPolicy, splitBatchSize));
             bucketToPartition = Optional.of(new int[1]);
         }
         else if (partitioningHandle.equals(SCALED_WRITER_DISTRIBUTION)) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/StageExecutionStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StageExecutionStrategy.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.sql.planner.plan.PlanNodeId;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class StageExecutionStrategy
+{
+    private final Set<PlanNodeId> groupedExecutionScanNodes;
+
+    private StageExecutionStrategy(Set<PlanNodeId> groupedExecutionScanNodes)
+    {
+        this.groupedExecutionScanNodes = groupedExecutionScanNodes;
+    }
+
+    public static StageExecutionStrategy ungroupedExecution()
+    {
+        return new StageExecutionStrategy(ImmutableSet.of());
+    }
+
+    public static StageExecutionStrategy groupedExecution(List<PlanNodeId> capableScanNodes)
+    {
+        requireNonNull(capableScanNodes, "capableScanNodes is null");
+        checkArgument(!capableScanNodes.isEmpty());
+        return new StageExecutionStrategy(ImmutableSet.copyOf(capableScanNodes));
+    }
+
+    public boolean isAnyScanGroupedExecution()
+    {
+        return !groupedExecutionScanNodes.isEmpty();
+    }
+
+    public boolean isGroupedExecution(PlanNodeId scanNodeId)
+    {
+        return groupedExecutionScanNodes.contains(scanNodeId);
+    }
+
+    @JsonCreator
+    public static StageExecutionStrategy jsonCreator(
+            @JsonProperty("groupedExecutionScanNodes") Set<PlanNodeId> groupedExecutionCapableScanNodes)
+    {
+        return new StageExecutionStrategy(ImmutableSet.copyOf(requireNonNull(groupedExecutionCapableScanNodes, "groupedExecutionScanNodes is null")));
+    }
+
+    @JsonProperty("groupedExecutionScanNodes")
+    public Set<PlanNodeId> getJsonSerializableGroupedExecutionScanNodes()
+    {
+        return groupedExecutionScanNodes;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -121,10 +121,10 @@ public class QueryExplainer
         switch (planType) {
             case LOGICAL:
                 Plan plan = getLogicalPlan(session, statement, parameters);
-                return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), statsCalculator, costCalculator, session);
+                return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), statsCalculator, costCalculator, session, 0, false);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters);
-                return PlanPrinter.textDistributedPlan(subPlan, metadata.getFunctionRegistry(), statsCalculator, costCalculator, session);
+                return PlanPrinter.textDistributedPlan(subPlan, metadata.getFunctionRegistry(), statsCalculator, costCalculator, session, false);
             case IO:
                 return IOPlanPrinter.textIOPlan(getLogicalPlan(session, statement, parameters).getRoot(), metadata, session);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DistributedExecutionPlanner.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.operator.PipelineExecutionStrategy;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.split.SampledSplitSource;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.split.SplitSource;
@@ -60,7 +60,6 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 
-import static com.facebook.presto.operator.PipelineExecutionStrategy.GROUPED_EXECUTION;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -105,7 +104,7 @@ public class DistributedExecutionPlanner
         PlanFragment currentFragment = root.getFragment();
 
         // get splits for this fragment, this is lazy so split assignments aren't actually calculated here
-        Map<PlanNodeId, SplitSource> splitSources = currentFragment.getRoot().accept(new Visitor(session, currentFragment.getPipelineExecutionStrategy(), allSplitSources), null);
+        Map<PlanNodeId, SplitSource> splitSources = currentFragment.getRoot().accept(new Visitor(session, currentFragment.getStageExecutionStrategy(), allSplitSources), null);
 
         // create child stages
         ImmutableList.Builder<StageExecutionPlan> dependencies = ImmutableList.builder();
@@ -123,13 +122,13 @@ public class DistributedExecutionPlanner
             extends PlanVisitor<Map<PlanNodeId, SplitSource>, Void>
     {
         private final Session session;
-        private final PipelineExecutionStrategy pipelineExecutionStrategy;
+        private final StageExecutionStrategy stageExecutionStrategy;
         private final ImmutableList.Builder<SplitSource> splitSources;
 
-        private Visitor(Session session, PipelineExecutionStrategy pipelineExecutionStrategy, ImmutableList.Builder<SplitSource> allSplitSources)
+        private Visitor(Session session, StageExecutionStrategy stageExecutionStrategy, ImmutableList.Builder<SplitSource> allSplitSources)
         {
             this.session = session;
-            this.pipelineExecutionStrategy = pipelineExecutionStrategy;
+            this.stageExecutionStrategy = stageExecutionStrategy;
             this.splitSources = allSplitSources;
         }
 
@@ -146,7 +145,7 @@ public class DistributedExecutionPlanner
             SplitSource splitSource = splitManager.getSplits(
                     session,
                     node.getLayout().get(),
-                    pipelineExecutionStrategy == GROUPED_EXECUTION ? GROUPED_SCHEDULING : UNGROUPED_SCHEDULING);
+                    stageExecutionStrategy.isGroupedExecution(node.getId()) ? GROUPED_SCHEDULING : UNGROUPED_SCHEDULING);
 
             splitSources.add(splitSource);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragment.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.sql.planner;
 
-import com.facebook.presto.operator.PipelineExecutionStrategy;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.PlanNode;
@@ -50,7 +50,7 @@ public class PlanFragment
     private final Set<PlanNode> partitionedSourceNodes;
     private final List<RemoteSourceNode> remoteSourceNodes;
     private final PartitioningScheme partitioningScheme;
-    private final PipelineExecutionStrategy pipelineExecutionStrategy;
+    private final StageExecutionStrategy stageExecutionStrategy;
 
     @JsonCreator
     public PlanFragment(
@@ -60,7 +60,7 @@ public class PlanFragment
             @JsonProperty("partitioning") PartitioningHandle partitioning,
             @JsonProperty("partitionedSources") List<PlanNodeId> partitionedSources,
             @JsonProperty("partitioningScheme") PartitioningScheme partitioningScheme,
-            @JsonProperty("pipelineExecutionStrategy") PipelineExecutionStrategy pipelineExecutionStrategy)
+            @JsonProperty("stageExecutionStrategy") StageExecutionStrategy stageExecutionStrategy)
     {
         this.id = requireNonNull(id, "id is null");
         this.root = requireNonNull(root, "root is null");
@@ -68,7 +68,7 @@ public class PlanFragment
         this.partitioning = requireNonNull(partitioning, "partitioning is null");
         this.partitionedSources = ImmutableList.copyOf(requireNonNull(partitionedSources, "partitionedSources is null"));
         this.partitionedSourcesSet = ImmutableSet.copyOf(partitionedSources);
-        this.pipelineExecutionStrategy = pipelineExecutionStrategy;
+        this.stageExecutionStrategy = requireNonNull(stageExecutionStrategy, "stageExecutionStrategy is null");
 
         checkArgument(partitionedSourcesSet.size() == partitionedSources.size(), "partitionedSources contains duplicates");
         checkArgument(ImmutableSet.copyOf(root.getOutputSymbols()).containsAll(partitioningScheme.getOutputLayout()),
@@ -129,9 +129,9 @@ public class PlanFragment
     }
 
     @JsonProperty
-    public PipelineExecutionStrategy getPipelineExecutionStrategy()
+    public StageExecutionStrategy getStageExecutionStrategy()
     {
-        return pipelineExecutionStrategy;
+        return stageExecutionStrategy;
     }
 
     public List<Type> getTypes()
@@ -185,12 +185,12 @@ public class PlanFragment
 
     public PlanFragment withBucketToPartition(Optional<int[]> bucketToPartition)
     {
-        return new PlanFragment(id, root, symbols, partitioning, partitionedSources, partitioningScheme.withBucketToPartition(bucketToPartition), pipelineExecutionStrategy);
+        return new PlanFragment(id, root, symbols, partitioning, partitionedSources, partitioningScheme.withBucketToPartition(bucketToPartition), stageExecutionStrategy);
     }
 
-    public PlanFragment withGroupedExecution(PipelineExecutionStrategy pipelineExecutionStrategy)
+    public PlanFragment withGroupedExecution(List<PlanNodeId> capableTableScanNodes)
     {
-        return new PlanFragment(id, root, symbols, partitioning, partitionedSources, partitioningScheme, pipelineExecutionStrategy);
+        return new PlanFragment(id, root, symbols, partitioning, partitionedSources, partitioningScheme, StageExecutionStrategy.groupedExecution(capableTableScanNodes));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -29,6 +29,7 @@ import com.facebook.presto.metadata.FunctionRegistry;
 import com.facebook.presto.metadata.OperatorNotFoundException;
 import com.facebook.presto.metadata.Signature;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.predicate.Domain;
@@ -122,7 +123,6 @@ import java.util.stream.Stream;
 import static com.facebook.presto.cost.PlanNodeCostEstimate.UNKNOWN_COST;
 import static com.facebook.presto.cost.PlanNodeStatsEstimate.UNKNOWN_STATS;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
-import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.planPrinter.PlanNodeStatsSummarizer.aggregatePlanNodeStats;
@@ -352,7 +352,7 @@ public class PlanPrinter
                     Joiner.on(", ").join(arguments),
                     formatHash(partitioningScheme.getHashColumn())));
         }
-        builder.append(indentString(1)).append(format("Execution Flow: %s\n", fragment.getPipelineExecutionStrategy()));
+        builder.append(indentString(1)).append(format("Grouped Execution: %s\n", fragment.getStageExecutionStrategy().isAnyScanGroupedExecution()));
 
         if (stageInfo.isPresent()) {
             builder.append(textLogicalPlan(fragment.getRoot(), TypeProvider.copyOf(fragment.getSymbols()), functionRegistry, statsCalculator, costCalculator, session, planNodeStats.get(), 1, verbose))
@@ -375,7 +375,7 @@ public class PlanPrinter
                 SINGLE_DISTRIBUTION,
                 ImmutableList.of(plan.getId()),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), plan.getOutputSymbols()),
-                UNGROUPED_EXECUTION);
+                StageExecutionStrategy.ungroupedExecution());
         return GraphvizPrinter.printLogical(ImmutableList.of(fragment));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -663,7 +663,7 @@ public class LocalQueryRunner
         Plan plan = createPlan(session, sql);
 
         if (printPlan) {
-            System.out.println(PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), statsCalculator, estimatedExchangesCostCalculator, session));
+            System.out.println(PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), statsCalculator, estimatedExchangesCostCalculator, session, 0, false));
         }
 
         SubPlan subplan = planFragmenter.createSubPlans(session, metadata, nodePartitioningManager, plan, true);

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -24,6 +24,7 @@ import com.facebook.presto.memory.MemoryPool;
 import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spi.Node;
@@ -76,7 +77,6 @@ import static com.facebook.presto.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.execution.StateMachine.StateChangeListener;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
-import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
@@ -119,7 +119,7 @@ public class MockRemoteTaskFactory
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(sourceId),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
-                UNGROUPED_EXECUTION);
+                StageExecutionStrategy.ungroupedExecution());
 
         ImmutableMultimap.Builder<PlanNodeId, Split> initialSplits = ImmutableMultimap.builder();
         for (Split sourceSplit : splits) {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -34,6 +34,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.PagesIndex;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -72,7 +73,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
-import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
@@ -112,7 +112,7 @@ public final class TaskTestUtils
             ImmutableList.of(TABLE_SCAN_NODE_ID),
             new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(SYMBOL))
                     .withBucketToPartition(Optional.of(new int[1])),
-            UNGROUPED_EXECUTION);
+            StageExecutionStrategy.ungroupedExecution());
 
     public static LocalExecutionPlanner createTestingPlanner()
     {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -37,6 +37,7 @@ import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.PipelineExecutionStrategy;
 import com.facebook.presto.operator.SourceOperator;
 import com.facebook.presto.operator.SourceOperatorFactory;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskOutputOperator.TaskOutputOperatorFactory;
 import com.facebook.presto.operator.ValuesOperator.ValuesOperatorFactory;
@@ -166,7 +167,8 @@ public class TestSqlTaskExecution
                             ImmutableList.of(testingScanOperatorFactory, taskOutputOperatorFactory),
                             OptionalInt.empty(),
                             executionStrategy)),
-                    ImmutableList.of(TABLE_SCAN_NODE_ID));
+                    ImmutableList.of(TABLE_SCAN_NODE_ID),
+                    executionStrategy == GROUPED_EXECUTION ? StageExecutionStrategy.groupedExecution(ImmutableList.of(TABLE_SCAN_NODE_ID)) : StageExecutionStrategy.ungroupedExecution());
             TaskContext taskContext = newTestingTaskContext(taskNotificationExecutor, driverYieldExecutor, taskStateMachine);
             SqlTaskExecution sqlTaskExecution = SqlTaskExecution.createSqlTaskExecution(
                     taskStateMachine,
@@ -416,7 +418,8 @@ public class TestSqlTaskExecution
                                     ImmutableList.of(valuesOperatorFactory3, buildOperatorFactoryC),
                                     OptionalInt.empty(),
                                     UNGROUPED_EXECUTION)),
-                    ImmutableList.of(scan2NodeId, scan0NodeId));
+                    ImmutableList.of(scan2NodeId, scan0NodeId),
+                    executionStrategy == GROUPED_EXECUTION ? StageExecutionStrategy.groupedExecution(ImmutableList.of(scan0NodeId, scan2NodeId)) : StageExecutionStrategy.ungroupedExecution());
             TaskContext taskContext = newTestingTaskContext(taskNotificationExecutor, driverYieldExecutor, taskStateMachine);
             SqlTaskExecution sqlTaskExecution = SqlTaskExecution.createSqlTaskExecution(
                     taskStateMachine,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.execution.scheduler.SplitSchedulerStats;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
@@ -33,7 +34,6 @@ import java.sql.SQLException;
 import java.util.concurrent.ExecutorService;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
-import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
@@ -330,7 +330,7 @@ public class TestStageStateMachine
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(valuesNodeId),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
-                UNGROUPED_EXECUTION);
+                StageExecutionStrategy.ungroupedExecution());
 
         return planFragment;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.Partitioning;
@@ -41,7 +42,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
@@ -255,6 +255,6 @@ public class TestPhasedExecutionSchedule
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(planNode.getId()),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), planNode.getOutputSymbols()),
-                UNGROUPED_EXECUTION);
+                StageExecutionStrategy.ungroupedExecution());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -29,6 +29,7 @@ import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.PrestoNode;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.FixedSplitSource;
@@ -75,7 +76,6 @@ import static com.facebook.presto.OutputBuffers.BufferType.PARTITIONED;
 import static com.facebook.presto.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.newSourcePartitionedSchedulerAsStageScheduler;
-import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
@@ -456,7 +456,7 @@ public class TestSourcePartitionedScheduler
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(tableScanNodeId),
                 new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
-                UNGROUPED_EXECUTION);
+                StageExecutionStrategy.ungroupedExecution());
 
         return new StageExecutionPlan(
                 testFragment,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -185,7 +185,7 @@ public class RuleAssert
 
     private String formatPlan(PlanNode plan, TypeProvider types)
     {
-        return inTransaction(session -> textLogicalPlan(plan, types, metadata.getFunctionRegistry(), statsCalculator, costCalculator, session, 2));
+        return inTransaction(session -> textLogicalPlan(plan, types, metadata.getFunctionRegistry(), statsCalculator, costCalculator, session, 2, false));
     }
 
     private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/PlanDeterminismChecker.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/PlanDeterminismChecker.java
@@ -68,7 +68,9 @@ public class PlanDeterminismChecker
                     localQueryRunner.getMetadata().getFunctionRegistry(),
                     localQueryRunner.getStatsCalculator(),
                     localQueryRunner.getCostCalculator(),
-                    transactionSession);
+                    transactionSession,
+                    0,
+                    false);
         });
     }
 }


### PR DESCRIPTION
Depends on #11261. Please skip the first commit in this PR during review.

Previously, grouped execution was determined on a per-fragment basis. This lead to two issues:

* LocalExecutionPlanner has been making additional determinations about planning that conceptually should happen in planner on the coordinator.
* Take a query with a plan like the following (letter represents whether it be executed in a grouped manner. This plan requires different execution strategy on an individual scan node basis for both SourceScheduler and LocalExecutionPlanner. Therefore, the determination has to happen on the coordinator.

```
                    J
                   / \
                  J   TS
                 / \  (y)
               TS   J
              (y)  / \
                 TS   TS
                 (y)  (n)