### PR TITLE
Remove transaction information from explain plan

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -219,6 +219,12 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-parser</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -13,10 +13,15 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
+import org.testng.annotations.Test;
 
 import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
+import static com.facebook.presto.sql.tree.ExplainType.Type.LOGICAL;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.tpch.TpchTable.getTables;
+import static org.testng.Assert.assertEquals;
 
 public class TestHiveDistributedQueries
         extends AbstractTestDistributedQueries
@@ -30,6 +35,14 @@ public class TestHiveDistributedQueries
     public void testDelete()
     {
         // Hive connector currently does not support row-by-row delete
+    }
+
+    @Test
+    public void testExplainOfCreateTableAs()
+    {
+        String query = "CREATE TABLE copy_orders AS SELECT * FROM orders";
+        MaterializedResult result = computeActual("EXPLAIN " + query);
+        assertEquals(getOnlyElement(result.getOnlyColumnAsSet()), getExplainPlan(query, LOGICAL));
     }
 
     // Hive specific tests should normally go in TestHiveIntegrationSmokeTest

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InsertTableHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InsertTableHandle.java
@@ -82,6 +82,6 @@ public final class InsertTableHandle
     @Override
     public String toString()
     {
-        return connectorId + ":" + transactionHandle + ":" + connectorHandle;
+        return connectorId + ":" + connectorHandle;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/OutputTableHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/OutputTableHandle.java
@@ -82,6 +82,6 @@ public final class OutputTableHandle
     @Override
     public String toString()
     {
-        return connectorId + ":" + transactionHandle + ":" + connectorHandle;
+        return connectorId + ":" + connectorHandle;
     }
 }


### PR DESCRIPTION
Remove transaction handle from TableCommit part of the `explain <query>`
plan as it can have random elements such as UUID.

When comparing explain plans, they may change between calls
even if the query or environment has not changed. This fixes one
of the known causes since a new UUID is generated on each query.

Following is an example of an `explain CREATE TABLE` query where the 
UUID of the transaction is printed out at the beginning:

```
- Output[rows] => [rows:bigint]
    - TableCommit[hive:475171d7-69f3-49b5-b983-076c63f3da1a:tpch.copy_orders] => [rows:bigint]
```

This fix makes it so that the InsertTableHandle::toString and
OutputTableHandle::toString do not return transaction handle data,
resulting in the following:

```
- Output[rows] => [rows:bigint]
    - TableCommit[hive:tpch.copy_orders] => [rows:bigint]
```

See: #11444, #11485 