### PR TITLE
Recover documentation for node-scheduler.network-topology

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -425,6 +425,12 @@ Node Scheduler Properties
     * **Allowed values:** ``legacy``, ``flat``
     * **Default value:** ``legacy``
 
+    Sets the network topology to use when scheduling splits. ``legacy`` will ignore
+    the topology when scheduling splits. ``flat`` will try to schedule splits on the host
+    where the data is located by reserving 50% of the work queue for local splits.
+    It is recommended to use ``flat`` for clusters where distributed storage runs on
+    the same nodes as Presto workers.
+
 
 Optimizer Properties
 --------------------


### PR DESCRIPTION
It looks like it was inadvertently deleted with the following commit: https://github.com/prestodb/presto/commit/06e9f7a817212e7919529ec7c3e31d47744b3d65 

I hope it's still valid though?