### PR TITLE
Minor improvements to ORC writer dictionary optimizer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
@@ -426,21 +426,10 @@ public class DictionaryCompressionOptimizer
             return 1.0 * getIndexBytes() / rowCount;
         }
 
-        public int getNullsBytes()
-        {
-            checkState(!directEncoded);
-            return (dictionaryColumn.getValueCount() - dictionaryColumn.getNonNullValueCount() + 7) / 8;
-        }
-
-        public int getCompressedBytes()
-        {
-            return getDictionaryBytes() + getIndexBytes() + getNullsBytes();
-        }
-
         public double getCompressionRatio()
         {
             checkState(!directEncoded);
-            return 1.0 * getRawBytes() / getCompressedBytes();
+            return 1.0 * getRawBytes() / getBufferedBytes();
         }
 
         public long getBufferedBytes()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
@@ -298,9 +298,9 @@ public class DictionaryCompressionOptimizer
 
     public interface DictionaryColumn
     {
-        int getValueCount();
+        long getValueCount();
 
-        int getNonNullValueCount();
+        long getNonNullValueCount();
 
         long getRawBytes();
 
@@ -322,10 +322,10 @@ public class DictionaryCompressionOptimizer
 
         private int rowCount;
 
-        private int pastValueCount;
+        private long pastValueCount;
         private int pastDictionaryEntries;
 
-        private int pendingPastValueCount;
+        private long pendingPastValueCount;
         private int pendingPastDictionaryEntries;
 
         public DictionaryColumnManager(DictionaryColumn dictionaryColumn)
@@ -356,7 +356,7 @@ public class DictionaryCompressionOptimizer
         public void updateHistory(int rowCount)
         {
             this.rowCount = rowCount;
-            int currentValueCount = dictionaryColumn.getValueCount();
+            long currentValueCount = dictionaryColumn.getValueCount();
             if (currentValueCount - pendingPastValueCount >= 1024) {
                 pastValueCount = pendingPastValueCount;
                 pastDictionaryEntries = pendingPastDictionaryEntries;
@@ -389,7 +389,7 @@ public class DictionaryCompressionOptimizer
             checkState(!directEncoded);
 
             int currentDictionaryEntries = dictionaryColumn.getDictionaryEntries();
-            int currentValueCount = dictionaryColumn.getValueCount();
+            long currentValueCount = dictionaryColumn.getValueCount();
 
             // average size of a dictionary entry
             double dictionaryBytesPerEntry = 1.0 * dictionaryColumn.getDictionaryBytes() / currentDictionaryEntries;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
@@ -296,21 +296,6 @@ public class DictionaryCompressionOptimizer
         return toIntExact(Math.min(stripeMaxBytes, stripeMaxBytes - bufferedBytes + DIRECT_COLUMN_SIZE_RANGE.toBytes()));
     }
 
-    public static int estimateIndexBytesPerValue(int dictionaryEntries)
-    {
-        // assume basic byte packing
-        if (dictionaryEntries <= 256) {
-            return 1;
-        }
-        if (dictionaryEntries <= 65_536) {
-            return 2;
-        }
-        if (dictionaryEntries <= 16_777_216) {
-            return 3;
-        }
-        return 4;
-    }
-
     public interface DictionaryColumn
     {
         int getValueCount();
@@ -322,6 +307,8 @@ public class DictionaryCompressionOptimizer
         int getDictionaryEntries();
 
         int getDictionaryBytes();
+
+        int getIndexBytes();
 
         OptionalInt tryConvertToDirect(int maxDirectBytes);
 
@@ -417,7 +404,7 @@ public class DictionaryCompressionOptimizer
         public int getIndexBytes()
         {
             checkState(!directEncoded);
-            return estimateIndexBytesPerValue(dictionaryColumn.getDictionaryEntries()) * dictionaryColumn.getNonNullValueCount();
+            return dictionaryColumn.getIndexBytes();
         }
 
         public double getIndexBytesPerRow()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -97,8 +97,8 @@ public class SliceDictionaryColumnWriter
     private StringStatisticsBuilder statisticsBuilder;
 
     private long rawBytes;
-    private int totalValueCount;
-    private int totalNonNullValueCount;
+    private long totalValueCount;
+    private long totalNonNullValueCount;
 
     private boolean closed;
     private boolean inRowGroup;
@@ -153,14 +153,14 @@ public class SliceDictionaryColumnWriter
     }
 
     @Override
-    public int getValueCount()
+    public long getValueCount()
     {
         checkState(!directEncoded);
         return totalValueCount;
     }
 
     @Override
-    public int getNonNullValueCount()
+    public long getNonNullValueCount()
     {
         checkState(!directEncoded);
         return totalNonNullValueCount;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -146,6 +146,13 @@ public class SliceDictionaryColumnWriter
     }
 
     @Override
+    public int getIndexBytes()
+    {
+        checkState(!directEncoded);
+        return toIntExact(tempDictionaryIdDataStream.getBufferedBytes());
+    }
+
+    @Override
     public int getValueCount()
     {
         checkState(!directEncoded);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.orc.DictionaryCompressionOptimizer.DICTIONARY_MEMORY_MAX_RANGE;
-import static com.facebook.presto.orc.DictionaryCompressionOptimizer.estimateIndexBytesPerValue;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static io.airlift.testing.Assertions.assertLessThan;
@@ -113,7 +112,7 @@ public class TestDictionaryCompressionOptimizer
 
         // construct a simulator that will hit the row limit first
         int stripeMaxBytes = megabytes(100);
-        int bytesPerRow = estimateIndexBytesPerValue(dictionaryEntries);
+        int bytesPerRow = TestDictionaryColumn.estimateIndexBytesPerValue(dictionaryEntries);
         int expectedMaxRowCount = stripeMaxBytes / bytesPerRow;
         DataSimulator simulator = new DataSimulator(0, stripeMaxBytes, expectedMaxRowCount * 10, megabytes(16), 0, column);
 
@@ -607,6 +606,12 @@ public class TestDictionaryCompressionOptimizer
         }
 
         @Override
+        public int getIndexBytes()
+        {
+            return estimateIndexBytesPerValue(getDictionaryEntries()) * getNonNullValueCount();
+        }
+
+        @Override
         public OptionalInt tryConvertToDirect(int maxDirectBytes)
         {
             assertFalse(direct);
@@ -623,6 +628,21 @@ public class TestDictionaryCompressionOptimizer
         public boolean isDirect()
         {
             return direct;
+        }
+
+        public static int estimateIndexBytesPerValue(int dictionaryEntries)
+        {
+            // assume basic byte packing
+            if (dictionaryEntries <= 256) {
+                return 1;
+            }
+            if (dictionaryEntries <= 65_536) {
+                return 2;
+            }
+            if (dictionaryEntries <= 16_777_216) {
+                return 3;
+            }
+            return 4;
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
@@ -575,15 +575,15 @@ public class TestDictionaryCompressionOptimizer
         }
 
         @Override
-        public int getValueCount()
+        public long getValueCount()
         {
-            return (int) (rowCount * valuesPerRow);
+            return (long) (rowCount * valuesPerRow);
         }
 
         @Override
-        public int getNonNullValueCount()
+        public long getNonNullValueCount()
         {
-            return (int) (getValueCount() * (1 - nullRate));
+            return (long) (getValueCount() * (1 - nullRate));
         }
 
         @Override
@@ -608,7 +608,7 @@ public class TestDictionaryCompressionOptimizer
         @Override
         public int getIndexBytes()
         {
-            return estimateIndexBytesPerValue(getDictionaryEntries()) * getNonNullValueCount();
+            return toIntExact(estimateIndexBytesPerValue(getDictionaryEntries()) * getNonNullValueCount());
         }
 
         @Override


### PR DESCRIPTION
MaxRowFlush writes small stripes when `MaxStripeRowCount=10M`, but such case becomes negligible when bumping  `MaxStripeRowCount` to `50M` (see the following figure). Unfortunately some corner-case bug will happen when bumping this config. This PR fix such bug to unblock bumping the config.


<img width="1285" alt="screen shot 2018-09-03 at 11 44 37 am" src="https://user-images.githubusercontent.com/799346/44999045-33cb6b00-af6f-11e8-9a50-15facdfe48b6.png">


