### PR TITLE
Disable maven repository caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ env:
 sudo: required
 dist: trusty
 
-cache:
-  directories:
-    - $HOME/.m2/repository
+#cache:
+#  directories:
+#   - $HOME/.m2/repository
 
 services:
   - docker


### PR DESCRIPTION
This is supposed to help to get rid of "jna-4.0.0.jar (Permission denied)" failures