### PR TITLE
Spill to disk for Window Operator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -284,6 +284,12 @@ public class OperatorContext
         return new InternalAggregatedMemoryContext(operatorMemoryContext.aggregateUserMemoryContext(), memoryFuture, this::updatePeakMemoryReservations, false);
     }
 
+    // caller shouldn't close this context as it's managed by the OperatorContext
+    public AggregatedMemoryContext aggregateRevocableMemoryContext()
+    {
+        return new InternalAggregatedMemoryContext(operatorMemoryContext.aggregateRevocableMemoryContext(), memoryFuture, this::updatePeakMemoryReservations, false);
+    }
+
     // caller should close this context as it's a new context
     public AggregatedMemoryContext newAggregateSystemMemoryContext()
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.operator.window.FramedWindowFunction;
 import com.facebook.presto.operator.window.WindowPartition;
@@ -33,8 +34,13 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.operator.WorkProcessor.ProcessorState.finished;
+import static com.facebook.presto.operator.WorkProcessor.ProcessorState.needsMoreData;
+import static com.facebook.presto.operator.WorkProcessor.ProcessorState.ofResult;
+import static com.facebook.presto.operator.WorkProcessor.ProcessorState.yield;
 import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_LAST;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkPositionIndex;
@@ -151,40 +157,27 @@ public class WindowOperator
         }
     }
 
-    private enum State
-    {
-        NEEDS_INPUT,
-        HAS_OUTPUT,
-        FINISHING,
-        FINISHED
-    }
-
     private final OperatorContext operatorContext;
+    private final List<Type> outputTypes;
     private final int[] outputChannels;
     private final List<FramedWindowFunction> windowFunctions;
     private final List<Integer> orderChannels;
     private final List<SortOrder> ordering;
-    private final LocalMemoryContext localUserMemoryContext;
 
     private final int[] preGroupedChannels;
 
+    private final PagesIndex pagesIndex;
     private final PagesHashStrategy preGroupedPartitionHashStrategy;
     private final PagesHashStrategy unGroupedPartitionHashStrategy;
     private final PagesHashStrategy preSortedPartitionHashStrategy;
     private final PagesHashStrategy peerGroupHashStrategy;
 
-    private final PagesIndex pagesIndex;
-
-    private final PageBuilder pageBuilder;
-
+    private final WorkProcessor<Page> outputPages;
     private final WindowInfo.DriverWindowInfoBuilder windowInfo;
     private final AtomicReference<Optional<WindowInfo.DriverWindowInfo>> driverWindowInfo = new AtomicReference<>(Optional.empty());
 
-    private State state = State.NEEDS_INPUT;
-
-    private WindowPartition partition;
-
     private Page pendingInput;
