### PR TITLE
Remove old shard assignment when reassigning shard in Raptor

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
@@ -231,7 +231,7 @@ public class RaptorSplitManager
                     throw new PrestoException(NO_NODES_AVAILABLE, "No nodes available to run query");
                 }
                 Node node = selectRandom(availableNodes);
-                shardManager.assignShard(tableId, shardId, node.getNodeIdentifier(), true);
+                shardManager.replaceShardAssignment(tableId, shardId, node.getNodeIdentifier(), true);
                 addresses = ImmutableList.of(node.getHostAndPort());
             }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardDao.java
@@ -46,10 +46,10 @@ public interface ShardDao
             "VALUES ((SELECT shard_id FROM shards WHERE shard_uuid = :shardUuid), :nodeId)")
     void insertShardNode(@Bind("shardUuid") UUID shardUuid, @Bind("nodeId") int nodeId);
 
-    @SqlUpdate("DELETE FROM shard_nodes\n" +
+    @SqlBatch("DELETE FROM shard_nodes\n" +
             "WHERE shard_id = (SELECT shard_id FROM shards WHERE shard_uuid = :shardUuid)\n" +
             "  AND node_id = :nodeId")
-    void deleteShardNode(@Bind("shardUuid") UUID shardUuid, @Bind("nodeId") int nodeId);
+    void deleteShardNodes(@Bind("shardUuid") UUID shardUuid, @Bind("nodeId") Iterable<Integer> nodeId);
 
     @SqlQuery("SELECT node_id FROM nodes WHERE node_identifier = :nodeIdentifier")
     Integer getNodeId(@Bind("nodeIdentifier") String nodeIdentifier);

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
@@ -78,14 +78,9 @@ public interface ShardManager
     ResultIterator<BucketShards> getShardNodesBucketed(long tableId, boolean merged, Map<Integer, String> bucketToNode, TupleDomain<RaptorColumnHandle> effectivePredicate);
 
     /**
-     * Assign a shard to a node.
+     * Remove all old shard assignments and assign a shard to a node
      */
-    void assignShard(long tableId, UUID shardUuid, String nodeIdentifier, boolean gracePeriod);
-
-    /**
-     * Remove shard assignment from a node.
-     */
-    void unassignShard(long tableId, UUID shardUuid, String nodeIdentifier);
+    void replaceShardAssignment(long tableId, UUID shardUuid, String nodeIdentifier, boolean gracePeriod);
 
     /**
      * Get the number of bytes used by assigned shards per node.

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardEjector.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardEjector.java
@@ -239,8 +239,7 @@ public class ShardEjector
             nodeSize -= shardSize;
 
             // move assignment
-            shardManager.assignShard(shard.getTableId(), shardUuid, target, false);
-            shardManager.unassignShard(shard.getTableId(), shardUuid, currentNode);
+            shardManager.replaceShardAssignment(shard.getTableId(), shardUuid, target, false);
 
             // delete local file
             File file = storageService.getStorageFile(shardUuid);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
@@ -181,30 +181,24 @@ public class TestDatabaseShardManager
         assertEquals(actual, new ShardNodes(shard, ImmutableSet.of("node1")));
 
         try {
-            shardManager.assignShard(tableId, shard, "node2", true);
+            shardManager.replaceShardAssignment(tableId, shard, "node2", true);
             fail("expected exception");
         }
         catch (PrestoException e) {
             assertEquals(e.getErrorCode(), SERVER_STARTING_UP.toErrorCode());
         }
 
-        shardManager.assignShard(tableId, shard, "node2", false);
-
-        // assign shard to another node
-        actual = getOnlyElement(getShardNodes(tableId, TupleDomain.all()));
-        assertEquals(actual, new ShardNodes(shard, ImmutableSet.of("node1", "node2")));
-
-        // assigning a shard should be idempotent
-        shardManager.assignShard(tableId, shard, "node2", false);
-
-        // remove assignment from first node
-        shardManager.unassignShard(tableId, shard, "node1");
+        // replace shard assignment to another node
+        shardManager.replaceShardAssignment(tableId, shard, "node2", false);
 
         actual = getOnlyElement(getShardNodes(tableId, TupleDomain.all()));
         assertEquals(actual, new ShardNodes(shard, ImmutableSet.of("node2")));
 
-        // removing an assignment should be idempotent
-        shardManager.unassignShard(tableId, shard, "node1");
+        // replacing shard assignment should be idempotent
+        shardManager.replaceShardAssignment(tableId, shard, "node2", false);
+
+        actual = getOnlyElement(getShardNodes(tableId, TupleDomain.all()));
+        assertEquals(actual, new ShardNodes(shard, ImmutableSet.of("node2")));
     }
 
     @Test
@@ -231,13 +225,13 @@ public class TestDatabaseShardManager
 
         assertEquals(shardManager.getNodeBytes(), ImmutableMap.of("node1", 88L));
 
-        shardManager.assignShard(tableId, shard1, "node2", false);
+        shardManager.replaceShardAssignment(tableId, shard1, "node2", false);
 
         assertEquals(getShardNodes(tableId, TupleDomain.all()), ImmutableSet.of(
-                new ShardNodes(shard1, ImmutableSet.of("node1", "node2")),
+                new ShardNodes(shard1, ImmutableSet.of("node2")),
                 new ShardNodes(shard2, ImmutableSet.of("node1"))));
 
-        assertEquals(shardManager.getNodeBytes(), ImmutableMap.of("node1", 88L, "node2", 33L));
+        assertEquals(shardManager.getNodeBytes(), ImmutableMap.of("node1", 55L, "node2", 33L));
     }
 
     @Test


### PR DESCRIPTION
Before this commit we never remove old assignments when assigning missing shards. It can result in multiple assignments of the same shard on different nodes, causing waste in storage. 

This commit guarantees at most one node is assigned for a shard.

**Behavior changes in a rare corner case**
This commit also changes the behavior when 2 queries both discover the missing shard and try to reassignment it at the same time. Before this change, we can have one of the 2 results:
(1) One of the query fails due to transaction conflict on metadata modification.
(2) Both queries succeed in assigning shards, results in multiple assignments of the same shard.

After this change, we can have:
(1) One of the query fails due to transaction conflict on metadata modification.
(2) Both queries succeed in reassigning shard, but one of them gets a stale split that contains the wrong node address, resulting in query failure due to shard not found on the node. 