### PR TITLE
Fix handling of thread interruption in JDBC driver

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/JsonResponse.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/JsonResponse.java
@@ -24,6 +24,7 @@ import okhttp3.ResponseBody;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -145,6 +146,11 @@ public final class JsonResponse<T>
             return new JsonResponse<>(response.code(), response.message(), response.headers(), body);
         }
         catch (IOException e) {
+            // OkHttp throws this after clearing the interrupt status
+            // TODO: remove after updating to Okio 1.15.0+
+            if ((e instanceof InterruptedIOException) && "thread interrupted".equals(e.getMessage())) {
+                Thread.currentThread().interrupt();
+            }
             throw new UncheckedIOException(e);
         }
     }

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -92,6 +92,7 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -1419,7 +1420,9 @@ public class TestPrestoDriver
 
         // make sure the query was aborted
         assertTrue(queryFinished.await(10, SECONDS));
-        assertNotNull(queryFailure.get());
+        assertThat(queryFailure.get())
+                .isInstanceOf(SQLException.class)
+                .hasMessage("ResultSet thread was interrupted");
         assertEquals(getQueryState(queryId.get()), FAILED);
     }
 


### PR DESCRIPTION
When using sockets created using SocketChannel, OkHttp handles thread
interruption differently and does not restore the interrupt status.