### PR TITLE
Raise required Java version to 151

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <air.check.skip-pmd>true</air.check.skip-pmd>
         <air.check.skip-jacoco>true</air.check.skip-jacoco>
 
-        <air.java.version>1.8.0-60</air.java.version>
+        <air.java.version>1.8.0-151</air.java.version>
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.6</dep.antlr.version>

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoSystemRequirements.java
@@ -104,7 +104,7 @@ final class PrestoSystemRequirements
         }
 
         JavaVersion version = JavaVersion.parse(javaVersion);
-        if (version.getMajor() == 8 && version.getUpdate().isPresent() && version.getUpdate().getAsInt() >= 92) {
+        if (version.getMajor() == 8 && version.getUpdate().isPresent() && version.getUpdate().getAsInt() >= 151) {
             return;
         }
 
@@ -112,7 +112,7 @@ final class PrestoSystemRequirements
             return;
         }
 
-        failRequirement("Presto requires Java 8u92+ (found %s)", javaVersion);
+        failRequirement("Presto requires Java 8u151+ (found %s)", javaVersion);
     }
 
     private static void verifyUsingG1Gc()


### PR DESCRIPTION
Testing with versions up to 121 gives unit test errors:
```
$ mvnw clean test -pl presto-main --am -Dtest=TestExpressionCompiler,TestMapOperators -DfailIfNoTests=false

[ERROR] Tests run: 61, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 188.726 s <<< FAILURE! - in TestSuite
[ERROR] testDistinctFrom(com.facebook.presto.type.TestMapOperators)  Time elapsed: 0.256 s  <<< FAILURE!
com.facebook.presto.spi.PrestoException: Value 3773704488 exceeds MAX_INT
	at com.facebook.presto.type.TestMapOperators.testDistinctFrom(TestMapOperators.java:725)

[ERROR] testMapConcat(com.facebook.presto.type.TestMapOperators)  Time elapsed: 1.025 s  <<< FAILURE!
java.lang.AssertionError: expected [{5.1=33.22, 1.0=2.20}] but found [{5.1=33.22, 373450121.6=2.20}]
	at com.facebook.presto.type.TestMapOperators.testMapConcat(TestMapOperators.java:806)

[ERROR] testNullif(com.facebook.presto.sql.gen.TestExpressionCompiler)  Time elapsed: 0.057 s  <<< FAILURE!
java.lang.RuntimeException: Error processing nullif(map(array[1], array[smallint '1']), map(array[1], array[integer '1']))
	at com.facebook.presto.sql.gen.TestExpressionCompiler.addCallable(TestExpressionCompiler.java:1795)
	at com.facebook.presto.sql.gen.TestExpressionCompiler.assertExecute(TestExpressionCompiler.java:1786)
	at com.facebook.presto.sql.gen.TestExpressionCompiler.testNullif(TestExpressionCompiler.java:1524)
Caused by: com.facebook.presto.spi.PrestoException: Value 3676796024 exceeds MAX_INT
	at com.facebook.presto.sql.gen.TestExpressionCompiler.addCallable(TestExpressionCompiler.java:1795)
	at com.facebook.presto.sql.gen.TestExpressionCompiler.assertExecute(TestExpressionCompiler.java:1786)
	at com.facebook.presto.sql.gen.TestExpressionCompiler.testNullif(TestExpressionCompiler.java:1524)

```

Travis is currently using 8u151 successfully, so let's use that.