### PR TITLE
Remove StreamReader local buffers and performance improvement

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
@@ -31,13 +31,12 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class BooleanStreamReader
@@ -108,23 +107,14 @@ public class BooleanStreamReader
             dataStream.getSetBits(type, nextBatchSize, builder);
         }
         else {
-            assureVectorSize();
-
-            while (nextBatchSize > 0) {
-                int subBatchSize = min(nextBatchSize, MAX_BATCH_SIZE);
-                int nullValues = presentStream.getUnsetBits(subBatchSize, nullVector);
-                if (nullValues != subBatchSize) {
-                    if (dataStream == null) {
-                        throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
-                    }
-                    dataStream.getSetBits(type, subBatchSize, builder, nullVector);
+            for (int i = 0; i < nextBatchSize; i++) {
+                if (presentStream.nextBit()) {
+                    verify(dataStream != null);
+                    type.writeBoolean(builder, dataStream.nextBit());
                 }
                 else {
-                    for (int i = 0; i < subBatchSize; i++) {
-                        builder.appendNull();
-                    }
+                    builder.appendNull();
                 }
-                nextBatchSize -= subBatchSize;
             }
         }
 
@@ -132,15 +122,6 @@ public class BooleanStreamReader
         nextBatchSize = 0;
 
         return builder.build();
-    }
-
-    private void assureVectorSize()
-    {
-        int requiredVectorLength = min(nextBatchSize, MAX_BATCH_SIZE);
-        if (nullVector.length < requiredVectorLength) {
-            nullVector = new boolean[requiredVectorLength];
-            systemMemoryContext.setBytes(getRetainedSizeInBytes());
-        }
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
@@ -32,13 +32,12 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class ByteStreamReader
@@ -109,23 +108,14 @@ public class ByteStreamReader
             dataStream.nextVector(type, nextBatchSize, builder);
         }
         else {
-            assureVectorSize();
-
-            while (nextBatchSize > 0) {
-                int subBatchSize = min(nextBatchSize, MAX_BATCH_SIZE);
-                int nullValues = presentStream.getUnsetBits(subBatchSize, nullVector);
-                if (nullValues != subBatchSize) {
-                    if (dataStream == null) {
-                        throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
-                    }
-                    dataStream.nextVector(type, subBatchSize, builder, nullVector);
+            for (int i = 0; i < nextBatchSize; i++) {
+                if (presentStream.nextBit()) {
+                    verify(dataStream != null);
+                    type.writeLong(builder, dataStream.next());
                 }
                 else {
-                    for (int i = 0; i < subBatchSize; i++) {
-                        builder.appendNull();
-                    }
+                    builder.appendNull();
                 }
-                nextBatchSize -= subBatchSize;
             }
         }
 
@@ -133,15 +123,6 @@ public class ByteStreamReader
         nextBatchSize = 0;
 
         return builder.build();
-    }
-
-    private void assureVectorSize()
-    {
-        int requiredVectorLength = min(nextBatchSize, MAX_BATCH_SIZE);
-        if (nullVector.length < requiredVectorLength) {
-            nullVector = new boolean[requiredVectorLength];
-            systemMemoryContext.setBytes(getRetainedSizeInBytes());
-        }
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
@@ -32,13 +32,12 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class DoubleStreamReader
@@ -109,23 +108,14 @@ public class DoubleStreamReader
             dataStream.nextVector(type, nextBatchSize, builder);
         }
         else {
-            assureVectorSize();
-
-            while (nextBatchSize > 0) {
-                int subBatchSize = min(nextBatchSize, MAX_BATCH_SIZE);
-                int nullValues = presentStream.getUnsetBits(subBatchSize, nullVector);
-                if (nullValues != subBatchSize) {
-                    if (dataStream == null) {
-                        throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
-                    }
-                    dataStream.nextVector(type, subBatchSize, builder, nullVector);
+            for (int i = 0; i < nextBatchSize; i++) {
+                if (presentStream.nextBit()) {
+                    verify(dataStream != null);
+                    type.writeDouble(builder, dataStream.next());
                 }
                 else {
-                    for (int i = 0; i < subBatchSize; i++) {
-                        builder.appendNull();
-                    }
+                    builder.appendNull();
                 }
-                nextBatchSize -= subBatchSize;
             }
         }
 
@@ -133,15 +123,6 @@ public class DoubleStreamReader
         nextBatchSize = 0;
 
         return builder.build();
-    }
-
-    private void assureVectorSize()
-    {
-        int requiredVectorLength = min(nextBatchSize, MAX_BATCH_SIZE);
-        if (nullVector.length < requiredVectorLength) {
-            nullVector = new boolean[requiredVectorLength];
-            systemMemoryContext.setBytes(getRetainedSizeInBytes());
-        }
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryStreamReader.java
@@ -30,10 +30,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_DICTIONARY;
@@ -41,7 +39,6 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class LongDictionaryStreamReader
@@ -123,64 +120,62 @@ public class LongDictionaryStreamReader
             }
         }
 
-        assureVectorSize();
-
         BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
-        while (nextBatchSize > 0) {
-            int subBatchSize = min(nextBatchSize, MAX_BATCH_SIZE);
-            if (presentStream == null) {
-                if (dataStream == null) {
+
+        if (presentStream == null) {
+            // Data doesn't have nulls
+            if (dataStream == null) {
+                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
+            }
+            if (inDictionaryStream == null) {
+                for (int i = 0; i < nextBatchSize; i++) {
+                    type.writeLong(builder, dictionary[((int) dataStream.next())]);
+                }
+            }
+            else {
+                for (int i = 0; i < nextBatchSize; i++) {
+                    long id = dataStream.next();
+                    if (inDictionaryStream.nextBit()) {
+                        type.writeLong(builder, dictionary[(int) id]);
+                    }
+                    else {
+                        type.writeLong(builder, id);
+                    }
+                }
+            }
+        }
+        else {
+            // Data has nulls
+            if (dataStream == null) {
+                // The only valid case for dataStream is null when data has nulls is that all values are nulls.
+                int nullValues = presentStream.getUnsetBits(nextBatchSize);
+                if (nullValues != nextBatchSize) {
                     throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
                 }
-                Arrays.fill(nullVector, false);
-                dataStream.nextLongVector(subBatchSize, dataVector);
-            }
-            else {
-                int nullValues = presentStream.getUnsetBits(subBatchSize, nullVector);
-                if (nullValues != subBatchSize) {
-                    if (dataStream == null) {
-                        throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
-                    }
-                    dataStream.nextLongVector(subBatchSize, dataVector, nullVector);
-                }
-            }
-
-            if (inDictionaryStream == null) {
-                Arrays.fill(inDictionaryVector, true);
-            }
-            else {
-                inDictionaryStream.getSetBits(subBatchSize, inDictionaryVector, nullVector);
-            }
-
-            for (int i = 0; i < subBatchSize; i++) {
-                if (nullVector[i]) {
+                for (int i = 0; i < nextBatchSize; i++) {
                     builder.appendNull();
                 }
-                else if (inDictionaryVector[i]) {
-                    type.writeLong(builder, dictionary[((int) dataVector[i])]);
-                }
-                else {
-                    type.writeLong(builder, dataVector[i]);
+            }
+            else {
+                for (int i = 0; i < nextBatchSize; i++) {
+                    if (!presentStream.nextBit()) {
+                        builder.appendNull();
+                    }
+                    else {
+                        long id = dataStream.next();
+                        if (inDictionaryStream == null || inDictionaryStream.nextBit()) {
+                            type.writeLong(builder, dictionary[(int) id]);
+                        }
+                        else {
+                            type.writeLong(builder, id);
+                        }
+                    }
                 }
             }
-            nextBatchSize -= subBatchSize;
         }
         readOffset = 0;
         nextBatchSize = 0;
-
         return builder.build();
-    }
-
-    private void assureVectorSize()
-    {
-        int requiredVectorLength = min(nextBatchSize, MAX_BATCH_SIZE);
-        // nullVector, dataVector and inDictionary should be of the same length
-        if (nullVector.length < requiredVectorLength) {
-            nullVector = new boolean[requiredVectorLength];
-            dataVector = new long[requiredVectorLength];
-            inDictionaryVector = new boolean[requiredVectorLength];
-            systemMemoryContext.setBytes(getRetainedSizeInBytes());
-        }
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
@@ -32,13 +32,12 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class LongDirectStreamReader
@@ -109,23 +108,14 @@ public class LongDirectStreamReader
             dataStream.nextLongVector(type, nextBatchSize, builder);
         }
         else {
-            assureVectorSize();
-
-            while (nextBatchSize > 0) {
-                int subBatchSize = min(nextBatchSize, MAX_BATCH_SIZE);
-                int nullValues = presentStream.getUnsetBits(subBatchSize, nullVector);
-                if (nullValues != subBatchSize) {
-                    if (dataStream == null) {
-                        throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
-                    }
-                    dataStream.nextLongVector(type, subBatchSize, builder, nullVector);
+            for (int i = 0; i < nextBatchSize; i++) {
+                if (presentStream.nextBit()) {
+                    verify(dataStream != null);
+                    type.writeLong(builder, dataStream.next());
                 }
                 else {
-                    for (int i = 0; i < subBatchSize; i++) {
-                        builder.appendNull();
-                    }
+                    builder.appendNull();
                 }
-                nextBatchSize -= subBatchSize;
             }
         }
 
@@ -133,15 +123,6 @@ public class LongDirectStreamReader
         nextBatchSize = 0;
 
         return builder.build();
-    }
-
-    private void assureVectorSize()
-    {
-        int requiredVectorLength = min(nextBatchSize, MAX_BATCH_SIZE);
-        if (nullVector.length < requiredVectorLength) {
-            nullVector = new boolean[requiredVectorLength];
-            systemMemoryContext.setBytes(getRetainedSizeInBytes());
-        }
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanInputStream.java
@@ -128,61 +128,11 @@ public class BooleanInputStream
     /**
      * Sets the vector element to true if the bit is set.
      */
-    public void getSetBits(int batchSize, boolean[] vector)
-            throws IOException
-    {
-        for (int i = 0; i < batchSize; i++) {
-            vector[i] = nextBit();
-        }
-    }
-
-    /**
-     * Sets the vector element to true if the bit is set, skipping the null values.
-     */
-    public void getSetBits(int batchSize, boolean[] vector, boolean[] isNull)
-            throws IOException
-    {
-        for (int i = 0; i < batchSize; i++) {
-            if (!isNull[i]) {
-                vector[i] = nextBit();
-            }
-        }
-    }
-
-    /**
-     * Sets the vector element to true if the bit is set.
-     */
     public void getSetBits(Type type, int batchSize, BlockBuilder builder)
             throws IOException
     {
         for (int i = 0; i < batchSize; i++) {
             type.writeBoolean(builder, nextBit());
-        }
-    }
-
-    /**
-     * Sets the vector element to true if the bit is set, skipping the null values.
-     */
-    public void getSetBits(Type type, int batchSize, BlockBuilder builder, boolean[] isNull)
-            throws IOException
-    {
-        getSetBits(type, batchSize, builder, isNull, 0);
-    }
-
-    /**
-     * Sets the vector element to true for the batchSize number of elements starting at offset
-     * if the bit is set, skipping the null values.
-     */
-    public void getSetBits(Type type, int batchSize, BlockBuilder builder, boolean[] isNull, int offset)
-            throws IOException
-    {
-        for (int i = offset; i < batchSize + offset; i++) {
-            if (isNull[i]) {
-                builder.appendNull();
-            }
-            else {
-                type.writeBoolean(builder, nextBit());
-            }
         }
     }
 
@@ -206,6 +156,19 @@ public class BooleanInputStream
         for (int i = offset; i < batchSize + offset; i++) {
             vector[i] = !nextBit();
             count += vector[i] ? 1 : 0;
+        }
+        return count;
+    }
+
+    /**
+     * Return the number of unset bits
+     */
+    public int getUnsetBits(int batchSize)
+            throws IOException
+    {
+        int count = 0;
+        for (int i = 0; i < batchSize; i++) {
+            count += nextBit() ? 0 : 1;
         }
         return count;
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteInputStream.java
@@ -126,17 +126,4 @@ public class ByteInputStream
             type.writeLong(builder, next());
         }
     }
-
-    public void nextVector(Type type, long items, BlockBuilder builder, boolean[] isNull)
-            throws IOException
-    {
-        for (int i = 0; i < items; i++) {
-            if (isNull[i]) {
-                builder.appendNull();
-            }
-            else {
-                type.writeLong(builder, next());
-            }
-        }
-    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalInputStream.java
@@ -23,7 +23,6 @@ import io.airlift.slice.Slice;
 
 import java.io.IOException;
 
-import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.rescale;
 import static java.lang.Long.MAX_VALUE;
 
 public class DecimalInputStream
@@ -95,35 +94,6 @@ public class DecimalInputStream
         }
 
         UnscaledDecimal128Arithmetic.pack(low, high, negative, result);
-    }
-
-    public void nextLongDecimalVector(int items, BlockBuilder builder, DecimalType targetType, long[] sourceScale)
-            throws IOException
-    {
-        Slice decimal = UnscaledDecimal128Arithmetic.unscaledDecimal();
-        Slice rescaledDecimal = UnscaledDecimal128Arithmetic.unscaledDecimal();
-        for (int i = 0; i < items; i++) {
-            nextLongDecimal(decimal);
-            rescale(decimal, (int) (targetType.getScale() - sourceScale[i]), rescaledDecimal);
-            targetType.writeSlice(builder, rescaledDecimal);
-        }
-    }
-
-    public void nextLongDecimalVector(int items, BlockBuilder builder, DecimalType targetType, long[] sourceScale, boolean[] isNull)
-            throws IOException
-    {
-        Slice decimal = UnscaledDecimal128Arithmetic.unscaledDecimal();
-        Slice rescaledDecimal = UnscaledDecimal128Arithmetic.unscaledDecimal();
-        for (int i = 0; i < items; i++) {
-            if (!isNull[i]) {
-                nextLongDecimal(decimal);
-                rescale(decimal, (int) (targetType.getScale() - sourceScale[i]), rescaledDecimal);
-                targetType.writeSlice(builder, rescaledDecimal);
-            }
-            else {
-                builder.appendNull();
-            }
-        }
     }
 
     public long nextLong()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
@@ -70,17 +70,4 @@ public class DoubleInputStream
             type.writeDouble(builder, next());
         }
     }
-
-    public void nextVector(Type type, long items, BlockBuilder builder, boolean[] isNull)
-            throws IOException
-    {
-        for (int i = 0; i < items; i++) {
-            if (isNull[i]) {
-                builder.appendNull();
-            }
-            else {
-                type.writeDouble(builder, next());
-            }
-        }
-    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
@@ -71,17 +71,4 @@ public class FloatInputStream
             type.writeLong(builder, floatToRawIntBits(next()));
         }
     }
-
-    public void nextVector(Type type, long items, BlockBuilder builder, boolean[] isNull)
-            throws IOException
-    {
-        for (int i = 0; i < items; i++) {
-            if (isNull[i]) {
-                builder.appendNull();
-            }
-            else {
-                type.writeLong(builder, floatToRawIntBits(next()));
-            }
-        }
-    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
@@ -61,37 +61,11 @@ public interface LongInputStream
         }
     }
 
-    default void nextLongVector(int items, long[] vector, boolean[] isNull)
-            throws IOException
-    {
-        checkPositionIndex(items, vector.length);
-        checkPositionIndex(items, isNull.length);
-
-        for (int i = 0; i < items; i++) {
-            if (!isNull[i]) {
-                vector[i] = next();
-            }
-        }
-    }
-
     default void nextLongVector(Type type, int items, BlockBuilder builder)
             throws IOException
     {
         for (int i = 0; i < items; i++) {
             type.writeLong(builder, next());
-        }
-    }
-
-    default void nextLongVector(Type type, int items, BlockBuilder builder, boolean[] isNull)
-            throws IOException
-    {
-        for (int i = 0; i < items; i++) {
-            if (isNull[i]) {
-                builder.appendNull();
-            }
-            else {
-                type.writeLong(builder, next());
-            }
         }
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkStreamReaders.java
@@ -1,0 +1,1109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.SqlDecimal;
+import com.facebook.presto.spi.type.SqlTimestamp;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
+import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
+import static com.facebook.presto.orc.OrcTester.writeOrcColumnHive;
+import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.io.Files.createTempDir;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.joda.time.DateTimeZone.UTC;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(3)
+@Warmup(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkStreamReaders
+{
+    public static final DecimalType DECIMAL_TYPE = createDecimalType(10, 5);
+    public static final int ROWS = 10_000_000;
+
+    @Benchmark
+    public Object readBooleanNoNull(BooleanNoNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(BOOLEAN, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readBooleanWithNull(BooleanWithNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(BOOLEAN, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readByteNoNull(TinyIntNoNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(TINYINT, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readByteWithNull(TinyIntWithNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(TINYINT, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readDecimalNoNull(DecimalNoNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(DECIMAL_TYPE, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readDecimalWithNull(DecimalWithNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(DECIMAL_TYPE, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readDoubleNoNull(DoubleNoNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(DOUBLE, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readDoubleWithNull(DoubleWithNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(DOUBLE, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readFloatNoNull(FloatNoNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(REAL, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readFloatWithNull(FloatWithNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(REAL, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readLongDirectNoNull(BigintNoNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(BIGINT, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readLongDirectWithNull(BigintWithNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(BIGINT, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readSliceDictionaryNoNull(VarcharNoNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(VARCHAR, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readSliceDictionaryWithNull(VarcharWithNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(VARCHAR, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readTimestampNoNull(TimestampNoNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(TIMESTAMP, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @Benchmark
+    public Object readTimestampWithNull(TimestampWithNullBenchmarkData data)
+            throws Throwable
+    {
+        OrcRecordReader recordReader = data.createRecordReader();
+        List<Block> blocks = new ArrayList<>();
+        while (recordReader.nextBatch() > 0) {
+            Block block = recordReader.readBlock(TIMESTAMP, 0);
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BooleanNoNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File booleanNoNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            booleanNoNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(booleanNoNullFile, ORC_12, NONE, BOOLEAN, createBooleanValuesNoNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(booleanNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, BOOLEAN),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Boolean> createBooleanValuesNoNull()
+        {
+            List<Boolean> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(random.nextBoolean());
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BooleanWithNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File booleanWithNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            booleanWithNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(booleanWithNullFile, ORC_12, NONE, BOOLEAN, createBooleanValuesWithNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(booleanWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, BOOLEAN),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Boolean> createBooleanValuesWithNull()
+        {
+            List<Boolean> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(random.nextBoolean() ? random.nextBoolean() : null);
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class TinyIntNoNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File tinyIntNoNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            tinyIntNoNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(tinyIntNoNullFile, ORC_12, NONE, TINYINT, createTinyIntValuesNoNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(tinyIntNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, TINYINT),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Byte> createTinyIntValuesNoNull()
+        {
+            List<Byte> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(Long.valueOf(random.nextLong()).byteValue());
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class TinyIntWithNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File tinyIntWithNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            tinyIntWithNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(tinyIntWithNullFile, ORC_12, NONE, TINYINT, createTinyIntValuesWithNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(tinyIntWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, TINYINT),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Byte> createTinyIntValuesWithNull()
+        {
+            List<Byte> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(Long.valueOf(random.nextLong()).byteValue());
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class DecimalNoNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File decimalNoNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            decimalNoNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(decimalNoNullFile, ORC_12, NONE, DECIMAL_TYPE, createDecimalValuesNoNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(decimalNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, DECIMAL_TYPE),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<SqlDecimal> createDecimalValuesNoNull()
+        {
+            Random random = new Random();
+            List<SqlDecimal> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(new SqlDecimal(BigInteger.valueOf(random.nextLong() % 10000000000L), 10, 5));
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class DecimalWithNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File decimalWithNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            decimalWithNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(decimalWithNullFile, ORC_12, NONE, DECIMAL_TYPE, createDecimalValuesWithNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(decimalWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, DECIMAL_TYPE),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<SqlDecimal> createDecimalValuesWithNull()
+        {
+            Random random = new Random();
+            List<SqlDecimal> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(new SqlDecimal(BigInteger.valueOf(random.nextLong() % 10000000000L), 10, 5));
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class DoubleNoNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File doubleNoNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            doubleNoNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(doubleNoNullFile, ORC_12, NONE, DOUBLE, createDoubleValuesNoNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(doubleNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, DOUBLE),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Double> createDoubleValuesNoNull()
+        {
+            List<Double> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(Double.valueOf(random.nextDouble()));
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class DoubleWithNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File doubleWithNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            doubleWithNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(doubleWithNullFile, ORC_12, NONE, DOUBLE, createDoubleValuesWithNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(doubleWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, DOUBLE),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Double> createDoubleValuesWithNull()
+        {
+            List<Double> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(Double.valueOf(random.nextDouble()));
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class FloatNoNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File floatNoNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            floatNoNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(floatNoNullFile, ORC_12, NONE, REAL, createFloatValuesNoNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(floatNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, REAL),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Float> createFloatValuesNoNull()
+        {
+            List<Float> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(Float.valueOf(random.nextFloat()));
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class FloatWithNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File floatWithNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            floatWithNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(floatWithNullFile, ORC_12, NONE, REAL, createFloatValuesWithNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(floatWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, REAL),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Float> createFloatValuesWithNull()
+        {
+            List<Float> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(Float.valueOf(random.nextFloat()));
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BigintNoNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File bigintNoNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+
+            bigintNoNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(bigintNoNullFile, ORC_12, NONE, BIGINT, createBigintValuesNoNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(bigintNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, BIGINT),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Long> createBigintValuesNoNull()
+        {
+            List<Long> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(Long.valueOf(random.nextLong()));
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BigintWithNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File bigintWithNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            bigintWithNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(bigintWithNullFile, ORC_12, NONE, BIGINT, createBigintValuesWithNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(bigintWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, BIGINT),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<Long> createBigintValuesWithNull()
+        {
+            List<Long> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(Long.valueOf(random.nextLong()));
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class VarcharNoNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File varcharNoNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            varcharNoNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(varcharNoNullFile, ORC_12, NONE, VARCHAR, createVarcharValuesNoNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(varcharNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, VARCHAR),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<String> createVarcharValuesNoNull()
+        {
+            List<String> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(Strings.repeat("0", 4));
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class VarcharWithNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File varcharWithNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+            varcharWithNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(varcharWithNullFile, ORC_12, NONE, VARCHAR, createVarcharValuesWithNulls().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(varcharWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, VARCHAR),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<String> createVarcharValuesWithNulls()
+        {
+            Random random = new Random();
+            List<String> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(Strings.repeat("0", 4));
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class TimestampNoNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File timestampNoNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+
+            timestampNoNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(timestampNoNullFile, ORC_12, NONE, TIMESTAMP, createSqlTimeStampValuesNoNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(timestampNoNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, TIMESTAMP),
+                    OrcPredicate.TRUE,
+                    UTC, // arbitrary
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<SqlTimestamp> createSqlTimeStampValuesNoNull()
+        {
+            List<SqlTimestamp> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                values.add(new SqlTimestamp((random.nextLong()), UTC_KEY));
+            }
+            return values;
+        }
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class TimestampWithNullBenchmarkData
+    {
+        protected File temporaryDirectory;
+        protected File timestampWithNullFile;
+        private Random random;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            random = new Random(0);
+            temporaryDirectory = createTempDir();
+
+            timestampWithNullFile = new File(temporaryDirectory, randomUUID().toString());
+            writeOrcColumnHive(timestampWithNullFile, ORC_12, NONE, TIMESTAMP, createSqlTimestampValuesWithNull().iterator());
+        }
+
+        @TearDown
+        public void tearDown()
+                throws IOException
+        {
+            deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
+        }
+
+        private OrcRecordReader createRecordReader()
+                throws IOException
+        {
+            OrcDataSource dataSource = new FileOrcDataSource(timestampWithNullFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            OrcReader orcReader = new OrcReader(dataSource, ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE));
+            return orcReader.createRecordReader(
+                    ImmutableMap.of(0, TIMESTAMP),
+                    OrcPredicate.TRUE,
+                    UTC,
+                    newSimpleAggregatedMemoryContext(),
+                    INITIAL_BATCH_SIZE);
+        }
+
+        private List<SqlTimestamp> createSqlTimestampValuesWithNull()
+        {
+            List<SqlTimestamp> values = new ArrayList<>();
+            for (int i = 0; i < ROWS; ++i) {
+                if (random.nextBoolean()) {
+                    values.add(new SqlTimestamp(random.nextLong(), UTC_KEY));
+                }
+                else {
+                    values.add(null);
+                }
+            }
+            return values;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkStreamReaders.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
@@ -50,7 +50,6 @@ import static com.facebook.presto.spi.block.MethodHandleUtil.nativeValueGetter;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static io.airlift.testing.Assertions.assertGreaterThan;
-import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static org.testng.Assert.assertEquals;
 
 public class TestOrcReaderMemoryUsage
@@ -95,12 +94,11 @@ public class TestOrcReaderMemoryUsage
 
                 // StripeReader memory should increase after reading a block.
                 assertGreaterThan(reader.getCurrentStripeRetainedSizeInBytes(), stripeReaderRetainedSize);
-                // We also account for the StreamReader local buffers. For SliceDictionaryStreamReader, there are two
-                // buffers: isNullVector and inDictionaryVector, and each buffer has 1024 boolean values.
-                assertGreaterThanOrEqual(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 2048L);
-                // The total retained size and system memory usage should be strictly larger than 2048L because of the instance sizes.
-                assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 2048L);
-                assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 2048L);
+                // There are no local buffers needed.
+                assertEquals(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 0L);
+                // The total retained size and system memory usage should be greater than 0 byte because of the instance sizes.
+                assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 0L);
+                assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 0L);
             }
         }
         finally {
@@ -143,12 +141,11 @@ public class TestOrcReaderMemoryUsage
 
                 // StripeReader memory should increase after reading a block.
                 assertGreaterThan(reader.getCurrentStripeRetainedSizeInBytes(), stripeReaderRetainedSize);
-                // We also account for the StreamReader local buffers. For LongDirectStreamReader, there is one
-                // buffer isNullVector, and it has 1024 boolean values.
-                assertGreaterThanOrEqual(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 1024L);
-                // The total retained size and system memory usage should be strictly larger than 2048L because of the instance sizes.
-                assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 1024L);
-                assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 1024L);
+                // There are no local buffers needed.
+                assertEquals(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 0L);
+                // The total retained size and system memory usage should be strictly larger than 0L because of the instance sizes.
+                assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 0L);
+                assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 0L);
             }
         }
         finally {
@@ -208,13 +205,11 @@ public class TestOrcReaderMemoryUsage
 
                 // StripeReader memory should increase after reading a block.
                 assertGreaterThan(reader.getCurrentStripeRetainedSizeInBytes(), stripeReaderRetainedSize);
-                // We also account the StreamReader local buffers. For MapStreamReader, there is a
-                // keyStreamReader(LongStreamReader) and a valueStreamReader(LongStreamReader), and each of them is
-                // holding a isNullVector buffer which has 1024 boolean values.
-                assertGreaterThanOrEqual(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 2048L);
-                // The total retained size and system memory usage should be strictly larger than 2048L because of the instance sizes.
-                assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 2048L);
-                assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 2048L);
+                // There are no local buffers needed.
+                assertEquals(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 0L);
+                // The total retained size and system memory usage should be strictly larger than 0L because of the instance sizes.
+                assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 0L);
+                assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 0L);
             }
         }
         finally {


### PR DESCRIPTION
We used to use local buffers in the StreamReader's to temporarily hold
data temporarily read from input streams, e.g. the isNullVector and
the inDictionaryVector. The memory used by these local buffers is
not neglegible because there could be many StreamReader objects on a
worker node. These buffers could be eliminated by the following
changes:

1) When the underlying input streams are null, we don't need to keep
the buffers;
2) Reuse each value in these buffers when processing the data across
multiple streams.

It helps to improve the performance because it eliminates multiple
repeating data filtering (branching) on multiple input streams. It
also simplifies the code by removing the subBatchSize logic.

Below is the JMH microbenchmark results on reading 10M rows of
different types, with and without nulls. The unit is s/op. Each test
was ran on 3 forks, and 20 warm up runs and 20 real runs. It shows
performance improvements for most StreamReader's. The few regressed
ones were mostly run to run variations and not real regressions.

                               | Before| var | After | var |Improvement
    readBooleanNoNull          | 0.029 |0.001| 0.028 |0.001| 3%
    readBooleanWithNull        | 0.125 |0.001| 0.102 |0.001|18%
    readByteNoNull             | 0.035 |0.001| 0.033 |0.001| 6%
    readByteWithNull           | 0.108 |0.002| 0.115 |0.001|-6%
    readDecimalNoNull          | 0.505 |0.008| 0.510 |0.019|-1%
    readDecimalWithNull        | 0.400 |0.008| 0.362 |0.019|10%
    readDoubleNoNull           | 0.253 |0.004| 0.259 |0.004|-2%
    readDoubleWithNull         | 0.215 |0.003| 0.204 |0.008| 5%
    readFloatNoNull            | 0.246 |0.004| 0.239 |0.003| 3%
    readFloatWithNull          | 0.211 |0.003| 0.203 |0.002| 4%
    readLongDirectNoNull       | 0.071 |0.002| 0.071 |0.001| 0%
    readLongDirectWithNull     | 0.138 |0.003| 0.120 |0.002|13%
    readSliceDictionaryNoNull  | 0.046 |0.001| 0.034 |0.001|26%
    readSliceDictionaryWithNull| 0.146 |0.002| 0.108 |0.002|26%
    readTimestampNoNull        | 0.242 |0.007| 0.200 |0.003|17%
    readTimestampWithNull      | 0.289 |0.006| 0.185 |0.003|36%
