### PR TITLE
Avoid writing huge stripes due to direct encode conversion

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
@@ -281,6 +281,8 @@ public class DictionaryCompressionOptimizer
         int getDictionaryBytes();
 
         long convertToDirect();
+
+        long getBufferedBytes();
     }
 
     private static class DictionaryColumnManager
@@ -397,7 +399,7 @@ public class DictionaryCompressionOptimizer
 
         public long getBufferedBytes()
         {
-            return getIndexBytes() + getDictionaryBytes();
+            return dictionaryColumn.getBufferedBytes();
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -354,7 +354,7 @@ public class OrcWriter
         }
 
         // convert any dictionary encoded column with a low compression ratio to direct
-        dictionaryCompressionOptimizer.finalOptimize();
+        dictionaryCompressionOptimizer.finalOptimize(bufferedBytes);
 
         columnWriters.forEach(ColumnWriter::close);
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -93,8 +93,6 @@ public class LongOutputStreamDwrf
     @Override
     public LongInputStream getLongInputStream()
     {
-        checkState(closed);
-
         FixedLengthSliceInput sliceInput = new ChunkedSliceInput(new ChainedSliceLoader(buffer.getCompressedSlices()), 32 * 1024);
         OrcDataSourceId orcDataSourceId = new OrcDataSourceId("LongOutputStream");
         try {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -202,7 +202,7 @@ public class LongOutputStreamV1
     @Override
     public LongInputStream getLongInputStream()
     {
-        checkState(closed);
+        flushSequence();
 
         FixedLengthSliceInput sliceInput = new ChunkedSliceInput(new ChainedSliceLoader(buffer.getCompressedSlices()), 32 * 1024);
         OrcDataSourceId orcDataSourceId = new OrcDataSourceId("LongOutputStream");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -767,7 +767,7 @@ public class LongOutputStreamV2
     @Override
     public LongInputStream getLongInputStream()
     {
-        checkState(closed);
+        flush();
 
         FixedLengthSliceInput sliceInput = new ChunkedSliceInput(new ChainedSliceLoader(buffer.getCompressedSlices()), 32 * 1024);
         OrcDataSourceId orcDataSourceId = new OrcDataSourceId("LongOutputStream");

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
@@ -55,13 +55,13 @@ public class TestDictionaryCompressionOptimizer
 
             // since there are no dictionary columns, the simulator should advance until the strip is full
             assertFalse(simulator.isDictionaryMemoryFull());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCount);
 
             simulator.finalOptimize();
 
             assertFalse(simulator.isDictionaryMemoryFull());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCount);
 
             simulator.reset();
@@ -90,14 +90,14 @@ public class TestDictionaryCompressionOptimizer
             // since there dictionary columns is only 1 MB, the simulator should advance until the strip is full
             assertFalse(simulator.isDictionaryMemoryFull());
             assertFalse(column.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCount);
 
             simulator.finalOptimize();
 
             assertFalse(simulator.isDictionaryMemoryFull());
             assertFalse(column.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCount);
 
             simulator.reset();
@@ -128,14 +128,14 @@ public class TestDictionaryCompressionOptimizer
             // since there dictionary columns is only 1 MB, the simulator should advance until the strip is full
             assertFalse(simulator.isDictionaryMemoryFull());
             assertFalse(column.isDirect());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertLessThan(simulator.getRowCount(), expectedMaxRowCount);
 
             simulator.finalOptimize();
 
             assertFalse(simulator.isDictionaryMemoryFull());
             assertFalse(column.isDirect());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertLessThan(simulator.getRowCount(), expectedMaxRowCount);
 
             simulator.reset();
@@ -167,14 +167,14 @@ public class TestDictionaryCompressionOptimizer
             // the simulator should advance until memory is full
             assertTrue(simulator.isDictionaryMemoryFull());
             assertFalse(column.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCount);
 
             simulator.finalOptimize();
 
             assertTrue(simulator.isDictionaryMemoryFull());
             assertFalse(column.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCount);
 
             simulator.reset();
@@ -206,7 +206,7 @@ public class TestDictionaryCompressionOptimizer
             // the simulator should advance until the dictionary column is converted to direct
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(column.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedRowCountAtFlip);
 
             simulator.advanceToNextStateChange();
@@ -214,14 +214,14 @@ public class TestDictionaryCompressionOptimizer
             // the simulator should advance until the stripe is full
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(column.isDirect());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCountAtFull);
 
             simulator.finalOptimize();
 
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(column.isDirect());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCountAtFull);
 
             simulator.reset();
