### PR TITLE
correct read time stats in parquet pagesource

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -64,7 +64,6 @@ public class ParquetPageSource
 
     private int batchId;
     private boolean closed;
-    private long readTimeNanos;
     private final boolean useParquetColumnNames;
 
     public ParquetPageSource(
@@ -125,7 +124,7 @@ public class ParquetPageSource
     @Override
     public long getReadTimeNanos()
     {
-        return readTimeNanos;
+        return parquetReader.getDataSource().getReadTimeNanos();
     }
 
     @Override
@@ -145,11 +144,7 @@ public class ParquetPageSource
     {
         try {
             batchId++;
-            long start = System.nanoTime();
-
             int batchSize = parquetReader.nextBatch();
-
-            readTimeNanos += System.nanoTime() - start;
 
             if (closed || batchSize <= 0) {
                 close();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetDataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetDataSource.java
@@ -21,6 +21,8 @@ public interface ParquetDataSource
 {
     long getReadBytes();
 
+    long getReadTimeNanos();
+
     long getSize();
 
     void readFully(long position, byte[] buffer);


### PR DESCRIPTION
current `readTimeNanos ` in `ParquetPageSource` doesn't reflect the correct stats. This patch aims to fix that. 