### PR TITLE
Ensure access control classes implement all methods v2

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -206,6 +206,13 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/security/TestLegacyAccessControl.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/security/TestLegacyAccessControl.java
@@ -18,11 +18,11 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 
-public class TestPartitionsAwareAccessControl
+public class TestLegacyAccessControl
 {
     @Test
-    public void testEverythingDelegated()
+    public void testEverythingImplemented()
     {
-        assertAllMethodsOverridden(ConnectorAccessControl.class, PartitionsAwareAccessControl.class);
+        assertAllMethodsOverridden(ConnectorAccessControl.class, LegacyAccessControl.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/security/TestSqlStandardAccessControl.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/security/TestSqlStandardAccessControl.java
@@ -18,11 +18,11 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 
-public class TestPartitionsAwareAccessControl
+public class TestSqlStandardAccessControl
 {
     @Test
-    public void testEverythingDelegated()
+    public void testEverythingImplemented()
     {
-        assertAllMethodsOverridden(ConnectorAccessControl.class, PartitionsAwareAccessControl.class);
+        assertAllMethodsOverridden(ConnectorAccessControl.class, SqlStandardAccessControl.class);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAllowAllSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAllowAllSystemAccessControl.java
@@ -11,18 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.hive.security;
+package com.facebook.presto.security;
 
-import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.security.SystemAccessControl;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 
-public class TestPartitionsAwareAccessControl
+public class TestAllowAllSystemAccessControl
 {
     @Test
-    public void testEverythingDelegated()
+    public void testEverythingImplemented()
     {
-        assertAllMethodsOverridden(ConnectorAccessControl.class, PartitionsAwareAccessControl.class);
+        assertAllMethodsOverridden(SystemAccessControl.class, AllowAllSystemAccessControl.class);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import static com.facebook.presto.security.FileBasedSystemAccessControl.Factory.CONFIG_FILE_NAME;
 import static com.facebook.presto.spi.security.Privilege.SELECT;
+import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -185,6 +186,12 @@ public class TestFileBasedSystemAccessControl
         assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateView(transactionId, bob, aliceView);
         }));
+    }
+
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(SystemAccessControl.class, FileBasedSystemAccessControl.class);
     }
 
     private AccessControlManager newAccessControlManager(TransactionManager transactionManager, String resourceName)

--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -77,6 +77,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/AllowAllAccessControl.java
@@ -25,6 +25,21 @@ public class AllowAllAccessControl
         implements ConnectorAccessControl
 {
     @Override
+    public void checkCanCreateSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    @Override
+    public void checkCanDropSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    @Override
+    public void checkCanRenameSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName, String newSchemaName)
+    {
+    }
+
+    @Override
     public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
     {
     }

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/FileBasedAccessControl.java
@@ -89,6 +89,21 @@ public class FileBasedAccessControl
     }
 
     @Override
+    public void checkCanCreateSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    @Override
+    public void checkCanDropSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName)
+    {
+    }
+
+    @Override
+    public void checkCanRenameSchema(ConnectorTransactionHandle transactionHandle, Identity identity, String schemaName, String newSchemaName)
+    {
+    }
+
+    @Override
     public void checkCanShowSchemas(ConnectorTransactionHandle transactionHandle, Identity identity)
     {
     }

--- a/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestAllowAllAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestAllowAllAccessControl.java
@@ -11,18 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.hive.security;
+package com.facebook.presto.plugin.base.security;
 
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 
-public class TestPartitionsAwareAccessControl
+public class TestAllowAllAccessControl
 {
     @Test
-    public void testEverythingDelegated()
+    public void testEverythingImplemented()
     {
-        assertAllMethodsOverridden(ConnectorAccessControl.class, PartitionsAwareAccessControl.class);
+        assertAllMethodsOverridden(ConnectorAccessControl.class, AllowAllAccessControl.class);
     }
 }

--- a/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
+++ b/presto-plugin-toolkit/src/test/java/com/facebook/presto/plugin/base/security/TestFileBasedAccessControl.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.Optional;
 
+import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertThrows;
 
@@ -84,6 +85,12 @@ public class TestFileBasedAccessControl
     {
         assertThatThrownBy(() -> createAccessControl("invalid.json"))
                 .hasMessageContaining("Invalid JSON");
+    }
+
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(ConnectorAccessControl.class, FileBasedAccessControl.class);
     }
 
     private static Identity user(String name)

--- a/presto-spi/src/test/java/com/facebook/presto/spi/connector/classloader/TestClassLoaderSafeWrappers.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/connector/classloader/TestClassLoaderSafeWrappers.java
@@ -20,14 +20,9 @@ import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
-import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Method;
-
-import static java.lang.String.format;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 
 public class TestClassLoaderSafeWrappers
 {
@@ -40,19 +35,5 @@ public class TestClassLoaderSafeWrappers
         assertAllMethodsOverridden(ConnectorPageSourceProvider.class, ClassLoaderSafeConnectorPageSourceProvider.class);
         assertAllMethodsOverridden(ConnectorSplitManager.class, ClassLoaderSafeConnectorSplitManager.class);
         assertAllMethodsOverridden(ConnectorNodePartitioningProvider.class, ClassLoaderSafeNodePartitioningProvider.class);
-    }
-
-    private static <I, C extends I> void assertAllMethodsOverridden(Class<I> iface, Class<C> clazz)
-    {
-        assertEquals(ImmutableSet.copyOf(clazz.getInterfaces()), ImmutableSet.of(iface));
-        for (Method method : iface.getMethods()) {
-            try {
-                Method override = clazz.getDeclaredMethod(method.getName(), method.getParameterTypes());
-                assertEquals(override.getReturnType(), method.getReturnType());
-            }
-            catch (NoSuchMethodException e) {
-                fail(format("%s does not override [%s]", clazz.getName(), method));
-            }
-        }
     }
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/testing/InterfaceTestUtils.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/testing/InterfaceTestUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.testing;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.reflect.Method;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public final class InterfaceTestUtils
+{
+    private InterfaceTestUtils() {}
+
+    public static <I, C extends I> void assertAllMethodsOverridden(Class<I> iface, Class<C> clazz)
+    {
+        assertEquals(ImmutableSet.copyOf(clazz.getInterfaces()), ImmutableSet.of(iface));
+        for (Method method : iface.getMethods()) {
+            try {
+                Method override = clazz.getDeclaredMethod(method.getName(), method.getParameterTypes());
+                assertEquals(override.getReturnType(), method.getReturnType());
+            }
+            catch (NoSuchMethodException e) {
+                fail(format("%s does not override [%s]", clazz.getName(), method));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ensure that access control implementations that are intended to be
complete implement all methods from the interface they override

supersedes https://github.com/prestodb/presto/pull/10649
cc @rschlussel 