### PR TITLE
Handle aliasing columns for table containing hidden columns

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/TestHiddenColumns.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestHiddenColumns.java
@@ -65,4 +65,14 @@ public class TestHiddenColumns
         assertEquals(runner.execute("SELECT *, row_number, * from REGION"), runner.execute("SELECT regionkey, name, comment, row_number, regionkey, name, comment from REGION"));
         assertEquals(runner.execute("SELECT row_number, x.row_number from REGION x"), runner.execute("SELECT row_number, row_number from REGION"));
     }
+
+    @Test
+    public void testAliasedTableColumns()
+    {
+        // https://github.com/prestodb/presto/issues/11385
+        // TPCH tables have a hidden "row_number" column, which triggers this bug.
+        assertEquals(
+                runner.execute("SELECT * FROM orders AS t (a, b, c, d, e, f, g, h, i)"),
+                runner.execute("SELECT * FROM orders"));
+    }
 }


### PR DESCRIPTION
Hidden columns were not being ignored when planning an aliased
relation. This caused a planning failure due to a mismatch between
the actual and expected number of columns.

Fixes #11385