### PR TITLE
[WIP] Implement write path for Thrift connector

### DIFF
--- a/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
+++ b/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
@@ -29,6 +29,9 @@ struct PrestoThriftTableMetadata {
    * {@code set<set<string>>} is not used here because some languages (like php) don't support it.
    */
   4: optional list<set<string>> indexableKeys;
+
+  5: optional list<string> bucketedBy;
+  6: optional i32 bucketCount;
 }
 
 struct PrestoThriftColumnMetadata {
@@ -220,6 +223,16 @@ struct PrestoThriftPageResult {
   3: optional PrestoThriftId nextToken;
 }
 
+struct PrestoThriftPage {
+  /**
+   * Returns data in a columnar format.
+   * Columns in this list must be in the order they were requested by the engine.
+   */
+  1: list<PrestoThriftBlock> columnBlocks;
+
+  2: i32 rowCount;
+}
+
 struct PrestoThriftNullableTableMetadata {
   1: optional PrestoThriftTableMetadata tableMetadata;
 }
@@ -354,4 +367,18 @@ service PrestoThriftService {
       3: i64 maxBytes,
       4: PrestoThriftNullableToken nextToken)
     throws (1: PrestoThriftServiceException ex1);
+
+   /**
+     * Returns a batch of rows for the given split.
+     *
+     * @param schemaTableName TODO
+     * @param page a list of column names to insert
+     * @param nextToken token from a previous batch or {@literal null} if it is the first call
+     * @return a batch of table data
+     */
+     PrestoThriftNullableToken prestoAddRows(
+     1: PrestoThriftSchemaTableName schemaTableName,
+     2: PrestoThriftPage page,
+     3: PrestoThriftNullableToken nextToken)
+     throws (1: PrestoThriftServiceException ex1);
 }

--- a/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftPage.java
+++ b/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftPage.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.api;
+
+import io.airlift.drift.annotations.ThriftConstructor;
+import io.airlift.drift.annotations.ThriftField;
+import io.airlift.drift.annotations.ThriftStruct;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+@ThriftStruct
+public final class PrestoThriftPage
+{
+    private final List<PrestoThriftBlock> columnBlocks;
+    private final int rowCount;
+
+    @ThriftConstructor
+    public PrestoThriftPage(List<PrestoThriftBlock> columnBlocks, int rowCount)
+    {
+        this.columnBlocks = requireNonNull(columnBlocks, "columnBlocks is null");
+        checkArgument(rowCount >= 0, "rowCount is negative");
+        // checkAllColumnsAreOfExpectedSize(columnBlocks, rowCount);
+        this.rowCount = rowCount;
+    }
+
+    /**
+     * Returns data in a columnar format.
+     * Columns in this list must be in the order they were requested by the engine.
+     */
+    @ThriftField(1)
+    public List<PrestoThriftBlock> getColumnBlocks()
+    {
+        return columnBlocks;
+    }
+
+    @ThriftField(2)
+    public int getRowCount()
+    {
+        return rowCount;
+    }
+
+    /*@Nullable
+    public Page toPage(List<Type> columnTypes)
+    {
+        if (rowCount == 0) {
+            return null;
+        }
+        checkArgument(columnBlocks.size() == columnTypes.size(), "columns and types have different sizes");
+        int numberOfColumns = columnBlocks.size();
+        if (numberOfColumns == 0) {
+            // request/response with no columns, used for queries like "select count star"
+            return new Page(rowCount);
+        }
+        Block[] blocks = new Block[numberOfColumns];
+        for (int i = 0; i < numberOfColumns; i++) {
+            blocks[i] = columnBlocks.get(i).toBlock(columnTypes.get(i));
+        }
+        return new Page(blocks);
+    }*/
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        PrestoThriftPage other = (PrestoThriftPage) obj;
+        return Objects.equals(this.columnBlocks, other.columnBlocks) &&
+                this.rowCount == other.rowCount;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnBlocks, rowCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columnBlocks", columnBlocks)
+                .add("rowCount", rowCount)
+                .toString();
+    }
+
+    /*public static PrestoThriftPageResult fromRecordSet(RecordSet recordSet)
+    {
+        List<Type> types = recordSet.getColumnTypes();
+        int numberOfColumns = types.size();
+        int positions = totalRecords(recordSet);
+        if (numberOfColumns == 0) {
+            return new PrestoThriftPageResult(ImmutableList.of(), positions, null);
+        }
+        List<PrestoThriftBlock> thriftBlocks = new ArrayList<>(numberOfColumns);
+        for (int columnIndex = 0; columnIndex < numberOfColumns; columnIndex++) {
+            thriftBlocks.add(fromRecordSetColumn(recordSet, columnIndex, positions));
+        }
+        return new PrestoThriftPageResult(thriftBlocks, positions, null);
+    }
+
+    private static void checkAllColumnsAreOfExpectedSize(List<PrestoThriftBlock> columnBlocks, int expectedNumberOfRows)
+    {
+        for (int i = 0; i < columnBlocks.size(); i++) {
+            checkArgument(columnBlocks.get(i).numberOfRecords() == expectedNumberOfRows,
+                    "Incorrect number of records for column with index %s: expected %s, got %s",
+                    i, expectedNumberOfRows, columnBlocks.get(i).numberOfRecords());
+        }
+    }
+
+    private static int totalRecords(RecordSet recordSet)
+    {
+        RecordCursor cursor = recordSet.cursor();
+        int result = 0;
+        while (cursor.advanceNextPosition()) {
+            result++;
+        }
+        return result;
+    }*/
+}

