### PR TITLE
Document geometry_union_agg function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -313,6 +313,10 @@ Aggregations
     Returns the minimum convex geometry that encloses all input geometries.
     This function doesn't support geometry collections.
 
+.. function:: geometry_union_agg(Geometry) -> Geometry
+
+    Returns a geometry that represents the point set union of all input geometries.
+
 Bing Tiles
 ----------
 


### PR DESCRIPTION
This line of documentation was missing in the original pull request (#11171).
This commit just adds the appropriate external documentation.

CC: @mbasmanova 