+    private boolean operatorFinishing;
 
     public WindowOperator(
             OperatorContext operatorContext,
@@ -213,13 +206,12 @@ public class WindowOperator
         checkArgument(preSortedChannelPrefix == 0 || ImmutableSet.copyOf(preGroupedChannels).equals(ImmutableSet.copyOf(partitionChannels)), "preSortedChannelPrefix can only be greater than zero if all partition channels are pre-grouped");
 
         this.operatorContext = operatorContext;
-        this.localUserMemoryContext = operatorContext.localUserMemoryContext();
         this.outputChannels = Ints.toArray(outputChannels);
         this.windowFunctions = windowFunctionDefinitions.stream()
                 .map(functionDefinition -> new FramedWindowFunction(functionDefinition.createWindowFunction(), functionDefinition.getFrameInfo()))
                 .collect(toImmutableList());
 
-        List<Type> types = Stream.concat(
+        this.outputTypes = Stream.concat(
                 outputChannels.stream()
                         .map(sourceTypes::get),
                 windowFunctionDefinitions.stream()
@@ -239,8 +231,6 @@ public class WindowOperator
         this.preSortedPartitionHashStrategy = pagesIndex.createPagesHashStrategy(preSortedChannels, OptionalInt.empty());
         this.peerGroupHashStrategy = pagesIndex.createPagesHashStrategy(sortChannels, OptionalInt.empty());
 
-        this.pageBuilder = new PageBuilder(types);
-
         if (preSortedChannelPrefix > 0) {
             // This already implies that set(preGroupedChannels) == set(partitionChannels) (enforced with checkArgument)
             this.orderChannels = ImmutableList.copyOf(Iterables.skip(sortChannels, preSortedChannelPrefix));
@@ -251,6 +241,10 @@ public class WindowOperator
             this.orderChannels = ImmutableList.copyOf(concat(unGroupedPartitionChannels, sortChannels));
             this.ordering = ImmutableList.copyOf(concat(nCopies(unGroupedPartitionChannels.size(), ASC_NULLS_LAST), sortOrder));
         }
+
+        this.outputPages = WorkProcessor.create(new ProducePagesIndexes(operatorContext.aggregateUserMemoryContext()))
+                .flatMap(new ProduceWindowPartitions())
+                .transform(new ProduceWindowResults());
 
         windowInfo = new WindowInfo.DriverWindowInfoBuilder();
         operatorContext.setInfoSupplier(this::getWindowInfo);
@@ -270,32 +264,24 @@ public class WindowOperator
     @Override
     public void finish()
     {
-        if (state == State.FINISHING || state == State.FINISHED) {
-            return;
-        }
-        if (state == State.NEEDS_INPUT) {
-            // Since was waiting for more input, prepare what we have for output since we will not be getting any more input
-            finishPagesIndex();
-        }
-        state = State.FINISHING;
+        operatorFinishing = true;
     }
 
     @Override
     public boolean isFinished()
     {
-        return state == State.FINISHED;
+        return outputPages.isFinished();
     }
 
     @Override
     public boolean needsInput()
     {
-        return state == State.NEEDS_INPUT;
+        return pendingInput == null && !operatorFinishing;
     }
 
     @Override
     public void addInput(Page page)
     {
-        checkState(state == State.NEEDS_INPUT, "Operator can not take input at this time");
         requireNonNull(page, "page is null");
         checkState(pendingInput == null, "Operator already has pending input");
 
@@ -304,34 +290,166 @@ public class WindowOperator
         }
 
         pendingInput = page;
-        if (processPendingInput()) {
-            state = State.HAS_OUTPUT;
-        }
-        localUserMemoryContext.setBytes(pagesIndex.getEstimatedSize().toBytes());
     }
 
-    /**
-     * @return true if a full group has been buffered after processing the pendingInput, false otherwise
-     */
-    private boolean processPendingInput()
+    @Override
+    public Page getOutput()
     {
-        checkState(pendingInput != null);
-        pendingInput = updatePagesIndex(pendingInput);
-
-        // If we have unused input or are finishing, then we have buffered a full group
-        if (pendingInput != null || state == State.FINISHING) {
-            finishPagesIndex();
-            return true;
+        if (!outputPages.process()) {
+            return null;
         }
-        else {
-            return false;
+
+        if (outputPages.isFinished()) {
+            return null;
+        }
+
+        return outputPages.getResult();
+    }
+
+    @Override
+    public void close()
+    {
+        driverWindowInfo.set(Optional.of(windowInfo.build()));
+    }
+
+    private class ProduceWindowResults
+            implements WorkProcessor.Transformation<WindowPartition, Page>
+    {
+        private final PageBuilder pageBuilder;
+
+        private ProduceWindowResults()
+        {
+            pageBuilder = new PageBuilder(outputTypes);
+        }
+
+        @Override
+        public WorkProcessor.ProcessorState<Page> process(Optional<WindowPartition> partitionOptional)
+        {
+            boolean finishing = !partitionOptional.isPresent();
+            if (finishing) {
+                if (pageBuilder.isEmpty()) {
+                    return finished();
+                }
+
+                // flush remaining page builder data
+                Page page = pageBuilder.build();
+                pageBuilder.reset();
+                return ofResult(page, false);
+            }
+
+            WindowPartition partition = partitionOptional.get();
+            while (!pageBuilder.isFull()) {
+                if (!partition.hasNext()) {
+                    return needsMoreData();
+                }
+
+                partition.processNextRow(pageBuilder);
+            }
+
+            Page page = pageBuilder.build();
+            pageBuilder.reset();
+            return ofResult(page, !partition.hasNext());
         }
     }
 
-    /**
-     * @return the unused section of the page, or null if fully applied.
-     * pagesIndex guaranteed to have at least one row after this method returns
-     */
+    private class ProduceWindowPartitions
+            implements Function<PagesIndex, WorkProcessor<WindowPartition>>
+    {
+        @Override
+        public WorkProcessor<WindowPartition> apply(PagesIndex pagesIndex)
+        {
+            return WorkProcessor.create(new WorkProcessor.Process<WindowPartition>()
+            {
+                int partitionStart;
+
+                @Override
+                public WorkProcessor.ProcessorState<WindowPartition> process()
+                {
+                    if (partitionStart == pagesIndex.getPositionCount()) {
+                        return finished();
+                    }
+
+                    int partitionEnd = findGroupEnd(pagesIndex, unGroupedPartitionHashStrategy, partitionStart);
+                    WindowPartition partition = new WindowPartition(pagesIndex, partitionStart, partitionEnd, outputChannels, windowFunctions, peerGroupHashStrategy);
+                    windowInfo.addPartition(partition);
+                    partitionStart = partitionEnd;
+                    return ofResult(partition);
+                }
+            });
+        }
+    }
+
+    private class ProducePagesIndexes
+            implements WorkProcessor.Process<PagesIndex>
+    {
+        private final LocalMemoryContext memoryContext;
+        private boolean resetPagesIndex;
+
+        private ProducePagesIndexes(AggregatedMemoryContext memoryContext)
+        {
+            this.memoryContext = memoryContext.newLocalMemoryContext(ProducePagesIndexes.class.getSimpleName());
+        }
+
+        @Override
+        public WorkProcessor.ProcessorState<PagesIndex> process()
+        {
+            if (resetPagesIndex) {
+                pagesIndex.clear();
+                updateMemoryUsage();
+                resetPagesIndex = false;
+            }
+
+            if (operatorFinishing && pendingInput == null && pagesIndex.getPositionCount() == 0) {
+                memoryContext.close();
+                return finished();
+            }
+
+            if (pendingInput != null) {
+                pendingInput = updatePagesIndex(pendingInput);
+                updateMemoryUsage();
+            }
+
+            // If we have unused input or are finishing, then we have buffered a full group
+            if (pendingInput != null || operatorFinishing) {
+                finishPagesIndex();
+                resetPagesIndex = true;
+                return ofResult(pagesIndex);
+            }
+
+            // pendingInput == null && !operatorFinishing
+            return yield();
+        }
+
+        private void updateMemoryUsage()
+        {
+            long bytes = pagesIndex.getEstimatedSize().toBytes();
+
+            if (pendingInput != null) {
+                bytes += pendingInput.getRetainedSizeInBytes();
+            }
+
+            memoryContext.setBytes(bytes);
+        }
+    }
+
+    private void sortPagesIndexIfNecessary()
+    {
+        if (pagesIndex.getPositionCount() > 1 && !orderChannels.isEmpty()) {
+            int startPosition = 0;
+            while (startPosition < pagesIndex.getPositionCount()) {
+                int endPosition = findGroupEnd(pagesIndex, preSortedPartitionHashStrategy, startPosition);
+                pagesIndex.sort(orderChannels, ordering, startPosition, endPosition);
+                startPosition = endPosition;
+            }
+        }
+    }
+
+    private void finishPagesIndex()
+    {
+        sortPagesIndexIfNecessary();
+        windowInfo.addIndex(pagesIndex);
+    }
+
     private Page updatePagesIndex(Page page)
     {
         checkArgument(page.getPositionCount() > 0);
@@ -360,90 +478,13 @@ public class WindowOperator
         }
     }
 
-    private static Page rearrangePage(Page page, int[] channels)
+    private Page rearrangePage(Page page, int[] channels)
     {
         Block[] newBlocks = new Block[channels.length];
         for (int i = 0; i < channels.length; i++) {
             newBlocks[i] = page.getBlock(channels[i]);
         }
         return new Page(page.getPositionCount(), newBlocks);
-    }
-
-    @Override
-    public Page getOutput()
-    {
-        if (state == State.NEEDS_INPUT || state == State.FINISHED) {
-            return null;
-        }
-
-        Page page = extractOutput();
-        localUserMemoryContext.setBytes(pagesIndex.getEstimatedSize().toBytes());
-        return page;
-    }
-
-    private Page extractOutput()
-    {
-        // INVARIANT: pagesIndex contains the full grouped & sorted data for one or more partitions
-
-        // Iterate through the positions sequentially until we have one full page
-        while (!pageBuilder.isFull()) {
-            if (partition == null || !partition.hasNext()) {
-                int partitionStart = partition == null ? 0 : partition.getPartitionEnd();
-
-                if (partitionStart >= pagesIndex.getPositionCount()) {
-                    // Finished all of the partitions in the current pagesIndex
-                    partition = null;
-                    pagesIndex.clear();
-
-                    // Try to extract more partitions from the pendingInput
-                    if (pendingInput != null && processPendingInput()) {
-                        partitionStart = 0;
-                    }
-                    else if (state == State.FINISHING) {
-                        state = State.FINISHED;
-                        // Output the remaining page if we have anything buffered
-                        if (!pageBuilder.isEmpty()) {
-                            Page page = pageBuilder.build();
-                            pageBuilder.reset();
-                            return page;
-                        }
-                        return null;
-                    }
-                    else {
-                        state = State.NEEDS_INPUT;
-                        return null;
-                    }
-                }
-
-                int partitionEnd = findGroupEnd(pagesIndex, unGroupedPartitionHashStrategy, partitionStart);
-                partition = new WindowPartition(pagesIndex, partitionStart, partitionEnd, outputChannels, windowFunctions, peerGroupHashStrategy);
-                windowInfo.addPartition(partition);
-            }
-
-            partition.processNextRow(pageBuilder);
-        }
-
-        Page page = pageBuilder.build();
-        pageBuilder.reset();
-        return page;
-    }
-
-    private void sortPagesIndexIfNecessary()
-    {
-        if (pagesIndex.getPositionCount() > 1 && !orderChannels.isEmpty()) {
-            int startPosition = 0;
-            while (startPosition < pagesIndex.getPositionCount()) {
-                int endPosition = findGroupEnd(pagesIndex, preSortedPartitionHashStrategy, startPosition);
-                pagesIndex.sort(orderChannels, ordering, startPosition, endPosition);
-                startPosition = endPosition;
-            }
-        }
-    }
-
-    private void finishPagesIndex()
-    {
-        sortPagesIndexIfNecessary();
-        windowInfo.addIndex(pagesIndex);
     }
 
     // Assumes input grouped on relevant pagesHashStrategy columns
@@ -519,11 +560,5 @@ public class WindowOperator
 
         // the input is sorted, but the algorithm has still failed
         throw new IllegalArgumentException("failed to find a group ending");
-    }
-
-    @Override
-    public void close()
-    {
-        driverWindowInfo.set(Optional.of(windowInfo.build()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -930,7 +930,9 @@ public class LocalExecutionPlanner
                     sortOrder,
                     node.getPreSortedOrderPrefix(),
                     10_000,
-                    pagesIndexFactory);
+                    pagesIndexFactory,
+                    isSpillEnabled(session),
+                    spillerFactory);
 
             return new PhysicalOperation(operatorFactory, outputMappings.build(), context, source);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -682,7 +682,7 @@ public class TestHashAggregationOperator
         return ((InMemoryHashAggregationBuilder) aggregationBuilder).getCapacity();
     }
 
-    private static class DummySpillerFactory
+    public static class DummySpillerFactory
             implements SpillerFactory
     {
         private long spillsCount;
@@ -713,6 +713,7 @@ public class TestHashAggregationOperator
                 @Override
                 public void close()
                 {
+                    spills.clear();
                 }
             };
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
@@ -34,6 +34,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -105,8 +106,16 @@ public class TestWindowOperator
         scheduledExecutor.shutdownNow();
     }
 
-    @Test
-    public void testRowNumber()
+    @DataProvider(name = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public static Object[][] testWithoutSpillEnabledAndSpillEnabled()
+    {
+        return new Object[][] {
+                {false},
+                {true}};
+    }
+
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testRowNumber(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)
                 .row(2L, 0.3)
@@ -123,7 +132,8 @@ public class TestWindowOperator
                 ROW_NUMBER,
                 Ints.asList(),
                 Ints.asList(0),
-                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}));
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), DOUBLE, BIGINT, BIGINT)
                 .row(-0.1, -1L, 1L)