--- a/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftService.java
+++ b/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftService.java
@@ -118,4 +118,20 @@ public interface PrestoThriftService
             @ThriftField(name = "columns") List<String> columns,
             @ThriftField(name = "maxBytes") long maxBytes,
             @ThriftField(name = "nextToken") PrestoThriftNullableToken nextToken);
+
+    /**
+     * Returns a batch of rows for the given split.
+     *
+     * @param schemaTableName TODO
+     * @param page a list of column names to insert
+     * @param nextToken token from a previous batch or {@literal null} if it is the first call
+     * @return a batch of table data
+     */
+    @ThriftMethod(
+            value = "prestoAddRows",
+            exception = @ThriftException(type = PrestoThriftServiceException.class, id = 1))
+    ListenableFuture<PrestoThriftNullableToken> addRows(
+            @ThriftField(name = "schemaTableName") PrestoThriftSchemaTableName schemaTableName,
+            @ThriftField(name = "page") PrestoThriftPage page,
+            @ThriftField(name = "nextToken") PrestoThriftNullableToken nextToken);
 }

--- a/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftTableMetadata.java
+++ b/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftTableMetadata.java
@@ -34,18 +34,31 @@ public final class PrestoThriftTableMetadata
     private final List<PrestoThriftColumnMetadata> columns;
     private final String comment;
     private final List<Set<String>> indexableKeys;
+    private final List<String> bucketedBy;
+    private final int bucketCount;
+    // TODO: increase once insert work for one Bingo worker node
+    private static final int DEFAULT_BUCKET_COUNT = 1;
 
     @ThriftConstructor
     public PrestoThriftTableMetadata(
             @ThriftField(name = "schemaTableName") PrestoThriftSchemaTableName schemaTableName,
             @ThriftField(name = "columns") List<PrestoThriftColumnMetadata> columns,
             @ThriftField(name = "comment") @Nullable String comment,
-            @ThriftField(name = "indexableKeys") @Nullable List<Set<String>> indexableKeys)
+            @ThriftField(name = "indexableKeys") @Nullable List<Set<String>> indexableKeys,
+            @ThriftField(name = "bucketedBy") @Nullable List<String> bucketedBy,
+            @ThriftField(name = "bucketCount") @Nullable Integer bucketCount)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.columns = requireNonNull(columns, "columns is null");
         this.comment = comment;
         this.indexableKeys = indexableKeys;
+        this.bucketedBy = bucketedBy;
+        if (bucketCount == null) {
+            this.bucketCount = DEFAULT_BUCKET_COUNT;
+        }
+        else {
+            this.bucketCount = bucketCount.intValue();
+        }
     }
 
     @ThriftField(1)
@@ -92,6 +105,20 @@ public final class PrestoThriftTableMetadata
         return Objects.equals(this.schemaTableName, other.schemaTableName) &&
                 Objects.equals(this.columns, other.columns) &&
                 Objects.equals(this.comment, other.comment);
