### PR TITLE
Add ORC max column size to convert to direct encoded

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -59,6 +59,7 @@ public final class HiveSessionProperties
     private static final String ORC_OPTIMIZED_WRITER_MAX_STRIPE_SIZE = "orc_optimized_writer_max_stripe_size";
     private static final String ORC_OPTIMIZED_WRITER_MAX_STRIPE_ROWS = "orc_optimized_writer_max_stripe_rows";
     private static final String ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY = "orc_optimized_writer_max_dictionary_memory";
+    private static final String ORC_OPTIMIZED_WRITER_MAX_COLUMN_SIZE_CONVERT_TO_DIRECT = "orc_optimized_writer_max_column_size_convert_to_direct";
     private static final String HIVE_STORAGE_FORMAT = "hive_storage_format";
     private static final String RESPECT_TABLE_FORMAT = "respect_table_format";
     private static final String PARQUET_PREDICATE_PUSHDOWN_ENABLED = "parquet_predicate_pushdown_enabled";
@@ -195,6 +196,11 @@ public final class HiveSessionProperties
                         ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY,
                         "Experimental: ORC: Max dictionary memory",
                         orcFileWriterConfig.getDictionaryMaxMemory(),
+                        false),
+                dataSizeSessionProperty(
+                        ORC_OPTIMIZED_WRITER_MAX_COLUMN_SIZE_CONVERT_TO_DIRECT,
+                        "Experimental: ORC: Max column size to convert to direct encoded from dictionary encoded",
+                        orcFileWriterConfig.getColumnMaxSizeConvertToDirect(),
                         false),
                 stringProperty(
                         HIVE_STORAGE_FORMAT,
@@ -376,6 +382,11 @@ public final class HiveSessionProperties
     public static DataSize getOrcOptimizedWriterMaxDictionaryMemory(ConnectorSession session)
     {
         return session.getProperty(ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY, DataSize.class);
+    }
+
+    public static DataSize getOrcOptimizedWriterMaxColumnSizeConvertToDirect(ConnectorSession session)
+    {
+        return session.getProperty(ORC_OPTIMIZED_WRITER_MAX_COLUMN_SIZE_CONVERT_TO_DIRECT, DataSize.class);
     }
 
     public static HiveStorageFormat getHiveStorageFormat(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -87,6 +87,18 @@ public class OrcFileWriterConfig
         return this;
     }
 
+    public DataSize getColumnMaxSizeConvertToDirect()
+    {
+        return options.getColumnMaxSizeConvertToDirect();
+    }
+
+    @Config("hive.orc.writer.column-max-size-convert-to-direct")
+    public OrcFileWriterConfig setColumnMaxSizeConvertToDirect(DataSize columnMaxSizeConvertToDirect)
+    {
+        options = options.withColumnMaxSizeConvertToDirect(columnMaxSizeConvertToDirect);
+        return this;
+    }
+
     public DataSize getStringStatisticsLimit()
     {
         return options.getMaxStringStatisticsLimit();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -52,6 +52,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxMergeDistance;
+import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWriterMaxColumnSizeConvertToDirect;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWriterMaxDictionaryMemory;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWriterMaxStripeRows;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWriterMaxStripeSize;
@@ -198,6 +199,7 @@ public class OrcFileWriterFactory
                             .withStripeMaxSize(getOrcOptimizedWriterMaxStripeSize(session))
                             .withStripeMaxRowCount(getOrcOptimizedWriterMaxStripeRows(session))
                             .withDictionaryMaxMemory(getOrcOptimizedWriterMaxDictionaryMemory(session))
+                            .withColumnMaxSizeConvertToDirect(getOrcOptimizedWriterMaxColumnSizeConvertToDirect(session))
                             .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session)),
                     fileInputColumnIndexes,
                     ImmutableMap.<String, String>builder()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -37,6 +37,7 @@ public class TestOrcFileWriterConfig
                 .setStripeMaxRowCount(10_000_000)
                 .setRowGroupMaxRowCount(10_000)
                 .setDictionaryMaxMemory(new DataSize(16, MEGABYTE))
