### PR TITLE
[Hotfix]nullsCount in columnStatistic should marked as not present in…

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -331,7 +331,7 @@ public final class ThriftMetastoreUtil
             LongColumnStatsData longStatsData = columnStatistics.getStatsData().getLongStats();
             OptionalLong min = longStatsData.isSetLowValue() ? OptionalLong.of(longStatsData.getLowValue()) : OptionalLong.empty();
             OptionalLong max = longStatsData.isSetHighValue() ? OptionalLong.of(longStatsData.getHighValue()) : OptionalLong.empty();
-            OptionalLong nullsCount = longStatsData.isSetNumNulls() ? OptionalLong.of(longStatsData.getNumNulls()) : OptionalLong.empty();
+            OptionalLong nullsCount = longStatsData.isSetNumNulls() ? fromMetastoreNullsCount(longStatsData.getNumNulls()) : OptionalLong.empty();
             OptionalLong distinctValuesCount = longStatsData.isSetNumDVs() ? OptionalLong.of(longStatsData.getNumDVs()) : OptionalLong.empty();
             return createIntegerColumnStatistics(min, max, nullsCount, fromMetastoreDistinctValuesCount(distinctValuesCount, nullsCount, rowCount));
         }
@@ -339,7 +339,7 @@ public final class ThriftMetastoreUtil
             DoubleColumnStatsData doubleStatsData = columnStatistics.getStatsData().getDoubleStats();
             OptionalDouble min = doubleStatsData.isSetLowValue() ? OptionalDouble.of(doubleStatsData.getLowValue()) : OptionalDouble.empty();
             OptionalDouble max = doubleStatsData.isSetHighValue() ? OptionalDouble.of(doubleStatsData.getHighValue()) : OptionalDouble.empty();
-            OptionalLong nullsCount = doubleStatsData.isSetNumNulls() ? OptionalLong.of(doubleStatsData.getNumNulls()) : OptionalLong.empty();
+            OptionalLong nullsCount = doubleStatsData.isSetNumNulls() ? fromMetastoreNullsCount(doubleStatsData.getNumNulls()) : OptionalLong.empty();
             OptionalLong distinctValuesCount = doubleStatsData.isSetNumDVs() ? OptionalLong.of(doubleStatsData.getNumDVs()) : OptionalLong.empty();
             return createDoubleColumnStatistics(min, max, nullsCount, fromMetastoreDistinctValuesCount(distinctValuesCount, nullsCount, rowCount));
         }
@@ -347,7 +347,7 @@ public final class ThriftMetastoreUtil
             DecimalColumnStatsData decimalStatsData = columnStatistics.getStatsData().getDecimalStats();
             Optional<BigDecimal> min = decimalStatsData.isSetLowValue() ? fromMetastoreDecimal(decimalStatsData.getLowValue()) : Optional.empty();
             Optional<BigDecimal> max = decimalStatsData.isSetHighValue() ? fromMetastoreDecimal(decimalStatsData.getHighValue()) : Optional.empty();
-            OptionalLong nullsCount = decimalStatsData.isSetNumNulls() ? OptionalLong.of(decimalStatsData.getNumNulls()) : OptionalLong.empty();
+            OptionalLong nullsCount = decimalStatsData.isSetNumNulls() ? fromMetastoreNullsCount(decimalStatsData.getNumNulls()) : OptionalLong.empty();
             OptionalLong distinctValuesCount = decimalStatsData.isSetNumDVs() ? OptionalLong.of(decimalStatsData.getNumDVs()) : OptionalLong.empty();
             return createDecimalColumnStatistics(min, max, nullsCount, fromMetastoreDistinctValuesCount(distinctValuesCount, nullsCount, rowCount));
         }
@@ -355,7 +355,7 @@ public final class ThriftMetastoreUtil
             DateColumnStatsData dateStatsData = columnStatistics.getStatsData().getDateStats();
             Optional<LocalDate> min = dateStatsData.isSetLowValue() ? fromMetastoreDate(dateStatsData.getLowValue()) : Optional.empty();
             Optional<LocalDate> max = dateStatsData.isSetHighValue() ? fromMetastoreDate(dateStatsData.getHighValue()) : Optional.empty();