+    }
+
+    @Nullable
+    @ThriftField(value = 5, requiredness = OPTIONAL)
+    public List<String> getBucketedBy()
+    {
+        return bucketedBy;
+    }
+
+    @Nullable
+    @ThriftField(value = 6, requiredness = OPTIONAL)
+    public Integer getBucketCount()
+    {
+        return bucketCount;
     }
 
     @Override

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftBucketFunction.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftBucketFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.BucketFunction;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+
+public class ThriftBucketFunction
+        implements BucketFunction
+{
+    private int bucketCount;
+    private static final int tileQuadkeyColumnNumber = 0;
+
+    public ThriftBucketFunction(int bucketCount)
+    {
+        this.bucketCount = bucketCount;
+    }
+    @Override
+    public int getBucket(Page page, int position)
+    {
+        Block singleValueBlock = page.getSingleValuePage(position).getBlock(tileQuadkeyColumnNumber);
+        String tileQuadkey = singleValueBlock.getSlice(0, 0, singleValueBlock.getSliceLength(0)).toStringUtf8();
+        System.out.println(tileQuadkey);
+        // TODO: improve hashing of the tile quadkey
+        return tileQuadkey.hashCode() % bucketCount;
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftBucketProperty.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftBucketProperty.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import java.util.List;
+
+public class ThriftBucketProperty
+{
+    private final List<String> bucketedBy;
+    private final int bucketCount;
+
+    public ThriftBucketProperty(List<String> bucketedBy, int bucketCount)
+    {
+        this.bucketedBy = bucketedBy;
+        this.bucketCount = bucketCount;
+    }
+
+    public List<String> getBucketedBy()
+    {
+        return bucketedBy;
+    }
+
+    public int getBucketCount()
+    {
+        return bucketCount;
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnector.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnector.java
@@ -16,15 +16,16 @@ package com.facebook.presto.connector.thrift;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorIndexProvider;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.log.Logger;
-
-import javax.inject.Inject;
 
 import java.util.List;
 
@@ -39,6 +40,8 @@ public class ThriftConnector
     private final ThriftMetadata metadata;
     private final ThriftSplitManager splitManager;
     private final ThriftPageSourceProvider pageSourceProvider;
+    private final ThriftPageSinkProvider pageSinkProvider;
+    private final ThriftNodePartitioningProvider partitioningProvider;
     private final ThriftSessionProperties sessionProperties;
     private final ThriftIndexProvider indexProvider;
 
@@ -48,6 +51,8 @@ public class ThriftConnector
             ThriftMetadata metadata,
             ThriftSplitManager splitManager,
             ThriftPageSourceProvider pageSourceProvider,
+            ThriftPageSinkProvider pageSinkProvider,
+            ThriftNodePartitioningProvider partitioningProvider,
             ThriftSessionProperties sessionProperties,
             ThriftIndexProvider indexProvider)
     {
@@ -55,6 +60,8 @@ public class ThriftConnector
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.partitioningProvider = requireNonNull(partitioningProvider, "partitioningProvider is null");
         this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
         this.indexProvider = requireNonNull(indexProvider, "indexProvider is null");
     }
@@ -81,6 +88,18 @@ public class ThriftConnector
     public ConnectorPageSourceProvider getPageSourceProvider()
     {
         return pageSourceProvider;
+    }
+
+    @Override
+    public ConnectorPageSinkProvider getPageSinkProvider()
+    {
+        return pageSinkProvider;
+    }
+
+    @Override
+    public ConnectorNodePartitioningProvider getNodePartitioningProvider()
+    {
+        return partitioningProvider;
     }
 
     @Override

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
@@ -15,6 +15,7 @@ package com.facebook.presto.connector.thrift;
 
 import com.facebook.presto.connector.thrift.util.RebindSafeMBeanServer;
 import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
@@ -67,6 +68,7 @@ public class ThriftConnectorFactory
                     binder -> {
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(getPlatformMBeanServer()));
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                     },
                     locationModule,
                     new ThriftModule(connectorId));

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftHandleResolver.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftHandleResolver.java
@@ -16,9 +16,11 @@ package com.facebook.presto.connector.thrift;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.ConnectorIndexHandle;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 
 public class ThriftHandleResolver
@@ -58,5 +60,17 @@ public class ThriftHandleResolver
     public Class<? extends ConnectorIndexHandle> getIndexHandleClass()
     {
         return ThriftIndexHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
+    {
+        return ThriftInsertTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass()
+    {
+        return ThriftPartitioningHandle.class;
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftInsertTableHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftInsertTableHandle.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ThriftInsertTableHandle
+        implements ConnectorInsertTableHandle
+{
+    private final String schemaName;
+    private final String tableName;
+    private final List<Type> columnTypes;
+
+    @JsonCreator
+    public ThriftInsertTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("columnTypes") List<Type> columnTypes)
+    {
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.columnTypes = requireNonNull(columnTypes, "columnTypes is null");
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @JsonProperty
+    public List<Type> getColumnTypes()
+    {
+        return columnTypes;
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
@@ -21,6 +21,8 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftService;
 import com.facebook.presto.connector.thrift.api.PrestoThriftServiceException;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorResolvedIndex;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
@@ -34,7 +36,10 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
+import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -42,16 +47,20 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import io.airlift.drift.TException;
 import io.airlift.drift.client.DriftClient;
+import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
 import io.airlift.units.Duration;
 
 import javax.inject.Inject;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.connector.thrift.ThriftErrorCode.THRIFT_SERVICE_INVALID_RESPONSE;
 import static com.facebook.presto.connector.thrift.util.ThriftExceptions.toPrestoException;
@@ -66,6 +75,7 @@ import static java.util.function.Function.identity;
 public class ThriftMetadata
         implements ConnectorMetadata
 {
+    private static final Logger log = Logger.get(ThriftMetadata.class);
     private static final Duration EXPIRE_AFTER_WRITE = new Duration(10, MINUTES);
     private static final Duration REFRESH_AFTER_WRITE = new Duration(2, MINUTES);
 
@@ -105,8 +115,7 @@ public class ThriftMetadata
     public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         return tableCache.getUnchecked(tableName)
-                .map(ThriftTableMetadata::getSchemaTableName)
-                .map(ThriftTableHandle::new)
+                .map(e -> new ThriftTableHandle(e.getSchemaTableName(), e.getBucketedBy(), e.getBucketCount()))
                 .orElse(null);
     }
 
@@ -150,6 +159,43 @@ public class ThriftMetadata
         catch (PrestoThriftServiceException | TException e) {
             throw toPrestoException(e);
         }
+    }
+
+    @Override
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        List<Type> columnTypes = getTableMetadata(session, tableHandle)
+                .getColumns()
+                .stream()
+                .map(e -> e.getType())
+                .collect(Collectors.toList());
+        ThriftTableHandle thriftTableHandle = (ThriftTableHandle) tableHandle;
+        return new ThriftInsertTableHandle(thriftTableHandle.getSchemaName(), thriftTableHandle.getTableName(), columnTypes);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        // Here's where we'd be finalizing all the inserts in the table. In Hive, this is where the folders where the data is stored get renamed to the
+        // destination folder.
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ConnectorNewTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        ThriftTableHandle thriftTableHandle = (ThriftTableHandle) tableHandle;
+        Optional<List<String>> bucketedBy = thriftTableHandle.getBucketedBy();
+        if (bucketedBy.isPresent()) {
+            // TODO: include the bucket count in the partitioningHandle
+            log.info("We DO return a new connector table layout");
+            log.info("SUCCESS!!!!!");
+            ThriftPartitioningHandle partitioningHandle = new ThriftPartitioningHandle(thriftTableHandle.getBucketCount());
+            return Optional.of(new ConnectorNewTableLayout(partitioningHandle, bucketedBy.get()));
+        }
+        log.info("We DO NOT return a new connector table layout");
+        log.info("FAILURE!!!!!");
+        return Optional.empty();
     }
 
     @Override

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
@@ -64,6 +64,8 @@ public class ThriftModule
         binder.bind(ThriftMetadata.class).in(Scopes.SINGLETON);
         binder.bind(ThriftSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ThriftPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ThriftPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ThriftNodePartitioningProvider.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(ThriftConnectorConfig.class);
         binder.bind(ThriftSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(ThriftIndexProvider.class).in(Scopes.SINGLETON);

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftNodePartitioningProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftNodePartitioningProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.BucketFunction;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
+import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ThriftNodePartitioningProvider
+        implements ConnectorNodePartitioningProvider
+{
+    private static final Logger log = Logger.get(ThriftNodePartitioningProvider.class);
+    private final NodeManager nodeManager;
+
+    @Inject
+    public ThriftNodePartitioningProvider(
+            @JsonProperty("nodeManager") NodeManager nodeManager)
+    {
+        this.nodeManager = nodeManager;
+    }
+
+    @Override
+    public Map<Integer, Node> getBucketToNode(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    {
+        ThriftPartitioningHandle handle = (ThriftPartitioningHandle) partitioningHandle;
+
+        List<Node> nodes = shuffle(nodeManager.getRequiredWorkerNodes());
+        // TODO: you're going to need to add the bucketedBy value in the ThriftPartitioningHandle, because since we now give a default value to bucketCount, we can no longer check it to see if we're actually bucketing stuff.
+        log.info("In getBucketToNode method. Bucket count is %s", String.valueOf(handle.getBucketCount()));
+        int bucketCount = handle.getBucketCount();
+        ImmutableMap.Builder<Integer, Node> distribution = ImmutableMap.builder();
+        for (int i = 0; i < bucketCount; i++) {
+            // I'm going to give all the data to one node and see what happens.
+            distribution.put(i, nodes.get(0)); //nodes.get(i % nodes.size()));
+        }
+        log.info("The nodes we're giving everything to is %s", nodes.get(0).getNodeIdentifier());
+        return distribution.build();
+    }
+
+    @Override
+    public ToIntFunction<ConnectorSplit> getSplitBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    {
+        // Reading splits by bucket is not supported
+        return (split) -> 0;
+    }
+
+    @Override
+    public BucketFunction getBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Type> partitionChannelTypes, int bucketCount)
+    {
+        return new ThriftBucketFunction(bucketCount);
+    }
+
+    @Override
+    public List<ConnectorPartitionHandle> listPartitionHandles(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    {
+        ThriftPartitioningHandle handle = (ThriftPartitioningHandle) partitioningHandle;
+        int bucketCount = handle.getBucketCount();
+        return IntStream.range(0, bucketCount).mapToObj(ThriftPartitionHandle::new).collect(Collectors.toList());
+    }
+
+    private static <T> List<T> shuffle(Collection<T> items)
+    {
+        List<T> list = new ArrayList<>(items);
+        Collections.shuffle(list);
+        return list;
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSink.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSink.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.connector.thrift.api.PrestoThriftBlock;
+import com.facebook.presto.connector.thrift.api.PrestoThriftId;
+import com.facebook.presto.connector.thrift.api.PrestoThriftNullableToken;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPage;
+import com.facebook.presto.connector.thrift.api.PrestoThriftSchemaTableName;
+import com.facebook.presto.connector.thrift.api.PrestoThriftService;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.drift.client.DriftClient;
+import io.airlift.drift.client.address.AddressSelector;
+import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class ThriftPageSink
+        implements ConnectorPageSink
+{
+    private static final Logger log = Logger.get(ThriftPageSink.class);
+
+    // This is the class that the worker will be used to actually place the data somewhere.
+    private final PrestoThriftService client;
+    private final ThriftInsertTableHandle insertTableHandle;
+    private final ThriftBucketFunction bucketFunction;
+    private ListenableFuture<PrestoThriftNullableToken> future;
+    private PrestoThriftId nextToken;
+
+    public <T> ThriftPageSink(DriftClient<PrestoThriftService> client, AddressSelector<?> addressSelector, ThriftInsertTableHandle insertTableHandle, Optional<ThriftBucketProperty> bucketProperty)
+    {
+        this.client = client.get(Optional.of(addressSelector.selectAddress(Optional.empty()).get().toString()));
+        // this.client = client.get();
+        this.insertTableHandle = insertTableHandle;
+        if (bucketProperty.isPresent()) {
+            bucketFunction = new ThriftBucketFunction(bucketProperty.get().getBucketCount());
+        }
+        else {
+            bucketFunction = null;
+        }
+        future = null;
+        nextToken = null;
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        // TODO: sort the data back into the buckets that they were in when presto sent the data to this worker. Check out the Hive PageSink operations for inspiration on how to do this.
+        // This is the append page, where I will start the process of inserting the data.
+        // If I were supporting transactions / concurrent inserts, this section would be
+        // more of a precommit. However, a simple implementation will just save the data
+        // where it needs to already.
+        log.info("appendPage called!");
+        log.info("The thrift object id is %s", this.toString());
+        log.info("client is %s", client.toString());
+        List<PrestoThriftBlock> prestoThriftBlocks = new ArrayList<>();
+        List<Type> columnTypes = insertTableHandle.getColumnTypes();
+        for (int i = 0; i < page.getChannelCount(); i++) {
+            Block block = page.getBlock(i);
+            prestoThriftBlocks.add(PrestoThriftBlock.fromBlock(block, columnTypes.get(i)));
+        }
+
+        PrestoThriftPage prestoThriftPage = new PrestoThriftPage(prestoThriftBlocks, page.getPositionCount());
+
+//        while (future == null || nextToken != null) {
+        try {
+            future = client.addRows(
+                new PrestoThriftSchemaTableName(
+                        insertTableHandle.getSchemaName(),
+                        insertTableHandle.getTableName()),
+                prestoThriftPage,
+                new PrestoThriftNullableToken(nextToken));
+            nextToken = future.get().getToken();
+        }
+        // TODO: implement transaction-like process for inserts so that if the execution gets interrupted, a rollback occurs.
+        catch (ExecutionException | InterruptedException e) {
+//            break;
+        }
+//        }
+        log.info("finished appendPage!");
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        // This method is the commit part of the process of inserting the data.
+        // However, since I'm not worrying about transactions / concurrent inserts,
+        // I don't need to do anything here.
+        return CompletableFuture.completedFuture(new ArrayList<>());
+    }
+
+    @Override
+    public void abort()
+    {
+        // This method is called when the transaction must abort. Since I'm not worrying
+        // about concurrent inserts, I don't have to worry about aborting.
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSinkProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSinkProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.connector.thrift.api.PrestoThriftService;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.airlift.drift.client.DriftClient;
+import io.airlift.drift.client.address.AddressSelector;
+import io.airlift.drift.client.guice.DefaultClient;
+import io.airlift.drift.client.guice.DriftClientAnnotationFactory;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class ThriftPageSinkProvider
+        implements ConnectorPageSinkProvider
+{
+    private final DriftClient<PrestoThriftService> client;
+    private final AddressSelector<?> addressSelector;
+
+    @Inject
+    public ThriftPageSinkProvider(DriftClient<PrestoThriftService> client, Injector injector)
+    {
+        this.client = requireNonNull(client, "client is null");
+        requireNonNull(injector, "injector is null");
+        this.addressSelector = injector.getInstance(Key.get(AddressSelector.class, DriftClientAnnotationFactory.getDriftClientAnnotation(PrestoThriftService.class, DefaultClient.class)));
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle)
+    {
+        // the method called when calling the 'CREATE TABLE' command.
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle)
+    {
+        // the method called when calling the 'INSERT INTO' command
+        // TODO: should I cast here or in the ThriftPageSink method itself?
+        // TODO: Change the third parameter to pass in a ThriftBucketProperty
+        return new ThriftPageSink(client, addressSelector, (ThriftInsertTableHandle) insertTableHandle, Optional.empty());
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPartitionHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPartitionHandle.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+
+import java.util.Objects;
+
+public class ThriftPartitionHandle
+        extends ConnectorPartitionHandle
+{
+    private final int bucket;
+
+    public ThriftPartitionHandle(int bucket)
+    {
+        this.bucket = bucket;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ThriftPartitionHandle other = (ThriftPartitionHandle) obj;
+        return this.bucket == other.bucket;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(bucket);
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPartitioningHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPartitioningHandle.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class ThriftPartitioningHandle
+        implements ConnectorPartitioningHandle
+{
+    private final int bucketCount;
+
+    @JsonCreator
+    public ThriftPartitioningHandle(
+            @JsonProperty("bucketCount") int bucketCount)
+    {
+        this.bucketCount = bucketCount;
+    }
+
+    @JsonProperty
+    public int getBucketCount()
+    {
+        return bucketCount;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("bucketCount", bucketCount)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ThriftPartitioningHandle other = (ThriftPartitioningHandle) obj;
+        return bucketCount == other.bucketCount;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(bucketCount);
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableHandle.java
@@ -18,7 +18,9 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -28,19 +30,25 @@ public final class ThriftTableHandle
 {
     private final String schemaName;
     private final String tableName;
+    private final Optional<List<String>> bucketedBy;
+    private final int bucketCount;
 
     @JsonCreator
     public ThriftTableHandle(
             @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName)
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("bucketedBy") Optional<List<String>> bucketedBy,
+            @JsonProperty("bucketCount") int bucketCount)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.bucketedBy = requireNonNull(bucketedBy, "bucketedBy is null");
+        this.bucketCount = bucketCount;
     }
 
-    public ThriftTableHandle(SchemaTableName schemaTableName)
+    public ThriftTableHandle(SchemaTableName schemaTableName, Optional<List<String>> bucketedBy, int bucketCount)
     {
-        this(schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        this(schemaTableName.getSchemaName(), schemaTableName.getTableName(), bucketedBy, bucketCount);
     }
 
     @JsonProperty
@@ -53,6 +61,17 @@ public final class ThriftTableHandle
     public String getTableName()
     {
         return tableName;
+    }
+
+    @JsonProperty
+    public Optional<List<String>> getBucketedBy()
+    {
+        return bucketedBy;
+    }
+
+    public int getBucketCount()
+    {
+        return bucketCount;
     }
 
     @Override
@@ -72,7 +91,7 @@ public final class ThriftTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName);
+        return Objects.hash(schemaName, tableName, bucketedBy);
     }
 
     @Override
@@ -81,6 +100,7 @@ public final class ThriftTableHandle
         return toStringHelper(this)
                 .add("schemaName", getSchemaName())
                 .add("tableName", getTableName())
+                .add("bucketedBy", getBucketedBy())
                 .toString();
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableMetadata.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableMetadata.java
@@ -40,13 +40,17 @@ class ThriftTableMetadata
     private final List<ColumnMetadata> columns;
     private final Optional<String> comment;
     private final Set<Set<String>> indexableKeys;
+    private final Optional<List<String>> bucketedBy;
+    private final int bucketCount;
 
-    public ThriftTableMetadata(SchemaTableName schemaTableName, List<ColumnMetadata> columns, Optional<String> comment, List<Set<String>> indexableKeys)
+    public ThriftTableMetadata(SchemaTableName schemaTableName, List<ColumnMetadata> columns, Optional<String> comment, List<Set<String>> indexableKeys, List<String> bucketedBy, int bucketCount)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.comment = requireNonNull(comment, "comment is null");
         this.indexableKeys = deepImmutableCopy(requireNonNull(indexableKeys, "indexableKeys is null"));
+        this.bucketedBy = Optional.ofNullable(bucketedBy);
+        this.bucketCount = bucketCount;
     }
 
     public ThriftTableMetadata(PrestoThriftTableMetadata thriftTableMetadata, TypeManager typeManager)
@@ -54,7 +58,9 @@ class ThriftTableMetadata
         this(thriftTableMetadata.getSchemaTableName().toSchemaTableName(),
                 columnMetadata(thriftTableMetadata.getColumns(), typeManager),
                 Optional.ofNullable(thriftTableMetadata.getComment()),
-                thriftTableMetadata.getIndexableKeys() != null ? thriftTableMetadata.getIndexableKeys() : ImmutableList.of());
+                thriftTableMetadata.getIndexableKeys() != null ? thriftTableMetadata.getIndexableKeys() : ImmutableList.of(),
+                thriftTableMetadata.getBucketedBy(),
+                thriftTableMetadata.getBucketCount());
     }
 
     public SchemaTableName getSchemaTableName()
@@ -74,6 +80,16 @@ class ThriftTableMetadata
                 .map(ThriftColumnHandle::getColumnName)
                 .collect(toImmutableSet());
         return indexableKeys.contains(keyColumns);
+    }
+
+    public Optional<List<String>> getBucketedBy()
+    {
+        return bucketedBy;
+    }
+
+    public int getBucketCount()
+    {
+        return bucketCount;
     }
 
     public ConnectorTableMetadata toConnectorTableMetadata()

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftNullableColumnSet;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableSchemaName;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableTableMetadata;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableToken;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPage;
 import com.facebook.presto.connector.thrift.api.PrestoThriftPageResult;
 import com.facebook.presto.connector.thrift.api.PrestoThriftSchemaTableName;
 import com.facebook.presto.connector.thrift.api.PrestoThriftService;
@@ -285,6 +286,12 @@ public class TestThriftIndexPageSource
             int offset = nextToken.getToken() != null ? Ints.fromByteArray(nextToken.getToken().getId()) : 0;
             PrestoThriftId newNextToken = offset + 1 < rowsPerSplit ? new PrestoThriftId(Ints.toByteArray(offset + 1)) : null;
             return immediateFuture(pageResult(key * 10 + offset, newNextToken));
+        }
+
+        @Override
+        public ListenableFuture<PrestoThriftNullableToken> addRows(PrestoThriftSchemaTableName schemaTableName, PrestoThriftPage page, PrestoThriftNullableToken nextToken)
+        {
+            throw new UnsupportedOperationException();
         }
 
         // methods below are not used for the test

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueries.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueries.java
@@ -23,7 +23,7 @@ public class TestThriftDistributedQueries
 {
     public TestThriftDistributedQueries()
     {
-        super(() -> createThriftQueryRunner(3, 3, false, ImmutableMap.of()));
+        super(() -> createThriftQueryRunner(3, 3, ThriftQueryRunner.EnableExtraPrestoFeature.NONE, ImmutableMap.of()));
     }
 
     @Override

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueriesIndexed.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueriesIndexed.java
@@ -23,7 +23,7 @@ public class TestThriftDistributedQueriesIndexed
 {
     public TestThriftDistributedQueriesIndexed()
     {
-        super(() -> createThriftQueryRunner(2, 2, true, ImmutableMap.of()));
+        super(() -> createThriftQueryRunner(2, 2, ThriftQueryRunner.EnableExtraPrestoFeature.INDEX_JOIN, ImmutableMap.of()));
     }
 
     @Override

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftInsertRows.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftInsertRows.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.integration;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.tests.QueryAssertions.assertContains;
+
+public class TestThriftInsertRows
+{
+    private QueryRunner queryRunner;
+
+    public TestThriftInsertRows()
+            throws Exception
+    {
+        queryRunner = ThriftQueryRunner.createThriftQueryRunner(1, 3, ThriftQueryRunner.EnableExtraPrestoFeature.INSERT_ROWS, ImmutableMap.of());
+    }
+
+    @Test
+    public void testShowSchemas()
+    {
+        MaterializedResult result = queryRunner.execute("SHOW SCHEMAS").toTestTypes();
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR)
+                .row("matiash");
+        assertContains(result, resultBuilder.build());
+    }
+
+    @Test
+    public void testListTables()
+    {
+        MaterializedResult result = queryRunner.execute("SHOW TABLES FROM matiash").toTestTypes();
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR)
+                .row("test_table");
+        assertContains(result, resultBuilder.build());
+    }
+
+    @Test
+    public void testGetTableMetadata()
+    {
+        MaterializedResult result = queryRunner.execute("SHOW COLUMNS FROM matiash.test_table").toTestTypes();
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, DOUBLE, INTEGER)
+                .row("value", "double", "", "")
+                .row("x", "integer", "", "")
+                .row("y", "integer", "", "")
+                .row("zoom_level", "integer", "", "");
+        assertContains(result, resultBuilder.build());
+    }
+
+    @Test
+    public void testGetRows()
+    {
+        MaterializedResult result = queryRunner.execute("SELECT * FROM matiash.test_table").toTestTypes();
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR);
+        assertContains(result, resultBuilder.build());
+    }
+
+//    @Test
+//    public void testAddRows()
+//    {
+//        queryRunner.execute("INSERT INTO matiash.test_table VALUES ('0', 1, 0, 0, 1), ('00', 56.432, 42, 50, 2)").toTestTypes();
+//        MaterializedResult result = queryRunner.execute("SELECT * FROM matiash.test_table").toTestTypes();
+//        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), DOUBLE, INTEGER)
+//                .row("0", 1.0, 0, 0, 1)
+//                .row("00", 56.432, 42, 50, 2);
+//        assertContains(result, resultBuilder.build());
+//    }
+}

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftIntegrationSmokeTest.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftIntegrationSmokeTest.java
@@ -27,7 +27,7 @@ public class TestThriftIntegrationSmokeTest
 {
     public TestThriftIntegrationSmokeTest()
     {
-        super(() -> createThriftQueryRunner(2, 2, false, ImmutableMap.of()));
+        super(() -> createThriftQueryRunner(2, 2, ThriftQueryRunner.EnableExtraPrestoFeature.NONE, ImmutableMap.of()));
     }
 
     @Override

--- a/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftInsertRowsService.java
+++ b/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftInsertRowsService.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.server;
+
+import com.facebook.presto.connector.thrift.api.PrestoThriftBlock;
+import com.facebook.presto.connector.thrift.api.PrestoThriftColumnMetadata;
+import com.facebook.presto.connector.thrift.api.PrestoThriftId;
+import com.facebook.presto.connector.thrift.api.PrestoThriftNullableColumnSet;
+import com.facebook.presto.connector.thrift.api.PrestoThriftNullableSchemaName;
+import com.facebook.presto.connector.thrift.api.PrestoThriftNullableTableMetadata;
+import com.facebook.presto.connector.thrift.api.PrestoThriftNullableToken;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPage;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPageResult;
+import com.facebook.presto.connector.thrift.api.PrestoThriftSchemaTableName;
+import com.facebook.presto.connector.thrift.api.PrestoThriftService;
+import com.facebook.presto.connector.thrift.api.PrestoThriftSplit;
+import com.facebook.presto.connector.thrift.api.PrestoThriftSplitBatch;
+import com.facebook.presto.connector.thrift.api.PrestoThriftTableMetadata;
+import com.facebook.presto.connector.thrift.api.PrestoThriftTupleDomain;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.facebook.presto.connector.thrift.server.ThriftTpchService.SPLIT_INFO_CODEC;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+
+public class ThriftInsertRowsService
+        implements PrestoThriftService
+{
+    private static final List<String> SCHEMA = Collections.singletonList("matiash");
+    private static final List<String> SCHEMATABLES = ImmutableList.of("test_table");
+    // TODO: You will need to return a token in addRows so that presto can continue to serve rows to the system.
+    private static final List<PrestoThriftPage> TESTTABLE = new ArrayList<>();
+    // TODO: allow for tag column names
+    private static final List<String> COLUMNNAMES = ImmutableList.of("tile_quadkey", "value", "x", "y", "zoom_level");
+    private static final List<Type> COLUMNTYPES = ImmutableList.of(VARCHAR, DOUBLE, INTEGER, INTEGER, INTEGER);
+    private static final int BUCKET_COUNT = 4096;
+
+    @Override
+    public List<String> listSchemaNames()
+    {
+        return SCHEMA;
+    }
+
+    @Override
+    public List<PrestoThriftSchemaTableName> listTables(PrestoThriftNullableSchemaName schemaNameOrNull)
+    {
+        if (SCHEMA.contains(schemaNameOrNull.getSchemaName())) {
+            List<PrestoThriftSchemaTableName> tables = new ArrayList<PrestoThriftSchemaTableName>() {};
+            for (String tableName : SCHEMATABLES) {
+                tables.add(new PrestoThriftSchemaTableName(SCHEMA.get(0), tableName));
+            }
+            return tables;
+        }
+        return ImmutableList.of();
+    }
+
+    @Override
+    public PrestoThriftNullableTableMetadata getTableMetadata(PrestoThriftSchemaTableName schemaTableName)
+    {
+        if (!SCHEMA.contains(schemaTableName.getSchemaName()) || !SCHEMATABLES.contains(schemaTableName.getTableName())) {
+            return new PrestoThriftNullableTableMetadata(null);
+        }
+
+        List<PrestoThriftColumnMetadata> columnMetadata = new ArrayList<>();
+        for (int i = 0; i < COLUMNNAMES.size(); i++) {
+            columnMetadata.add(new PrestoThriftColumnMetadata(COLUMNNAMES.get(i), getColumnTypeAsString(COLUMNTYPES.get(i)), null, false));
+        }
+        return new PrestoThriftNullableTableMetadata(new PrestoThriftTableMetadata(schemaTableName, columnMetadata, null, null, Collections.singletonList("tile_quadkey"), BUCKET_COUNT));
+    }
+
+    @Override
+    public ListenableFuture<PrestoThriftSplitBatch> getSplits(
+            PrestoThriftSchemaTableName schemaTableName,
+            PrestoThriftNullableColumnSet desiredColumns,
+            PrestoThriftTupleDomain outputConstraint,
+            int maxSplitCount,
+            PrestoThriftNullableToken nextToken)
+    {
+        return immediateFuture(getSplitsSync(schemaTableName, desiredColumns, outputConstraint, maxSplitCount, nextToken));
+    }
+
+    private PrestoThriftSplitBatch getSplitsSync(
+            PrestoThriftSchemaTableName schemaTableName,
+            PrestoThriftNullableColumnSet desiredColumns,
+            PrestoThriftTupleDomain outputConstraint,
+            int maxSplitCount,
+            PrestoThriftNullableToken nextToken)
+    {
+        SplitInfo splitInfo = SplitInfo.normalSplit(schemaTableName.getSchemaName(), schemaTableName.getTableName(), 1, 1);
+        List<PrestoThriftSplit> splits = Collections.singletonList(new PrestoThriftSplit(new PrestoThriftId(SPLIT_INFO_CODEC.toJsonBytes(splitInfo)), ImmutableList.of()));
+        return new PrestoThriftSplitBatch(splits, null);
+    }
+
+    @Override
+    public ListenableFuture<PrestoThriftSplitBatch> getIndexSplits(
+            PrestoThriftSchemaTableName schemaTableName,
+            List<String> indexColumnNames,
+            List<String> outputColumnNames,
+            PrestoThriftPageResult keys,
+            PrestoThriftTupleDomain outputConstraint,
+            int maxSplitCount,
+            PrestoThriftNullableToken nextToken)
+    {
+        return immediateFuture(getIndexSplitsInternal());
+    }
+
+    @Override
+    public ListenableFuture<PrestoThriftPageResult> getRows(PrestoThriftId splitId, List<String> columns, long maxBytes, PrestoThriftNullableToken nextToken)
+    {
+        return immediateFuture(getRowsSync(splitId, columns, maxBytes, nextToken));
+    }
+
+    private PrestoThriftPageResult getRowsSync(PrestoThriftId splitId, List<String> columns, long maxBytes, PrestoThriftNullableToken nextToken)
+    {
+        List<PrestoThriftBlock> blocks = new ArrayList<>();
+        int rowCount = 0;
+        for (PrestoThriftPage pageResult : TESTTABLE) {
+            blocks.addAll(pageResult.getColumnBlocks());
+            rowCount += pageResult.getRowCount();
+        }
+        return new PrestoThriftPageResult(blocks, rowCount, null);
+    }
+
+    @Override
+    public ListenableFuture<PrestoThriftNullableToken> addRows(PrestoThriftSchemaTableName schemaTableName, PrestoThriftPage page, PrestoThriftNullableToken nextToken)
+    {
+        // Since we don't have a limit on the size of the amount of rows we can insert, we don't use 'nextToken'.
+        if (SCHEMA.contains(schemaTableName.getSchemaName()) && SCHEMATABLES.contains(schemaTableName.getTableName())) {
+            TESTTABLE.add(page);
+        }
+        return immediateFuture(null);
+    }
+
+    private String getColumnTypeAsString(Type columnType)
+    {
+        return columnType.getTypeSignature().toString();
+    }
+
+    private PrestoThriftSplitBatch getIndexSplitsInternal()
+    {
+        throw new UnsupportedOperationException("getIndexSplits is unsupported");
+    }
+}

--- a/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
+++ b/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
@@ -20,6 +20,7 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftNullableColumnSet;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableSchemaName;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableTableMetadata;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableToken;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPage;
 import com.facebook.presto.connector.thrift.api.PrestoThriftPageResult;
 import com.facebook.presto.connector.thrift.api.PrestoThriftSchemaTableName;
 import com.facebook.presto.connector.thrift.api.PrestoThriftService;
@@ -106,7 +107,8 @@ public class ThriftTpchService
             columns.add(new PrestoThriftColumnMetadata(column.getSimplifiedColumnName(), getTypeString(column), null, false));
         }
         List<Set<String>> indexableKeys = getIndexableKeys(schemaName, tableName);
-        return new PrestoThriftNullableTableMetadata(new PrestoThriftTableMetadata(schemaTableName, columns, null, !indexableKeys.isEmpty() ? indexableKeys : null));
+        // TODO: change the last parameter to pass in a bucketedBy parameter. Note this is a different service than the one that's testing the insert rows.
+        return new PrestoThriftNullableTableMetadata(new PrestoThriftTableMetadata(schemaTableName, columns, null, !indexableKeys.isEmpty() ? indexableKeys : null, null, null));
     }
 
     protected List<Set<String>> getIndexableKeys(String schemaName, String tableName)
@@ -181,6 +183,12 @@ public class ThriftTpchService
             PrestoThriftNullableToken nextToken)
     {
         return executor.submit(() -> getRowsSync(splitId, outputColumns, maxBytes, nextToken));
+    }
+
+    @Override
+    public ListenableFuture<PrestoThriftNullableToken> addRows(PrestoThriftSchemaTableName schemaTableName, PrestoThriftPage page, PrestoThriftNullableToken nextToken)
+    {
+        throw new UnsupportedOperationException("Insert not supported");
     }
 
     private PrestoThriftPageResult getRowsSync(


### PR DESCRIPTION
There is currently no implementation for insertion using the Thrift connector. This diff implements the required methods to let the Thrift connector support writes.

This diff is also supports writing bucketed tables, though it is currently still being tested.

Finally, there is an extension of the PrestoThriftService to insert rows.

I'm still modifying this code to support insertion of large amounts of data, but the implementation currently works for inserting a couple of rows of data from the Bingo project.