### PR TITLE
Add config for setting the ACL type for S3 uploads

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -247,6 +247,9 @@ Property Name                                Description
                                              class also implements ``Configurable`` from the Hadoop
                                              API, the Hadoop configuration will be passed in after
                                              the object has been created.
+
+``hive.s3.upload-acl-type``                  Canned ACL to use when files are uploaded to S3 (defaults
+                                             to ``Private``).
 ============================================ =================================================================
 
 S3 Credentials

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Config.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Config.java
@@ -56,6 +56,7 @@ public class HiveS3Config
     private DataSize s3MultipartMinPartSize = new DataSize(5, MEGABYTE);
     private boolean pinS3ClientToCurrentRegion;
     private String s3UserAgentPrefix = "";
+    private PrestoS3AclType s3AclType = PrestoS3AclType.Private;
 
     public String getS3AwsAccessKey()
     {
@@ -372,6 +373,20 @@ public class HiveS3Config
     public HiveS3Config setS3UserAgentPrefix(String s3UserAgentPrefix)
     {
         this.s3UserAgentPrefix = s3UserAgentPrefix;
+        return this;
+    }
+
+    @NotNull
+    public PrestoS3AclType getS3AclType()
+    {
+        return s3AclType;
+    }
+
+    @Config("hive.s3.upload-acl-type")
+    @ConfigDescription("Canned ACL type for S3 uploads")
+    public HiveS3Config setS3AclType(PrestoS3AclType s3AclType)
+    {
+        this.s3AclType = s3AclType;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3AclType.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3AclType.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.s3;
+
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+
+import static java.util.Objects.requireNonNull;
+
+@SuppressWarnings("EnumeratedConstantNamingConvention")
+public enum PrestoS3AclType
+{
+    AuthenticatedRead(CannedAccessControlList.AuthenticatedRead),
+    AwsExecRead(CannedAccessControlList.AwsExecRead),
+    BucketOwnerFullControl(CannedAccessControlList.BucketOwnerFullControl),
+    BucketOwnerRead(CannedAccessControlList.BucketOwnerRead),
+    LogDeliveryWrite(CannedAccessControlList.LogDeliveryWrite),
+    Private(CannedAccessControlList.Private),
+    PublicRead(CannedAccessControlList.PublicRead),
+    PublicReadWrite(CannedAccessControlList.PublicReadWrite);
+
+    private final CannedAccessControlList cannedACL;
+
+    PrestoS3AclType(CannedAccessControlList cannedACL)
+    {
+        this.cannedACL = requireNonNull(cannedACL, "cannedACL is null");
+    }
+
+    CannedAccessControlList getCannedACL()
+    {
+        return cannedACL;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3ConfigurationUpdater.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3ConfigurationUpdater.java
@@ -48,6 +48,7 @@ public class PrestoS3ConfigurationUpdater
     private final File stagingDirectory;
     private final boolean pinClientToCurrentRegion;
     private final String userAgentPrefix;
+    private final PrestoS3AclType aclType;
 
     @Inject
     public PrestoS3ConfigurationUpdater(HiveS3Config config)
@@ -76,6 +77,7 @@ public class PrestoS3ConfigurationUpdater
         this.stagingDirectory = config.getS3StagingDirectory();
         this.pinClientToCurrentRegion = config.isPinS3ClientToCurrentRegion();
         this.userAgentPrefix = config.getS3UserAgentPrefix();
+        this.aclType = config.getS3AclType();
     }
 
     @Override
@@ -124,5 +126,6 @@ public class PrestoS3ConfigurationUpdater
         config.setLong(S3_MULTIPART_MIN_PART_SIZE, multipartMinPartSize.toBytes());
         config.setBoolean(S3_PIN_CLIENT_TO_CURRENT_REGION, pinClientToCurrentRegion);
         config.set(S3_USER_AGENT_PREFIX, userAgentPrefix);
+        config.set(S3_ACL_TYPE, aclType.name());
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/S3ConfigurationUpdater.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/S3ConfigurationUpdater.java
@@ -43,6 +43,7 @@ public interface S3ConfigurationUpdater
     String S3_ENDPOINT = "presto.s3.endpoint";
     String S3_SECRET_KEY = "presto.s3.secret-key";
     String S3_ACCESS_KEY = "presto.s3.access-key";
+    String S3_ACL_TYPE = "presto.s3.upload-acl-type";
 
     void updateConfiguration(Configuration config);
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/MockAmazonS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/MockAmazonS3.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.s3;
 
 import com.amazonaws.services.s3.AbstractAmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -30,6 +31,7 @@ public class MockAmazonS3
     private int getObjectHttpCode = SC_OK;
     private int getObjectMetadataHttpCode = SC_OK;
     private GetObjectMetadataRequest getObjectMetadataRequest;
+    private CannedAccessControlList acl;
 
     public void setGetObjectHttpErrorCode(int getObjectHttpErrorCode)
     {
@@ -39,6 +41,11 @@ public class MockAmazonS3
     public void setGetObjectMetadataHttpCode(int getObjectMetadataHttpCode)
     {
         this.getObjectMetadataHttpCode = getObjectMetadataHttpCode;
+    }
+
+    public CannedAccessControlList getAcl()
+    {
+        return this.acl;
     }
 
     public GetObjectMetadataRequest getGetObjectMetadataRequest()
@@ -72,6 +79,7 @@ public class MockAmazonS3
     @Override
     public PutObjectResult putObject(PutObjectRequest putObjectRequest)
     {
+        this.acl = putObjectRequest.getCannedAcl();
         return new PutObjectResult();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestHiveS3Config.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestHiveS3Config.java
@@ -57,7 +57,8 @@ public class TestHiveS3Config
                 .setS3MaxConnections(500)
                 .setS3StagingDirectory(new File(StandardSystemProperty.JAVA_IO_TMPDIR.value()))
                 .setPinS3ClientToCurrentRegion(false)
-                .setS3UserAgentPrefix(""));
+                .setS3UserAgentPrefix("")
+                .setS3AclType(PrestoS3AclType.Private));
     }
 
     @Test
@@ -88,6 +89,7 @@ public class TestHiveS3Config
                 .put("hive.s3.staging-directory", "/s3-staging")
                 .put("hive.s3.pin-client-to-current-region", "true")
                 .put("hive.s3.user-agent-prefix", "user-agent-prefix")
+                .put("hive.s3.upload-acl-type", "PublicRead")
                 .build();
 
         HiveS3Config expected = new HiveS3Config()
@@ -114,7 +116,8 @@ public class TestHiveS3Config
                 .setS3MaxConnections(77)
                 .setS3StagingDirectory(new File("/s3-staging"))
                 .setPinS3ClientToCurrentRegion(true)
-                .setS3UserAgentPrefix("user-agent-prefix");
+                .setS3UserAgentPrefix("user-agent-prefix")
+                .setS3AclType(PrestoS3AclType.PublicRead);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3EncryptionClient;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.EncryptionMaterials;
 import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
 import com.facebook.presto.hive.s3.PrestoS3FileSystem.UnrecoverableS3OperationException;
@@ -44,6 +45,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ACCESS_KEY;
+import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ACL_TYPE;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_CREDENTIALS_PROVIDER;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ENCRYPTION_MATERIALS_PROVIDER;
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_ENDPOINT;
@@ -530,5 +532,42 @@ public class TestPrestoS3FileSystem
 
         @Override
         public void refresh() {}
+    }
+
+    @Test
+    public void testDefaultAcl()
+            throws Exception
+    {
+        Configuration config = new Configuration();
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            MockAmazonS3 s3 = new MockAmazonS3();
+            String expectedBucketName = "test-bucket";
+            fs.initialize(new URI("s3n://" + expectedBucketName + "/"), config);
+            fs.setS3Client(s3);
+            try (FSDataOutputStream stream = fs.create(new Path("s3n://test-bucket/test"))) {
+                // initiate an upload by creating a stream & closing it immediately
+            }
+            assertEquals(CannedAccessControlList.Private, s3.getAcl());
+        }
+    }
+
+    @Test
+    public void testFullBucketOwnerControlAcl()
+            throws Exception
+    {
+        Configuration config = new Configuration();
+        config.set(S3_ACL_TYPE, "BucketOwnerFullControl");
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            MockAmazonS3 s3 = new MockAmazonS3();
+            String expectedBucketName = "test-bucket";
+            fs.initialize(new URI("s3n://" + expectedBucketName + "/"), config);
+            fs.setS3Client(s3);
+            try (FSDataOutputStream stream = fs.create(new Path("s3n://test-bucket/test"))) {
+                // initiate an upload by creating a stream & closing it immediately
+            }
+            assertEquals(CannedAccessControlList.BucketOwnerFullControl, s3.getAcl());
+        }
     }
 }


### PR DESCRIPTION
The purpose of this diff is to enable specifying an ACL Policy when uploading objects into S3 via the presto S3 File System. Our main motivation is that we have multiple accounts for our organization within AWS and we want to = enable cross account writes without breaking backwards compatibility. To do this, we need to set the proper canned ACL. (bucket owner full control in our case) This settings allows us to specify ACL.  