### PR TITLE
Return a constructed exception from utility method instead of throwing it

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HiveFileIterator.java
@@ -160,7 +160,7 @@ public class HiveFileIterator
         {
             namenodeStats.getRemoteIteratorNext().recordException(exception);
             if (exception instanceof FileNotFoundException) {
-                throw new PrestoException(HIVE_FILE_NOT_FOUND, "Partition location does not exist: " + path);
+                return new PrestoException(HIVE_FILE_NOT_FOUND, "Partition location does not exist: " + path);
             }
             return new PrestoException(HIVE_FILESYSTEM_ERROR, "Failed to list directory: " + path, exception);
         }


### PR DESCRIPTION
Tiny detail: processException is called from other catch blocks. Returning instead of throwing makes the stack trace reference the catch clause.