### PR TITLE
Implement write path for Thrift connector

### DIFF
--- a/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
+++ b/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
@@ -220,6 +220,16 @@ struct PrestoThriftPageResult {
   3: optional PrestoThriftId nextToken;
 }
 
+struct PrestoThriftPage {
+  /**
+   * Returns data in a columnar format.
+   * Columns in this list are in the order given by the metadata of the insert table.
+   */
+  1: list<PrestoThriftBlock> columnBlocks;
+
+  2: i32 rowCount;
+}
+
 struct PrestoThriftNullableTableMetadata {
   1: optional PrestoThriftTableMetadata tableMetadata;
 }
@@ -353,5 +363,34 @@ service PrestoThriftService {
       2: list<string> columns,
       3: i64 maxBytes,
       4: PrestoThriftNullableToken nextToken)
+    throws (1: PrestoThriftServiceException ex1);
+
+  /**
+   * Adds a page of rows to be stored in a given table.
+   *
+   * @param schemaTableName schema and table name
+   * @param page data to store
+   * @param insertId unique identifier for an insertion which may span multiple calls to prestoAddRows
+   */
+  void prestoAddRows(
+      1: PrestoThriftSchemaTableName schemaTableName,
+      2: PrestoThriftPage page,
+      3: string insertId)
+    throws (1: PrestoThriftServiceException ex1);
+
+  /**
+   * Signals the end of sending data to be stored.
+   *
+   * @param insertId unique identifier to notify which insertion should be committed
+   */
+  void prestoFinishAddRows(1: string insertId)
+    throws (1: PrestoThriftServiceException ex1);
+
+  /**
+   * Signals the abort of an insertion of rows
+   *
+   * @param insertId unique identifier to notify the insertion that should be aborted
+   */
+  void prestoAbortAddRows(1: string insertId)
     throws (1: PrestoThriftServiceException ex1);
 }

--- a/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
+++ b/presto-docs/src/main/sphinx/include/PrestoThriftService.thrift
@@ -29,6 +29,15 @@ struct PrestoThriftTableMetadata {
    * {@code set<set<string>>} is not used here because some languages (like php) don't support it.
    */
   4: optional list<set<string>> indexableKeys;
+
+  /**
+   * Returns the list of column names that the table should be partitioned by.
+   * Presto will then partition the data into buckets and pass whole buckets to
+   * Presto workers for processing. Useful for inserting data that should be inserted
+   * together.
+   * The list is expected to have only unique key sets.
+   */
+  5: optional list<string> bucketedBy;
 }
 
 struct PrestoThriftColumnMetadata {

--- a/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/ThriftBucketProperty.java
+++ b/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/ThriftBucketProperty.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Used to let Presto know that a table is bucketed by some set of columns,
+ * which changes the functionality of Presto when inserting data through the Thrift connector.
+ *
+ * bucketCount is currently a default value that gets passed in.
+ */
+public class ThriftBucketProperty
+{
+    private final List<String> bucketedBy;
+    private final int bucketCount;
+
+    @JsonCreator
+    public ThriftBucketProperty(
+            @JsonProperty("bucketedBy") List<String> bucketedBy,
+            @JsonProperty("bucketCount") int bucketCount)
+    {
+        this.bucketedBy = requireNonNull(bucketedBy, "bucketedBy is null");
+        this.bucketCount = requireNonNull(bucketCount, "bucketCount is null");
+    }
+
+    @JsonProperty
+    public List<String> getBucketedBy()
+    {
+        return bucketedBy;
+    }
+
+    @JsonProperty
+    public int getBucketCount()
+    {
+        return bucketCount;
+    }
+}

--- a/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftPage.java
+++ b/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftPage.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.api;
+
+import io.airlift.drift.annotations.ThriftConstructor;
+import io.airlift.drift.annotations.ThriftField;
+import io.airlift.drift.annotations.ThriftStruct;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+@ThriftStruct
+public final class PrestoThriftPage
+{
+    private final List<PrestoThriftBlock> columnBlocks;
+    private final int rowCount;
+
+    @ThriftConstructor
+    public PrestoThriftPage(List<PrestoThriftBlock> columnBlocks, int rowCount)
+    {
+        this.columnBlocks = requireNonNull(columnBlocks, "columnBlocks is null");
+        checkArgument(rowCount >= 0, "rowCount is negative");
+        this.rowCount = rowCount;
+    }
+
+    /**
+     * Returns data in a columnar format.
+     * Columns in this list are in the order given by the metadata of the insert table.
+     */
+    @ThriftField(1)
+    public List<PrestoThriftBlock> getColumnBlocks()
+    {
+        return columnBlocks;
+    }
+
+    @ThriftField(2)
+    public int getRowCount()
+    {
+        return rowCount;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        PrestoThriftPage other = (PrestoThriftPage) obj;
+        return Objects.equals(this.columnBlocks, other.columnBlocks) &&
+                this.rowCount == other.rowCount;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnBlocks, rowCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columnBlocks", columnBlocks)
+                .add("rowCount", rowCount)
+                .toString();
+    }
+}

--- a/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftService.java
+++ b/presto-thrift-connector-api/src/main/java/com/facebook/presto/connector/thrift/api/PrestoThriftService.java
@@ -118,4 +118,41 @@ public interface PrestoThriftService
             @ThriftField(name = "columns") List<String> columns,
             @ThriftField(name = "maxBytes") long maxBytes,
             @ThriftField(name = "nextToken") PrestoThriftNullableToken nextToken);
