### PR TITLE
Allow creating table in Hive metastore on top of empty S3 folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1064,6 +1064,22 @@
                 <version>3.1.4-1</version>
             </dependency>
 
+            <dependency>
+                <groupId>io.findify</groupId>
+                <artifactId>s3mock_2.11</artifactId>
+                <version>0.2.5</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.iq80.leveldb</groupId>
+                        <artifactId>leveldb</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.amazonaws</groupId>
+                        <artifactId>aws-java-sdk-s3</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <!-- force newer version to be used for dependencies -->
             <dependency>
                 <groupId>org.javassist</groupId>
@@ -1219,6 +1235,17 @@
                         <exclude>**/*jmhTest*.java</exclude>
                         <exclude>**/*jmhType*.java</exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>reference.conf</ignoredResourcePattern>
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
                 </configuration>
             </plugin>
         </plugins>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -258,6 +258,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.findify</groupId>
+            <artifactId>s3mock_2.11</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- for benchmark -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystemWithS3Mock.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystemWithS3Mock.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import io.findify.s3mock.S3Mock;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.UUID;
+
+import static com.facebook.presto.testing.TestngUtils.findUnusedPort;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestPrestoS3FileSystemWithS3Mock
+{
+    private S3Mock api;
+    private AwsClientBuilder.EndpointConfiguration endpoint;
+
+    @BeforeClass
+    public void beforeClass()
+            throws IOException
+    {
+        int port = findUnusedPort();
+        api = new S3Mock.Builder().withPort(port).withInMemoryBackend().build();
+        endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:" + port, "us-west-2");
+        api.start();
+    }
+
+    @AfterClass
+    public void afterTest()
+    {
+        api.shutdown();
+    }
+
+    @Test
+    public void testExistsBucket()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String emptyBucket = randomBucketName();
+        final String bucketWithDir = randomBucketName();
+        final String bucketWithFile = randomBucketName();
+        client.createBucket(emptyBucket);
+        client.createBucket(bucketWithDir);
+        client.createBucket(bucketWithFile);
+        createFolder(bucketWithDir, "dir", client);
+        client.putObject(bucketWithFile, "file.txt", "content");
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(format("s3n://%s/", emptyBucket)), new Configuration());
+            fs.setS3Client(client);
+            assertTrue(fs.exists(new Path(format("s3n://%s", emptyBucket))));
+            assertTrue(fs.exists(new Path(format("s3n://%s/", emptyBucket))));
+            assertTrue(fs.exists(new Path("/")));
+
+            fs.initialize(new URI(format("s3n://%s/", bucketWithDir)), new Configuration());
+            fs.setS3Client(client);
+            assertTrue(fs.exists(new Path(format("s3n://%s", bucketWithDir))));
+            assertTrue(fs.exists(new Path(format("s3n://%s/", bucketWithDir))));
+            assertTrue(fs.exists(new Path("/")));
+
+            fs.initialize(new URI(format("s3n://%s/", bucketWithFile)), new Configuration());
+            fs.setS3Client(client);
+            assertTrue(fs.exists(new Path(format("s3n://%s", bucketWithFile))));
+            assertTrue(fs.exists(new Path(format("s3n://%s/", bucketWithFile))));
+            assertTrue(fs.exists(new Path("/")));
+
+            fs.initialize(new URI("s3n://unknown-bucket/"), new Configuration());
+            fs.setS3Client(client);
+            assertFalse(fs.exists(new Path("s3n://unknown-bucket")));
+            assertFalse(fs.exists(new Path("s3n://unknown-bucket/")));
+            assertFalse(fs.exists(new Path("/")));
+        }
+    }
+
+    @Test
+    public void testExistsDirectory()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+        createFolder(testBucket, "empty-dir", client);
+        client.putObject(testBucket, "dir-with-file/file.txt", "content");
+        createFolder(testBucket, "dir-with-dir/dir", client);
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+            assertTrue(fs.exists(new Path(testBucketPath + "/empty-dir")));
+            assertTrue(fs.exists(new Path(testBucketPath + "/empty-dir/")));
+
+            assertTrue(fs.exists(new Path(testBucketPath + "/dir-with-file")));
+            assertTrue(fs.exists(new Path(testBucketPath + "/dir-with-file/")));
+
+            assertTrue(fs.exists(new Path(testBucketPath + "/dir-with-dir")));
+            assertTrue(fs.exists(new Path(testBucketPath + "/dir-with-dir/")));
+
+            assertFalse(fs.exists(new Path(testBucketPath + "/unknown-dir")));
+            assertFalse(fs.exists(new Path(testBucketPath + "/unknown-dir/")));
+        }
+    }
+
+    @Test
+    public void testExistsFile()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+        client.putObject(testBucket, "dir/file-inside-dir.txt", "content");
+        client.putObject(testBucket, "file-inside-bucket.txt", "content");
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+
+            assertTrue(fs.exists(new Path(testBucketPath + "/dir/file-inside-dir.txt")));
+            assertTrue(fs.exists(new Path(testBucketPath + "/file-inside-bucket.txt")));
+            assertFalse(fs.exists(new Path(testBucketPath + "/unknown-file.txt")));
+        }
+    }
+
+    @Test
+    public void testFileStatusEmpty()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+        createFolder(testBucket, "test", client);
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+            FileStatus fileStatus = fs.getFileStatus(new Path(testBucketPath + "/test"));
+            assertTrue(fileStatus.isDirectory());
+        }
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void testFileStatusNotFound()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+            fs.getFileStatus(new Path(testBucketPath + "/test"));
+        }
+    }
+
+    @Test
+    public void testFileStatusWithDir()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+        createFolder(testBucket, "test/dir", client);
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+            FileStatus fileStatus = fs.getFileStatus(new Path(testBucketPath + "/test"));
+            assertTrue(fileStatus.isDirectory());
+        }
+    }
+
+    @Test
+    public void testFileStatusWithFile()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+        client.putObject(testBucket, "test/dir/file", "content");
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+            FileStatus fileStatus = fs.getFileStatus(new Path(testBucketPath + "/test"));
+            assertTrue(fileStatus.isDirectory());
+        }
+    }
+
+    @Test
+    public void testListPrefix()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+        client.putObject(testBucket, "test/dir/file1", "content");
+        client.putObject(testBucket, "test/dir/file2", "content");
+        client.putObject(testBucket, "test/dir/file3", "content");
+        client.putObject(testBucket, "test/dir2/file4", "content");
+        client.putObject(testBucket, "test/dir3/file5", "content");
+        client.putObject(testBucket, "test/file6", "content");
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+            Iterator<LocatedFileStatus> fileStatuses = fs.listPrefix(new Path(testBucketPath + "/test"));
+            int dirCount = 0;
+            int fileCount = 0;
+            while (fileStatuses.hasNext()) {
+                if (fileStatuses.next().isDirectory()) {
+                    dirCount++;
+                }
+                else {
+                    fileCount++;
+                }
+            }
+            assertEquals(dirCount, 3);
+            assertEquals(fileCount, 1);
+        }
+    }
+
+    @Test
+    public void testListPrefixBucket()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+        client.putObject(testBucket, "test/dir/file1", "content");
+        client.putObject(testBucket, "test/dir/file2", "content");
+        client.putObject(testBucket, "test/dir/file3", "content");
+        client.putObject(testBucket, "test/dir2/file4", "content");
+        client.putObject(testBucket, "test/dir3/file5", "content");
+        client.putObject(testBucket, "test/file6", "content");
+        client.putObject(testBucket, "file7", "content");
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+            Iterator<LocatedFileStatus> fileStatuses = fs.listPrefix(new Path(testBucketPath));
+            int dirCount = 0;
+            int fileCount = 0;
+            while (fileStatuses.hasNext()) {
+                if (fileStatuses.next().isDirectory()) {
+                    dirCount++;
+                }
+                else {
+                    fileCount++;
+                }
+            }
+            assertEquals(dirCount, 1);
+            assertEquals(fileCount, 1);
+        }
+    }
+
+    @Test
+    public void testListPrefixEmptyDir()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+        createFolder(testBucket, "test", client);
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+            Iterator<LocatedFileStatus> fileStatuses = fs.listPrefix(new Path(testBucketPath + "/test"));
+            assertFalse(fileStatuses.hasNext());
+        }
+    }
+
+    @Test
+    public void testListPrefixNotFound()
+            throws Exception
+    {
+        final AmazonS3 client = amazonS3Client();
+        final String testBucket = randomBucketName();
+        final String testBucketPath = format("s3n://%s/", testBucket);
+        client.createBucket(testBucket);
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI(testBucketPath), new Configuration());
+            fs.setS3Client(client);
+            Iterator<LocatedFileStatus> fileStatuses = fs.listPrefix(new Path(testBucketPath + "/test"));
+            assertFalse(fileStatuses.hasNext());
+        }
+    }
+
+    public AmazonS3 amazonS3Client()
+    {
+        return AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(endpoint)
+                .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+                .build();
+    }
+
+    private String randomBucketName()
+    {
+        return "bucket" + UUID.randomUUID().toString();
+    }
+
+    private static void createFolder(String bucketName, String folderName, AmazonS3 client)
+    {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(0);
+        InputStream emptyContent = new ByteArrayInputStream(new byte[0]);
+        PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, folderName + "/", emptyContent, metadata);
+        client.putObject(putObjectRequest);
+    }
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedKafka.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedKafka.java
@@ -31,8 +31,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.facebook.presto.kafka.util.TestUtils.findUnusedPort;
 import static com.facebook.presto.kafka.util.TestUtils.toProperties;
