### PR TITLE
Fix JoinStatsRule crash when missing column statistics

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
@@ -36,7 +36,6 @@ import static com.facebook.presto.cost.PlanNodeStatsEstimate.UNKNOWN_STATS;
 import static com.facebook.presto.cost.SymbolStatsEstimate.buildFrom;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Sets.difference;
 import static java.lang.Double.NaN;
@@ -328,8 +327,6 @@ public class JoinStatsRule
             PlanNodeStatsEstimate baseJoinStats,
             PlanNodeStatsEstimate joinComplementStats)
     {
-        checkState(baseJoinStats.getSymbolsWithKnownStatistics().containsAll(joinComplementStats.getSymbolsWithKnownStatistics()));
-
         double joinOutputRowCount = baseJoinStats.getOutputRowCount();
         double joinComplementOutputRowCount = joinComplementStats.getOutputRowCount();
         double totalRowCount = joinOutputRowCount + joinComplementOutputRowCount;

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.cost.FilterStatsCalculator.UNKNOWN_FILTER_COEFFICIENT;
 import static com.facebook.presto.cost.PlanNodeStatsAssertion.assertThat;
+import static com.facebook.presto.cost.SymbolStatsEstimate.UNKNOWN_STATS;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -247,6 +248,20 @@ public class TestJoinStatsRule
     }
 
     @Test
+    public void testLeftJoinMissingStats()
+    {
+        PlanNodeStatsEstimate leftStats = planNodeStats(
+                0,
+                new SymbolStatistics(LEFT_JOIN_COLUMN, UNKNOWN_STATS),
+                new SymbolStatistics(LEFT_OTHER_COLUMN, UNKNOWN_STATS));
+        PlanNodeStatsEstimate rightStats = planNodeStats(
+                0,
+                new SymbolStatistics(RIGHT_JOIN_COLUMN, UNKNOWN_STATS),
+                new SymbolStatistics(RIGHT_OTHER_COLUMN, UNKNOWN_STATS));
+        assertJoinStats(LEFT, leftStats, rightStats, leftStats);
+    }
+
+    @Test
     public void testStatsForFullJoin()
     {
         double innerJoinRowCount = LEFT_ROWS_COUNT * RIGHT_ROWS_COUNT / LEFT_JOIN_COLUMN_NDV * LEFT_JOIN_COLUMN_NON_NULLS * RIGHT_JOIN_COLUMN_NON_NULLS;
@@ -331,6 +346,11 @@ public class TestJoinStatsRule
     {
         final Symbol symbol;
         final SymbolStatsEstimate estimate;
+
+        SymbolStatistics(String symbolName, SymbolStatsEstimate estimate)
+        {
+            this(new Symbol(symbolName), estimate);
+        }
 
         SymbolStatistics(Symbol symbol, SymbolStatsEstimate estimate)
         {


### PR DESCRIPTION
Although crossJoinStats adds 'UNKNOWN' statistics for every symbol, these
statistics are further removed by applying the filter estimate when estimating
inner join stats. Unknown statistics are removed by the normalize in the
filter estimate rule.

The check that is being removed is not needed. As further in addJoinComplementStats
PlanNodeStatsEstimate#getSymbolStatistics method is called to get symbol statistics.
That method never returns null, but instead it returns unknown statistics.