### PR TITLE
Add bechmarks for CPU timers

### DIFF
--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkCPUCounters.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkCPUCounters.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.Integer.getInteger;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkCPUCounters
+{
+    private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+
+    private static final int ITERATIONS = 1000;
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS)
+    public void nanoTime(Blackhole blackhole)
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            blackhole.consume(System.nanoTime());
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS)
+    public void cpuTime(Blackhole blackhole)
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            blackhole.consume(currentThreadCpuTime());
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(ITERATIONS)
+    public void userTime(Blackhole blackhole)
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            blackhole.consume(currentThreadUserTime());
+        }
+    }
+
+    private static long currentThreadCpuTime()
+    {
+        return THREAD_MX_BEAN.getCurrentThreadCpuTime();
+    }
+
+    private static long currentThreadUserTime()
+    {
+        return THREAD_MX_BEAN.getCurrentThreadUserTime();
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .threads(getInteger("threads", 1))
+                .include(".*" + BenchmarkCPUCounters.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
This benchmark shows that ThreadMXBean#getCurrentThreadUserTime is way slower
than ThreadMXBean#getCurrentThreadCpuTime, therefore the usege of this method
must be avoided.

Related JVM issue: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8210452

```
LINUX, 4.15.0-32, BARE METAL
-------------------------------------------------------------------
Benchmark                      Mode  Cnt     Score     Error  Units
BenchmarkCPUCounters.cpuTime   avgt   20   285.009 ±   2.446  ns/op
BenchmarkCPUCounters.nanoTime  avgt   20    17.281 ±   0.022  ns/op
BenchmarkCPUCounters.userTime  avgt   20  4928.495 ± 211.670  ns/op
```

```
LINUX, 4.11.3-67, VM
-------------------------------------------------------------------
Benchmark                      Mode  Cnt     Score     Error  Units
BenchmarkCPUCounters.cpuTime   avgt   20   273.611 ±  20.021  ns/op
BenchmarkCPUCounters.nanoTime  avgt   20    29.617 ±   1.540  ns/op
BenchmarkCPUCounters.userTime  avgt   20  8135.688 ± 537.767  ns/op
```

```
MAC OS High Sierra
------------------------------------------------------------------
Benchmark                      Mode  Cnt     Score    Error  Units
BenchmarkCPUCounters.cpuTime   avgt   20  1686.670 ± 42.182  ns/op
BenchmarkCPUCounters.nanoTime  avgt   20    35.061 ±  1.503  ns/op
BenchmarkCPUCounters.userTime  avgt   20  1673.923 ± 29.422  ns/op
```

```
LINUX, 4.15.0-32, BARE METAL, 6(12) cores cpu, 4 Threads
------------------------------------------------------------------
Benchmark                      Mode  Cnt     Score    Error  Units
BenchmarkCPUCounters.cpuTime   avgt   20   291.248 ±  6.676  ns/op
BenchmarkCPUCounters.nanoTime  avgt   20    17.635 ±  0.109  ns/op
BenchmarkCPUCounters.userTime  avgt   20  6972.293 ± 95.957  ns/op
```

```
LINUX, 4.15.0-32, BARE METAL, 6(12) cores cpu, 8 Threads
------------------------------------------------------------------
Benchmark                      Mode  Cnt     Score    Error  Units
BenchmarkCPUCounters.cpuTime   avgt   20   315.731 ±  2.769  ns/op
BenchmarkCPUCounters.nanoTime  avgt   20    19.300 ±  0.091  ns/op
BenchmarkCPUCounters.userTime  avgt   20  9667.381 ± 87.259  ns/op
```

```
LINUX, 4.15.0-32, BARE METAL, 16(12) cores cpu, 12 Threads
--------------------------------------------------------------------
Benchmark                      Mode  Cnt      Score     Error  Units
BenchmarkCPUCounters.cpuTime   avgt   20    362.335 ±   7.515  ns/op
BenchmarkCPUCounters.nanoTime  avgt   20     22.000 ±   0.367  ns/op
BenchmarkCPUCounters.userTime  avgt   20  12479.263 ± 196.111  ns/op
```