+                .setColumnMaxSizeConvertToDirect(new DataSize(256, MEGABYTE))
                 .setStringStatisticsLimit(new DataSize(64, BYTE))
                 .setMaxCompressionBufferSize(new DataSize(256, KILOBYTE)));
     }
@@ -50,6 +51,7 @@ public class TestOrcFileWriterConfig
                 .put("hive.orc.writer.stripe-max-rows", "44")
                 .put("hive.orc.writer.row-group-max-rows", "11")
                 .put("hive.orc.writer.dictionary-max-memory", "13MB")
+                .put("hive.orc.writer.column-max-size-convert-to-direct", "217MB")
                 .put("hive.orc.writer.string-statistics-limit", "17MB")
                 .put("hive.orc.writer.max-compression-buffer-size", "19MB")
                 .build();
@@ -60,6 +62,7 @@ public class TestOrcFileWriterConfig
                 .setStripeMaxRowCount(44)
                 .setRowGroupMaxRowCount(11)
                 .setDictionaryMaxMemory(new DataSize(13, MEGABYTE))
+                .setColumnMaxSizeConvertToDirect(new DataSize(217, MEGABYTE))
                 .setStringStatisticsLimit(new DataSize(17, MEGABYTE))
                 .setMaxCompressionBufferSize(new DataSize(19, MEGABYTE));
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -187,7 +187,8 @@ public class OrcWriter
                 stripeMinBytes,
                 stripeMaxBytes,
                 stripeMaxRowCount,
-                toIntExact(requireNonNull(options.getDictionaryMaxMemory(), "dictionaryMaxMemory is null").toBytes()));
+                toIntExact(requireNonNull(options.getDictionaryMaxMemory(), "dictionaryMaxMemory is null").toBytes()),
+                toIntExact(requireNonNull(options.getColumnMaxSizeConvertToDirect(), "columnMaxSizeConvertToDirect is null").toBytes()));
 
         for (Entry<String, String> entry : this.userMetadata.entrySet()) {
             recordValidation(validation -> validation.addMetadataProperty(entry.getKey(), utf8Slice(entry.getValue())));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -29,6 +29,7 @@ public class OrcWriterOptions
     private static final int DEFAULT_STRIPE_MAX_ROW_COUNT = 10_000_000;
     private static final int DEFAULT_ROW_GROUP_MAX_ROW_COUNT = 10_000;
     private static final DataSize DEFAULT_DICTIONARY_MAX_MEMORY = new DataSize(16, MEGABYTE);
+    private static final DataSize DEFAULT_COLUMN_MAX_SIZE_CONVERT_TO_DIRECT = new DataSize(256, MEGABYTE);
     public static final DataSize DEFAULT_MAX_STRING_STATISTICS_LIMIT = new DataSize(64, BYTE);
     private static final DataSize DEFAULT_MAX_COMPRESSION_BUFFER_SIZE = new DataSize(256, KILOBYTE);
 
@@ -37,6 +38,7 @@ public class OrcWriterOptions
     private final int stripeMaxRowCount;
     private final int rowGroupMaxRowCount;
     private final DataSize dictionaryMaxMemory;
+    private final DataSize columnMaxSizeConvertToDirect;
     private final DataSize maxStringStatisticsLimit;
     private final DataSize maxCompressionBufferSize;
 
@@ -48,6 +50,7 @@ public class OrcWriterOptions
                 DEFAULT_STRIPE_MAX_ROW_COUNT,
                 DEFAULT_ROW_GROUP_MAX_ROW_COUNT,
                 DEFAULT_DICTIONARY_MAX_MEMORY,
+                DEFAULT_COLUMN_MAX_SIZE_CONVERT_TO_DIRECT,
                 DEFAULT_MAX_STRING_STATISTICS_LIMIT,
                 DEFAULT_MAX_COMPRESSION_BUFFER_SIZE);
     }
