### PR TITLE
[WIP, Request Comment] Add non-linear transformation after structural hash

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
@@ -29,6 +29,7 @@ import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.type.TypeUtils.NULL_HASH_CODE;
 import static com.facebook.presto.util.Failures.internalError;
+import static java.lang.Long.rotateLeft;
 
 @ScalarOperator(HASH_CODE)
 public final class ArrayHashCodeOperator
@@ -47,7 +48,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invoke(readNativeValue(type, block, i)));
             }
-            return hash;
+            // non-linear transform inspired by xxhash64 mix
+            return rotateLeft(hash * 0xC2B2AE3D27D4EB4FL, 31);
         }
         catch (Throwable t) {
             throw internalError(t);
@@ -67,7 +69,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invokeExact(type.getLong(block, i)));
             }
-            return hash;
+            // non-linear transform inspired by xxhash64 mix
+            return rotateLeft(hash * 0xC2B2AE3D27D4EB4FL, 31);
         }
         catch (Throwable t) {
             throw internalError(t);
@@ -87,7 +90,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invokeExact(type.getBoolean(block, i)));
             }
-            return hash;
+            // non-linear transform inspired by xxhash64 mix
+            return rotateLeft(hash * 0xC2B2AE3D27D4EB4FL, 31);
         }
         catch (Throwable t) {
             throw internalError(t);
@@ -107,7 +111,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invokeExact(type.getSlice(block, i)));
             }
-            return hash;
+            // non-linear transform inspired by xxhash64 mix
+            return rotateLeft(hash * 0xC2B2AE3D27D4EB4FL, 31);
         }
         catch (Throwable t) {
             throw internalError(t);
@@ -127,7 +132,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invokeExact(type.getDouble(block, i)));
             }
-            return hash;
+            // non-linear transform inspired by xxhash64 mix
+            return rotateLeft(hash * 0xC2B2AE3D27D4EB4FL, 31);
         }
         catch (Throwable t) {
             throw internalError(t);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
@@ -28,6 +28,7 @@ import java.util.List;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.TypeUtils.checkElementNotNull;
 import static com.facebook.presto.spi.type.TypeUtils.hashPosition;
+import static java.lang.Long.rotateLeft;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
@@ -89,7 +90,8 @@ public class ArrayType
         for (int i = 0; i < array.getPositionCount(); i++) {
             hash = 31 * hash + hashPosition(elementType, array, i);
         }
-        return hash;
+
+        return HashUtils.shuffle(hash);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/HashUtils.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/HashUtils.java
@@ -1,0 +1,25 @@
+package com.facebook.presto.spi.type;
+
+import static java.lang.Long.rotateLeft;
+
+public class HashUtils
+{
+    private static final long PRIME64_1 = 0x9E3779B185EBCA87L;
+    private static final long PRIME64_2 = 0xC2B2AE3D27D4EB4FL;
+    private static final long PRIME64_3 = 0x165667B19E3779F9L;
+    private static final long PRIME64_4 = 0x85EBCA77C2b2AE63L;
+    private static final long PRIME64_5 = 0x27D4EB2F165667C5L;
+
+    public static long shuffle(long hash)
+    {
+        hash ^= hash >>> 33;
+        hash *= PRIME64_2;
+        hash ^= hash >>> 29;
+        hash *= PRIME64_3;
+        hash ^= hash >>> 32;
+        return hash;
+
+//        return rotateLeft(hash * 0xC2B2AE3D27D4EB4FL, 31);
+    }
+
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.TypeUtils.checkElementNotNull;
 import static com.facebook.presto.spi.type.TypeUtils.hashPosition;
+import static java.lang.Long.rotateLeft;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -118,7 +119,8 @@ public class MapType
         for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
             result += hashPosition(keyType, mapBlock, i) ^ hashPosition(valueType, mapBlock, i + 1);
         }
-        return result;
+
+        return HashUtils.shuffle(result);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.type.StandardTypes.ROW;
+import static java.lang.Long.rotateLeft;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -260,7 +261,8 @@ public class RowType
             Type elementType = fields.get(i).getType();
             result = 31 * result + TypeUtils.hashPosition(elementType, arrayBlock, i);
         }
-        return result;
+
+        return HashUtils.shuffle(result);
     }
 
     private static void checkElementNotNull(boolean isNull)


### PR DESCRIPTION
Both structural hash and checksum are linear functions to the hash
values of input elements. This makes unexpected checksum collision
by exchanging certain set values.
(e.g. values in the same nested column)

This commit avoids such checksum collision by adding non-linear
transformation at the end of structural hash computation.

Example for checksum collision:

```
SELECT checksum(value)
FROM (VALUES
    ARRAY['a', '1'],
    ARRAY['b', '2']
) AS t(value)
```

vs.

```
SELECT checksum(value)
FROM (VALUES
    ARRAY['a', '2'],
    ARRAY['b', '1']
) AS t(value)
```