### PR TITLE
Do not create Pages for channels in each JoinFilterFunctionFactory#cr…

### DIFF
--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
@@ -348,7 +348,7 @@ public class TestSpatialJoinOperator
     private PagesSpatialIndexFactory buildIndex(DriverContext driverContext, SpatialPredicate spatialRelationshipTest, Optional<Integer> radiusChannel, Optional<InternalJoinFilterFunction> filterFunction, RowPagesBuilder buildPages)
     {
         Optional<JoinFilterFunctionCompiler.JoinFilterFunctionFactory> filterFunctionFactory = filterFunction
-                .map(function -> (session, addresses, channels) -> new StandardJoinFilterFunction(function, addresses, channels));
+                .map(function -> (session, addresses, pages) -> new StandardJoinFilterFunction(function, addresses, pages));
 
         ValuesOperator.ValuesOperatorFactory valuesOperatorFactory = new ValuesOperator.ValuesOperatorFactory(0, new PlanNodeId("test"), buildPages.build());
         SpatialIndexBuilderOperatorFactory buildOperatorFactory = new SpatialIndexBuilderOperatorFactory(

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import com.google.common.collect.ImmutableList;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.isFastInequalityJoin;
+import static com.facebook.presto.operator.JoinUtils.channelsToPages;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -33,7 +35,7 @@ public class JoinHashSupplier
     private final Session session;
     private final PagesHash pagesHash;
     private final LongArrayList addresses;
-    private final List<List<Block>> channels;
+    private final List<Page> pages;
     private final Optional<PositionLinks.Factory> positionLinks;
     private final Optional<JoinFilterFunctionFactory> filterFunctionFactory;
     private final List<JoinFilterFunctionFactory> searchFunctionFactories;
@@ -49,9 +51,9 @@ public class JoinHashSupplier
     {
         this.session = requireNonNull(session, "session is null");
         this.addresses = requireNonNull(addresses, "addresses is null");
-        this.channels = requireNonNull(channels, "channels is null");
         this.filterFunctionFactory = requireNonNull(filterFunctionFactory, "filterFunctionFactory is null");
         this.searchFunctionFactories = ImmutableList.copyOf(searchFunctionFactories);
+        requireNonNull(channels, "pages is null");
         requireNonNull(pagesHashStrategy, "pagesHashStrategy is null");
 
         PositionLinks.FactoryBuilder positionLinksFactoryBuilder;
@@ -67,6 +69,7 @@ public class JoinHashSupplier
             positionLinksFactoryBuilder = ArrayPositionLinks.builder(addresses.size());
         }
 
+        this.pages = channelsToPages(channels);
         this.pagesHash = new PagesHash(addresses, pagesHashStrategy, positionLinksFactoryBuilder);
         this.positionLinks = positionLinksFactoryBuilder.isEmpty() ? Optional.empty() : Optional.of(positionLinksFactoryBuilder.build());
     }
@@ -95,13 +98,13 @@ public class JoinHashSupplier
         // We need to create new JoinFilterFunction per each thread using it, since those functions
         // are not thread safe...
         Optional<JoinFilterFunction> filterFunction =
-                filterFunctionFactory.map(factory -> factory.create(session.toConnectorSession(), addresses, channels));
+                filterFunctionFactory.map(factory -> factory.create(session.toConnectorSession(), addresses, pages));
         return new JoinHash(
                 pagesHash,
                 filterFunction,
                 positionLinks.map(links -> {
                     List<JoinFilterFunction> searchFunctions = searchFunctionFactories.stream()
-                            .map(factory -> factory.create(session.toConnectorSession(), addresses, channels))
+                            .map(factory -> factory.create(session.toConnectorSession(), addresses, pages))
                             .collect(toImmutableList());
                     return links.create(searchFunctions);
                 }));

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+final class JoinUtils
+{
+    private JoinUtils() {}
+
+    public static List<Page> channelsToPages(List<List<Block>> channels)
+    {
+        ImmutableList.Builder<Page> pagesBuilder = ImmutableList.builder();
+        if (!channels.isEmpty()) {
+            int pagesCount = channels.get(0).size();
+            for (int pageIndex = 0; pageIndex < pagesCount; ++pageIndex) {
+                Block[] blocks = new Block[channels.size()];
+                for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
+                    blocks[channelIndex] = channels.get(channelIndex).get(pageIndex);
+                }
+                pagesBuilder.add(new Page(blocks));
+            }
+        }
+        return pagesBuilder.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesRTreeIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesRTreeIndex.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 
 import static com.facebook.presto.geospatial.serde.GeometrySerde.deserialize;
+import static com.facebook.presto.operator.JoinUtils.channelsToPages;
 import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
 import static com.facebook.presto.operator.SyntheticAddress.decodeSliceIndex;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -89,7 +90,7 @@ public class PagesRTreeIndex
         this.rtree = requireNonNull(rtree, "rtree is null");
         this.radiusChannel = radiusChannel.orElse(-1);
         this.spatialRelationshipTest = requireNonNull(spatialRelationshipTest, "spatial relationship is null");
-        this.filterFunction = filterFunctionFactory.map(factory -> factory.create(session.toConnectorSession(), addresses, channels)).orElse(null);
+        this.filterFunction = filterFunctionFactory.map(factory -> factory.create(session.toConnectorSession(), addresses, channelsToPages(channels))).orElse(null);
     }
 
     private static Envelope getEnvelope(OGCGeometry ogcGeometry)

--- a/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunction.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.Page;
-import com.facebook.presto.spi.block.Block;
 import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 
@@ -33,33 +32,20 @@ public class StandardJoinFilterFunction
     private final LongArrayList addresses;
     private final List<Page> pages;
 
-    public StandardJoinFilterFunction(InternalJoinFilterFunction filterFunction, LongArrayList addresses, List<List<Block>> channels)
+    public StandardJoinFilterFunction(InternalJoinFilterFunction filterFunction, LongArrayList addresses, List<Page> pages)
     {
         this.filterFunction = requireNonNull(filterFunction, "filterFunction can not be null");
         this.addresses = requireNonNull(addresses, "addresses is null");
-
-        requireNonNull(channels, "channels can not be null");
-        ImmutableList.Builder<Page> pagesBuilder = ImmutableList.builder();
-        if (!channels.isEmpty()) {
-            int pagesCount = channels.get(0).size();
-            for (int pageIndex = 0; pageIndex < pagesCount; ++pageIndex) {
-                Block[] blocks = new Block[channels.size()];
-                for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
-                    blocks[channelIndex] = channels.get(channelIndex).get(pageIndex);
-                }
-                pagesBuilder.add(new Page(blocks));
-            }
-        }
-        this.pages = pagesBuilder.build();
+        this.pages = ImmutableList.copyOf(requireNonNull(pages, "pages is null"));
     }
 
     @Override
     public boolean filter(int leftPosition, int rightPosition, Page rightPage)
     {
         long pageAddress = addresses.getLong(leftPosition);
-        int blockIndex = decodeSliceIndex(pageAddress);
-        int blockPosition = decodePosition(pageAddress);
+        int pageIndex = decodeSliceIndex(pageAddress);
+        int pagePosition = decodePosition(pageAddress);
 
-        return filterFunction.filter(blockPosition, pages.isEmpty() ? EMPTY_PAGE : pages.get(blockIndex), rightPosition, rightPage);
+        return filterFunction.filter(pagePosition, pages.isEmpty() ? EMPTY_PAGE : pages.get(pageIndex), rightPosition, rightPage);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -247,7 +247,7 @@ public class JoinFilterFunctionCompiler
 
     public interface JoinFilterFunctionFactory
     {
-        JoinFilterFunction create(ConnectorSession session, LongArrayList addresses, List<List<Block>> channels);
+        JoinFilterFunction create(ConnectorSession session, LongArrayList addresses, List<Page> pages);
     }
 
     private static RowExpressionVisitor<BytecodeNode, Scope> fieldReferenceCompiler(
@@ -344,11 +344,11 @@ public class JoinFilterFunctionCompiler
         }
 
         @Override
-        public JoinFilterFunction create(ConnectorSession session, LongArrayList addresses, List<List<Block>> channels)
+        public JoinFilterFunction create(ConnectorSession session, LongArrayList addresses, List<Page> pages)
         {
             try {
                 InternalJoinFilterFunction internalJoinFilterFunction = internalJoinFilterFunctionConstructor.newInstance(session);
-                return isolatedJoinFilterFunctionConstructor.newInstance(internalJoinFilterFunction, addresses, channels);
+                return isolatedJoinFilterFunctionConstructor.newInstance(internalJoinFilterFunction, addresses, pages);
             }
             catch (ReflectiveOperationException e) {
                 throw new RuntimeException(e);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -1210,7 +1210,7 @@ public class TestHashJoinOperator
             SingleStreamSpillerFactory singleStreamSpillerFactory)
     {
         Optional<JoinFilterFunctionFactory> filterFunctionFactory = filterFunction
-                .map(function -> (session, addresses, channels) -> new StandardJoinFilterFunction(function, addresses, channels));
+                .map(function -> (session, addresses, pages) -> new StandardJoinFilterFunction(function, addresses, pages));
 
         int partitionCount = parallelBuild ? PARTITION_COUNT : 1;
         LocalExchangeFactory localExchangeFactory = new LocalExchangeFactory(


### PR DESCRIPTION
…eate

When broadcast join is used then JoinFilterFunction
is created for every instance of LookupJoinOperator
(therefore for every split) via JoinHash and
JoinHashSupplier.
JoinFilterFunction factory was creating new Pages
for the same channels. This caused GC pressure
and leak on unaccounted query memory
(created Pages reference same blocks but contain
overhead structures).
Now Pages are created beforehand from channels.