### PR TITLE
Fix Raptor SystemTable Query Bug when filtering multiples

### DIFF
--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
@@ -311,6 +311,26 @@ public class TestRaptorIntegrationSmokeTest
                         "SELECT 'tpch', 'orders', (SELECT count(*) FROM orders)\n" +
                         "UNION ALL\n" +
                         "SELECT 'tpch', 'lineitem', (SELECT count(*) FROM lineitem)");
+
+        assertQuery("" +
+                        "SELECT table_name, sum(row_count)\n" +
+                        "FROM system.shards\n" +
+                        "WHERE table_name IN ('orders', 'lineitem')\n" +
+                        "GROUP BY table_name",
+                "" +
+                        "SELECT 'orders', (SELECT count(*) FROM orders)\n" +
+                        "UNION ALL\n" +
+                        "SELECT 'lineitem', (SELECT count(*) FROM lineitem)");
+
+        assertQuery("" +
+                        "SELECT table_name, sum(row_count)\n" +
+                        "FROM system.shards\n" +
+                        "WHERE table_name = 'orders' or table_name = 'lineitem'\n" +
+                        "GROUP BY table_name",
+                "" +
+                        "SELECT 'orders', (SELECT count(*) FROM orders)\n" +
+                        "UNION ALL\n" +
+                        "SELECT 'lineitem', (SELECT count(*) FROM lineitem)");
     }
 
     @Test


### PR DESCRIPTION
Bug:
```
presto> select count(*) from system.shards where table_name in ('qe_first_exposures', 'qe_exposures');

com.facebook.presto.spi.PrestoException: Failed to perform metadata operation
        at com.facebook.presto.raptor.util.DatabaseUtil.metadataError(DatabaseUtil.java:85)
        at com.facebook.presto.raptor.util.DatabaseUtil.metadataError(DatabaseUtil.java:90)
        at com.facebook.presto.raptor.systemtables.ShardMetadataRecordCursor.getTableIds(ShardMetadataRecordCursor.java:367)
        at com.facebook.presto.raptor.systemtables.ShardMetadataRecordCursor.<init>(ShardMetadataRecordCursor.java:114)
        at com.facebook.presto.raptor.systemtables.ShardMetadataSystemTable.cursor(ShardMetadataSystemTable.java:57)
```
Fix:
Add support for IN Query. Add a new integration test.

Note that 'NOT IN' is still not supported.
```
select count(*) from system.shards where table_name NOT IN ('qe_first_exposures', 'qe_exposures');
```
We will add support when any customer needs it.