### PR TITLE
Add geometry_union scalar function to efficiently union an array of geometries

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -150,8 +150,6 @@ Operations
 
     Returns a geometry that represents the point set union of the input geometries.
 
-    This function doesn't support geometry collections.
-
     See also:  :func:`geometry_union`, :func:`geometry_union_agg`
 
 

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -2,8 +2,8 @@
 Geospatial Functions
 ====================
 
-Presto Geospatial functions support the SQL/MM specification.
-They are compliant with the Open Geospatial Consortium’s (OGC) OpenGIS Specifications.
+Presto Geospatial functions that begin with the ``ST_`` prefix support the SQL/MM specification
+and are compliant with the Open Geospatial Consortium’s (OGC) OpenGIS Specifications.
 As such, many Presto Geospatial functions require, or more accurately, assume that
 geometries that are operated on are both simple and valid. For example, it does not
 make sense to calculate the area of a polygon that has a hole defined outside of the
@@ -106,6 +106,12 @@ Relationship Tests
 Operations
 ----------
 
+.. function:: geometry_union(array(Geometry)) -> Geometry
+
+    Returns a geometry that represents the point set union of the input geometries. Performance
+    of this function, in conjunction with :func:`array_agg` to first aggregate the input geometries,
+    may be better than :func:`geometry_union_agg`, at the expense of higher memory utilization.
+
 .. function:: ST_Boundary(Geometry) -> Geometry
 
     Returns the closure of the combinatorial boundary of this geometry.
@@ -145,6 +151,8 @@ Operations
     Returns a geometry that represents the point set union of the input geometries.
 
     This function doesn't support geometry collections.
+
+    See also:  :func:`geometry_union`, :func:`geometry_union_agg`
 
 
 Accessors

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -15,16 +15,19 @@ package com.facebook.presto.plugin.geospatial;
 
 import com.esri.core.geometry.Envelope;
 import com.esri.core.geometry.GeometryCursor;
+import com.esri.core.geometry.ListeningGeometryCursor;
 import com.esri.core.geometry.MultiPath;
 import com.esri.core.geometry.MultiPoint;
 import com.esri.core.geometry.MultiVertexGeometry;
 import com.esri.core.geometry.NonSimpleResult;
 import com.esri.core.geometry.NonSimpleResult.Reason;
 import com.esri.core.geometry.OperatorSimplifyOGC;
+import com.esri.core.geometry.OperatorUnion;
 import com.esri.core.geometry.Point;
 import com.esri.core.geometry.Polygon;
 import com.esri.core.geometry.Polyline;
 import com.esri.core.geometry.SpatialReference;
+import com.esri.core.geometry.ogc.OGCConcreteGeometryCollection;
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCGeometryCollection;
 import com.esri.core.geometry.ogc.OGCLineString;
@@ -49,8 +52,14 @@ import io.airlift.slice.Slice;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.linearref.LengthIndexedLine;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 
@@ -88,6 +97,7 @@ import static java.lang.Math.sqrt;
 import static java.lang.Math.toIntExact;
 import static java.lang.Math.toRadians;
 import static java.lang.String.format;
+import static java.util.Arrays.setAll;
 import static java.util.Objects.requireNonNull;
 import static org.locationtech.jts.simplify.TopologyPreservingSimplifier.simplify;
 
@@ -106,6 +116,7 @@ public final class GeoFunctions
             .put(OGCPolygonSelfTangency, "Self-tangency")
             .put(OGCDisconnectedInterior, "Disconnected interior")
             .build();
+    private static final int NUMBER_OF_DIMENSIONS = 3;
 
     private GeoFunctions() {}
 
@@ -582,6 +593,60 @@ public final class GeoFunctions
         }
 
         return serialize(leftGeometry.union(rightGeometry));
