### PR TITLE
Fix value of currentConstraint when resolving TableLayout

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -75,7 +75,6 @@ import static com.facebook.presto.hive.HiveTableProperties.PARTITIONED_BY_PROPER
 import static com.facebook.presto.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
 import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
 import static com.facebook.presto.hive.HiveUtil.columnExtraInfo;
-import static com.facebook.presto.spi.predicate.Marker.Bound.ABOVE;
 import static com.facebook.presto.spi.predicate.Marker.Bound.EXACTLY;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.CharType.createCharType;
@@ -167,15 +166,6 @@ public class TestHiveIntegrationSmokeTest
                         ImmutableSet.of(new TableColumnInfo(
                                 new CatalogSchemaTableName(catalog, "tpch", "test_orders"),
                                 ImmutableSet.of(
-                                        new ColumnConstraint(
-                                                "custkey",
-                                                BIGINT.getTypeSignature(),
-                                                new FormattedDomain(
-                                                        false,
-                                                        ImmutableSet.of(
-                                                                new FormattedRange(
-                                                                        new FormattedMarker(Optional.empty(), ABOVE),
-                                                                        new FormattedMarker(Optional.of("10"), EXACTLY))))),
                                         new ColumnConstraint(
                                                 "orderkey",
                                                 BIGINT.getTypeSignature(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -317,7 +317,7 @@ public class PickTableLayout
                             node.getOutputSymbols(),
                             node.getAssignments(),
                             Optional.of(layout.getLayout().getHandle()),
-                            newDomain.intersect(layout.getLayout().getPredicate()),
+                            layout.getLayout().getPredicate(),
                             computeEnforced(newDomain, layout.getUnenforcedConstraint()));
 
                     // The order of the arguments to combineConjuncts matters:

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -202,7 +202,7 @@ public class HashGenerationOptimizer
         public PlanWithProperties visitDistinctLimit(DistinctLimitNode node, HashComputationSet parentPreference)
         {
             // skip hash symbol generation for single bigint
-            if (!canSkipHashGeneration(node.getDistinctSymbols())) {
+            if (canSkipHashGeneration(node.getDistinctSymbols())) {
                 return planSimpleNodeWithProperties(node, parentPreference);
             }
 
@@ -223,7 +223,7 @@ public class HashGenerationOptimizer
         public PlanWithProperties visitMarkDistinct(MarkDistinctNode node, HashComputationSet parentPreference)
         {
             // skip hash symbol generation for single bigint
-            if (!canSkipHashGeneration(node.getDistinctSymbols())) {
+            if (canSkipHashGeneration(node.getDistinctSymbols())) {
                 return planSimpleNodeWithProperties(node, parentPreference);
             }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
@@ -42,7 +41,6 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -53,7 +51,6 @@ import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_HASH_GENERATION;
 import static com.facebook.presto.spi.StandardErrorCode.SUBQUERY_MULTIPLE_ROWS;
 import static com.facebook.presto.spi.predicate.Domain.singleValue;
-import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
@@ -166,13 +163,13 @@ public class TestLogicalPlanner
     @Test
     public void testDistinctOverConstants()
     {
-        assertPlan("SELECT count(*), count(distinct orderkey) FROM (SELECT * FROM orders WHERE orderkey = 1)",
+        assertPlan("SELECT count(*), count(distinct orderstatus) FROM (SELECT * FROM orders WHERE orderstatus = 'F')",
                 anyTree(
-                        markDistinct("is_distinct", ImmutableList.of("orderkey"), "hash",
+                        markDistinct(
+                                "is_distinct",
+                                ImmutableList.of("orderstatus"),
                                 anyTree(
-                                        project(ImmutableMap.of("hash", expression("combine_hash(bigint '0', coalesce(\"$operator$hash_code\"(orderkey), 0))")),
-                                                filter("orderkey = BIGINT '1'",
-                                                        tableScan("orders", ImmutableMap.of("orderkey", "orderkey"))))))));
+                                        tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus"))))));
     }
 
     @Test
@@ -277,23 +274,27 @@ public class TestLogicalPlanner
     @Test
     public void testPushDownJoinConditionConjunctsToInnerSideBasedOnInheritedPredicate()
     {
-        Map<String, Domain> tableScanConstraint = ImmutableMap.<String, Domain>builder()
-                .put("name", singleValue(createVarcharType(25), utf8Slice("blah")))
-                .build();
-
         assertPlan(
                 "SELECT nationkey FROM nation LEFT OUTER JOIN region " +
                         "ON nation.regionkey = region.regionkey and nation.name = region.name WHERE nation.name = 'blah'",
                 anyTree(
                         join(LEFT, ImmutableList.of(equiJoinClause("NATION_NAME", "REGION_NAME"), equiJoinClause("NATION_REGIONKEY", "REGION_REGIONKEY")),
                                 anyTree(
-                                        constrainedTableScan("nation", tableScanConstraint, ImmutableMap.of(
-                                                "NATION_NAME", "name",
-                                                "NATION_REGIONKEY", "regionkey"))),
+                                        filter("NATION_NAME = CAST ('blah' AS VARCHAR(25))",
+                                                constrainedTableScan(
+                                                        "nation",
+                                                        ImmutableMap.of(),
+                                                        ImmutableMap.of(
+                                                                "NATION_NAME", "name",
+                                                                "NATION_REGIONKEY", "regionkey")))),
                                 anyTree(
-                                        constrainedTableScan("region", tableScanConstraint, ImmutableMap.of(
-                                                "REGION_NAME", "name",
-                                                "REGION_REGIONKEY", "regionkey"))))));
+                                        filter("REGION_NAME = CAST ('blah' AS VARCHAR(25))",
+                                                constrainedTableScan(
+                                                        "region",
+                                                        ImmutableMap.of(),
+                                                        ImmutableMap.of(
+                                                                "REGION_NAME", "name",
+                                                                "REGION_REGIONKEY", "regionkey")))))));
     }
 
     @Test
@@ -628,14 +629,21 @@ public class TestLogicalPlanner
     @Test
     public void testPickTableLayoutWithFilter()
     {
-        Map<String, Domain> filterConstraint = ImmutableMap.<String, Domain>builder()
-                .put("orderkey", singleValue(BIGINT, 5L))
-                .build();
         assertPlan(
                 "SELECT orderkey FROM orders WHERE orderkey=5",
                 output(
                         filter("orderkey = BIGINT '5'",
-                                constrainedTableScanWithTableLayout("orders", filterConstraint, ImmutableMap.of("orderkey", "orderkey")))));
+                                constrainedTableScanWithTableLayout(
+                                        "orders",
+                                        ImmutableMap.of(),
+                                        ImmutableMap.of("orderkey", "orderkey")))));
+        assertPlan(
+                "SELECT orderkey FROM orders WHERE orderstatus='F'",
+                output(
+                        constrainedTableScanWithTableLayout(
+                                "orders",
+                                ImmutableMap.of("orderstatus", singleValue(createVarcharType(1), utf8Slice("F"))),
+                                ImmutableMap.of("orderkey", "orderkey"))));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
@@ -51,6 +51,7 @@ public class TestPickTableLayout
     private TableHandle nationTableHandle;
     private TableHandle ordersTableHandle;
     private TableLayoutHandle nationTableLayoutHandle;
+    private TableLayoutHandle ordersTableLayoutHandle;
     private ConnectorId connectorId;
 
     @BeforeClass
@@ -70,6 +71,10 @@ public class TestPickTableLayout
                 connectorId,
                 TestingTransactionHandle.create(),
                 new TpchTableLayoutHandle((TpchTableHandle) nationTableHandle.getConnectorHandle(), TupleDomain.all()));
+        ordersTableLayoutHandle = new TableLayoutHandle(
+                connectorId,
+                TestingTransactionHandle.create(),
+                new TpchTableLayoutHandle((TpchTableHandle) ordersTableHandle.getConnectorHandle(), TupleDomain.all()));
     }
 
     @Test
@@ -98,18 +103,13 @@ public class TestPickTableLayout
     public void eliminateTableScanWhenNoLayoutExist()
     {
         tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
-                .on(p -> p.filter(expression("nationkey = BIGINT '44'"),
+                .on(p -> p.filter(expression("orderstatus = 'G'"),
                         p.tableScan(
-                                nationTableHandle,
-                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
-                                ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)),
-                                Optional.of(nationTableLayoutHandle))))
-                .matches(
-                        filter("nationkey = BIGINT '44'",
-                                constrainedTableScanWithTableLayout(
-                                        "nation",
-                                        ImmutableMap.of("nationkey", singleValue(BIGINT, 44L)),
-                                        ImmutableMap.of("nationkey", "nationkey"))));
+                                ordersTableHandle,
+                                ImmutableList.of(p.symbol("orderstatus", createVarcharType(1))),
+                                ImmutableMap.of(p.symbol("orderstatus", createVarcharType(1)), new TpchColumnHandle("orderstatus", createVarcharType(1))),
+                                Optional.of(ordersTableLayoutHandle))))
+                .matches(values("A"));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
@@ -63,7 +63,7 @@ public class TestPickTableLayout
         nationTableHandle = new TableHandle(
                 connectorId,
                 new TpchTableHandle(connectorId.toString(), "nation", 1.0));
