### PR TITLE
Add workaround for Mac JDK IPv6 bug for CLI and JDBC

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.cli;
 
 import com.facebook.presto.client.ClientSession;
+import com.facebook.presto.client.SocketChannelSocketFactory;
 import com.facebook.presto.client.StatementClient;
 import com.google.common.net.HostAndPort;
 import okhttp3.OkHttpClient;
@@ -71,6 +72,8 @@ public class QueryRunner
         this.sslSetup = builder -> setupSsl(builder, keystorePath, keystorePassword, truststorePath, truststorePassword);
 
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
+
+        builder.socketFactory(new SocketChannelSocketFactory());
 
         setupTimeouts(builder, 30, SECONDS);
         setupCookieJar(builder);

--- a/presto-client/src/main/java/com/facebook/presto/client/SocketChannelSocketFactory.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/SocketChannelSocketFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import javax.net.SocketFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+
+/**
+ * Workaround for JDK IPv6 bug on Mac. Sockets created with the basic socket
+ * API often cannot connect to IPv6 destinations due to JDK-8131133. However,
+ * NIO sockets do not have this problem, even if used in blocking mode.
+ */
+public class SocketChannelSocketFactory
+        extends SocketFactory
+{
+    @Override
+    public Socket createSocket()
+            throws IOException
+    {
+        return SocketChannel.open().socket();
+    }
+
+    @Override
+    public Socket createSocket(String host, int port)
+            throws IOException
+    {
+        return SocketChannel.open(new InetSocketAddress(host, port)).socket();
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localAddress, int localPort)
+            throws IOException
+    {
+        throw new SocketException("not supported");
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port)
+            throws IOException
+    {
+        return SocketChannel.open(new InetSocketAddress(address, port)).socket();
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+            throws IOException
+    {
+        throw new SocketException("not supported");
+    }
+}

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriver.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.jdbc;
 
+import com.facebook.presto.client.SocketChannelSocketFactory;
 import okhttp3.OkHttpClient;
 
 import java.io.Closeable;
@@ -41,8 +42,9 @@ public class PrestoDriver
 
     private static final String DRIVER_URL_START = "jdbc:presto:";
 
-    private final OkHttpClient httpClient = new OkHttpClient().newBuilder()
+    private final OkHttpClient httpClient = new OkHttpClient.Builder()
             .addInterceptor(userAgent(DRIVER_NAME + "/" + DRIVER_VERSION))
+            .socketFactory(new SocketChannelSocketFactory())
             .build();
 
     static {


### PR DESCRIPTION
https://medium.com/@quelgar/java-sockets-broken-for-ipv6-on-mac-5aae72f06b21