+
+    /**
+     * Adds a page of rows to be stored in a given table.
+     *
+     * @param schemaTableName schema and table name
+     * @param page data to store
+     * @param insertId unique identifier for an insertion which may span multiple calls to prestoAddRows
+     */
+    @ThriftMethod(
+            value = "prestoAddRows",
+            exception = @ThriftException(type = PrestoThriftServiceException.class, id = 1))
+    ListenableFuture<Void> addRows(
+            @ThriftField(name = "schemaTableName") PrestoThriftSchemaTableName schemaTableName,
+            @ThriftField(name = "page") PrestoThriftPage page,
+            @ThriftField(name = "insertId") String insertId);
+
+    /**
+     * Signals the end of sending data to be stored.
+     *
+     * @param insertId unique identifier to notify which insertion should be committed
+     */
+    @ThriftMethod(
+            value = "prestoFinishAddRows",
+            exception = @ThriftException(type = PrestoThriftServiceException.class, id = 1))
+    ListenableFuture<Void> finishAddRows(
+            @ThriftField(name = "insertId") String insertId);
+
+    /**
+     * Signals the abort of an insertion of rows
+     *
+     * @param insertId unique identifier to notify the insertion that should be aborted
+     */
+    @ThriftMethod(
+            value = "prestoAbortAddRows",
+            exception = @ThriftException(type = PrestoThriftServiceException.class, id = 1))
+    ListenableFuture<Void> abortAddRows(
+            @ThriftField(name = "insertId") String insertId);
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftBucketFunction.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftBucketFunction.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.BucketFunction;
+import com.facebook.presto.spi.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class ThriftBucketFunction
+        implements BucketFunction
+{
+    private int bucketCount;
+    private List<Integer> bucketedByPositions;
+
+    public ThriftBucketFunction(int bucketCount, List<Integer> bucketedByPositions)
+    {
+        this.bucketCount = bucketCount;
+        this.bucketedByPositions = requireNonNull(bucketedByPositions, "bucketedByPositions is null");
+    }
+
+    @Override
+    public int getBucket(Page page, int position)
+    {
+        /*
+            This implementation assumes bucketing by columns with string values. Currently, bucketing by other values is not supported.
+
+            One could support this by passing in the types of the columns that define the buckets, and checking the types
+            here to get the values to hash.
+         */
+        List<String> bucketedByValues = bucketedByPositions.stream()
+                .map(e -> page.getSingleValuePage(position).getBlock(e))
+                .map(block -> block.getSlice(0, 0, block.getSliceLength(0)).toStringUtf8()).collect(Collectors.toList());
+
+        // TODO: improve hashing method
+        return bucketedByValues.hashCode() % bucketCount;
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnector.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnector.java
@@ -16,6 +16,7 @@ package com.facebook.presto.connector.thrift;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorIndexProvider;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
@@ -40,6 +41,7 @@ public class ThriftConnector
     private final ThriftSplitManager splitManager;
     private final ThriftPageSourceProvider pageSourceProvider;
     private final ThriftPageSinkProvider pageSinkProvider;
+    private final ThriftNodePartitioningProvider partitioningProvider;
     private final ThriftSessionProperties sessionProperties;
     private final ThriftIndexProvider indexProvider;
 
@@ -50,6 +52,7 @@ public class ThriftConnector
             ThriftSplitManager splitManager,
             ThriftPageSourceProvider pageSourceProvider,
             ThriftPageSinkProvider pageSinkProvider,
+            ThriftNodePartitioningProvider partitioningProvider,
             ThriftSessionProperties sessionProperties,
             ThriftIndexProvider indexProvider)
     {
@@ -58,6 +61,7 @@ public class ThriftConnector
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.partitioningProvider = requireNonNull(partitioningProvider, "partitioningProvider is null");
         this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
         this.indexProvider = requireNonNull(indexProvider, "indexProvider is null");
     }
@@ -90,6 +94,12 @@ public class ThriftConnector
     public ConnectorPageSinkProvider getPageSinkProvider()
     {
         return pageSinkProvider;
+    }
+
+    @Override
+    public ConnectorNodePartitioningProvider getNodePartitioningProvider()
+    {
+        return partitioningProvider;
     }
 
     @Override

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnector.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnector.java
@@ -16,15 +16,15 @@ package com.facebook.presto.connector.thrift;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorIndexProvider;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.log.Logger;
-
-import javax.inject.Inject;
 
 import java.util.List;
 
@@ -39,6 +39,7 @@ public class ThriftConnector
     private final ThriftMetadata metadata;
     private final ThriftSplitManager splitManager;
     private final ThriftPageSourceProvider pageSourceProvider;
+    private final ThriftPageSinkProvider pageSinkProvider;
     private final ThriftSessionProperties sessionProperties;
     private final ThriftIndexProvider indexProvider;
 
@@ -48,6 +49,7 @@ public class ThriftConnector
             ThriftMetadata metadata,
             ThriftSplitManager splitManager,
             ThriftPageSourceProvider pageSourceProvider,
+            ThriftPageSinkProvider pageSinkProvider,
             ThriftSessionProperties sessionProperties,
             ThriftIndexProvider indexProvider)
     {
@@ -55,6 +57,7 @@ public class ThriftConnector
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
         this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
         this.indexProvider = requireNonNull(indexProvider, "indexProvider is null");
     }
@@ -81,6 +84,12 @@ public class ThriftConnector
     public ConnectorPageSourceProvider getPageSourceProvider()
     {
         return pageSourceProvider;
+    }
+
+    @Override
+    public ConnectorPageSinkProvider getPageSinkProvider()
+    {
+        return pageSinkProvider;
     }
 
     @Override

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
@@ -15,6 +15,7 @@ package com.facebook.presto.connector.thrift;
 
 import com.facebook.presto.connector.thrift.util.RebindSafeMBeanServer;
 import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
@@ -67,6 +68,7 @@ public class ThriftConnectorFactory
                     binder -> {
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(getPlatformMBeanServer()));
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                     },
                     locationModule,
                     new ThriftModule(catalogName));

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftHandleResolver.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftHandleResolver.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 
 public class ThriftHandleResolver