+import static com.facebook.presto.testing.TestngUtils.findUnusedPort;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedZookeeper.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedZookeeper.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.testing.TestngUtils.findUnusedPort;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 
@@ -42,7 +43,7 @@ public class EmbeddedZookeeper
     public EmbeddedZookeeper()
             throws IOException
     {
-        this(TestUtils.findUnusedPort());
+        this(findUnusedPort());
     }
 
     public EmbeddedZookeeper(int port)

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/TestUtils.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/TestUtils.java
@@ -25,7 +25,6 @@ import com.google.common.io.ByteStreams;
 import io.airlift.json.JsonCodec;
 
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Optional;
@@ -37,14 +36,6 @@ import static java.lang.String.format;
 public final class TestUtils
 {
     private TestUtils() {}
-
-    public static int findUnusedPort()
-            throws IOException
-    {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        }
-    }
 
     public static Properties toProperties(Map<String, String> map)
     {

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestngUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestngUtils.java
@@ -13,12 +13,22 @@
  */
 package com.facebook.presto.testing;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.stream.Collector;
 
 public final class TestngUtils
 {
     private TestngUtils() {}
+
+    public static int findUnusedPort()
+            throws IOException
+    {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
 
     public static <T> Collector<T, ?, Object[][]> toDataProvider()
     {


### PR DESCRIPTION
There is a use case when table is needed for third-party tool. This tool inserts data into the table later.
Athena allows to create empty table. Whereas create table through Presto fails with "External location must be a directory" exception.