### PR TITLE
Decrease amount of logs produced by product tests

### DIFF
--- a/presto-product-tests/conf/presto/etc/log.properties
+++ b/presto-product-tests/conf/presto/etc/log.properties
@@ -8,5 +8,5 @@
 com.facebook.presto=INFO
 com.sun.jersey.guice.spi.container.GuiceComponentProviderFactory=WARN
 com.ning.http.client=DEBUG
-com.facebook.presto.server.PluginManager=DEBUG
+com.facebook.presto.server.PluginManager=INFO
 io.airlift.discovery.client=INFO


### PR DESCRIPTION
Build is failing with "The log length has exceeded the limit of 4 MB".
Majority of the logs are listings of jars loaded by different plugins.
Although it might be useful information for debugging, keeping it enabled
by default doesn't make much sense.