+    }
+
+    @Description("Returns a geometry that represents the point set union of the input geometries.")
+    @ScalarFunction("geometry_union")
+    @SqlType(GEOMETRY_TYPE_NAME)
+    public static Slice geometryUnion(@SqlType("array(" + GEOMETRY_TYPE_NAME + ")") Block input)
+    {
+        return stUnion(getGeometrySlicesFromBlock(input));
+    }
+
+    private static Slice stUnion(Iterable<Slice> slices)
+    {
+        // The current state of Esri/geometry-api-java does not allow support for multiple dimensions being
+        // fed to the union operator without dropping the lower dimensions:
+        // https://github.com/Esri/geometry-api-java/issues/199
+        // When operating over a collection of geometries, it is more efficient to reuse the same operator
+        // for the entire operation.  Therefore, split the inputs and operators by dimension, and then union
+        // each dimension's result at the end.
+        ListeningGeometryCursor[] cursorsByDimension = new ListeningGeometryCursor[NUMBER_OF_DIMENSIONS];
+        GeometryCursor[] operatorsByDimension = new GeometryCursor[NUMBER_OF_DIMENSIONS];
+
+        setAll(cursorsByDimension, i -> new ListeningGeometryCursor());
+        setAll(operatorsByDimension, i -> OperatorUnion.local().execute(cursorsByDimension[i], null, null));
+
+        Iterator<Slice> slicesIterator = slices.iterator();
+        if (!slicesIterator.hasNext()) {
+            return null;
+        }
+        while (slicesIterator.hasNext()) {
+            Slice slice = slicesIterator.next();
+            // Ignore null inputs
+            if (slice.getInput().available() == 0) {
+                continue;
+            }
+
+            for (OGCGeometry geometry : flattenCollection(deserialize(slice))) {
+                int dimension = geometry.dimension();
+                cursorsByDimension[dimension].tick(geometry.getEsriGeometry());
+                operatorsByDimension[dimension].tock();
+            }
+        }
+
+        List<OGCGeometry> outputs = new ArrayList<>();
+        for (GeometryCursor operator : operatorsByDimension) {
+            OGCGeometry unionedGeometry = createFromEsriGeometry(operator.next(), null);
+            if (unionedGeometry != null) {
+                outputs.add(unionedGeometry);
+            }
+        }
+
+        if (outputs.size() == 1) {
+            return serialize(outputs.get(0));
+        }
+        return serialize(new OGCConcreteGeometryCollection(outputs, null).flattenAndRemoveOverlaps().reduceFromMulti());
     }
 
     @SqlNullable
@@ -1241,5 +1306,77 @@ public final class GeoFunctions
     private interface EnvelopesPredicate
     {
         boolean apply(Envelope left, Envelope right);
+    }
+
+    private static Iterable<Slice> getGeometrySlicesFromBlock(Block block)
+    {
+        requireNonNull(block, "block is null");
+        return () -> new Iterator<Slice>() {
+            private int iteratorPosition;
+
+            @Override
+            public boolean hasNext()
+            {
+                return iteratorPosition != block.getPositionCount();
+            }
+
+            @Override
+            public Slice next()
+            {
+                if (!hasNext()) {
+                    throw new NoSuchElementException("Slices have been consumed");
+                }
+                return GEOMETRY.getSlice(block, iteratorPosition++);
+            }
+        };
+    }
+
+    private static Iterable<OGCGeometry> flattenCollection(OGCGeometry geometry)
+    {
+        if (geometry == null) {
+            return ImmutableList.of();
+        }
+        if (!(geometry instanceof OGCConcreteGeometryCollection)) {
+            return ImmutableList.of(geometry);
+        }
+        if (((OGCConcreteGeometryCollection) geometry).numGeometries() == 0) {
+            return ImmutableList.of();
+        }
+        return () -> new GeometryCollectionIterator(geometry);
+    }
+
+    private static class GeometryCollectionIterator
+            implements Iterator<OGCGeometry>
+    {
+        private final Deque<OGCGeometry> geometriesDeque = new ArrayDeque<>();
+
+        GeometryCollectionIterator(OGCGeometry geometries)
+        {
+            geometriesDeque.push(requireNonNull(geometries, "geometries is null"));
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            if (geometriesDeque.isEmpty()) {
+                return false;
+            }
+            while (geometriesDeque.peek() instanceof OGCConcreteGeometryCollection) {
+                OGCGeometryCollection collection = (OGCGeometryCollection) geometriesDeque.pop();
+                for (int i = 0; i < collection.numGeometries(); i++) {
+                    geometriesDeque.push(collection.geometryN(i));
+                }
+            }
+            return !geometriesDeque.isEmpty();
+        }
+
+        @Override
+        public OGCGeometry next()
+        {
+            if (!hasNext()) {
+                throw new NoSuchElementException("Geometries have been consumed");
+            }
+            return geometriesDeque.pop();
+        }
     }
 }

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -47,6 +47,7 @@ import com.facebook.presto.spi.function.SqlNullable;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import org.locationtech.jts.geom.Geometry;
@@ -572,27 +573,12 @@ public final class GeoFunctions
         return ((OGCGeometryCollection) geometry).numGeometries();
     }
 
