### PR TITLE
Avoid using currentConstraint as predicate for getLayouts call

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/TableLayoutResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TableLayoutResult.java
@@ -14,13 +14,17 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class TableLayoutResult
@@ -55,5 +59,55 @@ public class TableLayoutResult
                 .collect(toImmutableList());
 
         return columns.containsAll(nodeColumnHandles);
+    }
+
+    public static TupleDomain<ColumnHandle> computeEnforced(TupleDomain<ColumnHandle> predicate, TupleDomain<ColumnHandle> unenforced)
+    {
+        if (predicate.isNone()) {
+            // If the engine requests that the connector provides a layout with a domain of "none". The connector can have two possible reactions, either:
+            // 1. The connector can provide an empty table layout.
+            //   * There would be no unenforced predicate, i.e., unenforced predicate is TupleDomain.all().
+            //   * The predicate was successfully enforced. Enforced predicate would be same as predicate: TupleDomain.none().
+            // 2. The connector can't/won't.
+            //   * The connector would tell the engine to put a filter on top of the scan, i.e., unenforced predicate is TupleDomain.none().
+            //   * The connector didn't successfully enforce anything. Therefore, enforced predicate would be TupleDomain.all().
+            if (unenforced.isNone()) {
+                return TupleDomain.all();
+            }
+            if (unenforced.isAll()) {
+                return TupleDomain.none();
+            }
+            throw new IllegalArgumentException();
+        }
+
+        // The engine requested the connector provides a layout with a non-none TupleDomain.
+        // A TupleDomain is effectively a list of column-Domain pairs.
+        // The connector is expected enforce the respective domain entirely on none, some, or all of the columns.
+        // 1. When the connector could enforce none of the domains, the unenforced would be equal to predicate;
+        // 2. When the connector could enforce some of the domains, the unenforced would contain a subset of the column-Domain pairs;
+        // 3. When the connector could enforce all of the domains, the unenforced would be TupleDomain.all().
+
+        // In all 3 cases shown above, the unenforced is not TupleDomain.none().
+        checkArgument(!unenforced.isNone());
+
+        Map<ColumnHandle, Domain> predicateDomains = predicate.getDomains().get();
+        Map<ColumnHandle, Domain> unenforcedDomains = unenforced.getDomains().get();
+        ImmutableMap.Builder<ColumnHandle, Domain> enforcedDomainsBuilder = ImmutableMap.builder();
+        for (Map.Entry<ColumnHandle, Domain> entry : predicateDomains.entrySet()) {
+            ColumnHandle predicateColumnHandle = entry.getKey();
+            if (unenforcedDomains.containsKey(predicateColumnHandle)) {
+                checkArgument(
+                        entry.getValue().equals(unenforcedDomains.get(predicateColumnHandle)),
+                        "Enforced tuple domain cannot be determined. The connector is expected to enforce the respective domain entirely on none, some, or all of the column.");
+            }
+            else {
+                enforcedDomainsBuilder.put(predicateColumnHandle, entry.getValue());
+            }
+        }
+        Map<ColumnHandle, Domain> enforcedDomains = enforcedDomainsBuilder.build();
+        checkArgument(
+                enforcedDomains.size() + unenforcedDomains.size() == predicateDomains.size(),
+                "Enforced tuple domain cannot be determined. Connector returned an unenforced TupleDomain that contains columns not in predicate.");
+        return TupleDomain.withColumnDomains(enforcedDomains);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -495,10 +495,7 @@ public final class HttpRemoteTask
 
         List<TaskSource> sources = getSources();
 
-        Optional<PlanFragment> fragment = Optional.empty();
-        if (sendPlan.get()) {
-            fragment = Optional.of(planFragment);
-        }
+        Optional<PlanFragment> fragment = sendPlan.get() ? Optional.of(planFragment) : Optional.empty();
         TaskUpdateRequest updateRequest = new TaskUpdateRequest(
                 session.toSessionRepresentation(),
                 fragment,

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -89,9 +89,9 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
-import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -502,12 +502,16 @@ public final class HttpRemoteTask
                 sources,
                 outputBuffers.get(),
                 totalPartitions);
+        byte[] taskUpdateRequestJson = taskUpdateRequestCodec.toJsonBytes(updateRequest);
+        if (fragment.isPresent()) {
+            stats.updateWithPlanBytes(taskUpdateRequestJson.length);
+        }
 
         HttpUriBuilder uriBuilder = getHttpUriBuilder(taskStatus);
         Request request = preparePost()
                 .setUri(uriBuilder.build())
                 .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString())
-                .setBodyGenerator(jsonBodyGenerator(taskUpdateRequestCodec, updateRequest))
+                .setBodyGenerator(createStaticBodyGenerator(taskUpdateRequestJson))
                 .build();
 
         updateErrorTracker.startRequest();

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/RemoteTaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/RemoteTaskStats.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.server.remotetask;
 
 import com.google.common.util.concurrent.AtomicDouble;
