### PR TITLE
Make hive metastore test database name configurable

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -2188,7 +2188,7 @@ public abstract class AbstractTestHiveClient
         Path targetPath;
         try {
             try (Transaction transaction = newTransaction()) {
-                LocationService locationService = getLocationService(schemaName);
+                LocationService locationService = getLocationService();
                 LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(schemaName), session, schemaName, tableName);
                 targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
                 Table table = createSimpleTable(schemaTableName, columns, session, targetPath, "q1");
@@ -2580,7 +2580,7 @@ public abstract class AbstractTestHiveClient
 
     protected void testUpdateTableStatistics(SchemaTableName tableName, PartitionStatistics initialStatistics, PartitionStatistics... statistics)
     {
-        ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
+        ExtendedHiveMetastore metastoreClient = getMetastoreClient();
         assertThat(metastoreClient.getTableStatistics(tableName.getSchemaName(), tableName.getTableName()))
                 .isEqualTo(initialStatistics);
 
@@ -2681,7 +2681,7 @@ public abstract class AbstractTestHiveClient
     {
         doCreateEmptyTable(tableName, ORC, columns);
 
-        ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
+        ExtendedHiveMetastore metastoreClient = getMetastoreClient();
         Table table = metastoreClient.getTable(tableName.getSchemaName(), tableName.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(tableName));
 
@@ -2722,7 +2722,7 @@ public abstract class AbstractTestHiveClient
         String firstPartitionName = "ds=2016-01-01";
         String secondPartitionName = "ds=2016-01-02";
 
-        ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
+        ExtendedHiveMetastore metastoreClient = getMetastoreClient();
         assertThat(metastoreClient.getPartitionStatistics(tableName.getSchemaName(), tableName.getTableName(), ImmutableSet.of(firstPartitionName, secondPartitionName)))
                 .isEqualTo(ImmutableMap.of(firstPartitionName, initialStatistics, secondPartitionName, initialStatistics));
 
@@ -2779,7 +2779,7 @@ public abstract class AbstractTestHiveClient
         try {
             doCreateEmptyTable(tableName, ORC, columns);
 
-            ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
+            ExtendedHiveMetastore metastoreClient = getMetastoreClient();
             Table table = metastoreClient.getTable(tableName.getSchemaName(), tableName.getTableName())
                     .orElseThrow(() -> new TableNotFoundException(tableName));
 
@@ -2847,7 +2847,7 @@ public abstract class AbstractTestHiveClient
         try (Transaction transaction = newTransaction()) {
             ConnectorSession session = newSession();
             SemiTransactionalHiveMetastore metastore = transaction.getMetastore(schemaTableName.getSchemaName());
-            LocationService locationService = getLocationService(schemaTableName.getSchemaName());
+            LocationService locationService = getLocationService();
             Table table = metastore.getTable(schemaTableName.getSchemaName(), schemaTableName.getTableName()).get();
             LocationHandle handle = locationService.forExistingTable(metastore, session, table);
             return locationService.getPartitionWriteInfo(handle, Optional.empty(), partitionName).getTargetPath().toString();
@@ -2872,7 +2872,7 @@ public abstract class AbstractTestHiveClient
 
         try {
             createDummyPartitionedTable(tableName, columns);
-            ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
+            ExtendedHiveMetastore metastoreClient = getMetastoreClient();
             metastoreClient.updatePartitionStatistics(tableName.getSchemaName(), tableName.getTableName(), "ds=2016-01-01", actualStatistics -> statistics);
             metastoreClient.updatePartitionStatistics(tableName.getSchemaName(), tableName.getTableName(), "ds=2016-01-02", actualStatistics -> statistics);
 
@@ -3008,7 +3008,7 @@ public abstract class AbstractTestHiveClient
             assertEqualsIgnoreOrder(result.getMaterializedRows(), CREATE_TABLE_DATA.getMaterializedRows());
 
             // verify the node version and query ID in table
-            Table table = getMetastoreClient(tableName.getSchemaName()).getTable(tableName.getSchemaName(), tableName.getTableName()).get();
+            Table table = getMetastoreClient().getTable(tableName.getSchemaName(), tableName.getTableName()).get();
             assertEquals(table.getParameters().get(PRESTO_VERSION_NAME), TEST_SERVER_VERSION);
             assertEquals(table.getParameters().get(PRESTO_QUERY_ID_NAME), queryId);
 
@@ -3207,7 +3207,7 @@ public abstract class AbstractTestHiveClient
     protected Path getStagingPathRoot(ConnectorInsertTableHandle insertTableHandle)
     {
         HiveInsertTableHandle handle = (HiveInsertTableHandle) insertTableHandle;
-        WriteInfo writeInfo = getLocationService(handle.getSchemaName()).getQueryWriteInfo(handle.getLocationHandle());
+        WriteInfo writeInfo = getLocationService().getQueryWriteInfo(handle.getLocationHandle());
         if (writeInfo.getWriteMode() != STAGE_AND_MOVE_TO_TARGET_DIRECTORY) {
             throw new AssertionError("writeMode is not STAGE_AND_MOVE_TO_TARGET_DIRECTORY");
         }
@@ -3217,7 +3217,7 @@ public abstract class AbstractTestHiveClient
     protected Path getStagingPathRoot(ConnectorOutputTableHandle outputTableHandle)
     {
         HiveOutputTableHandle handle = (HiveOutputTableHandle) outputTableHandle;
-        return getLocationService(handle.getSchemaName())
+        return getLocationService()
                 .getQueryWriteInfo(handle.getLocationHandle())
                 .getWritePath();
     }
@@ -3226,7 +3226,7 @@ public abstract class AbstractTestHiveClient
     {
         HiveInsertTableHandle hiveInsertTableHandle = (HiveInsertTableHandle) insertTableHandle;
 
-        return getLocationService(hiveInsertTableHandle.getSchemaName())
+        return getLocationService()
                 .getQueryWriteInfo(hiveInsertTableHandle.getLocationHandle())
                 .getTargetPath();
     }
@@ -3305,7 +3305,7 @@ public abstract class AbstractTestHiveClient
                     .collect(toList()));
 
             // verify the node versions in partitions
-            Map<String, Optional<Partition>> partitions = getMetastoreClient(tableName.getSchemaName()).getPartitionsByNames(tableName.getSchemaName(), tableName.getTableName(), partitionNames);
+            Map<String, Optional<Partition>> partitions = getMetastoreClient().getPartitionsByNames(tableName.getSchemaName(), tableName.getTableName(), partitionNames);
             assertEquals(partitions.size(), partitionNames.size());
             for (String partitionName : partitionNames) {
                 Partition partition = partitions.get(partitionName).get();
@@ -3555,7 +3555,7 @@ public abstract class AbstractTestHiveClient
 
     private void eraseStatistics(SchemaTableName schemaTableName)
     {
-        ExtendedHiveMetastore metastoreClient = getMetastoreClient(schemaTableName.getSchemaName());
+        ExtendedHiveMetastore metastoreClient = getMetastoreClient();
         metastoreClient.updateTableStatistics(schemaTableName.getSchemaName(), schemaTableName.getTableName(), statistics -> new PartitionStatistics(createEmptyStatistics(), ImmutableMap.of()));
         Table table = metastoreClient.getTable(schemaTableName.getSchemaName(), schemaTableName.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(schemaTableName));
@@ -4044,12 +4044,12 @@ public abstract class AbstractTestHiveClient
         return new MaterializedResult(allRows.build(), getTypes(columnHandles));
     }
 
-    public ExtendedHiveMetastore getMetastoreClient(String namespace)
+    public ExtendedHiveMetastore getMetastoreClient()
     {
         return metastoreClient;
     }
 
-    public LocationService getLocationService(String namespace)
+    public LocationService getLocationService()
     {
         return locationService;
     }
@@ -4279,7 +4279,7 @@ public abstract class AbstractTestHiveClient
             String schemaName = schemaTableName.getSchemaName();
             String tableName = schemaTableName.getTableName();
 
-            LocationService locationService = getLocationService(schemaName);
+            LocationService locationService = getLocationService();
             LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(schemaName), session, schemaName, tableName);
             targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
 
@@ -4650,7 +4650,7 @@ public abstract class AbstractTestHiveClient
         {
             // This method bypasses transaction interface because this method is inherently hacky and doesn't work well with the transaction abstraction.
             // Additionally, this method is not part of a test. Its purpose is to set up an environment for another test.
-            ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
+            ExtendedHiveMetastore metastoreClient = getMetastoreClient();
             Optional<Partition> partition = metastoreClient.getPartition(tableName.getSchemaName(), tableName.getTableName(), copyPartitionFrom);
             conflictPartition = Partition.builder(partition.get())
                     .setValues(toPartitionValues(partitionNameToConflict))
@@ -4666,7 +4666,7 @@ public abstract class AbstractTestHiveClient
         {
             // This method bypasses transaction interface because this method is inherently hacky and doesn't work well with the transaction abstraction.
             // Additionally, this method is not part of a test. Its purpose is to set up an environment for another test.
-            ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
+            ExtendedHiveMetastore metastoreClient = getMetastoreClient();
             Optional<Partition> actualPartition = metastoreClient.getPartition(tableName.getSchemaName(), tableName.getTableName(), toPartitionValues(partitionNameToConflict));
             // Make sure the partition inserted to trigger conflict was not overwritten
             // Checking storage location is sufficient because implement never uses .../pk1=a/pk2=a2 as the directory for partition [b, b2].
@@ -4685,7 +4685,7 @@ public abstract class AbstractTestHiveClient
         {
             // This method bypasses transaction interface because this method is inherently hacky and doesn't work well with the transaction abstraction.
             // Additionally, this method is not part of a test. Its purpose is to set up an environment for another test.
-            ExtendedHiveMetastore metastoreClient = getMetastoreClient(tableName.getSchemaName());
+            ExtendedHiveMetastore metastoreClient = getMetastoreClient();
             metastoreClient.dropPartition(tableName.getSchemaName(), tableName.getTableName(), partitionValueToConflict, false);
         }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
@@ -29,12 +29,25 @@ import java.io.IOException;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractTestHiveClientLocal
         extends AbstractTestHiveClient
 {
-    private static final String TEST_DB_NAME = "test";
+    private static final String DEFAULT_TEST_DB_NAME = "test";
+
     private File tempDir;
+    private String testDbName;
+
+    protected AbstractTestHiveClientLocal()
+    {
+        this(DEFAULT_TEST_DB_NAME);
+    }
+
+    protected AbstractTestHiveClientLocal(String testDbName)
+    {
+        this.testDbName = requireNonNull(testDbName, "testDbName is null");
+    }
 
     protected abstract ExtendedHiveMetastore createMetastore(File tempDir);
 
@@ -46,7 +59,7 @@ public abstract class AbstractTestHiveClientLocal
         ExtendedHiveMetastore metastore = createMetastore(tempDir);
 
         metastore.createDatabase(Database.builder()
-                .setDatabaseName(TEST_DB_NAME)
+                .setDatabaseName(testDbName)
                 .setOwnerName("public")
                 .setOwnerType(PrincipalType.ROLE)
                 .build());
@@ -54,7 +67,7 @@ public abstract class AbstractTestHiveClientLocal
         HiveClientConfig hiveConfig = new HiveClientConfig()
                 .setTimeZone("America/Los_Angeles");
 
-        setup(TEST_DB_NAME, hiveConfig, metastore);
+        setup(testDbName, hiveConfig, metastore);
     }
 
     @AfterClass(alwaysRun = true)
@@ -62,7 +75,7 @@ public abstract class AbstractTestHiveClientLocal
             throws IOException
     {
         try {
-            getMetastoreClient(TEST_DB_NAME).dropDatabase(TEST_DB_NAME);
+            getMetastoreClient(testDbName).dropDatabase(testDbName);
         }
         finally {
             deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
@@ -75,7 +75,7 @@ public abstract class AbstractTestHiveClientLocal
             throws IOException
     {
         try {
-            getMetastoreClient(testDbName).dropDatabase(testDbName);
+            getMetastoreClient().dropDatabase(testDbName);
         }
         finally {
             deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
@@ -24,9 +24,17 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 
 import java.io.File;
 
+import static java.util.Locale.ENGLISH;
+import static java.util.UUID.randomUUID;
+
 public class TestHiveClientGlueMetastore
         extends AbstractTestHiveClientLocal
 {
+    public TestHiveClientGlueMetastore()
+    {
+        super("test_glue" + randomUUID().toString().toLowerCase(ENGLISH).replace("-", ""));
+    }
+
     /**
      * GlueHiveMetastore currently uses AWS Default Credential Provider Chain,
      * See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default


### PR DESCRIPTION
This allows for running multiple AWS Glue tests in parallel