-    @Description("Returns a geometry that represents the point set union of the input geometries. This function doesn't support geometry collections.")
+    @Description("Returns a geometry that represents the point set union of the input geometries.")
     @ScalarFunction("ST_Union")
     @SqlType(GEOMETRY_TYPE_NAME)
     public static Slice stUnion(@SqlType(GEOMETRY_TYPE_NAME) Slice left, @SqlType(GEOMETRY_TYPE_NAME) Slice right)
     {
-        // Only supports Geometry but not GeometryCollection due to ESRI library limitation
-        // https://github.com/Esri/geometry-api-java/issues/176
-        // https://github.com/Esri/geometry-api-java/issues/177
-        OGCGeometry leftGeometry = deserialize(left);
-        validateType("ST_Union", leftGeometry, EnumSet.of(POINT, MULTI_POINT, LINE_STRING, MULTI_LINE_STRING, POLYGON, MULTI_POLYGON));
-        if (leftGeometry.isEmpty()) {
-            return right;
-        }
-
-        OGCGeometry rightGeometry = deserialize(right);
-        validateType("ST_Union", rightGeometry, EnumSet.of(POINT, MULTI_POINT, LINE_STRING, MULTI_LINE_STRING, POLYGON, MULTI_POLYGON));
-        if (rightGeometry.isEmpty()) {
-            return left;
-        }
-
-        return serialize(leftGeometry.union(rightGeometry));
+        return stUnion(ImmutableList.of(left, right));
     }
 
     @Description("Returns a geometry that represents the point set union of the input geometries.")

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeometryType.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeometryType.java
@@ -59,12 +59,20 @@ public class GeometryType
     @Override
     public void writeSlice(BlockBuilder blockBuilder, Slice value)
     {
+        if (value == null) {
+            blockBuilder.appendNull();
+            return;
+        }
         writeSlice(blockBuilder, value, 0, value.length());
     }
 
     @Override
     public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
     {
+        if (value == null) {
+            blockBuilder.appendNull();
+            return;
+        }
         blockBuilder.writeBytes(value, offset, length).closeEntry();
     }
 

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryUnionAgg.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryUnionAgg.java
@@ -29,8 +29,8 @@ import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY;
 import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY_TYPE_NAME;
 
 /**
- * Aggregate form of ST_Union which takes a set of geometries and unions them into a single geometry, resulting in no intersecting
- * regions.  The output may be a multi-geometry, a single geometry or a geometry collection.
+ * Aggregate form of ST_Union which takes a set of geometries and unions them into a single geometry using an iterative approach,
+ * resulting in no intersecting regions.  The output may be a multi-geometry, a single geometry or a geometry collection.
  */
 @Description("Returns a geometry that represents the point set union of the input geometries.")
 @AggregationFunction("geometry_union_agg")

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkGeometryAggregations.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/BenchmarkGeometryAggregations.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import com.facebook.presto.plugin.memory.MemoryConnectorFactory;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.google.common.collect.ImmutableMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(3)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class BenchmarkGeometryAggregations
+{
+    @State(Thread)
+    public static class Context
+    {
+        private LocalQueryRunner queryRunner;
+
+        public LocalQueryRunner getQueryRunner()
+        {
+            return queryRunner;
+        }
+
+        @Setup
+        public void setUp()
+                throws IOException
+        {
+            queryRunner = new LocalQueryRunner(testSessionBuilder()
+                    .setCatalog("memory")
+                    .setSchema("default")
+                    .build());
+            queryRunner.installPlugin(new GeoPlugin());
+            queryRunner.createCatalog("memory", new MemoryConnectorFactory(), ImmutableMap.of());
+
+            Path path = Paths.get(BenchmarkGeometryAggregations.class.getClassLoader().getResource("us-states.tsv").getPath());
+            String polygonValues = Files.lines(path)
+                    .map(line -> line.split("\t"))
+                    .map(parts -> format("('%s', '%s')", parts[0], parts[1]))
+                    .collect(Collectors.joining(","));
+
+            queryRunner.execute(
+                    format("CREATE TABLE memory.default.us_states AS SELECT ST_GeometryFromText(t.wkt) AS geom FROM (VALUES %s) as t (name, wkt)",
+                            polygonValues));
+        }
+
+        @TearDown
+        public void tearDown()
+        {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+
+    @Benchmark
+    public MaterializedResult benchmarkArrayUnion(Context context)
+    {
+        return context.getQueryRunner()
+                .execute("SELECT geometry_union(array_agg(p.geom)) FROM us_states p");
+    }
+
+    @Benchmark
+    public MaterializedResult benchmarkUnion(Context context)
+    {
+        return context.getQueryRunner()
+                .execute("SELECT geometry_union_agg(p.geom) FROM us_states p");
+    }
+
+    @Benchmark
+    public MaterializedResult benchmarkConvexHull(Context context)
+    {
+        return context.getQueryRunner()
+                .execute("SELECT convex_hull_agg(p.geom) FROM us_states p");
+    }
+
+    @Test
+    public void verify()
+            throws IOException
+    {
+        Context context = new Context();
+        try {
+            context.setUp();
+
+            BenchmarkGeometryAggregations benchmark = new BenchmarkGeometryAggregations();
+            benchmark.benchmarkUnion(context);
+            benchmark.benchmarkArrayUnion(context);
+            benchmark.benchmarkConvexHull(context);
+        }
+        finally {
+            context.queryRunner.close();
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        new BenchmarkGeometryAggregations().verify();
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkGeometryAggregations.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -806,7 +806,8 @@ public class TestGeoFunctions
                         "LINESTRING EMPTY",
                         "MULTILINESTRING EMPTY",
                         "POLYGON EMPTY",
-                        "MULTIPOLYGON EMPTY");
+                        "MULTIPOLYGON EMPTY",
+                        "GEOMETRYCOLLECTION EMPTY");
         List<String> simpleWkts =
                 ImmutableList.of(
                         "POINT (1 2)",
@@ -814,12 +815,8 @@ public class TestGeoFunctions
                         "LINESTRING (0 0, 2 2, 4 4)",
                         "MULTILINESTRING ((0 0, 2 2, 4 4), (5 5, 7 7, 9 9))",
                         "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
-                        "MULTIPOLYGON (((1 1, 3 1, 3 3, 1 3, 1 1)), ((2 4, 6 4, 6 6, 2 6, 2 4)))");
-
-        // invalid type GEOMETRYCOLLECTION
-        for (String simpleWkt : simpleWkts) {
-            assertInvalidGeometryCollectionUnion(simpleWkt);
-        }
+                        "MULTIPOLYGON (((1 1, 3 1, 3 3, 1 3, 1 1)), ((2 4, 6 4, 6 6, 2 6, 2 4)))",
+                        "GEOMETRYCOLLECTION (LINESTRING (0 5, 5 5), POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1)))");
 
         // empty geometry
         for (String emptyWkt : emptyWkts) {
@@ -840,19 +837,22 @@ public class TestGeoFunctions
         assertUnion("MULTILINESTRING ((0 0, 2 2, 4 4), (5 5, 7 7, 9 9))", "MULTILINESTRING ((5 5, 7 7, 9 9), (11 11, 13 13, 15 15))", "MULTILINESTRING ((0 0, 2 2, 4 4), (5 5, 7 7, 9 9), (11 11, 13 13, 15 15))");
         assertUnion("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", "POLYGON ((1 0, 2 0, 2 1, 1 1, 1 0))", "POLYGON ((0 0, 1 0, 2 0, 2 1, 1 1, 0 1, 0 0))");
         assertUnion("MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)))", "MULTIPOLYGON (((1 0, 2 0, 2 1, 1 1, 1 0)))", "POLYGON ((0 0, 1 0, 2 0, 2 1, 1 1, 0 1, 0 0))");
+        assertUnion("GEOMETRYCOLLECTION (POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0)), POINT (1 2))", "GEOMETRYCOLLECTION (POLYGON ((1 0, 2 0, 2 1, 1 1, 1 0)), MULTIPOINT ((1 2), (3 4)))", "GEOMETRYCOLLECTION (MULTIPOINT ((1 2), (3 4)), POLYGON ((0 0, 1 0, 2 0, 2 1, 1 1, 0 1, 0 0)))");
 
         // within union
         assertUnion("MULTIPOINT ((20 20), (25 25))", "POINT (25 25)", "MULTIPOINT ((20 20), (25 25))");
         assertUnion("LINESTRING (20 20, 30 30)", "POINT (25 25)", "LINESTRING (20 20, 25 25, 30 30)");
         assertUnion("LINESTRING (20 20, 30 30)", "LINESTRING (25 25, 27 27)", "LINESTRING (20 20, 25 25, 27 27, 30 30)");
         assertUnion("POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))", "POLYGON ((1 1, 1 2, 2 2, 2 1, 1 1))", "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))");
-        assertUnion("MULTIPOLYGON (((0 0 , 0 2, 2 2, 2 0)), ((2 2, 2 4, 4 4, 4 2)))", "POLYGON ((2 2, 2 3, 3 3, 3 2))", "MULTIPOLYGON (((0 0, 2 0, 2 2, 0 2, 0 0)), ((2 2, 3 2, 4 2, 4 4, 2 4, 2 3, 2 2)))");
+        assertUnion("MULTIPOLYGON (((0 0 , 0 2, 2 2, 2 0)), ((2 2, 2 4, 4 4, 4 2)))", "POLYGON ((2 2, 2 3, 3 3, 3 2))", "MULTIPOLYGON (((2 2, 3 2, 4 2, 4 4, 2 4, 2 3, 2 2)), ((0 0, 2 0, 2 2, 0 2, 0 0)))");
+        assertUnion("GEOMETRYCOLLECTION (POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0)), MULTIPOINT ((20 20), (25 25)))", "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 2, 2 2, 2 1, 1 1)), POINT (25 25))", "GEOMETRYCOLLECTION (MULTIPOINT ((20 20), (25 25)), POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0)))");
 
         // overlap union
         assertUnion("LINESTRING (1 1, 3 1)", "LINESTRING (2 1, 4 1)", "LINESTRING (1 1, 2 1, 3 1, 4 1)");
         assertUnion("MULTILINESTRING ((1 1, 3 1))", "MULTILINESTRING ((2 1, 4 1))", "LINESTRING (1 1, 2 1, 3 1, 4 1)");
         assertUnion("POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))", "POLYGON ((2 2, 4 2, 4 4, 2 4, 2 2))", "POLYGON ((1 1, 3 1, 3 2, 4 2, 4 4, 2 4, 2 3, 1 3, 1 1))");
         assertUnion("MULTIPOLYGON (((1 1, 3 1, 3 3, 1 3, 1 1)))", "MULTIPOLYGON (((2 2, 4 2, 4 4, 2 4, 2 2)))", "POLYGON ((1 1, 3 1, 3 2, 4 2, 4 4, 2 4, 2 3, 1 3, 1 1))");
+        assertUnion("GEOMETRYCOLLECTION (POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1)), LINESTRING (1 1, 3 1))", "GEOMETRYCOLLECTION (POLYGON ((2 2, 4 2, 4 4, 2 4, 2 2)), LINESTRING (2 1, 4 1))", "GEOMETRYCOLLECTION (LINESTRING (3 1, 4 1), POLYGON ((1 1, 2 1, 3 1, 3 2, 4 2, 4 4, 2 4, 2 3, 1 3, 1 1)))");
     }
 
     private void assertUnion(String leftWkt, String rightWkt, String expectWkt)


### PR DESCRIPTION
A benchmark has been added to measure geometry aggregation performance.
Here are some benchmark numbers which demonstrate the performance over
50 states:

```
Benchmark                                         Mode  Cnt    Score    Error  Units
BenchmarkGeometryAggregation.benchmarkArrayUnion  avgt   30   24.601 ±  0.659  ms/op
BenchmarkGeometryAggregation.benchmarkConvexHull  avgt   30   23.169 ±  0.673  ms/op
BenchmarkGeometryAggregation.benchmarkUnion       avgt   30  647.646 ± 14.411  ms/op