### PR TITLE
Issue-11277: Optimise InternalResourceGroup::enforceLimits

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -180,6 +180,18 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public Duration getElapsedTime()
+    {
+        return stateMachine.getElpasedTime();
+    }
+
+    @Override
+    public Duration getExecutionTime()
+    {
+        return stateMachine.getExecutionTime();
+    }
+
+    @Override
     public void cancelStage(StageId stageId)
     {
         // no-op

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -155,6 +155,18 @@ public class FailedQueryExecution
     }
 
     @Override
+    public Duration getElapsedTime()
+    {
+        return new Duration(0, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public Duration getExecutionTime()
+    {
+        return new Duration(0, TimeUnit.SECONDS);
+    }
+
+    @Override
     public void cancelStage(StageId stageId)
     {
         // no-op

--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryAwareQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryAwareQueryExecution.java
@@ -129,6 +129,18 @@ public class MemoryAwareQueryExecution
     }
 
     @Override
+    public Duration getElapsedTime()
+    {
+        return delegate.getElapsedTime();
+    }
+
+    @Override
+    public Duration getExecutionTime()
+    {
+        return delegate.getElapsedTime();
+    }
+
+    @Override
     public Session getSession()
     {
         return delegate.getSession();

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -66,6 +66,10 @@ public interface QueryExecution
 
     Duration getTotalCpuTime();
 
+    Duration getElapsedTime();
+
+    Duration getExecutionTime();
+
     Session getSession();
 
     void start();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -237,6 +237,18 @@ public class SqlQueryExecution
     }
 
     @Override
+    public Duration getElapsedTime()
+    {
+        return stateMachine.getElpasedTime();
+    }
+
+    @Override
+    public Duration getExecutionTime()
+    {
+        return stateMachine.getExecutionTime();
+    }
+
+    @Override
     public Duration getTotalCpuTime()
     {
         SqlQueryScheduler scheduler = queryScheduler.get();

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -844,13 +844,13 @@ public class InternalResourceGroup
                 group.enforceTimeLimits();
             }
             for (QueryExecution query : runningQueries) {
-                Duration runningTime = query.getQueryInfo().getQueryStats().getExecutionTime();
+                Duration runningTime = query.getExecutionTime();
                 if (runningQueries.contains(query) && runningTime != null && runningTime.compareTo(runningTimeLimit) > 0) {
                     query.fail(new PrestoException(EXCEEDED_TIME_LIMIT, "query exceeded resource group runtime limit"));
                 }
             }
             for (QueryExecution query : queuedQueries) {
-                Duration elapsedTime = query.getQueryInfo().getQueryStats().getElapsedTime();
+                Duration elapsedTime = query.getElapsedTime();
                 if (queuedQueries.contains(query) && elapsedTime != null && elapsedTime.compareTo(queuedTimeLimit) > 0) {
                     query.fail(new PrestoException(EXCEEDED_TIME_LIMIT, "query exceeded resource group queued time limit"));
                 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -32,6 +32,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static com.facebook.presto.SystemSessionProperties.QUERY_PRIORITY;
@@ -271,6 +272,18 @@ public class MockQueryExecution
     {
         state = FAILED;
         fireStateChange();
+    }
+
+    @Override
+    public Duration getElapsedTime()
+    {
+        return new Duration(0.0, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public Duration getExecutionTime()
+    {
+        return new Duration(0.0, TimeUnit.SECONDS);
     }
 
     @Override


### PR DESCRIPTION
"InternalResourceGroup::enforceLimits" mainly makes use of elpasedTime for the queries. However, as a part of retrieving this field, it ends up computing the entire stage info which can be optimized. Here is the flamegraph for the same.

<img width="1073" alt="internalresourcegroup_enforcelimits" src="https://user-images.githubusercontent.com/323339/44148507-4a13026e-a0b6-11e8-8021-374d05a5a2e5.png">