@@ -136,8 +146,8 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testRowNumberPartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testRowNumberPartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(VARCHAR, BIGINT, DOUBLE, BOOLEAN)
                 .row("b", -1L, -0.1, true)
@@ -154,7 +164,8 @@ public class TestWindowOperator
                 ROW_NUMBER,
                 Ints.asList(0),
                 Ints.asList(1),
-                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}));
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, BIGINT, DOUBLE, BOOLEAN, BIGINT)
                 .row("a", 2L, 0.3, false, 1L)
@@ -167,7 +178,6 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
     public void testRowNumberArbitrary()
     {
         List<Page> input = rowPagesBuilder(BIGINT)
@@ -188,7 +198,8 @@ public class TestWindowOperator
                 ROW_NUMBER,
                 Ints.asList(),
                 Ints.asList(),
-                ImmutableList.copyOf(new SortOrder[] {}));
+                ImmutableList.copyOf(new SortOrder[] {}),
+                false);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, BIGINT)
                 .row(1L, 1L)
@@ -198,6 +209,44 @@ public class TestWindowOperator
                 .row(2L, 5L)
                 .row(4L, 6L)
                 .row(6L, 7L)
+                .row(8L, 8L)
+                .build();
+
+        assertOperatorEquals(operatorFactory, driverContext, input, expected);
+    }
+
+    @Test
+    public void testRowNumberArbitraryWithSpill()
+    {
+        List<Page> input = rowPagesBuilder(BIGINT)
+                .row(1L)
+                .row(3L)
+                .row(5L)
+                .row(7L)
+                .pageBreak()
+                .row(2L)
+                .row(4L)
+                .row(6L)
+                .row(8L)
+                .build();
+
+        WindowOperatorFactory operatorFactory = createFactoryUnbounded(
+                ImmutableList.of(BIGINT),
+                Ints.asList(0),
+                ROW_NUMBER,
+                Ints.asList(),
+                Ints.asList(),
+                ImmutableList.copyOf(new SortOrder[] {}),
+                true);
+
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, BIGINT)
+                .row(1L, 1L)
+                .row(2L, 2L)
+                .row(3L, 3L)
+                .row(4L, 4L)
+                .row(5L, 5L)
+                .row(6L, 6L)
+                .row(7L, 7L)
                 .row(8L, 8L)
                 .build();
 
