### PR TITLE
Fix reading float in hive-parquet reader

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/reader/ParquetFloatColumnReader.java
@@ -31,7 +31,7 @@ public class ParquetFloatColumnReader
     protected void readValue(BlockBuilder blockBuilder, Type type)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
-            type.writeLong(blockBuilder, floatToRawIntBits(valuesReader.readFloat()));
+            type.writeDouble(blockBuilder, floatToRawIntBits(valuesReader.readFloat()));
         }
         else if (isValueNull()) {
             blockBuilder.appendNull();


### PR DESCRIPTION
We noticed this error while reading float columns in hive connector. 
```
Query 20180820_203000_01686_e7ind failed: java.lang.UnsupportedOperationException
com.facebook.presto.spi.type.DoubleType
com.facebook.presto.spi.type.AbstractType.writeLong(AbstractType.java:111)
com.facebook.presto.hive.parquet.reader.ParquetFloatColumnReader.readValue(ParquetFloatColumnReader.java:34)
```