### PR TITLE
Report error when partition schema and parquet file schema mismatch

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HdfsParquetDataSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/HdfsParquetDataSource.java
@@ -46,6 +46,12 @@ public class HdfsParquetDataSource
     }
 
     @Override
+    public String getPath()
+    {
+        return name;
+    }
+
+    @Override
     public final long getReadBytes()
     {
         return readBytes;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetDataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetDataSource.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 public interface ParquetDataSource
         extends Closeable
 {
+    String getPath();
+
     long getReadBytes();
 
     long getSize();


### PR DESCRIPTION
Current parquet reader will throw internal error when parquet schema and partition schema mismatch, e,g, `double` in partition schema but `float` in parquet file. This patch propose a friendly error message for that.