@@ -58,6 +61,7 @@ public class OrcWriterOptions
             int stripeMaxRowCount,
             int rowGroupMaxRowCount,
             DataSize dictionaryMaxMemory,
+            DataSize columnMaxSizeConvertToDirect,
             DataSize maxStringStatisticsLimit,
             DataSize maxCompressionBufferSize)
     {
@@ -66,6 +70,7 @@ public class OrcWriterOptions
         checkArgument(stripeMaxRowCount >= 1, "stripeMaxRowCount must be at least 1");
         checkArgument(rowGroupMaxRowCount >= 1, "rowGroupMaxRowCount must be at least 1");
         requireNonNull(dictionaryMaxMemory, "dictionaryMaxMemory is null");
+        requireNonNull(columnMaxSizeConvertToDirect, "columnMaxSizeConvertToDirect is null");
         requireNonNull(maxStringStatisticsLimit, "maxStringStatisticsLimit is null");
         requireNonNull(maxCompressionBufferSize, "maxCompressionBufferSize is null");
 
@@ -74,6 +79,7 @@ public class OrcWriterOptions
         this.stripeMaxRowCount = stripeMaxRowCount;
         this.rowGroupMaxRowCount = rowGroupMaxRowCount;
         this.dictionaryMaxMemory = dictionaryMaxMemory;
+        this.columnMaxSizeConvertToDirect = columnMaxSizeConvertToDirect;
         this.maxStringStatisticsLimit = maxStringStatisticsLimit;
         this.maxCompressionBufferSize = maxCompressionBufferSize;
     }
@@ -103,6 +109,11 @@ public class OrcWriterOptions
         return dictionaryMaxMemory;
     }
 
+    public DataSize getColumnMaxSizeConvertToDirect()
+    {
+        return columnMaxSizeConvertToDirect;
+    }
+
     public DataSize getMaxStringStatisticsLimit()
     {
         return maxStringStatisticsLimit;
@@ -115,37 +126,42 @@ public class OrcWriterOptions
 
     public OrcWriterOptions withStripeMinSize(DataSize stripeMinSize)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, columnMaxSizeConvertToDirect, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withStripeMaxSize(DataSize stripeMaxSize)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, columnMaxSizeConvertToDirect, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withStripeMaxRowCount(int stripeMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, columnMaxSizeConvertToDirect, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withRowGroupMaxRowCount(int rowGroupMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, columnMaxSizeConvertToDirect, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withDictionaryMaxMemory(DataSize dictionaryMaxMemory)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, columnMaxSizeConvertToDirect, maxStringStatisticsLimit, maxCompressionBufferSize);
+    }
+
+    public OrcWriterOptions withColumnMaxSizeConvertToDirect(DataSize columnMaxSizeConvertToDirect)
+    {
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, columnMaxSizeConvertToDirect, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withMaxStringStatisticsLimit(DataSize maxStringStatisticsLimit)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, columnMaxSizeConvertToDirect, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     public OrcWriterOptions withMaxCompressionBufferSize(DataSize maxCompressionBufferSize)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, columnMaxSizeConvertToDirect, maxStringStatisticsLimit, maxCompressionBufferSize);
     }
 
     @Override
@@ -157,6 +173,7 @@ public class OrcWriterOptions
                 .add("stripeMaxRowCount", stripeMaxRowCount)
                 .add("rowGroupMaxRowCount", rowGroupMaxRowCount)
                 .add("dictionaryMaxMemory", dictionaryMaxMemory)
+                .add("columnMaxSizeConvertToDirect", columnMaxSizeConvertToDirect)
                 .add("maxStringStatisticsLimit", maxStringStatisticsLimit)
                 .add("maxCompressionBufferSize", maxCompressionBufferSize)
                 .toString();


### PR DESCRIPTION
A column with large raw size should not be converted to direct encoded
to avoid too large stripe size