@@ -225,13 +274,14 @@ public class TestWindowOperator
                 ROW_NUMBER,
                 Ints.asList(),
                 Ints.asList(0),
-                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}));
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                false);
 
         toPages(operatorFactory, driverContext, input);
     }
 
-    @Test
-    public void testFirstValuePartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testFirstValuePartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
                 .row("b", "A1", 1L, true, "")
@@ -249,7 +299,8 @@ public class TestWindowOperator
                 FIRST_VALUE,
                 Ints.asList(0),
                 Ints.asList(2),
-                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}));
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
                 .row("a", "A2", 1L, false, "A2")
@@ -263,8 +314,8 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testLastValuePartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testLastValuePartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
                 .row("b", "A1", 1L, true, "")
@@ -282,7 +333,8 @@ public class TestWindowOperator
                 LAST_VALUE,
                 Ints.asList(0),
                 Ints.asList(2),
-                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}));
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
                 .row("a", "A2", 1L, false, "C2")
@@ -295,8 +347,8 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testNthValuePartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testNthValuePartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(VARCHAR, VARCHAR, BIGINT, BIGINT, BOOLEAN, VARCHAR)
                 .row("b", "A1", 1L, 2L, true, "")
@@ -314,7 +366,8 @@ public class TestWindowOperator
                 NTH_VALUE,
                 Ints.asList(0),
                 Ints.asList(2),
