### PR TITLE
Allow alternate implementations of HiveMetadata

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -52,7 +52,6 @@ import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.ViewNotFoundException;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.Domain;
@@ -196,7 +195,7 @@ import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
 import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
 
 public class HiveMetadata
-        implements ConnectorMetadata
+        implements TransactionalMetadata
 {
     public static final String PRESTO_VERSION_NAME = "presto_version";
     public static final String PRESTO_QUERY_ID_NAME = "presto_query_id";
@@ -1774,11 +1773,13 @@ public class HiveMetadata
                 handle.isHidden());
     }
 
+    @Override
     public void rollback()
     {
         metastore.rollback();
     }
 
+    @Override
     public void commit()
     {
         metastore.commit();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -26,10 +26,12 @@ import org.joda.time.DateTimeZone;
 import javax.inject.Inject;
 
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
 public class HiveMetadataFactory
+        implements Supplier<TransactionalMetadata>
 {
     private static final Logger log = Logger.get(HiveMetadataFactory.class);
 
@@ -135,7 +137,8 @@ public class HiveMetadataFactory
         renameExecution = new BoundedExecutor(executorService, maxConcurrentFileRenames);
     }
 
-    public HiveMetadata create()
+    @Override
+    public HiveMetadata get()
     {
         SemiTransactionalHiveMetastore metastore = new SemiTransactionalHiveMetastore(
                 hdfsEnvironment,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTransactionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTransactionManager.java
@@ -25,24 +25,24 @@ import static com.google.common.base.Preconditions.checkState;
 
 public class HiveTransactionManager
 {
-    private final ConcurrentMap<ConnectorTransactionHandle, ConnectorMetadata> transactions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<ConnectorTransactionHandle, TransactionalMetadata> transactions = new ConcurrentHashMap<>();
 
     @Inject
     public HiveTransactionManager()
     {
     }
 
-    public ConnectorMetadata get(ConnectorTransactionHandle transactionHandle)
+    public TransactionalMetadata get(ConnectorTransactionHandle transactionHandle)
     {
         return transactions.get(transactionHandle);
     }
 
-    public ConnectorMetadata remove(ConnectorTransactionHandle transactionHandle)
+    public TransactionalMetadata remove(ConnectorTransactionHandle transactionHandle)
     {
         return transactions.remove(transactionHandle);
     }
 
-    public void put(ConnectorTransactionHandle transactionHandle, ConnectorMetadata metadata)
+    public void put(ConnectorTransactionHandle transactionHandle, TransactionalMetadata metadata)
     {
         ConnectorMetadata previousValue = transactions.putIfAbsent(transactionHandle, metadata);
         checkState(previousValue == null);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/TransactionalMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/TransactionalMetadata.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+
+public interface TransactionalMetadata
+        extends ConnectorMetadata
+{
+    void commit();
+
+    void rollback();
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -798,7 +798,7 @@ public abstract class AbstractTestHiveClient
 
     protected Transaction newTransaction()
     {
-        return new HiveTransaction(transactionManager, metadataFactory.create());
+        return new HiveTransaction(transactionManager, metadataFactory.get());
     }
 
     interface Transaction

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -219,7 +219,7 @@ public abstract class AbstractTestHiveFileSystem
 
     protected Transaction newTransaction()
     {
-        return new HiveTransaction(transactionManager, metadataFactory.create());
+        return new HiveTransaction(transactionManager, metadataFactory.get());
     }
 
     @Test


### PR DESCRIPTION
Extracting an interface allows implementations that use delegation
rather than subclasses.