-            OptionalLong nullsCount = dateStatsData.isSetNumNulls() ? OptionalLong.of(dateStatsData.getNumNulls()) : OptionalLong.empty();
+            OptionalLong nullsCount = dateStatsData.isSetNumNulls() ? fromMetastoreNullsCount(dateStatsData.getNumNulls()) : OptionalLong.empty();
             OptionalLong distinctValuesCount = dateStatsData.isSetNumDVs() ? OptionalLong.of(dateStatsData.getNumDVs()) : OptionalLong.empty();
             return createDateColumnStatistics(min, max, nullsCount, fromMetastoreDistinctValuesCount(distinctValuesCount, nullsCount, rowCount));
         }
@@ -364,13 +364,13 @@ public final class ThriftMetastoreUtil
             return createBooleanColumnStatistics(
                     booleanStatsData.isSetNumTrues() ? OptionalLong.of(booleanStatsData.getNumTrues()) : OptionalLong.empty(),
                     booleanStatsData.isSetNumFalses() ? OptionalLong.of(booleanStatsData.getNumFalses()) : OptionalLong.empty(),
-                    booleanStatsData.isSetNumNulls() ? OptionalLong.of(booleanStatsData.getNumNulls()) : OptionalLong.empty());
+                    booleanStatsData.isSetNumNulls() ? fromMetastoreNullsCount(booleanStatsData.getNumNulls()) : OptionalLong.empty());
         }
         if (columnStatistics.getStatsData().isSetStringStats()) {
             StringColumnStatsData stringStatsData = columnStatistics.getStatsData().getStringStats();
             OptionalLong maxColumnLength = stringStatsData.isSetMaxColLen() ? OptionalLong.of(stringStatsData.getMaxColLen()) : OptionalLong.empty();
             OptionalDouble averageColumnLength = stringStatsData.isSetAvgColLen() ? OptionalDouble.of(stringStatsData.getAvgColLen()) : OptionalDouble.empty();
-            OptionalLong nullsCount = stringStatsData.isSetNumNulls() ? OptionalLong.of(stringStatsData.getNumNulls()) : OptionalLong.empty();
+            OptionalLong nullsCount = stringStatsData.isSetNumNulls() ? fromMetastoreNullsCount(stringStatsData.getNumNulls()) : OptionalLong.empty();
             OptionalLong distinctValuesCount = stringStatsData.isSetNumDVs() ? OptionalLong.of(stringStatsData.getNumDVs()) : OptionalLong.empty();
             return createStringColumnStatistics(
                     maxColumnLength,
@@ -382,7 +382,7 @@ public final class ThriftMetastoreUtil
             BinaryColumnStatsData binaryStatsData = columnStatistics.getStatsData().getBinaryStats();
             OptionalLong maxColumnLength = binaryStatsData.isSetMaxColLen() ? OptionalLong.of(binaryStatsData.getMaxColLen()) : OptionalLong.empty();
             OptionalDouble averageColumnLength = binaryStatsData.isSetAvgColLen() ? OptionalDouble.of(binaryStatsData.getAvgColLen()) : OptionalDouble.empty();
-            OptionalLong nullsCount = binaryStatsData.isSetNumNulls() ? OptionalLong.of(binaryStatsData.getNumNulls()) : OptionalLong.empty();
+            OptionalLong nullsCount = binaryStatsData.isSetNumNulls() ? fromMetastoreNullsCount(binaryStatsData.getNumNulls()) : OptionalLong.empty();
             return createBinaryColumnStatistics(
                     maxColumnLength,
                     getTotalSizeInBytes(averageColumnLength, rowCount, nullsCount),
@@ -399,6 +399,18 @@ public final class ThriftMetastoreUtil
             return Optional.empty();
         }
         return Optional.of(LocalDate.ofEpochDay(date.getDaysSinceEpoch()));
+    }
+
+    /**
+     * Impala `COMPUTE STATS` will write -1 as the null count.
+     * @see <a href="https://issues.apache.org/jira/browse/IMPALA-7497">IMPALA-7497</a>
+     */
+    public static OptionalLong fromMetastoreNullsCount(long nullsCount)
+    {
+        if (nullsCount == -1L) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(nullsCount);
     }
 
     public static Optional<BigDecimal> fromMetastoreDecimal(@Nullable Decimal decimal)


### PR DESCRIPTION
My presto is running on my Cloudera 5.7.6 hive meastore.
When upgrading to 0.210, Many queries previously run successfully failed with following error:
```
java.lang.IllegalArgumentException: Nulls fraction should be within [0, 1] or NaN, got: -0.16666666666666666
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:210)
	at com.facebook.presto.cost.SymbolStatsEstimate.<init>(SymbolStatsEstimate.java:54)
	at com.facebook.presto.cost.SymbolStatsEstimate$Builder.build(SymbolStatsEstimate.java:225)
	at com.facebook.presto.cost.TableScanStatsRule.toSymbolStatistics(TableScanStatsRule.java:92)
	at com.facebook.presto.cost.TableScanStatsRule.lambda$doCalculate$0(TableScanStatsRule.java:73)
	at java.util.Optional.map(Optional.java:215)
	at com.facebook.presto.cost.TableScanStatsRule.doCalculate(TableScanStatsRule.java:73)
	at com.facebook.presto.cost.TableScanStatsRule.doCalculate(TableScanStatsRule.java:41)
	at com.facebook.presto.cost.SimpleStatsRule.calculate(SimpleStatsRule.java:39)
	at com.facebook.presto.cost.ComposableStatsCalculator.calculateStats(ComposableStatsCalculator.java:80)
	at com.facebook.presto.cost.ComposableStatsCalculator.calculateStats(ComposableStatsCalculator.java:70)
	at com.facebook.presto.cost.CachingStatsProvider.getStats(CachingStatsProvider.java:70)
	at com.facebook.presto.cost.CostCalculatorUsingExchanges$CostEstimator.getStats(CostCalculatorUsingExchanges.java:243)
	at com.facebook.presto.cost.CostCalculatorUsingExchanges$CostEstimator.visitTableScan(CostCalculatorUsingExchanges.java:141)
	at com.facebook.presto.cost.CostCalculatorUsingExchanges$CostEstimator.visitTableScan(CostCalculatorUsingExchanges.java:99)
	at com.facebook.presto.sql.planner.plan.TableScanNode.accept(TableScanNode.java:128)
	at com.facebook.presto.cost.CostCalculatorUsingExchanges.calculateCost(CostCalculatorUsingExchanges.java:96)
	at com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges.calculateCost(CostCalculatorWithEstimatedExchanges.java:73)
	at com.facebook.presto.cost.CachingCostProvider.calculateCumulativeCost(CachingCostProvider.java:103)
	at com.facebook.presto.cost.CachingCostProvider.getGroupCost(CachingCostProvider.java:95)
	at com.facebook.presto.cost.CachingCostProvider.getCumulativeCost(CachingCostProvider.java:72)
	at com.facebook.presto.sql.planner.iterative.rule.ReorderJoins$JoinEnumerator.createJoinEnumerationResult(ReorderJoins.java:391)
	at com.facebook.presto.sql.planner.iterative.rule.ReorderJoins$JoinEnumerator.getJoinSource(ReorderJoins.java:342)
	at com.facebook.presto.sql.planner.iterative.rule.ReorderJoins$JoinEnumerator.createJoin(ReorderJoins.java:258)
	at com.facebook.presto.sql.planner.iterative.rule.ReorderJoins$JoinEnumerator.createJoinAccordingToPartitioning(ReorderJoins.java:229)
	at com.facebook.presto.sql.planner.iterative.rule.ReorderJoins$JoinEnumerator.chooseJoinOrder(ReorderJoins.java:173)
	at com.facebook.presto.sql.planner.iterative.rule.ReorderJoins$JoinEnumerator.access$000(ReorderJoins.java:135)
	at com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.apply(ReorderJoins.java:127)
	at com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.apply(ReorderJoins.java:88)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:165)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:138)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:103)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:185)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:105)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:185)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:105)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.optimize(IterativeOptimizer.java:94)
	at com.facebook.presto.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:150)
	at com.facebook.presto.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:139)
	at com.facebook.presto.execution.SqlQueryExecution.doAnalyzeQuery(SqlQueryExecution.java:360)
	at com.facebook.presto.execution.SqlQueryExecution.analyzeQuery(SqlQueryExecution.java:345)
	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:289)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

This is because hive metastore use -1 to mark the column nullCounts as unavailable. 

After I upgrading to master branch, the error still exists and the error become this:
```
com.facebook.presto.spi.PrestoException: Corrupted partition statistics (Table: default.plus_higher_category Partition: [<UNPARTITIONED>] Column: plus_higher_category_name): nullsCount must be greater than or equal to zero: -1
	at com.facebook.presto.hive.statistics.MetastoreHiveStatisticsProvider.checkStatistics(MetastoreHiveStatisticsProvider.java:350)
	at com.facebook.presto.hive.statistics.MetastoreHiveStatisticsProvider.lambda$validateColumnStatistics$14(MetastoreHiveStatisticsProvider.java:222)
	at java.util.OptionalLong.ifPresent(OptionalLong.java:142)
	at com.facebook.presto.hive.statistics.MetastoreHiveStatisticsProvider.validateColumnStatistics(MetastoreHiveStatisticsProvider.java:221)
	at com.facebook.presto.hive.statistics.MetastoreHiveStatisticsProvider.lambda$null$10(MetastoreHiveStatisticsProvider.java:211)
	at com.google.common.collect.RegularImmutableMap.forEach(RegularImmutableMap.java:187)
	at com.facebook.presto.hive.statistics.MetastoreHiveStatisticsProvider.lambda$validatePartitionStatistics$11(MetastoreHiveStatisticsProvider.java:211)
	at com.google.common.collect.SingletonImmutableBiMap.forEach(SingletonImmutableBiMap.java:65)
	at com.facebook.presto.hive.statistics.MetastoreHiveStatisticsProvider.validatePartitionStatistics(MetastoreHiveStatisticsProvider.java:204)
	at com.facebook.presto.hive.statistics.MetastoreHiveStatisticsProvider.getTableStatistics(MetastoreHiveStatisticsProvider.java:142)
	at com.facebook.presto.hive.HiveMetadata.getTableStatistics(HiveMetadata.java:536)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.getTableStatistics(ClassLoaderSafeConnectorMetadata.java:201)
	at com.facebook.presto.metadata.MetadataManager.getTableStatistics(MetadataManager.java:401)
	at com.facebook.presto.cost.TableScanStatsRule.doCalculate(TableScanStatsRule.java:61)
	at com.facebook.presto.cost.TableScanStatsRule.doCalculate(TableScanStatsRule.java:36)
	at com.facebook.presto.cost.SimpleStatsRule.calculate(SimpleStatsRule.java:39)
	at com.facebook.presto.cost.ComposableStatsCalculator.calculateStats(ComposableStatsCalculator.java:80)
	at com.facebook.presto.cost.ComposableStatsCalculator.calculateStats(ComposableStatsCalculator.java:70)
	at com.facebook.presto.cost.CachingStatsProvider.getGroupStats(CachingStatsProvider.java:91)
	at com.facebook.presto.cost.CachingStatsProvider.getStats(CachingStatsProvider.java:68)
	at com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges$ExchangeCostEstimator.getStats(CostCalculatorWithEstimatedExchanges.java:198)
	at com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges$ExchangeCostEstimator.calculateJoinCost(CostCalculatorWithEstimatedExchanges.java:153)
	at com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges$ExchangeCostEstimator.visitJoin(CostCalculatorWithEstimatedExchanges.java:133)
	at com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges$ExchangeCostEstimator.visitJoin(CostCalculatorWithEstimatedExchanges.java:76)
	at com.facebook.presto.sql.planner.plan.JoinNode.accept(JoinNode.java:289)
	at com.facebook.presto.cost.CostCalculatorWithEstimatedExchanges.calculateCost(CostCalculatorWithEstimatedExchanges.java:72)
	at com.facebook.presto.cost.CachingCostProvider.calculateCumulativeCost(CachingCostProvider.java:103)
	at com.facebook.presto.cost.CachingCostProvider.getCumulativeCost(CachingCostProvider.java:80)
	at com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.getJoinNodeWithCost(DetermineJoinDistributionType.java:133)
	at com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.getCostBasedJoin(DetermineJoinDistributionType.java:77)
	at com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.apply(DetermineJoinDistributionType.java:66)
	at com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.apply(DetermineJoinDistributionType.java:43)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:165)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:138)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:103)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:185)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:105)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:185)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:105)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.optimize(IterativeOptimizer.java:94)
	at com.facebook.presto.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:150)
	at com.facebook.presto.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:139)
	at com.facebook.presto.execution.SqlQueryExecution.doAnalyzeQuery(SqlQueryExecution.java:362)
	at com.facebook.presto.execution.SqlQueryExecution.analyzeQuery(SqlQueryExecution.java:347)
	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:291)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
The safe solution is to mark the nullsCount as unavailable when hive return -1 for it, instead of just failing user's query!
**Anytime we should not fail users' query when statistic information is not present or looks illegal! Illegal statistics information should be marked as absent **  