-                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}));
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
                 .row("a", "A2", 1L, false, "C2")
@@ -328,8 +381,8 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testLagPartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testLagPartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(VARCHAR, VARCHAR, BIGINT, BIGINT, VARCHAR, BOOLEAN, VARCHAR)
                 .row("b", "A1", 1L, 1L, "D", true, "")
@@ -347,7 +400,8 @@ public class TestWindowOperator
                 LAG,
                 Ints.asList(0),
                 Ints.asList(2),
-                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}));
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
                 .row("a", "A2", 1L, false, "D")
@@ -361,8 +415,8 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testLeadPartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testLeadPartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(VARCHAR, VARCHAR, BIGINT, BIGINT, VARCHAR, BOOLEAN, VARCHAR)
                 .row("b", "A1", 1L, 1L, "D", true, "")
@@ -380,7 +434,8 @@ public class TestWindowOperator
                 LEAD,
                 Ints.asList(0),
                 Ints.asList(2),
-                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}));
+                ImmutableList.copyOf(new SortOrder[] {SortOrder.ASC_NULLS_LAST}),
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), VARCHAR, VARCHAR, BIGINT, BOOLEAN, VARCHAR)
                 .row("a", "A2", 1L, false, "C2")
@@ -394,8 +449,8 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testPartiallyPreGroupedPartitionWithEmptyInput()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testPartiallyPreGroupedPartitionWithEmptyInput(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(BIGINT, VARCHAR, BIGINT, VARCHAR)
                 .pageBreak()
@@ -410,7 +465,8 @@ public class TestWindowOperator
                 Ints.asList(1),
                 Ints.asList(3),
                 ImmutableList.of(SortOrder.ASC_NULLS_LAST),
-                0);
+                0,
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, VARCHAR, BIGINT, VARCHAR, BIGINT)
                 .build();
