### PR TITLE
Don't asssume we have input operator stats in getPlanNodeStats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -156,9 +156,11 @@ public class PlanNodeStatsSummarizer
             PlanNodeId planNodeId = entry.getKey();
             stats.add(new PlanNodeStats(
                     planNodeId,
+                    // It's possible there will be no input stats because all the pipelines that we observed were non-input.
+                    // For instance we could receive stats for exchange source, but not exchange sink.
                     new Duration(planNodeWallMillis.get(planNodeId), MILLISECONDS),
-                    planNodeInputPositions.get(planNodeId),
-                    succinctDataSize(planNodeInputBytes.get(planNodeId), BYTE),
+                    planNodeInputPositions.getOrDefault(planNodeId, 0L),
+                    succinctDataSize(planNodeInputBytes.getOrDefault(planNodeId, 0L), BYTE),
                     // It's possible there will be no output stats because all the pipelines that we observed were non-output.
                     // For example in a query like SELECT * FROM a JOIN b ON c = d LIMIT 1
                     // It's possible to observe stats after the build starts, but before the probe does


### PR DESCRIPTION
Fixes flaky testExplainAnalyze
https://github.com/prestodb/presto/issues/8494