### PR TITLE
Infer output predicates for inner joins in equality inference

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -231,11 +231,12 @@ public class EffectivePredicateExtractor
 
             switch (node.getType()) {
                 case INNER:
-                    return combineConjuncts(ImmutableList.<Expression>builder()
-                            .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))
-                            .add(pullExpressionThroughSymbols(rightPredicate, node.getOutputSymbols()))
-                            .addAll(pullExpressionsThroughSymbols(joinConjuncts, node.getOutputSymbols()))
-                            .build());
+                    return pullExpressionThroughSymbols(combineConjuncts(ImmutableList.<Expression>builder()
+                            .add(leftPredicate)
+                            .add(rightPredicate)
+                            .add(combineConjuncts(joinConjuncts))
+                            .add(node.getFilter().orElse(TRUE_LITERAL))
+                            .build()), node.getOutputSymbols());
                 case LEFT:
                     return combineConjuncts(ImmutableList.<Expression>builder()
                             .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -406,24 +406,10 @@ public class TestEffectivePredicateExtractor
         List<JoinNode.EquiJoinClause> criteria = criteriaBuilder.build();
 
         Map<Symbol, ColumnHandle> leftAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(A, B, C)));
-        TableScanNode leftScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(leftAssignments.keySet()),
-                leftAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode leftScan = tableScanNode(leftAssignments);
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
-        TableScanNode rightScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(rightAssignments.keySet()),
-                rightAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode rightScan = tableScanNode(rightAssignments);
 
         FilterNode left = filter(leftScan,
                 and(
@@ -466,24 +452,10 @@ public class TestEffectivePredicateExtractor
     public void testInnerJoinPropagatesPredicatesViaEquiConditions()
     {
         Map<Symbol, ColumnHandle> leftAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(A, B, C)));
-        TableScanNode leftScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(leftAssignments.keySet()),
-                leftAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode leftScan = tableScanNode(leftAssignments);
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
-        TableScanNode rightScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(rightAssignments.keySet()),
-                rightAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode rightScan = tableScanNode(rightAssignments);
 
         FilterNode left = filter(leftScan, equals(AE, bigintLiteral(10)));
 
@@ -512,24 +484,10 @@ public class TestEffectivePredicateExtractor
     public void testInnerJoinWithFalseFilter()
     {
         Map<Symbol, ColumnHandle> leftAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(A, B, C)));
-        TableScanNode leftScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(leftAssignments.keySet()),
-                leftAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode leftScan = tableScanNode(leftAssignments);
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
-        TableScanNode rightScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(rightAssignments.keySet()),
-                rightAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode rightScan = tableScanNode(rightAssignments);
 
         PlanNode node = new JoinNode(newId(),
                 JoinNode.Type.INNER,
@@ -559,24 +517,10 @@ public class TestEffectivePredicateExtractor
         List<JoinNode.EquiJoinClause> criteria = criteriaBuilder.build();
 
         Map<Symbol, ColumnHandle> leftAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(A, B, C)));
-        TableScanNode leftScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(leftAssignments.keySet()),
-                leftAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode leftScan = tableScanNode(leftAssignments);
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
-        TableScanNode rightScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(rightAssignments.keySet()),
-                rightAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode rightScan = tableScanNode(rightAssignments);
 
         FilterNode left = filter(leftScan,
                 and(
@@ -619,24 +563,10 @@ public class TestEffectivePredicateExtractor
         List<JoinNode.EquiJoinClause> criteria = ImmutableList.of(new JoinNode.EquiJoinClause(A, D));
 
         Map<Symbol, ColumnHandle> leftAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(A, B, C)));
-        TableScanNode leftScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(leftAssignments.keySet()),
-                leftAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode leftScan = tableScanNode(leftAssignments);
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
-        TableScanNode rightScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(rightAssignments.keySet()),
-                rightAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode rightScan = tableScanNode(rightAssignments);
 
         FilterNode left = filter(leftScan,
                 and(
@@ -676,24 +606,10 @@ public class TestEffectivePredicateExtractor
         List<JoinNode.EquiJoinClause> criteria = criteriaBuilder.build();
 
         Map<Symbol, ColumnHandle> leftAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(A, B, C)));
-        TableScanNode leftScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(leftAssignments.keySet()),
-                leftAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode leftScan = tableScanNode(leftAssignments);
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
-        TableScanNode rightScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(rightAssignments.keySet()),
-                rightAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode rightScan = tableScanNode(rightAssignments);
 
         FilterNode left = filter(leftScan,
                 and(
@@ -736,24 +652,10 @@ public class TestEffectivePredicateExtractor
         List<JoinNode.EquiJoinClause> criteria = ImmutableList.of(new JoinNode.EquiJoinClause(A, D));
 
         Map<Symbol, ColumnHandle> leftAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(A, B, C)));
-        TableScanNode leftScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(leftAssignments.keySet()),
-                leftAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode leftScan = tableScanNode(leftAssignments);
 
         Map<Symbol, ColumnHandle> rightAssignments = Maps.filterKeys(scanAssignments, Predicates.in(ImmutableList.of(D, E, F)));
-        TableScanNode rightScan = new TableScanNode(
-                newId(),
-                DUAL_TABLE_HANDLE,
-                ImmutableList.copyOf(rightAssignments.keySet()),
-                rightAssignments,
-                Optional.empty(),
-                TupleDomain.all(),
-                TupleDomain.all());
+        TableScanNode rightScan = tableScanNode(rightAssignments);
 
         FilterNode left = filter(leftScan, FALSE_LITERAL);
         FilterNode right = filter(rightScan,
@@ -799,6 +701,18 @@ public class TestEffectivePredicateExtractor
         // Currently, only pull predicates through the source plan
         assertEquals(normalizeConjuncts(effectivePredicate),
                 normalizeConjuncts(and(greaterThan(AE, bigintLiteral(10)), lessThan(AE, bigintLiteral(100)))));
+    }
+
+    private static TableScanNode tableScanNode(Map<Symbol, ColumnHandle> scanAssignments)
+    {
+        return new TableScanNode(
+                newId(),
+                DUAL_TABLE_HANDLE,
+                ImmutableList.copyOf(scanAssignments.keySet()),
+                scanAssignments,
+                Optional.empty(),
+                TupleDomain.all(),
+                TupleDomain.all());
     }
 
     private static PlanNodeId newId()


### PR DESCRIPTION
There are more possible improvements in join equality inference:
* for outer joins outer side we could infer via inner side symbols (with `OR inner side symbols null` condition)
* for outer joins inner side we could infer via outer side symbols with (with `OR inner side symbols null` condition)
* for outer joins filter conditions we could produce predicate (with `OR inner side symbols null` condition)

Additionally equality inference `rewrite` mechianism could be improved so that expressions like:
```
p1 OR (p2 AND p3 AND p4)
```
are rewritten (expanded) into:
```
p1 OR (p2 AND p4)
```
when `p3` cannot be rewritten. Currently `rewrite` would just return `null`