@@ -418,8 +474,8 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testPartiallyPreGroupedPartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testPartiallyPreGroupedPartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(BIGINT, VARCHAR, BIGINT, VARCHAR)
                 .pageBreak()
@@ -442,7 +498,8 @@ public class TestWindowOperator
                 Ints.asList(1),
                 Ints.asList(3),
                 ImmutableList.of(SortOrder.ASC_NULLS_LAST),
-                0);
+                0,
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, VARCHAR, BIGINT, VARCHAR, BIGINT)
                 .row(1L, "a", 100L, "A", 1L)
@@ -456,8 +513,8 @@ public class TestWindowOperator
         assertOperatorEqualsIgnoreOrder(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testFullyPreGroupedPartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testFullyPreGroupedPartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(BIGINT, VARCHAR, BIGINT, VARCHAR)
                 .pageBreak()
@@ -481,7 +538,8 @@ public class TestWindowOperator
                 Ints.asList(0, 1),
                 Ints.asList(3),
                 ImmutableList.of(SortOrder.ASC_NULLS_LAST),
-                0);
+                0,
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, VARCHAR, BIGINT, VARCHAR, BIGINT)
                 .row(1L, "a", 100L, "A", 1L)
@@ -496,8 +554,8 @@ public class TestWindowOperator
         assertOperatorEqualsIgnoreOrder(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testFullyPreGroupedAndPartiallySortedPartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testFullyPreGroupedAndPartiallySortedPartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(BIGINT, VARCHAR, BIGINT, VARCHAR)
                 .pageBreak()
@@ -522,7 +580,8 @@ public class TestWindowOperator
                 Ints.asList(0, 1),
                 Ints.asList(3, 2),
                 ImmutableList.of(SortOrder.ASC_NULLS_LAST, SortOrder.ASC_NULLS_LAST),
-                1);
+                1,
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, VARCHAR, BIGINT, VARCHAR, BIGINT)
                 .row(1L, "a", 100L, "A", 1L)