-        TableHandle ordersTableHandle = new TableHandle(
+        ordersTableHandle = new TableHandle(
                 connectorId,
                 new TpchTableHandle(connectorId.toString(), "orders", 1.0));
 
@@ -159,35 +159,33 @@ public class TestPickTableLayout
     public void ruleAddedTableLayoutToFilterTableScan()
     {
         Map<String, Domain> filterConstraint = ImmutableMap.<String, Domain>builder()
-                .put("nationkey", singleValue(BIGINT, 44L))
+                .put("orderstatus", singleValue(createVarcharType(1), utf8Slice("F")))
                 .build();
         tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
-                .on(p -> p.filter(expression("nationkey = BIGINT '44'"),
+                .on(p -> p.filter(expression("orderstatus = CAST ('F' AS VARCHAR(1))"),
                         p.tableScan(
-                                nationTableHandle,
-                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
-                                ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)))))
+                                ordersTableHandle,
+                                ImmutableList.of(p.symbol("orderstatus", createVarcharType(1))),
+                                ImmutableMap.of(p.symbol("orderstatus", createVarcharType(1)), new TpchColumnHandle("orderstatus", createVarcharType(1))))))
                 .matches(
-                        filter("nationkey = BIGINT '44'",
-                                constrainedTableScanWithTableLayout("nation", filterConstraint, ImmutableMap.of("nationkey", "nationkey"))));
+                        constrainedTableScanWithTableLayout("orders", filterConstraint, ImmutableMap.of("orderstatus", "orderstatus")));
     }
 
     @Test
     public void ruleAddedNewTableLayoutIfTableScanHasEmptyConstraint()
     {
         tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
-                .on(p -> p.filter(expression("nationkey = BIGINT '44'"),
+                .on(p -> p.filter(expression("orderstatus = 'F'"),
                         p.tableScan(
-                                nationTableHandle,
-                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
-                                ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)),
-                                Optional.of(nationTableLayoutHandle))))
+                                ordersTableHandle,
+                                ImmutableList.of(p.symbol("orderstatus", createVarcharType(1))),
+                                ImmutableMap.of(p.symbol("orderstatus", createVarcharType(1)), new TpchColumnHandle("orderstatus", createVarcharType(1))),
+                                Optional.of(ordersTableLayoutHandle))))
                 .matches(
-                        filter("nationkey = BIGINT '44'",
-                                constrainedTableScanWithTableLayout(
-                                        "nation",
-                                        ImmutableMap.of("nationkey", singleValue(BIGINT, 44L)),
-                                        ImmutableMap.of("nationkey", "nationkey"))));
+                        constrainedTableScanWithTableLayout(
+                                "orders",
+                                ImmutableMap.of("orderstatus", singleValue(createVarcharType(1), utf8Slice("F"))),
+                                ImmutableMap.of("orderstatus", "orderstatus")));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPickTableLayout.java
@@ -49,6 +49,7 @@ public class TestPickTableLayout
 {
     private PickTableLayout pickTableLayout;
     private TableHandle nationTableHandle;
+    private TableHandle ordersTableHandle;
     private TableLayoutHandle nationTableLayoutHandle;
     private ConnectorId connectorId;
 
@@ -61,8 +62,12 @@ public class TestPickTableLayout
         nationTableHandle = new TableHandle(
                 connectorId,
                 new TpchTableHandle(connectorId.toString(), "nation", 1.0));
+        TableHandle ordersTableHandle = new TableHandle(
+                connectorId,
+                new TpchTableHandle(connectorId.toString(), "orders", 1.0));
 
-        nationTableLayoutHandle = new TableLayoutHandle(connectorId,
+        nationTableLayoutHandle = new TableLayoutHandle(
+                connectorId,
                 TestingTransactionHandle.create(),
                 new TpchTableLayoutHandle((TpchTableHandle) nationTableHandle.getConnectorHandle(), TupleDomain.all()));
     }
@@ -188,9 +193,6 @@ public class TestPickTableLayout
     @Test
     public void ruleWithPushdownableToTableLayoutPredicate()
     {
-        TableHandle ordersTableHandle = new TableHandle(
-                connectorId,
-                new TpchTableHandle(connectorId.toString(), "orders", 1.0));
         Type orderStatusType = createVarcharType(1);
         tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
                 .on(p -> p.filter(expression("orderstatus = 'O'"),
@@ -207,9 +209,6 @@ public class TestPickTableLayout
     @Test
     public void nonDeterministicPredicate()
     {
-        TableHandle ordersTableHandle = new TableHandle(
-                connectorId,
-                new TpchTableHandle(connectorId.toString(), "orders", 1.0));
         Type orderStatusType = createVarcharType(1);
         tester().assertThat(pickTableLayout.pickTableLayoutForPredicate())
                 .on(p -> p.filter(expression("orderstatus = 'O' AND rand() = 0"),


### PR DESCRIPTION
This change should have been part of d54521f24ebf49754da2833f748d8fb2d4149cc7
but was not placed there due to oversight.

As clarified in commit d54521f24ebf49754da2833f748d8fb2d4149cc7 and explained
in the commit message of the same commit, currentConstraint is supposed to be
a TupleDomain that represents a predicate that every row produced by
this TableScan node is guaranteed to satisfy.

To recap, a table scan is not guaranteed to only produce rows that satisfies
the filter on top of itself. As a result, it is incorrect to have
the intersection.

This commit affects EXPLAIN IO. However, although EXPLAIN IO was introduced
before this commit, only showing successfully pushed down predicates in
EXPLAIN IO has always been the intended semantics.