+import io.airlift.stats.DistributionStat;
 import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -24,6 +26,7 @@ public class RemoteTaskStats
     private final IncrementalAverage infoRoundTripMillis = new IncrementalAverage();
     private final IncrementalAverage statusRoundTripMillis = new IncrementalAverage();
     private final IncrementalAverage responseSizeBytes = new IncrementalAverage();
+    private final DistributionStat updateWithPlanBytes = new DistributionStat();
 
     private long requestSuccess;
     private long requestFailure;
@@ -56,6 +59,11 @@ public class RemoteTaskStats
     public void updateFailure()
     {
         requestFailure++;
+    }
+
+    public void updateWithPlanBytes(long bytes)
+    {
+        updateWithPlanBytes.add(bytes);
     }
 
     @Managed
@@ -92,6 +100,13 @@ public class RemoteTaskStats
     public long getRequestFailure()
     {
         return requestFailure;
+    }
+
+    @Managed
+    @Nested
+    public DistributionStat getUpdateWithPlanBytes()
+    {
+        return updateWithPlanBytes;
     }
 
     @ThreadSafe

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -333,7 +333,7 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        new PickTableLayout(metadata).rules()),
+                        new PickTableLayout(metadata, sqlParser).rules()),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(
                         ruleStats,
@@ -382,7 +382,7 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        new PickTableLayout(metadata).rules()),
+                        new PickTableLayout(metadata, sqlParser).rules()),
                 projectionPushDown,
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -18,7 +18,6 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.block.SortOrder;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Field;
@@ -218,7 +217,7 @@ class QueryPlanner
         fields.add(rowIdField);
 
         // create table scan
-        PlanNode tableScan = new TableScanNode(idAllocator.getNextId(), handle, outputSymbols.build(), columns.build(), Optional.empty(), TupleDomain.all());
+        PlanNode tableScan = new TableScanNode(idAllocator.getNextId(), handle, outputSymbols.build(), columns.build());
         Scope scope = Scope.builder().withRelationType(RelationId.anonymous(), new RelationType(fields.build())).build();
         RelationPlan relationPlan = new RelationPlan(tableScan, scope, outputSymbols.build());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -18,7 +18,6 @@ import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.spi.ColumnHandle;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
@@ -159,7 +158,7 @@ class RelationPlanner
         }
 
         List<Symbol> outputSymbols = outputSymbolsBuilder.build();
-        PlanNode root = new TableScanNode(idAllocator.getNextId(), handle, outputSymbols, columns.build(), Optional.empty(), TupleDomain.all());
+        PlanNode root = new TableScanNode(idAllocator.getNextId(), handle, outputSymbols, columns.build());
         return new RelationPlan(root, scope, outputSymbols);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -167,6 +167,11 @@ public class PickTableLayout
             }
 
             TableScanNode rewrittenTableScan = (TableScanNode) rewrittenFilter.getSource();
+
+            if (!tableScan.getLayout().isPresent() && rewrittenTableScan.getLayout().isPresent()) {
+                return false;
+            }
+
             return Objects.equals(tableScan.getCurrentConstraint(), rewrittenTableScan.getCurrentConstraint())
                     && Objects.equals(tableScan.getEnforcedConstraint(), rewrittenTableScan.getEnforcedConstraint());
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -21,16 +21,26 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableLayoutResult;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.DomainTranslator;
+import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.LiteralEncoder;
+import com.facebook.presto.sql.planner.LookupSymbolResolver;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolsExtractor;
+import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.sql.tree.NullLiteral;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -46,13 +56,19 @@ import static com.facebook.presto.matching.Capture.newCapture;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.filterDeterministicConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.filterNonDeterministicConjuncts;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.planner.iterative.rule.PreconditionRules.checkRulesAreFiredBeforeAddExchangesRule;
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
 import static com.facebook.presto.sql.planner.plan.Patterns.tableScan;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Sets.intersection;
