### PR TITLE
Do not set distinct values count to 0 when nulls fraction is not 1.0

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -435,9 +435,15 @@ public final class ThriftMetastoreUtil
     private static long fromMetastoreDistinctValuesCount(long distinctValuesCount, long nullsCount, long rowCount)
     {
         long nonNullsCount = rowCount - nullsCount;
-        if (nullsCount > 0) {
+        if (nullsCount > 0 && distinctValuesCount > 0) {
             distinctValuesCount--;
         }
+
+        // normalize distinctValuesCount in case there is a non null element
+        if (nonNullsCount > 0 && distinctValuesCount == 0) {
+            distinctValuesCount = 1;
+        }
+
         // the metastore may store an estimate, so the value stored may be higher than the total number of rows
         if (distinctValuesCount > nonNullsCount) {
             return nonNullsCount;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestThriftMetastoreUtil.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/thrift/TestThriftMetastoreUtil.java
@@ -342,6 +342,28 @@ public class TestThriftMetastoreUtil
     }
 
     @Test
+    public void testSingleDistinctValue()
+    {
+        DoubleColumnStatsData doubleColumnStatsData = new DoubleColumnStatsData();
+        doubleColumnStatsData.setNumNulls(10);
+        doubleColumnStatsData.setNumDVs(1);
+        ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", DOUBLE_TYPE_NAME, doubleStats(doubleColumnStatsData));
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(10));
+
+        assertEquals(actual.getNullsCount(), OptionalLong.of(10));
+        assertEquals(actual.getDistinctValuesCount(), OptionalLong.of(0));
+
+        doubleColumnStatsData = new DoubleColumnStatsData();
+        doubleColumnStatsData.setNumNulls(10);
+        doubleColumnStatsData.setNumDVs(1);
+        columnStatisticsObj = new ColumnStatisticsObj("my_col", DOUBLE_TYPE_NAME, doubleStats(doubleColumnStatsData));
+        actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(11));
+
+        assertEquals(actual.getNullsCount(), OptionalLong.of(10));
+        assertEquals(actual.getDistinctValuesCount(), OptionalLong.of(1));
+    }
+
+    @Test
     public void testBasicStatisticsRoundTrip()
     {
         testBasicStatisticsRoundTrip(new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.empty(), OptionalLong.empty(), OptionalLong.empty()));


### PR DESCRIPTION
In Hive we got table:
```
hive> select distinct ca_country from customer_address;
NULL
United States
```

but:
hive> describe formatted customer_address.ca_country;
OK
```
name       type         ndv
ca_country varchar(20)  1
```