### PR TITLE
Fix incorrect predicate pushdown through empty grouping set

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -998,8 +998,9 @@ public class PredicatePushDown
         @Override
         public PlanNode visitAggregation(AggregationNode node, RewriteContext<Expression> context)
         {
-            if (node.getGroupingKeys().isEmpty()) {
-                // cannot push predicates down through aggregations without any grouping columns
+            if (node.hasEmptyGroupingSet()) {
+                // TODO: in case of grouping sets, we should be able to push the filters over grouping keys below the aggregation
+                // and also preserve the filter above the aggregation if it has an empty grouping set
                 return visitPlan(node, context);
             }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestGroupingSets.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestGroupingSets.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.query;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestGroupingSets
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testPredicateOverGroupingKeysWithEmptyGroupingSet()
+    {
+        assertions.assertQuery(
+                "WITH t AS (" +
+                        "    SELECT a" +
+                        "    FROM (" +
+                        "        VALUES 1, 2" +
+                        "    ) AS u(a)" +
+                        "    GROUP BY GROUPING SETS ((), (a))" +
+                        ")" +
+                        "SELECT * " +
+                        "FROM t " +
+                        "WHERE a IS NOT NULL",
+                "VALUES 1, 2");
+    }
+}


### PR DESCRIPTION
PredicatePushdown is incorrectly pushing down predicates the refer only
to grouping keys when there's a empty grouping set present in the aggregation.

While it's safe to push filters below an aggregation with no empty grouping sets
(because they will ultimately be filtered out anyway), the empty grouping set has
 to produce a row. So, the filter has to be retained above the aggregation in that
 case. This is analogous to pushing down a filter through a global aggregation.

Fixes #11296