### PR TITLE
DATA-6885 Support more data types in IO explain plan

### DIFF
--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -95,6 +95,11 @@
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.keedio.openx.data</groupId>
+            <artifactId>json-serde</artifactId>
+            <version>1.3.7.3</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/presto-hive-hadoop2/src/main/java/org/apache/hadoop/hive/contrib/serde2/JsonSerde.java
+++ b/presto-hive-hadoop2/src/main/java/org/apache/hadoop/hive/contrib/serde2/JsonSerde.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.contrib.serde2;
+
+import org.openx.data.jsonserde.JsonSerDe;
+
+public class JsonSerde
+        extends JsonSerDe
+{
+    public JsonSerde()
+    {
+        super();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -33,6 +33,7 @@ import com.amazonaws.services.s3.AmazonS3Builder;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3EncryptionClient;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.KMSEncryptionMaterialsProvider;
@@ -1056,6 +1057,7 @@ public class PrestoS3FileSystem
                     }
                 }
 
+                request.withCannedAcl(CannedAccessControlList.BucketOwnerFullControl);
                 Upload upload = transferManager.upload(request);
 
                 if (log.isDebugEnabled()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
@@ -20,18 +20,12 @@ import com.facebook.presto.metadata.TableMetadata;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.Marker;
 import com.facebook.presto.spi.predicate.Marker.Bound;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.spi.type.BigintType;
-import com.facebook.presto.spi.type.IntegerType;
-import com.facebook.presto.spi.type.SmallintType;
-import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeSignature;
-import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
@@ -46,7 +40,6 @@ import com.facebook.presto.sql.planner.planPrinter.IOPlanPrinter.IOPlan.IOPlanBu
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.slice.Slice;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -54,7 +47,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.predicate.Marker.Bound.EXACTLY;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -560,13 +552,7 @@ public class IOPlanPrinter
 
         private String getVarcharValue(Type type, Object value)
         {
-            if (type instanceof VarcharType) {
-                return ((Slice) value).toStringUtf8();
-            }
-            if (type instanceof TinyintType || type instanceof SmallintType || type instanceof IntegerType || type instanceof BigintType) {
-                return ((Long) value).toString();
-            }
-            throw new PrestoException(NOT_SUPPORTED, format("Unsupported data type in EXPLAIN (TYPE IO): %s", type.getDisplayName()));
+            return PlanPrinterUtil.castToVarchar(type, value, metadata.getFunctionRegistry(), session);
         }
 
         private Void processChildren(PlanNode node, IOPlanBuilder context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinterUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinterUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.planPrinter;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.OperatorNotFoundException;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.InterpretedFunctionInvoker;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+public class PlanPrinterUtil
+{
+    private PlanPrinterUtil()
+    {
+    }
+
+    static String castToVarchar(Type type, Object value, FunctionRegistry functionRegistry, Session session)
+    {
+        if (value == null) {
+            return "NULL";
+        }
+
+        try {
+            Signature coercion = functionRegistry.getCoercion(type, VARCHAR);
+            Slice coerced = (Slice) new InterpretedFunctionInvoker(functionRegistry).invoke(coercion, session.toConnectorSession(), value);
+            return coerced.toStringUtf8();
+        }
+        catch (OperatorNotFoundException e) {
+            return "<UNREPRESENTABLE VALUE>";
+        }
+    }
+}


### PR DESCRIPTION
The current generation of the IO explain plan breaks if columns other than simple numeric or varchar columns are used while filtering. This causes an UnsupportedOperationException to be thrown for us when a date or timestamp field is used in a WHERE clause. Rather than add another special case in the code for these types, this PR refactors the code that converts any type to a string from the regular explain plan and uses that to generate the strings for constants used in the WHERE clause.

FYI, there was some discussion [here](https://github.com/prestodb/presto/pull/11049#discussion_r215084671) on this idea from the original author of the IO explain plan. He seems resistant to handling all types, but I don't see the downside. I've filed [this](https://github.com/prestodb/presto/issues/11500) issue to track this in presto OS.

Please review @nishantrayan and/or @puneetjaiswal