@@ -252,7 +252,7 @@ public class TestDictionaryCompressionOptimizer
             // the simulator should advance until the dictionary column is flipped
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(column.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedRowCountAtFlip);
 
             simulator.advanceToNextStateChange();
@@ -260,14 +260,14 @@ public class TestDictionaryCompressionOptimizer
             // the simulator should advance until the stripe is full
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(column.isDirect());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCountAtFull);
 
             simulator.finalOptimize();
 
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(column.isDirect());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCountAtFull);
 
             simulator.reset();
@@ -302,7 +302,7 @@ public class TestDictionaryCompressionOptimizer
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(directColumn.isDirect());
             assertFalse(dictionaryColumn.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedRowCountAtFlip);
 
             simulator.advanceToNextStateChange();
@@ -311,7 +311,7 @@ public class TestDictionaryCompressionOptimizer
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(directColumn.isDirect());
             assertFalse(dictionaryColumn.isDirect());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCountAtFull);
 
             simulator.finalOptimize();
@@ -319,7 +319,7 @@ public class TestDictionaryCompressionOptimizer
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(directColumn.isDirect());
             assertFalse(dictionaryColumn.isDirect());
-            assertGreaterThanOrEqual(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertGreaterThanOrEqual(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedMaxRowCountAtFull);
 
             simulator.reset();
@@ -358,7 +358,7 @@ public class TestDictionaryCompressionOptimizer
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(directColumn.isDirect());
             assertFalse(dictionaryColumn.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), expectedRowCountAtFlip);
 
             simulator.advanceToNextStateChange();
@@ -367,7 +367,7 @@ public class TestDictionaryCompressionOptimizer
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(directColumn.isDirect());
             assertFalse(dictionaryColumn.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), maxRowCount);
 
             simulator.finalOptimize();
@@ -375,7 +375,7 @@ public class TestDictionaryCompressionOptimizer
             assertFalse(simulator.isDictionaryMemoryFull());
             assertTrue(directColumn.isDirect());
             assertFalse(dictionaryColumn.isDirect());
-            assertLessThan(simulator.getBufferedBytes(), stripeMaxBytes);
+            assertLessThan(simulator.getBufferedBytes(), (long) stripeMaxBytes);
             assertGreaterThanOrEqual(simulator.getRowCount(), maxRowCount);
 
             simulator.reset();
@@ -423,7 +423,7 @@ public class TestDictionaryCompressionOptimizer
                 for (TestDictionaryColumn dictionaryColumn : dictionaryColumns) {
                     dictionaryColumn.advanceTo(rowCount);
                 }
-                optimizer.optimize(getBufferedBytes(), getRowCount());
+                optimizer.optimize(toIntExact(getBufferedBytes()), getRowCount());
             }
         }
 
@@ -453,11 +453,11 @@ public class TestDictionaryCompressionOptimizer
             }
         }
 
-        public int getBufferedBytes()
+        public long getBufferedBytes()
         {
-            return (rowCount * otherColumnsBytesPerRow) +
+            return (long) rowCount * otherColumnsBytesPerRow +
                     dictionaryColumns.stream()
-                            .mapToInt(TestDictionaryColumn::getBufferedBytes)
+                            .mapToLong(TestDictionaryColumn::getBufferedBytes)
                             .sum();
         }
 
@@ -526,10 +526,10 @@ public class TestDictionaryCompressionOptimizer
             this.rowCount = rowCount;
         }
 
-        public int getBufferedBytes()
+        public long getBufferedBytes()
         {
             if (direct) {
-                return (int) (rowCount * valuesPerRow * bytesPerEntry);
+                return (long) (rowCount * valuesPerRow * bytesPerEntry);
             }
             int dictionaryEntries = getDictionaryEntries();
             int bytesPerValue = estimateIndexBytesPerValue(dictionaryEntries);


### PR DESCRIPTION
We always convert column to direct encoding when stripe is small after
05b66c041970fff317f88b15bbc991bd8d1ead35. However, in cases that
columns has extremely well compression, it can end up with writing
huge stripes (larger than 2G in a corner case that each value is the
same array of varchar).

This commit fixed this by only convert to direct encode when the new
size is under a given limit.