@@ -538,8 +597,8 @@ public class TestWindowOperator
         assertOperatorEqualsIgnoreOrder(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testFullyPreGroupedAndFullySortedPartition()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testFullyPreGroupedAndFullySortedPartition(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(BIGINT, VARCHAR, BIGINT, VARCHAR)
                 .pageBreak()
@@ -564,7 +623,8 @@ public class TestWindowOperator
                 Ints.asList(0, 1),
                 Ints.asList(3),
                 ImmutableList.of(SortOrder.ASC_NULLS_LAST),
-                1);
+                1,
+                spillEnabled);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, VARCHAR, BIGINT, VARCHAR, BIGINT)
                 .row(1L, "a", 100L, "A", 1L)
@@ -620,7 +680,8 @@ public class TestWindowOperator
             List<WindowFunctionDefinition> functions,
             List<Integer> partitionChannels,
             List<Integer> sortChannels,
-            List<SortOrder> sortOrder)
+            List<SortOrder> sortOrder,
+            boolean spillEnabled)
     {
         return createFactoryUnbounded(
                 sourceTypes,
@@ -630,7 +691,8 @@ public class TestWindowOperator
                 ImmutableList.of(),
                 sortChannels,
                 sortOrder,
-                0);
+                0,
+                spillEnabled);
     }
 
     private static WindowOperatorFactory createFactoryUnbounded(
@@ -641,7 +703,8 @@ public class TestWindowOperator
             List<Integer> preGroupedChannels,
             List<Integer> sortChannels,
             List<SortOrder> sortOrder,
-            int preSortedChannelPrefix)
+            int preSortedChannelPrefix,
+            boolean spillEnabled)
     {
         return new WindowOperatorFactory(
                 0,
@@ -655,6 +718,8 @@ public class TestWindowOperator
                 sortOrder,
                 preSortedChannelPrefix,
                 10,
-                new PagesIndex.TestingFactory(false));
+                new PagesIndex.TestingFactory(false),
+                spillEnabled,
+                new TestHashAggregationOperator.DummySpillerFactory());
     }
 }

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryTrackingContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryTrackingContext.java
@@ -112,6 +112,11 @@ public final class MemoryTrackingContext
         return userAggregateMemoryContext;
     }
 
+    public AggregatedMemoryContext aggregateRevocableMemoryContext()
+    {
+        return revocableAggregateMemoryContext;
+    }
+
     public AggregatedMemoryContext newAggregateSystemMemoryContext()
     {
         return systemAggregateMemoryContext.newAggregatedMemoryContext();


### PR DESCRIPTION
Thanks a ton @sopel39 for helping with the entire design, porting of window operator to work processors, review and miscellaneous fixes

This PR introduces the following changes:

1) Refactor ``WindowOperator`` to use ``WorkProcessor``. (credits @sopel39 )

2) Introduce revocable aggregated memory in ``OperatorExecutionContext``. This change is specifically for adding spill to disk in window aggregates.

3) Spill to disk for window aggregates:

Window Aggregates can now spill intermediate tuples to disk during accumulation of input. ``WindowOperator`` will use revocable memory for ``PagesIndex``, and during a memory revoke signal, the current pages accumulated in memory will be dumped to disk and the revocable memory returned. The spilled pages will be sorted by partition key.

During the calculation of result for a group, spilled pages will be read back from disk and merged with in memory pages. The final merged `PagesIndex` will be used to construct window partitions and passed on to calculate window results.

This approach will be useful for cases where a lot of reasonably sized partitions are present and exhaust the memory. However, a single large partition will still need to be sorted in memory, so this approach will not help there. Solutions to that problem will be discussed in separate PRs.