### PR TITLE
Evaluate Aggregate Assignment Only When FILTER Clause Is True

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
@@ -86,4 +86,29 @@ public class TestFilteredAggregations
                         "(2, BIGINT '4', BIGINT '1'), " +
                         "(CAST(NULL AS INTEGER), BIGINT '5', BIGINT '2')");
     }
+
+    @Test
+    public void testFilterProjectionExecutedConditionally()
+    {
+        assertions.assertQuery("select sum(1 / a) filter (where a <> 0) from (values (1), (0)) t(a)",
+                "VALUES (BIGINT '1')");
+    }
+
+    @Test
+    public void testFilterProjectionExecutedConditionallyInCTE()
+    {
+        assertions.assertQuery(
+                "WITH test AS (" +
+                        "    SELECT * FROM (" +
+                        "        VALUES" +
+                        "            ('1', 'a', 'good'),\n" +
+                        "            ('2', 'b', 'good'),\n" +
+                        "            ('x', 'c', 'bad')\n" +
+                        "    ) AS t (v, k, name)\n" +
+                        ")\n" +
+                        "SELECT" +
+                        "    SUM(CAST(v AS BIGINT)) FILTER (WHERE name = 'good') AS col2\n" +
+                        "FROM test",
+                "VALUES (BIGINT '3')");
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
@@ -90,22 +90,19 @@ public class TestFilteredAggregations
     @Test
     public void testFilterProjectionExecutedConditionally()
     {
-        assertions.assertQuery("select sum(1 / a) filter (where a <> 0) from (values (1), (0)) t(a)",
+        assertions.assertQuery(
+                "select sum(1 / a) filter (where a <> 0) from (values (1), (0)) t(a)",
                 "VALUES (BIGINT '1')");
-    }
 
-    @Test
-    public void testFilterProjectionExecutedConditionallyInCTE()
-    {
         assertions.assertQuery(
                 "WITH test AS (" +
                         "    SELECT * FROM (" +
                         "        VALUES" +
-                        "            ('1', 'a', 'good'),\n" +
-                        "            ('2', 'b', 'good'),\n" +
-                        "            ('x', 'c', 'bad')\n" +
-                        "    ) AS t (v, k, name)\n" +
-                        ")\n" +
+                        "            ('1', 'a', 'good')," +
+                        "            ('2', 'b', 'good')," +
+                        "            ('x', 'c', 'bad')" +
+                        "    ) AS t (v, k, name)" +
+                        ")" +
                         "SELECT" +
                         "    SUM(CAST(v AS BIGINT)) FILTER (WHERE name = 'good') AS col2\n" +
                         "FROM test",

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionCall.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/FunctionCall.java
@@ -51,6 +51,11 @@ public class FunctionCall
         this(Optional.empty(), name, Optional.empty(), filter, Optional.empty(), distinct, arguments);
     }
 
+    public FunctionCall(QualifiedName name, boolean distinct, List<Expression> arguments, Optional<OrderBy> orderBy, Optional<Expression> filter)
+    {
+        this(Optional.empty(), name, Optional.empty(), filter, orderBy, distinct, arguments);
+    }
+
     public FunctionCall(QualifiedName name, Optional<Window> window, boolean distinct, List<Expression> arguments)
     {
         this(Optional.empty(), name, window, Optional.empty(), Optional.empty(), distinct, arguments);


### PR DESCRIPTION
FILTER clauses in aggregates are today planned as mask field in aggregation.
This implies that we add a projection underneath the aggregate which will
project the aggregate expression and mask expression. However, this leads
to evaluating the aggregate expression assignment for all the input tuples,
whereas the assignment should be evaluated only for tuples where the filter
clause is true.