### PR TITLE
[WIP] Optimize geometry_union_agg and convex_hull_agg to reuse GeometryCursor

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryCursorUtils.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryCursorUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.Geometry;
+import com.esri.core.geometry.GeometryCursor;
+import com.esri.core.geometry.ListeningGeometryCursor;
+import com.esri.core.geometry.ogc.OGCConcreteGeometryCollection;
+import com.esri.core.geometry.ogc.OGCGeometry;
+
+final class GeometryCursorUtils
+{
+    private GeometryCursorUtils() {}
+
+    static void processGeometry(OGCGeometry geometry, ListeningGeometryCursor input, GeometryCursor operator)
+    {
+        if (geometry == null || geometry.isEmpty()) {
+            return;
+        }
+        if (geometry instanceof OGCConcreteGeometryCollection) {
+            OGCConcreteGeometryCollection flattenedCollection = ((OGCConcreteGeometryCollection) geometry).flatten();
+            for (int i = 0; i < flattenedCollection.numGeometries(); i++) {
+                Geometry geometryN = flattenedCollection.geometryN(i).getEsriGeometry();
+                if (!geometryN.isEmpty()) {
+                    input.tick(geometryN);
+                    operator.tock();
+                }
+            }
+        }
+        else {
+            input.tick(geometry.getEsriGeometry());
+            operator.tock();
+        }
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryOperatorFactory.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryOperatorFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.GeometryCursor;
+import com.esri.core.geometry.ListeningGeometryCursor;
+import com.esri.core.geometry.SpatialReference;
+
+public interface GeometryOperatorFactory
+{
+    GeometryCursor create(ListeningGeometryCursor input, SpatialReference spatialReference);
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryOperatorState.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryOperatorState.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+import static com.facebook.presto.plugin.geospatial.aggregation.GeometryOperatorStateFactory.GeometryConvexHullOperatorStateFactory;
+import static com.facebook.presto.plugin.geospatial.aggregation.GeometryOperatorStateFactory.GeometryUnionOperatorStateFactory;
+
+public interface GeometryOperatorState
+        extends AccumulatorState
+{
+    OGCGeometry getGeometry();
+
+    void add(OGCGeometry geometry);
+
+    @AccumulatorStateMetadata(stateSerializerClass = GeometryOperatorStateSerializer.class, stateFactoryClass = GeometryUnionOperatorStateFactory.class)
+    interface GeometryUnionOperatorState
+            extends GeometryOperatorState
+    {}
+
+    @AccumulatorStateMetadata(stateSerializerClass = GeometryOperatorStateSerializer.class, stateFactoryClass = GeometryConvexHullOperatorStateFactory.class)
+    interface GeometryConvexHullOperatorState
+            extends GeometryOperatorState
+    {}
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryOperatorStateFactory.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryOperatorStateFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.OperatorConvexHull;
+import com.esri.core.geometry.OperatorUnion;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+
+public class GeometryOperatorStateFactory
+        implements AccumulatorStateFactory<GeometryOperatorState>
+{
+    private final GeometryOperatorFactory operatorFactory;
+
+    public GeometryOperatorStateFactory(GeometryOperatorFactory operatorFactory)
+    {
+        this.operatorFactory = operatorFactory;
+    }
+
+    @Override
+    public GeometryOperatorState createSingleState()
+    {
+        return new SingleGeometryOperatorState(operatorFactory);
+    }
+
+    @Override
+    public Class<? extends GeometryOperatorState> getSingleStateClass()
+    {
+        return SingleGeometryOperatorState.class;
+    }
+
+    @Override
+    public GeometryOperatorState createGroupedState()
+    {
+        return new GroupedGeometryOperatorState(operatorFactory);
+    }
+
+    @Override
+    public Class<? extends GeometryOperatorState> getGroupedStateClass()
+    {
+        return GroupedGeometryOperatorState.class;
+    }
+
+    public static final class GeometryConvexHullOperatorStateFactory
+            extends GeometryOperatorStateFactory
+    {
+        public GeometryConvexHullOperatorStateFactory()
+        {
+            super((input, spatialReference) -> OperatorConvexHull.local().execute(input, true, null));
+        }
+    }
+
+    public static final class GeometryUnionOperatorStateFactory
+            extends GeometryOperatorStateFactory
+    {
+        public GeometryUnionOperatorStateFactory()
+        {
+            super((input, spatialReference) -> OperatorUnion.local().execute(input, spatialReference, null));
+        }
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryOperatorStateSerializer.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryOperatorStateSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.geospatial.serde.GeometrySerde;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+
+import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY;
+
+public class GeometryOperatorStateSerializer
+        implements AccumulatorStateSerializer<GeometryOperatorState.GeometryUnionOperatorState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return GEOMETRY;
+    }
+
+    @Override
+    public void serialize(GeometryOperatorState.GeometryUnionOperatorState state, BlockBuilder out)
+    {
+        OGCGeometry geometry = state.getGeometry();
+        if (geometry == null) {
+            out.appendNull();
+        }
+        else {
+            GEOMETRY.writeSlice(out, GeometrySerde.serialize(geometry));
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, GeometryOperatorState.GeometryUnionOperatorState state)
+    {
+        state.add(GeometrySerde.deserialize(GEOMETRY.getSlice(block, index)));
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GroupedGeometryOperatorState.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GroupedGeometryOperatorState.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.GeometryCursor;
+import com.esri.core.geometry.ListeningGeometryCursor;
+import com.esri.core.geometry.SpatialReference;
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.spi.function.GroupedAccumulatorState;
+
+import static com.facebook.presto.plugin.geospatial.aggregation.GeometryCursorUtils.processGeometry;
+
+public class GroupedGeometryOperatorState
+        implements GeometryOperatorState.GeometryUnionOperatorState, GeometryOperatorState.GeometryConvexHullOperatorState, GroupedAccumulatorState
+{
+    private final GeometryOperatorFactory operatorFactory;
+    private long groupId;
+    private ObjectBigArray<GeometryCursor> operators = new ObjectBigArray<>();
+    private ObjectBigArray<ListeningGeometryCursor> inputs = new ObjectBigArray<>();
+    private SpatialReference spatialReference;
+
+    public GroupedGeometryOperatorState(GeometryOperatorFactory operatorFactory) {
+        this.operatorFactory = operatorFactory;
+    }
+
+    @Override
+    public OGCGeometry getGeometry()
+    {
+        GeometryCursor gc = operators.get(groupId);
+        if (gc == null) {
+            return null;
+        }
+        return OGCGeometry.createFromEsriCursor(gc, spatialReference);
+    }
+
+    @Override
+    public void add(OGCGeometry geometry)
+    {
+        if (geometry == null || geometry.isEmpty()) {
+            return;
+        }
+        if (spatialReference == null) {
+            spatialReference = geometry.getEsriSpatialReference();
+        }
+        GeometryCursor operator = operators.get(groupId);
+        ListeningGeometryCursor input;
+        if (operator == null) {
+            input = new ListeningGeometryCursor();
+            operator = operatorFactory.create(input, spatialReference);
+            inputs.set(groupId, input);
+            operators.set(groupId, operator);
+        }
+        else {
+            input = inputs.get(groupId);
+        }
+        processGeometry(geometry, input, operator);
+    }
+
+    @Override
+    public void ensureCapacity(long size)
+    {
+        operators.ensureCapacity(size);
+        inputs.ensureCapacity(size);
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return 0; // FIXME: missing logic to retrieve the estimated memory size of cursors
+    }
+
+    @Override
+    public final void setGroupId(long groupId)
+    {
+        this.groupId = groupId;
+    }
+}

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/SingleGeometryOperatorState.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/SingleGeometryOperatorState.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial.aggregation;
+
+import com.esri.core.geometry.GeometryCursor;
+import com.esri.core.geometry.ListeningGeometryCursor;
+import com.esri.core.geometry.SpatialReference;
+import com.esri.core.geometry.ogc.OGCGeometry;
+
+import static com.facebook.presto.plugin.geospatial.aggregation.GeometryCursorUtils.processGeometry;
+
+public class SingleGeometryOperatorState
+        implements GeometryOperatorState.GeometryUnionOperatorState, GeometryOperatorState.GeometryConvexHullOperatorState
+{
+    private final ListeningGeometryCursor input;
+    private final GeometryOperatorFactory operatorFactory;
+    private GeometryCursor operator;
+    private SpatialReference spatialReference;
+
+    public SingleGeometryOperatorState(GeometryOperatorFactory operatorFactory)
+    {
+        this.input = new ListeningGeometryCursor();
+        this.operatorFactory = operatorFactory;
+    }
+
+    @Override
+    public OGCGeometry getGeometry()
+    {
+        if (operator == null) {
+            return null;
+        }
+        return OGCGeometry.createFromEsriCursor(operator, spatialReference);
+    }
+
+    @Override
+    public void add(OGCGeometry geometry)
+    {
+        if (geometry == null || geometry.isEmpty()) {
+            return;
+        }
+        if (operator == null) {
+            spatialReference = geometry.getEsriSpatialReference();
+            operator = operatorFactory.create(input, spatialReference);
+        }
+        processGeometry(geometry, input, operator);
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return 0; // FIXME: missing logic to retrieve the estimated memory size of cursors
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkGeometryAggregation.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkGeometryAggregation.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import com.facebook.presto.plugin.memory.MemoryConnectorFactory;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.google.common.collect.ImmutableMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(3)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class BenchmarkGeometryAggregation
+{
+    @State(Thread)
+    public static class Context
+    {
+        private LocalQueryRunner queryRunner;
+
+        public LocalQueryRunner getQueryRunner()
+        {
+            return queryRunner;
+        }
+
+        @Setup
+        public void setUp()
+                throws IOException
+        {
+            queryRunner = new LocalQueryRunner(testSessionBuilder()
+                    .setCatalog("memory")
+                    .setSchema("default")
+                    .build());
+            queryRunner.installPlugin(new GeoPlugin());
+            queryRunner.createCatalog("memory", new MemoryConnectorFactory(), ImmutableMap.of());
+
+            Path path = Paths.get(BenchmarkGeometryAggregation.class.getClassLoader().getResource("us-states.tsv").getPath());
+            String polygonValues = Files.lines(path)
+                    .map(line -> line.split("\t"))
+                    .map(parts -> format("('%s', '%s')", parts[0], parts[1]))
+                    .collect(Collectors.joining(","));
+            queryRunner.execute(
+                    format("CREATE TABLE memory.default.geometry_union_agg_polygons AS SELECT st_geometryfromtext(t.wkt) as geom FROM (VALUES %s) as t (name, wkt)",
+                            polygonValues));
+        }
+
+        @TearDown
+        public void tearDown()
+        {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+
+    @Benchmark
+    public MaterializedResult benchmarkUnion(Context context)
+    {
+        return context.getQueryRunner()
+                .execute("SELECT geometry_union_agg(p.geom) FROM geometry_union_agg_polygons p ");
+    }
+
+    @Benchmark
+    public MaterializedResult benchmarkConvexHull(Context context)
+    {
+        return context.getQueryRunner()
+                .execute("SELECT convex_hull_agg(p.geom) FROM geometry_union_agg_polygons p ");
+    }
+
+    @Test
+    public void verify()
+            throws IOException
+    {
+        Context context = new Context();
+        try {
+            context.setUp();
+
+            BenchmarkGeometryAggregation benchmark = new BenchmarkGeometryAggregation();
+            benchmark.benchmarkUnion(context);
+            benchmark.benchmarkConvexHull(context);
+        }
+        finally {
+            context.queryRunner.close();
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        new BenchmarkGeometryAggregation().verify();
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkGeometryAggregation.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryUnionGeoAggregation.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryUnionGeoAggregation.java
@@ -271,18 +271,18 @@ public class TestGeometryUnionGeoAggregation
                                 "GEOMETRYCOLLECTION ( POLYGON (( 3 0, 3 2, 5 2, 5 0, 3 0 )), POLYGON (( 3 3, 3 5, 5 5, 5 3, 3 3 )) )"},
                 },
                 {
-                        "square with a line crossed becomes geometry collection",
-                        "GEOMETRYCOLLECTION (MULTILINESTRING ((0 2, 1 2), (3 2, 5 2)), POLYGON ((1 1, 3 1, 3 2, 3 3, 1 3, 1 2, 1 1)))",
+                        "square with a line crossed loses the line (lower dimension is dropped)",
+                        "POLYGON ((1 1, 3 1, 3 2, 3 3, 1 3, 1 2, 1 1))",
                         new String[] {"POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))", "LINESTRING (0 2, 5 2)"},
                 },
                 {
-                        "square with adjacent line becomes geometry collection",
-                        "GEOMETRYCOLLECTION (LINESTRING (0 5, 5 5), POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1)))",
+                        "square with adjacent line loses the line (lower dimension is dropped)",
+                        "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
                         new String[] {"POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))", "LINESTRING (0 5, 5 5)"},
                 },
                 {
-                        "square with adjacent point becomes geometry collection",
-                        "GEOMETRYCOLLECTION (POINT (5 2), POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1)))",
+                        "square with adjacent point loses the point (lower dimension is dropped)",
+                        "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
                         new String[] {"POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))", "POINT (5 2)"},
                 },
         };


### PR DESCRIPTION
Current geometry aggregation functions will serialize the input OGCGeometry and perform simple union or convexHull on them iteratively.  This works, but it suffers from poor memory locality, and it has a nontrivial object allocation overhead.  The idea of this PR is to use the internal operators that are invoked inside these two methods, to reuse the operators, and save on object allocation and get better in-memory performance.

The most significant effect of reusing the cursors is that we have access to the optimizations that exist inside them, instead of throwing them away after every iteration of the operation.  For example, for union, with this changeset, the individual union operations will now be grouped by coarsely defined bins which are based on the point count of the geometry with the number of dimensions, batched inside the union cursor, and once the internal batch size exceeds a constant value (10000), they will be unioned in aggregate.  This may result in an increase in memory, but the performance wins should outweigh the relative cost.  At the best case, where we continuously union geometries which overlap, this implementation will suffer from higher memory usage relative to the old implementation--for example, the points which resided inside other polygons will stick in memory longer.  At the worst case, where we are unioning non-overlapping geometries, there shouldn't be much difference in memory utilization, nor performance if the inputs are sufficiently large--once there are over 10000 non-overlapping geometries in a single node, performance may not be much better for whatever number that exceeds 10000.

I have added a JMH benchmark which performs union and convex hull on 50 states.  The performance improvements are stark.  Here are the results for the old method:

```
Result "com.facebook.presto.plugin.geospatial.BenchmarkGeometryAggregation.benchmarkConvexHull":
  23.716 ±(99.9%) 0.572 ms/op [Average]
  (min, avg, max) = (22.057, 23.716, 25.605), stdev = 0.856
  CI (99.9%): [23.144, 24.288] (assumes normal distribution)
```

```
Result "com.facebook.presto.plugin.geospatial.BenchmarkGeometryAggregation.benchmarkUnion":
  628.715 ±(99.9%) 10.353 ms/op [Average]
  (min, avg, max) = (601.299, 628.715, 671.803), stdev = 15.495
  CI (99.9%): [618.362, 639.068] (assumes normal distribution)
```

Here are the results for the new method:

```
Result "com.facebook.presto.plugin.geospatial.BenchmarkGeometryAggregation.benchmarkConvexHull":
  4.556 ±(99.9%) 0.182 ms/op [Average]
  (min, avg, max) = (4.124, 4.556, 5.187), stdev = 0.273
  CI (99.9%): [4.374, 4.739] (assumes normal distribution)
```

```
Result "com.facebook.presto.plugin.geospatial.BenchmarkGeometryAggregation.benchmarkUnion":
  21.780 ±(99.9%) 1.320 ms/op [Average]
  (min, avg, max) = (20.106, 21.780, 31.502), stdev = 1.976
  CI (99.9%): [20.460, 23.101] (assumes normal distribution)
```

There are a few things of note or which need to be fixed before this is ready for full review and merge:

1) There is no way presently to determine the memory utilization of a GeometryCursor.  This will need to be added to the Esri/geometry-api-java library.
2) In the proposed changes, there is a change in behavior for union, which will drop lower dimensions if two dimensional geometries are unioned.  For example, if one were to union a disjoint point and linestring, the union would return only the linestring.
3) There are some differences in behavior with convex hull which are either bugs in the library or something which needs to be fixed in this PR (some tests are failing for convex hull).
4) The above note regarding memory utilization needs to thoroughly studied.  If the 10000 number proves to be too large, we can easily modify the library to make it configurable.

I would be happy to receive feedback on this approach, given the caveats above.  CC: @mbasmanova 