### PR TITLE
Fix flaky testComplexStateEstimatedSize test

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
@@ -290,7 +290,7 @@ public class TestStateCompiler
         return overhead;
     }
 
-    @Test
+    @Test(invocationCount = 100, successPercentage = 90)
     public void testComplexStateEstimatedSize()
     {
         Map<String, Type> fieldMap = ImmutableMap.of("Block", new ArrayType(BIGINT), "AnotherBlock", mapType(BIGINT, VARCHAR));


### PR DESCRIPTION
This test is non deterministic, as it checks the estimated retained memory usage.
The memory usage estimate over the SliceBigArray and over the BlockBigArray is non
deterministic because of usage of the ReferenceCountMap, which stores it's values
by the non deterministic identity hash that allows collisions.

The fix runs the test 100 times and checks if 90% of runs are successful.