+import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 /**
  * These rules should not be run after AddExchanges so as not to overwrite the TableLayout
@@ -61,11 +77,13 @@ import static java.util.Objects.requireNonNull;
 public class PickTableLayout
 {
     private final Metadata metadata;
+    private final SqlParser parser;
     private final DomainTranslator domainTranslator;
 
-    public PickTableLayout(Metadata metadata)
+    public PickTableLayout(Metadata metadata, SqlParser parser)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
+        this.parser = requireNonNull(parser, "parser is null");
         this.domainTranslator = new DomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
     }
 
@@ -79,23 +97,25 @@ public class PickTableLayout
 
     public PickTableLayoutForPredicate pickTableLayoutForPredicate()
     {
-        return new PickTableLayoutForPredicate(metadata, domainTranslator);
+        return new PickTableLayoutForPredicate(metadata, parser, domainTranslator);
     }
 
     public PickTableLayoutWithoutPredicate pickTableLayoutWithoutPredicate()
     {
-        return new PickTableLayoutWithoutPredicate(metadata, domainTranslator);
+        return new PickTableLayoutWithoutPredicate(metadata, parser, domainTranslator);
     }
 
     private static final class PickTableLayoutForPredicate
             implements Rule<FilterNode>
     {
         private final Metadata metadata;
+        private final SqlParser parser;
         private final DomainTranslator domainTranslator;
 
-        private PickTableLayoutForPredicate(Metadata metadata, DomainTranslator domainTranslator)
+        private PickTableLayoutForPredicate(Metadata metadata, SqlParser parser, DomainTranslator domainTranslator)
         {
             this.metadata = requireNonNull(metadata, "metadata is null");
+            this.parser = requireNonNull(parser, "parser is null");
             this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
         }
 
@@ -121,7 +141,7 @@ public class PickTableLayout
         {
             TableScanNode tableScan = captures.get(TABLE_SCAN);
 
-            PlanNode rewritten = planTableScan(tableScan, filterNode.getPredicate(), context, metadata, domainTranslator);
+            PlanNode rewritten = planTableScan(tableScan, filterNode.getPredicate(), context.getSession(), context.getSymbolAllocator().getTypes(), context.getIdAllocator(), metadata, parser, domainTranslator);
 
             if (arePlansSame(filterNode, tableScan, rewritten)) {
                 return Result.empty();
@@ -154,11 +174,13 @@ public class PickTableLayout
             implements Rule<TableScanNode>
     {
         private final Metadata metadata;
+        private final SqlParser parser;
         private final DomainTranslator domainTranslator;
 
-        private PickTableLayoutWithoutPredicate(Metadata metadata, DomainTranslator domainTranslator)
+        private PickTableLayoutWithoutPredicate(Metadata metadata, SqlParser parser, DomainTranslator domainTranslator)
         {
             this.metadata = requireNonNull(metadata, "metadata is null");
+            this.parser = requireNonNull(parser, "parser is null");
             this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
         }
 
@@ -183,55 +205,159 @@ public class PickTableLayout
                 return Result.empty();
             }
 
-            return Result.ofPlanNode(planTableScan(tableScanNode, TRUE_LITERAL, context, metadata, domainTranslator));
+            return Result.ofPlanNode(planTableScan(tableScanNode, TRUE_LITERAL, context.getSession(), context.getSymbolAllocator().getTypes(), context.getIdAllocator(), metadata, parser, domainTranslator));
         }
     }
 
-    private static PlanNode planTableScan(TableScanNode node, Expression predicate, Rule.Context context, Metadata metadata, DomainTranslator domainTranslator)
+    private static PlanNode planTableScan(
+            TableScanNode node,
+            Expression predicate,
+            Session session,
+            TypeProvider types,
+            PlanNodeIdAllocator idAllocator,
+            Metadata metadata,
+            SqlParser parser,
+            DomainTranslator domainTranslator)
     {
+        return listTableLayouts(
+                node,
+                predicate,
+                false,
+                session,
+                types,
+                idAllocator,
+                metadata,
+                parser,
+                domainTranslator)
+                .get(0);
+    }
+
+    public static List<PlanNode> listTableLayouts(
+            TableScanNode node,
+            Expression predicate,
+            boolean pruneWithPredicateExpression,
+            Session session,
+            TypeProvider types,
+            PlanNodeIdAllocator idAllocator,
+            Metadata metadata,
+            SqlParser parser,
+            DomainTranslator domainTranslator)
+    {
+        // don't include non-deterministic predicates
         Expression deterministicPredicate = filterDeterministicConjuncts(predicate);
+
         DomainTranslator.ExtractionResult decomposedPredicate = DomainTranslator.fromPredicate(
                 metadata,
-                context.getSession(),
+                session,
                 deterministicPredicate,
-                context.getSymbolAllocator().getTypes());
+                types);
 
-        TupleDomain<ColumnHandle> simplifiedConstraint = decomposedPredicate.getTupleDomain()
+        TupleDomain<ColumnHandle> newDomain = decomposedPredicate.getTupleDomain()
                 .transform(node.getAssignments()::get)
                 .intersect(node.getCurrentConstraint());
 
-        List<TableLayoutResult> layouts = metadata.getLayouts(
-                context.getSession(),
-                node.getTable(),
-                new Constraint<>(simplifiedConstraint),
-                Optional.of(ImmutableSet.copyOf(node.getAssignments().values())));
-        if (layouts.isEmpty()) {
-            return new ValuesNode(context.getIdAllocator().getNextId(), node.getOutputSymbols(), ImmutableList.of());
+        Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
+
+        Constraint<ColumnHandle> constraint;
+        if (pruneWithPredicateExpression) {
+            LayoutConstraintEvaluator evaluator = new LayoutConstraintEvaluator(
+                    metadata,
+                    parser,
+                    session,
+                    types,
+                    node.getAssignments(),
+                    combineConjuncts(
+                            deterministicPredicate,
+                            // Simplify the tuple domain to avoid creating an expression with too many nodes,
+                            // which would be expensive to evaluate in the call to isCandidate below.
+                            domainTranslator.toPredicate(newDomain.simplify().transform(assignments::get))));
+            constraint = new Constraint<>(newDomain, evaluator::isCandidate);
         }
+        else {
+            // Currently, invoking the expression interpreter is very expensive.
+            // TODO invoke the interpreter unconditionally when the interpreter becomes cheap enough.
+            constraint = new Constraint<>(newDomain);
+        }
+
+        // Layouts will be returned in order of the connector's preference
+        List<TableLayoutResult> layouts = metadata.getLayouts(
+                session,
+                node.getTable(),
+                constraint,
+                Optional.of(node.getOutputSymbols().stream()
+                        .map(node.getAssignments()::get)
+                        .collect(toImmutableSet())));
+
+        if (layouts.isEmpty()) {
+            return ImmutableList.of(new ValuesNode(idAllocator.getNextId(), node.getOutputSymbols(), ImmutableList.of()));
+        }
+
+        // Filter out layouts that cannot supply all the required columns
         layouts = layouts.stream()
                 .filter(layout -> layout.hasAllOutputs(node))
-                .collect(toImmutableList());
+                .collect(toList());
+        checkState(!layouts.isEmpty(), "No usable layouts for %s", node);
 
-        TableLayoutResult layout = layouts.get(0);
-
-        TableScanNode result = new TableScanNode(
-                node.getId(),
-                node.getTable(),
-                node.getOutputSymbols(),
-                node.getAssignments(),
-                Optional.of(layout.getLayout().getHandle()),
-                simplifiedConstraint.intersect(layout.getLayout().getPredicate()));
-
-        Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
-        Expression resultingPredicate = combineConjuncts(
-                decomposedPredicate.getRemainingExpression(),
-                filterNonDeterministicConjuncts(predicate),
-                domainTranslator.toPredicate(layout.getUnenforcedConstraint().transform(assignments::get)));
-
-        if (!TRUE_LITERAL.equals(resultingPredicate)) {
-            return new FilterNode(context.getIdAllocator().getNextId(), result, resultingPredicate);
+        if (layouts.stream().anyMatch(layout -> layout.getLayout().getPredicate().isNone())) {
+            return ImmutableList.of(new ValuesNode(idAllocator.getNextId(), node.getOutputSymbols(), ImmutableList.of()));
         }
 
-        return result;
+        return layouts.stream()
+                .map(layout -> {
+                    TableScanNode tableScan = new TableScanNode(
+                            node.getId(),
+                            node.getTable(),
+                            node.getOutputSymbols(),
+                            node.getAssignments(),
+                            Optional.of(layout.getLayout().getHandle()),
+                            newDomain.intersect(layout.getLayout().getPredicate()));
+
+                    Expression resultingPredicate = combineConjuncts(
+                            decomposedPredicate.getRemainingExpression(),
+                            filterNonDeterministicConjuncts(predicate),
+                            domainTranslator.toPredicate(layout.getUnenforcedConstraint().transform(assignments::get)));
+
+                    if (!TRUE_LITERAL.equals(resultingPredicate)) {
+                        return new FilterNode(idAllocator.getNextId(), tableScan, resultingPredicate);
+                    }
+
+                    return tableScan;
+                })
+                .collect(toImmutableList());
+    }
+
+    private static class LayoutConstraintEvaluator
+    {
+        private final Map<Symbol, ColumnHandle> assignments;
+        private final ExpressionInterpreter evaluator;
+        private final Set<ColumnHandle> arguments;
+
+        public LayoutConstraintEvaluator(Metadata metadata, SqlParser parser, Session session, TypeProvider types, Map<Symbol, ColumnHandle> assignments, Expression expression)
+        {
+            this.assignments = assignments;
+
+            Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(session, metadata, parser, types, expression, emptyList());
+
+            evaluator = ExpressionInterpreter.expressionOptimizer(expression, metadata, session, expressionTypes);
+            arguments = SymbolsExtractor.extractUnique(expression).stream()
+                    .map(assignments::get)
+                    .collect(toImmutableSet());
+        }
+
+        private boolean isCandidate(Map<ColumnHandle, NullableValue> bindings)
+        {
+            if (intersection(bindings.keySet(), arguments).isEmpty()) {
+                return true;
+            }
+            LookupSymbolResolver inputs = new LookupSymbolResolver(assignments, bindings);
+
+            // If any conjuncts evaluate to FALSE or null, then the whole predicate will never be true and so the partition should be pruned
+            Object optimized = evaluator.optimize(inputs);
+            if (Boolean.FALSE.equals(optimized) || optimized == null || optimized instanceof NullLiteral) {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneTableScanColumns.java
@@ -43,6 +43,7 @@ public class PruneTableScanColumns
                         filteredCopy(tableScanNode.getOutputSymbols(), referencedOutputs::contains),
                         filterKeys(tableScanNode.getAssignments(), referencedOutputs::contains),
                         tableScanNode.getLayout(),
-                        tableScanNode.getCurrentConstraint()));
+                        tableScanNode.getCurrentConstraint(),
+                        tableScanNode.getEnforcedConstraint()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
@@ -191,7 +191,7 @@ public class BeginTableWrite
                         scan.getOutputSymbols(),
                         scan.getAssignments(),
                         Optional.of(layoutResult.getLayout().getHandle()),
-                        scan.getCurrentConstraint(),
+                        layoutResult.getLayout().getPredicate(),
                         computeEnforced(originalEnforcedConstraint, layoutResult.getUnenforcedConstraint()));
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
@@ -16,9 +16,10 @@ package com.facebook.presto.sql.planner.optimizations;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableHandle;
-import com.facebook.presto.metadata.TableLayoutHandle;
 import com.facebook.presto.metadata.TableLayoutResult;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.metadata.TableLayoutResult.computeEnforced;
 import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isAtMostScalar;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.google.common.base.Preconditions.checkState;
@@ -173,22 +175,24 @@ public class BeginTableWrite
         {
             if (node instanceof TableScanNode) {
                 TableScanNode scan = (TableScanNode) node;
+                TupleDomain<ColumnHandle> originalEnforcedConstraint = scan.getEnforcedConstraint();
 
                 List<TableLayoutResult> layouts = metadata.getLayouts(
                         session,
                         handle,
-                        new Constraint<>(scan.getCurrentConstraint()),
+                        new Constraint<>(originalEnforcedConstraint),
                         Optional.of(ImmutableSet.copyOf(scan.getAssignments().values())));
                 verify(layouts.size() == 1, "Expected exactly one layout for delete");
-                TableLayoutHandle layout = Iterables.getOnlyElement(layouts).getLayout().getHandle();
+                TableLayoutResult layoutResult = Iterables.getOnlyElement(layouts);
 
                 return new TableScanNode(
                         scan.getId(),
                         handle,
                         scan.getOutputSymbols(),
                         scan.getAssignments(),
-                        Optional.of(layout),
-                        scan.getCurrentConstraint());
+                        Optional.of(layoutResult.getLayout().getHandle()),
+                        scan.getCurrentConstraint(),
+                        computeEnforced(originalEnforcedConstraint, layoutResult.getUnenforcedConstraint()));
             }
 
             if (node instanceof FilterNode) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -278,7 +278,7 @@ public class IndexJoinOptimizer
 
             TupleDomain<ColumnHandle> simplifiedConstraint = decomposedPredicate.getTupleDomain()
                     .transform(node.getAssignments()::get)
-                    .intersect(node.getCurrentConstraint());
+                    .intersect(node.getEnforcedConstraint());
 
             checkState(node.getOutputSymbols().containsAll(context.getLookupSymbols()));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -401,7 +401,8 @@ public class PruneUnreferencedOutputs
                     newOutputs,
                     newAssignments,
                     node.getLayout(),
-                    node.getCurrentConstraint());
+                    node.getCurrentConstraint(),
+                    node.getEnforcedConstraint());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableScanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableScanNode.java
@@ -63,6 +63,15 @@ public class TableScanNode
             PlanNodeId id,
             TableHandle table,
             List<Symbol> outputs,
+            Map<Symbol, ColumnHandle> assignments)
+    {
+        this(id, table, outputs, assignments, Optional.empty(), TupleDomain.all());
+    }
+
+    public TableScanNode(
+            PlanNodeId id,
+            TableHandle table,
+            List<Symbol> outputs,
             Map<Symbol, ColumnHandle> assignments,
             Optional<TableLayoutHandle> tableLayout,
             @Nullable TupleDomain<ColumnHandle> currentConstraint)

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -581,6 +581,7 @@ public class TestCostCalculator
                 symbolsList,
                 assignments.build(),
                 Optional.of(new TableLayoutHandle(new ConnectorId("tpch"), INSTANCE, new TpchTableLayoutHandle(tableHandle, TupleDomain.all()))),
+                TupleDomain.all(),
                 TupleDomain.all());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -29,7 +29,6 @@ import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.memory.MemoryPoolId;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spiller.SpillSpaceTracker;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
@@ -64,7 +63,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -111,9 +109,7 @@ public class MockRemoteTaskFactory
                         sourceId,
                         new TableHandle(new ConnectorId("test"), new TestingTableHandle()),
                         ImmutableList.of(symbol),
-                        ImmutableMap.of(symbol, new TestingColumnHandle("column")),
-                        Optional.empty(),
-                        TupleDomain.all()),
+                        ImmutableMap.of(symbol, new TestingColumnHandle("column"))),
                 ImmutableMap.of(symbol, VARCHAR),
                 SOURCE_DISTRIBUTION,
                 ImmutableList.of(sourceId),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -38,7 +38,6 @@ import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.StageExecutionStrategy;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.TestingTypeManager;
 import com.facebook.presto.spiller.GenericSpillerFactory;
 import com.facebook.presto.split.PageSinkManager;
@@ -105,9 +104,7 @@ public final class TaskTestUtils
                     TABLE_SCAN_NODE_ID,
                     new TableHandle(CONNECTOR_ID, new TestingTableHandle()),
                     ImmutableList.of(SYMBOL),
-                    ImmutableMap.of(SYMBOL, new TestingColumnHandle("column", 0, BIGINT)),
-                    Optional.empty(),
-                    TupleDomain.all()),
+                    ImmutableMap.of(SYMBOL, new TestingColumnHandle("column", 0, BIGINT))),
             ImmutableMap.of(SYMBOL, VARCHAR),
             SOURCE_DISTRIBUTION,
             ImmutableList.of(TABLE_SCAN_NODE_ID),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -16,7 +16,6 @@ package com.facebook.presto.execution.scheduler;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.operator.StageExecutionStrategy;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
@@ -183,9 +182,7 @@ public class TestPhasedExecutionSchedule
                 new PlanNodeId(name),
                 new TableHandle(new ConnectorId("test"), new TestingTableHandle()),
                 ImmutableList.of(symbol),
-                ImmutableMap.of(symbol, new TestingColumnHandle("column")),
-                Optional.empty(),
-                TupleDomain.all());
+                ImmutableMap.of(symbol, new TestingColumnHandle("column")));
 
         RemoteSourceNode remote = new RemoteSourceNode(new PlanNodeId("build_id"), buildFragment.getId(), ImmutableList.of(), Optional.empty(), REPLICATE);
         PlanNode join = new JoinNode(
@@ -235,9 +232,7 @@ public class TestPhasedExecutionSchedule
                 new PlanNodeId(name),
                 new TableHandle(new ConnectorId("test"), new TestingTableHandle()),
                 ImmutableList.of(symbol),
-                ImmutableMap.of(symbol, new TestingColumnHandle("column")),
-                Optional.empty(),
-                TupleDomain.all());
+                ImmutableMap.of(symbol, new TestingColumnHandle("column")));
 
         return createFragment(planNode);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -37,7 +37,6 @@ import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
-import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.split.ConnectorAwareSplitSource;
 import com.facebook.presto.split.SplitSource;
 import com.facebook.presto.sql.planner.Partitioning;
@@ -432,9 +431,7 @@ public class TestSourcePartitionedScheduler
                 tableScanNodeId,
                 new TableHandle(CONNECTOR_ID, new TestingTableHandle()),
                 ImmutableList.of(symbol),
-                ImmutableMap.of(symbol, new TestingColumnHandle("column")),
-                Optional.empty(),
-                TupleDomain.all());
+                ImmutableMap.of(symbol, new TestingColumnHandle("column")));
 
         RemoteSourceNode remote = new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId("plan_fragment_id"), ImmutableList.of(), Optional.empty(), GATHER);
         PlanFragment testFragment = new PlanFragment(

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestTableLayoutResult.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestTableLayoutResult.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.TestingColumnHandle;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.metadata.TableLayoutResult.computeEnforced;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static org.testng.Assert.fail;
+
+public class TestTableLayoutResult
+{
+    @Test
+    public void testComputeEnforced()
+    {
+        assertComputeEnforced(TupleDomain.all(), TupleDomain.all(), TupleDomain.all());
+        assertComputeEnforcedFails(TupleDomain.all(), TupleDomain.none());
+        assertComputeEnforced(TupleDomain.none(), TupleDomain.all(), TupleDomain.none());
+        assertComputeEnforced(TupleDomain.none(), TupleDomain.none(), TupleDomain.all());
+
+        assertComputeEnforced(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L))),
+                TupleDomain.all(),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L))));
+        assertComputeEnforced(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L))),
+                TupleDomain.all());
+        assertComputeEnforcedFails(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L))),
+                TupleDomain.none());
+        assertComputeEnforcedFails(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 9999L))));
+        assertComputeEnforcedFails(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c9999"), Domain.singleValue(BIGINT, 1L))));
+
+        assertComputeEnforced(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L),
+                        new TestingColumnHandle("c2"), Domain.singleValue(BIGINT, 2L))),
+                TupleDomain.all(),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L),
+                        new TestingColumnHandle("c2"), Domain.singleValue(BIGINT, 2L))));
+        assertComputeEnforced(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L),
+                        new TestingColumnHandle("c2"), Domain.singleValue(BIGINT, 2L))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c2"), Domain.singleValue(BIGINT, 2L))));
+        assertComputeEnforced(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L),
+                        new TestingColumnHandle("c2"), Domain.singleValue(BIGINT, 2L))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c2"), Domain.singleValue(BIGINT, 2L))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L))));
+        assertComputeEnforced(
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L),
+                        new TestingColumnHandle("c2"), Domain.singleValue(BIGINT, 2L))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(
+                        new TestingColumnHandle("c1"), Domain.singleValue(BIGINT, 1L),
+                        new TestingColumnHandle("c2"), Domain.singleValue(BIGINT, 2L))),
+                TupleDomain.all());
+    }
+
+    private void assertComputeEnforcedFails(TupleDomain<ColumnHandle> predicate, TupleDomain<ColumnHandle> unenforced)
+    {
+        try {
+            TupleDomain<ColumnHandle> enforced = computeEnforced(predicate, unenforced);
+            fail(String.format("expected IllegalArgumentException but found [%s]", enforced.toString(SESSION)));
+        }
+        catch (IllegalArgumentException e) {
+            // do nothing
+        }
+    }
+
+    private void assertComputeEnforced(TupleDomain<ColumnHandle> predicate, TupleDomain<ColumnHandle> unenforced, TupleDomain<ColumnHandle> expectedEnforced)
+    {
+        TupleDomain<ColumnHandle> enforced = computeEnforced(predicate, unenforced);
+        if (!enforced.equals(expectedEnforced)) {
+            fail(String.format("expected [%s] but found [%s]", expectedEnforced.toString(SESSION), enforced.toString(SESSION)));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -134,9 +134,7 @@ public class TestEffectivePredicateExtractor
                 newId(),
                 DUAL_TABLE_HANDLE,
                 ImmutableList.copyOf(assignments.keySet()),
-                assignments,
-                Optional.empty(),
-                TupleDomain.all());
+                assignments);
 
         expressionNormalizer = new ExpressionIdentityNormalizer();
     }
@@ -329,9 +327,7 @@ public class TestEffectivePredicateExtractor
                 newId(),
                 DUAL_TABLE_HANDLE,
                 ImmutableList.copyOf(assignments.keySet()),
-                assignments,
-                Optional.empty(),
-                TupleDomain.all());
+                assignments);
         Expression effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(effectivePredicate, BooleanLiteral.TRUE_LITERAL);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -337,7 +337,8 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 Optional.of(TESTING_TABLE_LAYOUT),
-                TupleDomain.none());
+                TupleDomain.none(),
+                TupleDomain.all());
         effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(effectivePredicate, FALSE_LITERAL);
 
@@ -347,7 +348,8 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 Optional.of(TESTING_TABLE_LAYOUT),
-                TupleDomain.withColumnDomains(ImmutableMap.of(scanAssignments.get(A), Domain.singleValue(BIGINT, 1L))));
+                TupleDomain.withColumnDomains(ImmutableMap.of(scanAssignments.get(A), Domain.singleValue(BIGINT, 1L))),
+                TupleDomain.all());
         effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(1L), AE)));
 
@@ -359,7 +361,8 @@ public class TestEffectivePredicateExtractor
                 Optional.of(TESTING_TABLE_LAYOUT),
                 TupleDomain.withColumnDomains(ImmutableMap.of(
                         scanAssignments.get(A), Domain.singleValue(BIGINT, 1L),
-                        scanAssignments.get(B), Domain.singleValue(BIGINT, 2L))));
+                        scanAssignments.get(B), Domain.singleValue(BIGINT, 2L))),
+                TupleDomain.all());
         effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(normalizeConjuncts(effectivePredicate), normalizeConjuncts(equals(bigintLiteral(2L), BE), equals(bigintLiteral(1L), AE)));
 
@@ -369,6 +372,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
         effectivePredicate = effectivePredicateExtractor.extract(node);
         assertEquals(effectivePredicate, BooleanLiteral.TRUE_LITERAL);
@@ -408,6 +412,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(leftAssignments.keySet()),
                 leftAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
@@ -417,6 +422,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(rightAssignments.keySet()),
                 rightAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         FilterNode left = filter(leftScan,
@@ -470,6 +476,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(leftAssignments.keySet()),
                 leftAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
@@ -479,6 +486,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(rightAssignments.keySet()),
                 rightAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         FilterNode left = filter(leftScan,
@@ -528,6 +536,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(leftAssignments.keySet()),
                 leftAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
@@ -537,6 +546,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(rightAssignments.keySet()),
                 rightAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         FilterNode left = filter(leftScan,
@@ -583,6 +593,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(leftAssignments.keySet()),
                 leftAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
@@ -592,6 +603,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(rightAssignments.keySet()),
                 rightAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         FilterNode left = filter(leftScan,
@@ -641,6 +653,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(leftAssignments.keySet()),
                 leftAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
@@ -650,6 +663,7 @@ public class TestEffectivePredicateExtractor
                 ImmutableList.copyOf(rightAssignments.keySet()),
                 rightAssignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
 
         FilterNode left = filter(leftScan, FALSE_LITERAL);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -101,6 +101,7 @@ public class TestTypeValidator
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
                 Optional.empty(),
+                TupleDomain.all(),
                 TupleDomain.all());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
@@ -118,6 +118,7 @@ public class TestPickTableLayout
                                 ImmutableList.of(p.symbol("nationkey", BIGINT)),
                                 ImmutableMap.of(p.symbol("nationkey", BIGINT), columnHandle),
                                 Optional.of(nationTableLayoutHandle),
+                                TupleDomain.none(),
                                 TupleDomain.none())))
                 .matches(values("A"));
     }
@@ -132,6 +133,7 @@ public class TestPickTableLayout
                                 ImmutableList.of(p.symbol("nationkey", BIGINT)),
                                 ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)),
                                 Optional.of(nationTableLayoutHandle),
+                                TupleDomain.all(),
                                 TupleDomain.all())))
                 .doesNotFire();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.testing.TestingTransactionHandle;
@@ -54,7 +55,7 @@ public class TestPickTableLayout
     @BeforeClass
     public void setUpBeforeClass()
     {
-        pickTableLayout = new PickTableLayout(tester().getMetadata());
+        pickTableLayout = new PickTableLayout(tester().getMetadata(), new SqlParser());
 
         connectorId = tester().getCurrentConnectorId();
         nationTableHandle = new TableHandle(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -358,7 +358,7 @@ public class PlanBuilder
     public TableScanNode tableScan(List<Symbol> symbols, Map<Symbol, ColumnHandle> assignments)
     {
         TableHandle tableHandle = new TableHandle(new ConnectorId("testConnector"), new TestingTableHandle());
-        return tableScan(tableHandle, symbols, assignments, Optional.empty(), TupleDomain.all());
+        return tableScan(tableHandle, symbols, assignments, Optional.empty(), TupleDomain.all(), TupleDomain.all());
     }
 
     public TableScanNode tableScan(TableHandle tableHandle, List<Symbol> symbols, Map<Symbol, ColumnHandle> assignments)
@@ -372,7 +372,7 @@ public class PlanBuilder
             Map<Symbol, ColumnHandle> assignments,
             Optional<TableLayoutHandle> tableLayout)
     {
-        return tableScan(tableHandle, symbols, assignments, tableLayout, TupleDomain.all());
+        return tableScan(tableHandle, symbols, assignments, tableLayout, TupleDomain.all(), TupleDomain.all());
     }
 
     public TableScanNode tableScan(
@@ -380,7 +380,8 @@ public class PlanBuilder
             List<Symbol> symbols,
             Map<Symbol, ColumnHandle> assignments,
             Optional<TableLayoutHandle> tableLayout,
-            TupleDomain<ColumnHandle> tupleDomain)
+            TupleDomain<ColumnHandle> currentConstraint,
+            TupleDomain<ColumnHandle> enforcedConstraint)
     {
         return new TableScanNode(
                 idAllocator.getNextId(),
@@ -388,7 +389,8 @@ public class PlanBuilder
                 symbols,
                 assignments,
                 tableLayout,
-                tupleDomain);
+                currentConstraint,
+                enforcedConstraint);
     }
 
     public TableFinishNode tableDelete(SchemaTableName schemaTableName, PlanNode deleteSource, Symbol deleteRowId)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableLayout.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableLayout.java
@@ -84,8 +84,11 @@ public class ConnectorTableLayout
     }
 
     /**
-     * A predicate that describes the universe of data in this layout. It may be used by the query engine to
-     * infer additional properties and perform further optimizations
+     * A TupleDomain that represents a predicate that every row this TableScan node
+     * produces is guaranteed to satisfy.
+     * <p>
+     * This guarantee can have different origins.
+     * For example, it may be successful predicate push down, or inherent guarantee provided by the underlying data.
      */
     public TupleDomain<ColumnHandle> getPredicate()
     {


### PR DESCRIPTION
Fixes #11134

For the query mentioned in #11134: a query with 16 scans of a table with 10000 partitions (without any partition filter). The query's planning time reduced by 4X, from 115 seconds to 25 seconds. The query's initial task update request size reduced by 600X, from 4.4MB (half of what was claimed in #11134 due to #11133) to 7KB.