@@ -64,5 +65,11 @@ public class ThriftHandleResolver
     public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
     {
         return ThriftInsertTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass()
+    {
+        return ThriftPartitioningHandle.class;
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftHandleResolver.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftHandleResolver.java
@@ -16,6 +16,7 @@ package com.facebook.presto.connector.thrift;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.ConnectorIndexHandle;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -58,5 +59,10 @@ public class ThriftHandleResolver
     public Class<? extends ConnectorIndexHandle> getIndexHandleClass()
     {
         return ThriftIndexHandle.class;
+    }
+
+    public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
+    {
+        return ThriftInsertTableHandle.class;
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftInsertTableHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftInsertTableHandle.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ThriftInsertTableHandle
+        implements ConnectorInsertTableHandle
+{
+    private final String schemaName;
+    private final String tableName;
+    private final List<Type> columnTypes;
+    private final List<String> columnNames;
+
+    @JsonCreator
+    public ThriftInsertTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("columnTypes") List<Type> columnTypes,
+            @JsonProperty("columnNames") List<String> columnNames)
+    {
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.columnTypes = requireNonNull(columnTypes, "columnTypes is null");
+        this.columnNames = requireNonNull(columnNames, "columnNames is null");
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @JsonProperty
+    public List<Type> getColumnTypes()
+    {
+        return columnTypes;
+    }
+
+    @JsonProperty
+    public List<String> getColumnNames()
+    {
+        return columnNames;
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftInsertTableHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftInsertTableHandle.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -29,18 +30,21 @@ public final class ThriftInsertTableHandle
     private final String tableName;
     private final List<Type> columnTypes;
     private final List<String> columnNames;
+    private final Optional<ThriftBucketProperty> bucketProperty;
 
     @JsonCreator
     public ThriftInsertTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("columnTypes") List<Type> columnTypes,
-            @JsonProperty("columnNames") List<String> columnNames)
+            @JsonProperty("columnNames") List<String> columnNames,
+            @JsonProperty("bucketProperty") Optional<ThriftBucketProperty> bucketProperty)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.columnTypes = requireNonNull(columnTypes, "columnTypes is null");
         this.columnNames = requireNonNull(columnNames, "columnNames is null");
+        this.bucketProperty = requireNonNull(bucketProperty, "bucketProperty is null");
     }
 
     @JsonProperty
@@ -65,5 +69,11 @@ public final class ThriftInsertTableHandle
     public List<String> getColumnNames()
     {
         return columnNames;
+    }
+
+    @JsonProperty
+    public Optional<ThriftBucketProperty> getBucketProperty()
+    {
+        return bucketProperty;
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
@@ -21,6 +21,7 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftService;
 import com.facebook.presto.connector.thrift.api.PrestoThriftServiceException;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorResolvedIndex;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
@@ -34,7 +35,10 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
+import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -42,16 +46,19 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import io.airlift.drift.TException;
 import io.airlift.drift.client.DriftClient;
+import io.airlift.slice.Slice;
 import io.airlift.units.Duration;
 
 import javax.inject.Inject;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.connector.thrift.ThriftErrorCode.THRIFT_SERVICE_INVALID_RESPONSE;
 import static com.facebook.presto.connector.thrift.util.ThriftExceptions.toPrestoException;
@@ -150,6 +157,27 @@ public class ThriftMetadata
         catch (PrestoThriftServiceException | TException e) {
             throw toPrestoException(e);
         }
+    }
+
+    @Override
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        List<ColumnMetadata> columns = getTableMetadata(session, tableHandle).getColumns();
+        List<Type> columnTypes = columns.stream()
+                .map(e -> e.getType())
+                .collect(Collectors.toList());
+        List<String> columnNames = columns.stream()
+                .map(e -> e.getName())
+                .collect(Collectors.toList());
+        ThriftTableHandle thriftTableHandle = (ThriftTableHandle) tableHandle;
+        return new ThriftInsertTableHandle(thriftTableHandle.getSchemaName(), thriftTableHandle.getTableName(), columnTypes, columnNames);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        // This implementation of the write path does not do anything when finishInsert is called.
+        return Optional.empty();
     }
 
     @Override

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
@@ -64,6 +64,7 @@ public class ThriftModule
         binder.bind(ThriftMetadata.class).in(Scopes.SINGLETON);
         binder.bind(ThriftSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ThriftPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ThriftPageSinkProvider.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(ThriftConnectorConfig.class);
         binder.bind(ThriftSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(ThriftIndexProvider.class).in(Scopes.SINGLETON);

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
@@ -65,6 +65,7 @@ public class ThriftModule
         binder.bind(ThriftSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ThriftPageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(ThriftPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ThriftNodePartitioningProvider.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(ThriftConnectorConfig.class);
         binder.bind(ThriftSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(ThriftIndexProvider.class).in(Scopes.SINGLETON);

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftNodePartitioningProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftNodePartitioningProvider.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.BucketFunction;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
+import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Provides the bucket function for bucketing the data.
+ * Decides which buckets of data get sent to which Presto nodes.
+ */
+public class ThriftNodePartitioningProvider
+        implements ConnectorNodePartitioningProvider
+{
+    private final NodeManager nodeManager;
+
+    @Inject
+    public ThriftNodePartitioningProvider(
+            @JsonProperty("nodeManager") NodeManager nodeManager)
+    {
+        this.nodeManager = requireNonNull(nodeManager);
+    }
+
+    @Override
+    public Map<Integer, Node> getBucketToNode(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    {
+        ThriftPartitioningHandle handle = (ThriftPartitioningHandle) partitioningHandle;
+
+        List<Node> nodes = shuffle(nodeManager.getRequiredWorkerNodes());
+        int bucketCount = handle.getBucketCount();
+        ImmutableMap.Builder<Integer, Node> distribution = ImmutableMap.builder();
+        for (int i = 0; i < bucketCount; i++) {
+            distribution.put(i, nodes.get(i % nodes.size()));
+        }
+        return distribution.build();
+    }
+
+    @Override
+    public ToIntFunction<ConnectorSplit> getSplitBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    {
+        // Reading splits by bucket is not supported
+        return (split) -> 0;
+    }
+
+    @Override
+    public BucketFunction getBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Type> partitionChannelTypes, int bucketCount)
+    {
+        ThriftPartitioningHandle thriftPartitionHandle = (ThriftPartitioningHandle) partitioningHandle;
+        return new ThriftBucketFunction(bucketCount, thriftPartitionHandle.getBucketedByPositions());
+    }
+
+    @Override
+    public List<ConnectorPartitionHandle> listPartitionHandles(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    {
+        ThriftPartitioningHandle handle = (ThriftPartitioningHandle) partitioningHandle;
+        int bucketCount = handle.getBucketCount();
+        return IntStream.range(0, bucketCount).mapToObj(ThriftPartitionHandle::new).collect(Collectors.toList());
+    }
+
+    private static <T> List<T> shuffle(Collection<T> items)
+    {
+        List<T> list = new ArrayList<>(items);
+        Collections.shuffle(list);
+        return list;
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSink.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSink.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.connector.thrift.api.PrestoThriftBlock;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPage;
+import com.facebook.presto.connector.thrift.api.PrestoThriftSchemaTableName;
+import com.facebook.presto.connector.thrift.api.PrestoThriftService;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.drift.client.DriftClient;
+import io.airlift.drift.client.address.AddressSelector;
+import io.airlift.drift.transport.client.Address;
+import io.airlift.slice.Slice;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static java.util.Objects.requireNonNull;
+
+public class ThriftPageSink
+        implements ConnectorPageSink
+{
+    private final PrestoThriftService client;
+    private final ThriftInsertTableHandle insertTableHandle;
+    private ListenableFuture<Void> future;
+    private UUID insertId = UUID.randomUUID();
+
+    public ThriftPageSink(DriftClient<PrestoThriftService> client, AddressSelector<Address> addressSelector, Map<String, String> thriftHeader,
+            ThriftInsertTableHandle insertTableHandle)
+    {
+        this.insertTableHandle = requireNonNull(insertTableHandle, "insertTableHandle is null");
+        // Sticky connection is not supported until bucketing is supported.
+        this.client = client.get(thriftHeader);
+        future = null;
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        List<Type> columnTypes = insertTableHandle.getColumnTypes();
+        List<PrestoThriftBlock> prestoThriftBlocks = IntStream.range(0, page.getChannelCount())
+                .mapToObj(i -> PrestoThriftBlock.fromBlock(page.getBlock(i), columnTypes.get(i)))
+                .collect(Collectors.toList());
+        PrestoThriftPage prestoThriftPage = new PrestoThriftPage(prestoThriftBlocks, page.getPositionCount());
+        future = client.addRows(
+                new PrestoThriftSchemaTableName(
+                        insertTableHandle.getSchemaName(),
+                        insertTableHandle.getTableName()),
+                prestoThriftPage,
+                insertId.toString());
+        // We wait on this call to ensure that all appendPage calls occur before the finish method is called.
+        getFutureValue(future);
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        // Signal the end of sending data to be inserted so that the system can store the data.
+        ListenableFuture<Void> finished = client.finishAddRows(insertId.toString());
+        getFutureValue(finished);
+        return CompletableFuture.completedFuture(ImmutableList.of());
+    }
+
+    @Override
+    public void abort()
+    {
+        ListenableFuture<Void> finished = client.abortAddRows(insertId.toString());
+        getFutureValue(finished);
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSinkProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSinkProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.connector.thrift.api.PrestoThriftService;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.airlift.drift.client.DriftClient;
+import io.airlift.drift.client.address.AddressSelector;
+import io.airlift.drift.client.guice.DefaultClient;
+import io.airlift.drift.client.guice.DriftClientAnnotationFactory;
+import io.airlift.drift.transport.client.Address;
+
+import static java.util.Objects.requireNonNull;
+
+public class ThriftPageSinkProvider
+        implements ConnectorPageSinkProvider
+{
+    private final DriftClient<PrestoThriftService> client;
+    private final AddressSelector<Address> addressSelector;
+    private final ThriftHeaderProvider thriftHeaderProvider;
+
+    @Inject
+    public ThriftPageSinkProvider(DriftClient<PrestoThriftService> client, Injector injector, ThriftHeaderProvider thriftHeaderProvider)
+    {
+        this.client = requireNonNull(client, "client is null");
+        requireNonNull(injector, "injector is null");
+        this.addressSelector = injector.getInstance(Key.get(AddressSelector.class, DriftClientAnnotationFactory.getDriftClientAnnotation(PrestoThriftService.class, DefaultClient.class)));
+        this.thriftHeaderProvider = requireNonNull(thriftHeaderProvider, "thriftHeaderProvider is null");
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle)
+    {
+        // the method called when calling the 'CREATE TABLE' command.
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle)
+    {
+        // the method called when calling the 'INSERT INTO' command
+        return new ThriftPageSink(client, addressSelector, thriftHeaderProvider.getHeaders(session), (ThriftInsertTableHandle) insertTableHandle);
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPartitionHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPartitionHandle.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+
+import java.util.Objects;
+
+public class ThriftPartitionHandle
+        extends ConnectorPartitionHandle
+{
+    private final int bucket;
+
+    public ThriftPartitionHandle(int bucket)
+    {
+        this.bucket = bucket;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ThriftPartitionHandle other = (ThriftPartitionHandle) obj;
+        return this.bucket == other.bucket;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(bucket);
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPartitioningHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPartitioningHandle.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Handle that helps define the layout of a table that is partitioned, or "bucketed", by a set of table columns.
+ */
+public class ThriftPartitioningHandle
+        implements ConnectorPartitioningHandle
+{
+    private final int bucketCount;
+    private final List<Integer> bucketedByPositions;
+
+    @JsonCreator
+    public ThriftPartitioningHandle(
+            @JsonProperty("bucketCount") int bucketCount,
+            @JsonProperty("bucketedByPositions") List<Integer> bucketedByPositions)
+    {
+        this.bucketCount = bucketCount;
+        this.bucketedByPositions = requireNonNull(bucketedByPositions);
+    }
+
+    @JsonProperty
+    public int getBucketCount()
+    {
+        return bucketCount;
+    }
+
+    @JsonProperty
+    public List<Integer> getBucketedByPositions()
+    {
+        return bucketedByPositions;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("bucketCount", bucketCount)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ThriftPartitioningHandle other = (ThriftPartitioningHandle) obj;
+        return bucketCount == other.bucketCount;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(bucketCount);
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableHandle.java
@@ -18,7 +18,9 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -28,19 +30,25 @@ public final class ThriftTableHandle
 {
     private final String schemaName;
     private final String tableName;
+    private final Optional<List<String>> bucketedBy;
+    private final int bucketCount;
 
     @JsonCreator
     public ThriftTableHandle(
             @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName)
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("bucketedBy") Optional<List<String>> bucketedBy,
+            @JsonProperty("bucketCount") int bucketCount)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.bucketedBy = requireNonNull(bucketedBy, "bucketedBy is null");
+        this.bucketCount = bucketCount;
     }
 
-    public ThriftTableHandle(SchemaTableName schemaTableName)
+    public ThriftTableHandle(SchemaTableName schemaTableName, Optional<List<String>> bucketedBy, int bucketCount)
     {
-        this(schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        this(schemaTableName.getSchemaName(), schemaTableName.getTableName(), bucketedBy, bucketCount);
     }
 
     @JsonProperty
@@ -53,6 +61,17 @@ public final class ThriftTableHandle
     public String getTableName()
     {
         return tableName;
+    }
+
+    @JsonProperty
+    public Optional<List<String>> getBucketedBy()
+    {
+        return bucketedBy;
+    }
+
+    public int getBucketCount()
+    {
+        return bucketCount;
     }
 
     @Override
@@ -72,7 +91,7 @@ public final class ThriftTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName);
+        return Objects.hash(schemaName, tableName, bucketedBy);
     }
 
     @Override
@@ -81,6 +100,7 @@ public final class ThriftTableHandle
         return toStringHelper(this)
                 .add("schemaName", getSchemaName())
                 .add("tableName", getTableName())
+                .add("bucketedBy", getBucketedBy())
                 .toString();
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableMetadata.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableMetadata.java
@@ -40,13 +40,17 @@ class ThriftTableMetadata
     private final List<ColumnMetadata> columns;
     private final Optional<String> comment;
     private final Set<Set<String>> indexableKeys;
+    private final Optional<List<String>> bucketedBy;
+    private final int bucketCount;
 
-    public ThriftTableMetadata(SchemaTableName schemaTableName, List<ColumnMetadata> columns, Optional<String> comment, List<Set<String>> indexableKeys)
+    public ThriftTableMetadata(SchemaTableName schemaTableName, List<ColumnMetadata> columns, Optional<String> comment, List<Set<String>> indexableKeys, List<String> bucketedBy, int bucketCount)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.comment = requireNonNull(comment, "comment is null");
         this.indexableKeys = deepImmutableCopy(requireNonNull(indexableKeys, "indexableKeys is null"));
+        this.bucketedBy = Optional.ofNullable(bucketedBy);
+        this.bucketCount = bucketCount;
     }
 
     public ThriftTableMetadata(PrestoThriftTableMetadata thriftTableMetadata, TypeManager typeManager)
@@ -54,7 +58,9 @@ class ThriftTableMetadata
         this(thriftTableMetadata.getSchemaTableName().toSchemaTableName(),
                 columnMetadata(thriftTableMetadata.getColumns(), typeManager),
                 Optional.ofNullable(thriftTableMetadata.getComment()),
-                thriftTableMetadata.getIndexableKeys() != null ? thriftTableMetadata.getIndexableKeys() : ImmutableList.of());
+                thriftTableMetadata.getIndexableKeys() != null ? thriftTableMetadata.getIndexableKeys() : ImmutableList.of(),
+                thriftTableMetadata.getBucketedBy(),
+                thriftTableMetadata.getBucketCount());
     }
 
     public SchemaTableName getSchemaTableName()
@@ -74,6 +80,16 @@ class ThriftTableMetadata
                 .map(ThriftColumnHandle::getColumnName)
                 .collect(toImmutableSet());
         return indexableKeys.contains(keyColumns);
+    }
+
+    public Optional<List<String>> getBucketedBy()
+    {
+        return bucketedBy;
+    }
+
+    public int getBucketCount()
+    {
+        return bucketCount;
     }
 
     public ConnectorTableMetadata toConnectorTableMetadata()

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftNullableColumnSet;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableSchemaName;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableTableMetadata;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableToken;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPage;
 import com.facebook.presto.connector.thrift.api.PrestoThriftPageResult;
 import com.facebook.presto.connector.thrift.api.PrestoThriftSchemaTableName;
 import com.facebook.presto.connector.thrift.api.PrestoThriftService;
@@ -312,6 +313,24 @@ public class TestThriftIndexPageSource
 
         @Override
         public ListenableFuture<PrestoThriftSplitBatch> getSplits(PrestoThriftSchemaTableName schemaTableName, PrestoThriftNullableColumnSet desiredColumns, PrestoThriftTupleDomain outputConstraint, int maxSplitCount, PrestoThriftNullableToken nextToken)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ListenableFuture<Void> addRows(PrestoThriftSchemaTableName schemaTableName, PrestoThriftPage page, String insertId)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ListenableFuture<Void> finishAddRows(String insertId)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ListenableFuture<Void> abortAddRows(String insertId)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueries.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueries.java
@@ -23,7 +23,7 @@ public class TestThriftDistributedQueries
 {
     public TestThriftDistributedQueries()
     {
-        super(() -> createThriftQueryRunner(3, 3, false, ImmutableMap.of()));
+        super(() -> createThriftQueryRunner(3, 3, ThriftQueryRunner.EnableExtraPrestoFeature.NONE, ImmutableMap.of()));
     }
 
     @Override

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueriesIndexed.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueriesIndexed.java
@@ -23,7 +23,7 @@ public class TestThriftDistributedQueriesIndexed
 {
     public TestThriftDistributedQueriesIndexed()
     {
-        super(() -> createThriftQueryRunner(2, 2, true, ImmutableMap.of()));
+        super(() -> createThriftQueryRunner(2, 2, ThriftQueryRunner.EnableExtraPrestoFeature.INDEX_JOIN, ImmutableMap.of()));
     }
 
     @Override

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftInsertRows.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftInsertRows.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.integration;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.tests.QueryAssertions.assertContains;
+
+public class TestThriftInsertRows
+{
+    private QueryRunner queryRunner;
+
+    public TestThriftInsertRows()
+            throws Exception
+    {
+        queryRunner = ThriftQueryRunner.createThriftQueryRunner(1, 3, ThriftQueryRunner.EnableExtraPrestoFeature.INSERT_ROWS, ImmutableMap.of());
+    }
+
+    @Test
+    public void testShowSchemas()
+    {
+        MaterializedResult result = queryRunner.execute("SHOW SCHEMAS").toTestTypes();
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR)
+                .row("matiash");
+        assertContains(result, resultBuilder.build());
+    }
+
+    @Test
+    public void testListTables()
+    {
+        MaterializedResult result = queryRunner.execute("SHOW TABLES FROM matiash").toTestTypes();
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR)
+                .row("test_table");
+        assertContains(result, resultBuilder.build());
+    }
+
+    @Test
+    public void testGetTableMetadata()
+    {
+        MaterializedResult result = queryRunner.execute("SHOW COLUMNS FROM matiash.test_table").toTestTypes();
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR, DOUBLE, INTEGER)
+                .row("value", "double", "", "")
+                .row("x", "integer", "", "")
+                .row("y", "integer", "", "")
+                .row("zoom_level", "integer", "", "");
+        assertContains(result, resultBuilder.build());
+    }
+
+    @Test
+    public void testGetRows()
+    {
+        MaterializedResult result = queryRunner.execute("SELECT * FROM matiash.test_table").toTestTypes();
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VARCHAR);
+        assertContains(result, resultBuilder.build());
+    }
+
+    @Test
+    public void testAddRows()
+    {
+        queryRunner.execute("INSERT INTO matiash.test_table VALUES ('0', 1, 0, 0, 1), ('00', 12.345, 42, 50, 2)").toTestTypes();
+        MaterializedResult result = queryRunner.execute("SELECT * FROM matiash.test_table").toTestTypes();
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), DOUBLE, INTEGER)
+                .row("0", 1.0, 0, 0, 1)
+                .row("00", 12.345, 42, 50, 2);
+        assertContains(result, resultBuilder.build());
+    }
+}

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftIntegrationSmokeTest.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftIntegrationSmokeTest.java
@@ -27,7 +27,7 @@ public class TestThriftIntegrationSmokeTest
 {
     public TestThriftIntegrationSmokeTest()
     {
-        super(() -> createThriftQueryRunner(2, 2, false, ImmutableMap.of()));
+        super(() -> createThriftQueryRunner(2, 2, ThriftQueryRunner.EnableExtraPrestoFeature.NONE, ImmutableMap.of()));
     }
 
     @Override

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
@@ -16,6 +16,7 @@ package com.facebook.presto.connector.thrift.integration;
 import com.facebook.presto.Session;
 import com.facebook.presto.connector.thrift.ThriftPlugin;
 import com.facebook.presto.connector.thrift.server.ThriftIndexedTpchService;
+import com.facebook.presto.connector.thrift.server.ThriftInsertRowsService;
 import com.facebook.presto.connector.thrift.server.ThriftTpchService;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.metadata.Metadata;
@@ -55,15 +56,21 @@ public final class ThriftQueryRunner
 {
     public static final ThriftCodecManager CODEC_MANAGER = new ThriftCodecManager();
 
+    public enum EnableExtraPrestoFeature {
+        NONE,
+        INDEX_JOIN,
+        INSERT_ROWS
+    }
+
     private ThriftQueryRunner() {}
 
-    public static QueryRunner createThriftQueryRunner(int thriftServers, int nodeCount, boolean enableIndexJoin, Map<String, String> properties)
+    public static QueryRunner createThriftQueryRunner(int thriftServers, int nodeCount, EnableExtraPrestoFeature extraPrestoFeature, Map<String, String> properties)
             throws Exception
     {
         List<DriftServer> servers = null;
         DistributedQueryRunner runner = null;
         try {
-            servers = startThriftServers(thriftServers, enableIndexJoin);
+            servers = startThriftServers(thriftServers, extraPrestoFeature);
             runner = createThriftQueryRunnerInternal(servers, nodeCount, properties);
             return new ThriftQueryRunnerWithServers(runner, servers);
         }
@@ -84,23 +91,34 @@ public final class ThriftQueryRunner
     {
         Logging.initialize();
         Map<String, String> properties = ImmutableMap.of("http-server.http.port", "8080");
-        ThriftQueryRunnerWithServers queryRunner = (ThriftQueryRunnerWithServers) createThriftQueryRunner(3, 3, true, properties);
+        ThriftQueryRunnerWithServers queryRunner = (ThriftQueryRunnerWithServers) createThriftQueryRunner(3, 3, EnableExtraPrestoFeature.INDEX_JOIN, properties);
         Thread.sleep(10);
         Logger log = Logger.get(ThriftQueryRunner.class);
         log.info("======== SERVER STARTED ========");
         log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
     }
 
-    private static List<DriftServer> startThriftServers(int thriftServers, boolean enableIndexJoin)
+    private static List<DriftServer> startThriftServers(int thriftServers, EnableExtraPrestoFeature extraPrestoFeature)
     {
         List<DriftServer> servers = new ArrayList<>(thriftServers);
         for (int i = 0; i < thriftServers; i++) {
-            ThriftTpchService service = enableIndexJoin ? new ThriftIndexedTpchService() : new ThriftTpchService();
+            DriftService driftService = null;
+            switch (extraPrestoFeature) {
+                case NONE:
+                    driftService = new DriftService(new ThriftTpchService());
+                    break;
+                case INDEX_JOIN:
+                    driftService = new DriftService(new ThriftIndexedTpchService());
+                    break;
+                case INSERT_ROWS:
+                    driftService = new DriftService(new ThriftInsertRowsService());
+                    break;
+            }
             DriftServer server = new DriftServer(
                     new DriftNettyServerTransportFactory(new DriftNettyServerConfig()),
                     CODEC_MANAGER,
                     new NullMethodInvocationStatsFactory(),
-                    ImmutableSet.of(new DriftService(service)),
+                    ImmutableSet.of(driftService),
                     ImmutableSet.of());
             server.start();
             servers.add(server);

--- a/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftInsertRowsService.java
+++ b/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftInsertRowsService.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.server;
+
+import com.facebook.presto.connector.thrift.api.PrestoThriftBlock;
+import com.facebook.presto.connector.thrift.api.PrestoThriftColumnMetadata;
+import com.facebook.presto.connector.thrift.api.PrestoThriftId;
+import com.facebook.presto.connector.thrift.api.PrestoThriftNullableColumnSet;
+import com.facebook.presto.connector.thrift.api.PrestoThriftNullableSchemaName;
+import com.facebook.presto.connector.thrift.api.PrestoThriftNullableTableMetadata;
+import com.facebook.presto.connector.thrift.api.PrestoThriftNullableToken;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPage;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPageResult;
+import com.facebook.presto.connector.thrift.api.PrestoThriftSchemaTableName;
+import com.facebook.presto.connector.thrift.api.PrestoThriftService;
+import com.facebook.presto.connector.thrift.api.PrestoThriftSplit;
+import com.facebook.presto.connector.thrift.api.PrestoThriftSplitBatch;
+import com.facebook.presto.connector.thrift.api.PrestoThriftTableMetadata;
+import com.facebook.presto.connector.thrift.api.PrestoThriftTupleDomain;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.connector.thrift.server.ThriftTpchService.SPLIT_INFO_CODEC;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+
+public class ThriftInsertRowsService
+        implements PrestoThriftService
+{
+    private static final List<String> SCHEMA = Collections.singletonList("matiash");
+    private static final List<String> SCHEMA_TABLES = ImmutableList.of("test_table");
+    private static final List<PrestoThriftPage> TEST_TABLE = new ArrayList<>();
+    private static final Map<String, List<PrestoThriftPage>> INSERT_BUFFER = new HashMap<>();
+    private static final List<String> COLUMN_NAMES = ImmutableList.of("tile_quadkey", "value", "x", "y", "zoom_level");
+    private static final List<Type> COLUMN_TYPES = ImmutableList.of(VARCHAR, DOUBLE, INTEGER, INTEGER, INTEGER);
+
+    @Override
+    public List<String> listSchemaNames()
+    {
+        return SCHEMA;
+    }
+
+    @Override
+    public List<PrestoThriftSchemaTableName> listTables(PrestoThriftNullableSchemaName schemaNameOrNull)
+    {
+        if (SCHEMA.contains(schemaNameOrNull.getSchemaName())) {
+            List<PrestoThriftSchemaTableName> tables = new ArrayList<PrestoThriftSchemaTableName>() {};
+            for (String tableName : SCHEMA_TABLES) {
+                tables.add(new PrestoThriftSchemaTableName(SCHEMA.get(0), tableName));
+            }
+            return tables;
+        }
+        return ImmutableList.of();
+    }
+
+    @Override
+    public PrestoThriftNullableTableMetadata getTableMetadata(PrestoThriftSchemaTableName schemaTableName)
+    {
+        if (!SCHEMA.contains(schemaTableName.getSchemaName()) || !SCHEMA_TABLES.contains(schemaTableName.getTableName())) {
+            return new PrestoThriftNullableTableMetadata(null);
+        }
+
+        List<PrestoThriftColumnMetadata> columnMetadata = new ArrayList<>();
+        for (int i = 0; i < COLUMN_NAMES.size(); i++) {
+            columnMetadata.add(new PrestoThriftColumnMetadata(COLUMN_NAMES.get(i), getColumnTypeAsString(COLUMN_TYPES.get(i)), null, false));
+        }
+        return new PrestoThriftNullableTableMetadata(new PrestoThriftTableMetadata(schemaTableName, columnMetadata, null, null, Collections.singletonList("tile_quadkey")));
+    }
+
+    @Override
+    public ListenableFuture<PrestoThriftSplitBatch> getSplits(
+            PrestoThriftSchemaTableName schemaTableName,
+            PrestoThriftNullableColumnSet desiredColumns,
+            PrestoThriftTupleDomain outputConstraint,
+            int maxSplitCount,
+            PrestoThriftNullableToken nextToken)
+    {
+        return immediateFuture(getSplitsSync(schemaTableName, desiredColumns, outputConstraint, maxSplitCount, nextToken));
+    }
+
+    private PrestoThriftSplitBatch getSplitsSync(
+            PrestoThriftSchemaTableName schemaTableName,
+            PrestoThriftNullableColumnSet desiredColumns,
+            PrestoThriftTupleDomain outputConstraint,
+            int maxSplitCount,
+            PrestoThriftNullableToken nextToken)
+    {
+        SplitInfo splitInfo = SplitInfo.normalSplit(schemaTableName.getSchemaName(), schemaTableName.getTableName(), 1, 1);
+        List<PrestoThriftSplit> splits = Collections.singletonList(new PrestoThriftSplit(new PrestoThriftId(SPLIT_INFO_CODEC.toJsonBytes(splitInfo)), ImmutableList.of()));
+        return new PrestoThriftSplitBatch(splits, null);
+    }
+
+    @Override
+    public ListenableFuture<PrestoThriftSplitBatch> getIndexSplits(
+            PrestoThriftSchemaTableName schemaTableName,
+            List<String> indexColumnNames,
+            List<String> outputColumnNames,
+            PrestoThriftPageResult keys,
+            PrestoThriftTupleDomain outputConstraint,
+            int maxSplitCount,
+            PrestoThriftNullableToken nextToken)
+    {
+        return immediateFuture(getIndexSplitsInternal());
+    }
+
+    @Override
+    public ListenableFuture<PrestoThriftPageResult> getRows(PrestoThriftId splitId, List<String> columns, long maxBytes, PrestoThriftNullableToken nextToken)
+    {
+        return immediateFuture(getRowsSync(splitId, columns, maxBytes, nextToken));
+    }
+
+    private PrestoThriftPageResult getRowsSync(PrestoThriftId splitId, List<String> columns, long maxBytes, PrestoThriftNullableToken nextToken)
+    {
+        List<PrestoThriftBlock> blocks = new ArrayList<>();
+        int rowCount = 0;
+        for (PrestoThriftPage pageResult : TEST_TABLE) {
+            blocks.addAll(pageResult.getColumnBlocks());
+            rowCount += pageResult.getRowCount();
+        }
+        return new PrestoThriftPageResult(blocks, rowCount, null);
+    }
+
+    @Override
+    public ListenableFuture<Void> addRows(PrestoThriftSchemaTableName schemaTableName, PrestoThriftPage page, String insertId)
+    {
+        if (SCHEMA.contains(schemaTableName.getSchemaName()) && SCHEMA_TABLES.contains(schemaTableName.getTableName())) {
+            if (!INSERT_BUFFER.containsKey(insertId)) {
+                INSERT_BUFFER.put(insertId, new ArrayList<>());
+            }
+            INSERT_BUFFER.get(insertId).add(page);
+        }
+        return immediateFuture(null);
+    }
+
+    @Override
+    public ListenableFuture<Void> finishAddRows(String insertId)
+    {
+        if (INSERT_BUFFER.containsKey(insertId)) {
+            TEST_TABLE.addAll(INSERT_BUFFER.get(insertId));
+        }
+        return immediateFuture(null);
+    }
+
+    @Override
+    public ListenableFuture<Void> abortAddRows(String insertId)
+    {
+        INSERT_BUFFER.remove(insertId);
+        return immediateFuture(null);
+    }
+
+    private String getColumnTypeAsString(Type columnType)
+    {
+        return columnType.getTypeSignature().toString();
+    }
+
+    private PrestoThriftSplitBatch getIndexSplitsInternal()
+    {
+        throw new UnsupportedOperationException("getIndexSplits is unsupported");
+    }
+}

--- a/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
+++ b/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
@@ -20,6 +20,7 @@ import com.facebook.presto.connector.thrift.api.PrestoThriftNullableColumnSet;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableSchemaName;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableTableMetadata;
 import com.facebook.presto.connector.thrift.api.PrestoThriftNullableToken;
+import com.facebook.presto.connector.thrift.api.PrestoThriftPage;
 import com.facebook.presto.connector.thrift.api.PrestoThriftPageResult;
 import com.facebook.presto.connector.thrift.api.PrestoThriftSchemaTableName;
 import com.facebook.presto.connector.thrift.api.PrestoThriftService;
@@ -201,6 +202,24 @@ public class ThriftTpchService
             pageSource = createLookupPageSource(splitInfo, outputColumns);
         }
         return getRowsInternal(pageSource, splitInfo.getTableName(), outputColumns, nextToken.getToken());
+    }
+
+    @Override
+    public ListenableFuture<Void> addRows(PrestoThriftSchemaTableName schemaTableName, PrestoThriftPage page, String insertId)
+    {
+        throw new UnsupportedOperationException("Insert not supported");
+    }
+
+    @Override
+    public ListenableFuture<Void> finishAddRows(String insertId)
+    {
+        throw new UnsupportedOperationException("Insert not supported");
+    }
+
+    @Override
+    public ListenableFuture<Void> abortAddRows(String insertId)
+    {
+        throw new UnsupportedOperationException("Insert not supported");
     }
 
     protected ConnectorPageSource createLookupPageSource(SplitInfo splitInfo, List<String> outputColumnNames)

--- a/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
+++ b/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftTpchService.java
@@ -107,7 +107,7 @@ public class ThriftTpchService
             columns.add(new PrestoThriftColumnMetadata(column.getSimplifiedColumnName(), getTypeString(column), null, false));
         }
         List<Set<String>> indexableKeys = getIndexableKeys(schemaName, tableName);
-        return new PrestoThriftNullableTableMetadata(new PrestoThriftTableMetadata(schemaTableName, columns, null, !indexableKeys.isEmpty() ? indexableKeys : null));
+        return new PrestoThriftNullableTableMetadata(new PrestoThriftTableMetadata(schemaTableName, columns, null, !indexableKeys.isEmpty() ? indexableKeys : null, null));
     }
 
     protected List<Set<String>> getIndexableKeys(String schemaName, String tableName)


### PR DESCRIPTION
This PR introduces writing functionality to the Thrift connector as well as support to write bucketed tables. The PR is divided into four parts:
1. Introduce the new insert methods to the PrestoThriftService
2. Implement the methods in the Thrift Connector to handle inserts through the API
3. Support writing bucketed tables, dividing the data Presto receives into buckets specified through the connector, and sending the buckets to Presto worker nodes.
4. Add a test service to test that inserting data works as intended.