### PR TITLE
Adding support for NOT NULL in DDL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -723,7 +723,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.44</version>
+                <version>5.1.46</version>
             </dependency>
 
             <dependency>
@@ -893,7 +893,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>testing-mysql-server</artifactId>
-                <version>5.7.22-1</version>
+                <version>8.0.12-1</version>
             </dependency>
 
             <dependency>

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloDistributedQueries.java
@@ -43,6 +43,12 @@ public class TestAccumuloDistributedQueries
     }
 
     @Override
+    protected boolean supportsNotNullColumns()
+    {
+        return false;
+    }
+
+    @Override
     public void testAddColumn()
     {
         // Adding columns via SQL are not supported until adding columns with comments are supported

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -72,6 +72,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
+import static java.sql.ResultSetMetaData.columnNullable;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -208,7 +209,8 @@ public class BaseJdbcClient
                     // skip unsupported column types
                     if (columnMapping.isPresent()) {
                         String columnName = resultSet.getString("COLUMN_NAME");
-                        columns.add(new JdbcColumnHandle(connectorId, columnName, typeHandle, columnMapping.get().getType()));
+                        boolean nullable = columnNullable == resultSet.getInt("NULLABLE");
+                        columns.add(new JdbcColumnHandle(connectorId, columnName, typeHandle, columnMapping.get().getType(), nullable));
                     }
                 }
                 if (columns.isEmpty()) {
@@ -364,6 +366,9 @@ public class BaseJdbcClient
                 .append(quoted(columnName))
                 .append(" ")
                 .append(toSqlType(column.getType()));
+        if (!column.isNullable()) {
+            sb.append(" NOT NULL");
+        }
         return sb.toString();
     }
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableMetadata;
@@ -61,6 +62,16 @@ public interface JdbcClient
 
     PreparedStatement buildSql(Connection connection, JdbcSplit split, List<JdbcColumnHandle> columnHandles)
             throws SQLException;
+
+    void addColumn(JdbcTableHandle handle, ColumnMetadata column);
+
+    void dropColumn(JdbcTableHandle handle, JdbcColumnHandle column);
+
+    void renameColumn(JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName);
+
+    void renameTable(JdbcTableHandle handle, SchemaTableName newTableName);
+
+    void createTable(ConnectorTableMetadata tableMetadata);
 
     JdbcOutputTableHandle beginCreateTable(ConnectorTableMetadata tableMetadata);
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcColumnHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcColumnHandle.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
 public final class JdbcColumnHandle
@@ -31,18 +32,21 @@ public final class JdbcColumnHandle
     private final String columnName;
     private final JdbcTypeHandle jdbcTypeHandle;
     private final Type columnType;
+    private final boolean nullable;
 
     @JsonCreator
     public JdbcColumnHandle(
             @JsonProperty("connectorId") String connectorId,
             @JsonProperty("columnName") String columnName,
             @JsonProperty("jdbcTypeHandle") JdbcTypeHandle jdbcTypeHandle,
-            @JsonProperty("columnType") Type columnType)
+            @JsonProperty("columnType") Type columnType,
+            @JsonProperty("nullable") boolean nullable)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.jdbcTypeHandle = requireNonNull(jdbcTypeHandle, "jdbcTypeHandle is null");
         this.columnType = requireNonNull(columnType, "columnType is null");
+        this.nullable = nullable;
     }
 
     @JsonProperty
@@ -69,9 +73,15 @@ public final class JdbcColumnHandle
         return columnType;
     }
 
+    @JsonProperty
+    public boolean isNullable()
+    {
+        return nullable;
+    }
+
     public ColumnMetadata getColumnMetadata()
     {
-        return new ColumnMetadata(columnName, columnType);
+        return new ColumnMetadata(columnName, columnType, nullable, null, null, false, emptyMap());
     }
 
     @Override
@@ -102,6 +112,7 @@ public final class JdbcColumnHandle
                 .add("columnName", columnName)
                 .add("jdbcTypeHandle", jdbcTypeHandle)
                 .add("columnType", columnType)
+                .add("nullable", nullable)
                 .toString();
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
@@ -33,9 +34,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static com.facebook.presto.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcConnector
@@ -148,5 +151,11 @@ public class JdbcConnector
         catch (Exception e) {
             log.error(e, "Error shutting down connector");
         }
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getCapabilities()
+    {
+        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -175,6 +175,12 @@ public class JdbcMetadata
     }
 
     @Override
+    public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        jdbcClient.createTable(tableMetadata);
+    }
+
+    @Override
     public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         JdbcOutputTableHandle handle = (JdbcOutputTableHandle) tableHandle;
@@ -212,6 +218,36 @@ public class JdbcMetadata
         JdbcOutputTableHandle jdbcInsertHandle = (JdbcOutputTableHandle) tableHandle;
         jdbcClient.finishInsertTable(jdbcInsertHandle);
         return Optional.empty();
+    }
+
+    @Override
+    public void addColumn(ConnectorSession session, ConnectorTableHandle table, ColumnMetadata columnMetadata)
+    {
+        JdbcTableHandle tableHandle = (JdbcTableHandle) table;
+        jdbcClient.addColumn(tableHandle, columnMetadata);
+    }
+
+    @Override
+    public void dropColumn(ConnectorSession session, ConnectorTableHandle table, ColumnHandle column)
+    {
+        JdbcTableHandle tableHandle = (JdbcTableHandle) table;
+        JdbcColumnHandle columnHandle = (JdbcColumnHandle) column;
+        jdbcClient.dropColumn(tableHandle, columnHandle);
+    }
+
+    @Override
+    public void renameColumn(ConnectorSession session, ConnectorTableHandle table, ColumnHandle column, String target)
+    {
+        JdbcTableHandle tableHandle = (JdbcTableHandle) table;
+        JdbcColumnHandle columnHandle = (JdbcColumnHandle) column;
+        jdbcClient.renameColumn(tableHandle, columnHandle, target);
+    }
+
+    @Override
+    public void renameTable(ConnectorSession session, ConnectorTableHandle table, SchemaTableName newTableName)
+    {
+        JdbcTableHandle tableHandle = (JdbcTableHandle) table;
+        jdbcClient.renameTable(tableHandle, newTableName);
     }
 
     @Override

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -29,6 +30,7 @@ import java.util.List;
 
 import static com.facebook.presto.plugin.jdbc.TestingDatabase.CONNECTOR_ID;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DATE;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DOUBLE;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_REAL;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
@@ -38,6 +40,7 @@ import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.util.Collections.emptyMap;
 import static java.util.Locale.ENGLISH;
 import static java.util.UUID.randomUUID;
 import static org.testng.Assert.assertEquals;
@@ -89,9 +92,9 @@ public class TestJdbcClient
         assertEquals(table.getTableName(), "NUMBERS");
         assertEquals(table.getSchemaTableName(), schemaTableName);
         assertEquals(jdbcClient.getColumns(session, table), ImmutableList.of(
-                new JdbcColumnHandle(CONNECTOR_ID, "TEXT", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle(CONNECTOR_ID, "TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
-                new JdbcColumnHandle(CONNECTOR_ID, "VALUE", JDBC_BIGINT, BIGINT)));
+                new JdbcColumnHandle(CONNECTOR_ID, "TEXT", JDBC_VARCHAR, VARCHAR, true),
+                new JdbcColumnHandle(CONNECTOR_ID, "TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32), true),
+                new JdbcColumnHandle(CONNECTOR_ID, "VALUE", JDBC_BIGINT, BIGINT, true)));
     }
 
     @Test
@@ -101,8 +104,8 @@ public class TestJdbcClient
         JdbcTableHandle table = jdbcClient.getTableHandle(schemaTableName);
         assertNotNull(table, "table is null");
         assertEquals(jdbcClient.getColumns(session, table), ImmutableList.of(
-                new JdbcColumnHandle(CONNECTOR_ID, "TE_T", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle(CONNECTOR_ID, "VA%UE", JDBC_BIGINT, BIGINT)));
+                new JdbcColumnHandle(CONNECTOR_ID, "TE_T", JDBC_VARCHAR, VARCHAR, true),
+                new JdbcColumnHandle(CONNECTOR_ID, "VA%UE", JDBC_BIGINT, BIGINT, true)));
     }
 
     @Test
@@ -112,18 +115,22 @@ public class TestJdbcClient
         JdbcTableHandle table = jdbcClient.getTableHandle(schemaTableName);
         assertNotNull(table, "table is null");
         assertEquals(jdbcClient.getColumns(session, table), ImmutableList.of(
-                new JdbcColumnHandle(CONNECTOR_ID, "COL1", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle(CONNECTOR_ID, "COL2", JDBC_DOUBLE, DOUBLE),
-                new JdbcColumnHandle(CONNECTOR_ID, "COL3", JDBC_DOUBLE, DOUBLE),
-                new JdbcColumnHandle(CONNECTOR_ID, "COL4", JDBC_REAL, REAL)));
+                new JdbcColumnHandle(CONNECTOR_ID, "COL1", JDBC_BIGINT, BIGINT, true),
+                new JdbcColumnHandle(CONNECTOR_ID, "COL2", JDBC_DOUBLE, DOUBLE, true),
+                new JdbcColumnHandle(CONNECTOR_ID, "COL3", JDBC_DOUBLE, DOUBLE, true),
+                new JdbcColumnHandle(CONNECTOR_ID, "COL4", JDBC_REAL, REAL, true)));
     }
 
     @Test
-    public void testCreateTable()
+    public void testCreateWithNullableColumns()
     {
         String tableName = randomUUID().toString().toUpperCase(ENGLISH);
         SchemaTableName schemaTableName = new SchemaTableName("example", tableName);
-        List<ColumnMetadata> expectedColumns = ImmutableList.of(new ColumnMetadata("columnA", BigintType.BIGINT, null, null, false));
+        List<ColumnMetadata> expectedColumns = ImmutableList.of(
+                new ColumnMetadata("columnA", BigintType.BIGINT, null, null, false),
+                new ColumnMetadata("columnB", BigintType.BIGINT, true, null, null, false, emptyMap()),
+                new ColumnMetadata("columnC", BigintType.BIGINT, false, null, null, false, emptyMap()),
+                new ColumnMetadata("columnD", DateType.DATE, false, null, null, false, emptyMap()));
 
         jdbcClient.createTable(new ConnectorTableMetadata(schemaTableName, expectedColumns));
 
@@ -132,7 +139,10 @@ public class TestJdbcClient
         try {
             assertEquals(tableHandle.getTableName(), tableName);
             assertEquals(jdbcClient.getColumns(session, tableHandle), ImmutableList.of(
-                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT)));
+                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT, true),
+                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNB", JDBC_BIGINT, BigintType.BIGINT, true),
+                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNC", JDBC_BIGINT, BigintType.BIGINT, false),
+                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMND", JDBC_DATE, DateType.DATE, false)));
         }
         finally {
             jdbcClient.dropTable(tableHandle);
@@ -154,16 +164,16 @@ public class TestJdbcClient
         try {
             assertEquals(tableHandle.getTableName(), tableName);
             assertEquals(jdbcClient.getColumns(session, tableHandle), ImmutableList.of(
-                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT)));
+                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT, true)));
 
             jdbcClient.addColumn(tableHandle, new ColumnMetadata("columnB", DoubleType.DOUBLE, null, null, false));
             assertEquals(jdbcClient.getColumns(session, tableHandle), ImmutableList.of(
-                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT),
-                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNB", JDBC_DOUBLE, DoubleType.DOUBLE)));
+                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT, true),
+                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNB", JDBC_DOUBLE, DoubleType.DOUBLE, true)));
 
-            jdbcClient.dropColumn(tableHandle, new JdbcColumnHandle(CONNECTOR_ID, "COLUMNB", JDBC_DOUBLE, DoubleType.DOUBLE));
+            jdbcClient.dropColumn(tableHandle, new JdbcColumnHandle(CONNECTOR_ID, "COLUMNB", JDBC_BIGINT, BigintType.BIGINT, true));
             assertEquals(jdbcClient.getColumns(session, tableHandle), ImmutableList.of(
-                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT)));
+                    new JdbcColumnHandle(CONNECTOR_ID, "COLUMNA", JDBC_BIGINT, BigintType.BIGINT, true)));
         }
         finally {
             jdbcClient.dropTable(tableHandle);

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcColumnHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcColumnHandle.java
@@ -28,7 +28,7 @@ public class TestJdbcColumnHandle
     @Test
     public void testJsonRoundTrip()
     {
-        assertJsonRoundTrip(COLUMN_CODEC, new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR));
+        assertJsonRoundTrip(COLUMN_CODEC, new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR, true));
     }
 
     @Test
@@ -36,20 +36,20 @@ public class TestJdbcColumnHandle
     {
         EquivalenceTester.equivalenceTester()
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("connectorId", "columnName", JDBC_BIGINT, BIGINT),
-                        new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR))
+                        new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR, true),
+                        new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR, true),
+                        new JdbcColumnHandle("connectorId", "columnName", JDBC_BIGINT, BIGINT, true),
+                        new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR, true))
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_BIGINT, BIGINT),
-                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_VARCHAR, VARCHAR))
+                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_VARCHAR, VARCHAR, true),
+                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_VARCHAR, VARCHAR, true),
+                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_BIGINT, BIGINT, true),
+                        new JdbcColumnHandle("connectorIdX", "columnName", JDBC_VARCHAR, VARCHAR, true))
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_BIGINT, BIGINT),
-                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_VARCHAR, VARCHAR))
+                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_VARCHAR, VARCHAR, true),
+                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_VARCHAR, VARCHAR, true),
+                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_BIGINT, BIGINT, true),
+                        new JdbcColumnHandle("connectorId", "columnNameX", JDBC_VARCHAR, VARCHAR, true))
                 .check();
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static java.util.Collections.emptyMap;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -85,9 +86,9 @@ public class TestJdbcMetadata
     {
         // known table
         assertEquals(metadata.getColumnHandles(SESSION, tableHandle), ImmutableMap.of(
-                "text", new JdbcColumnHandle(CONNECTOR_ID, "TEXT", JDBC_VARCHAR, VARCHAR),
-                "text_short", new JdbcColumnHandle(CONNECTOR_ID, "TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
-                "value", new JdbcColumnHandle(CONNECTOR_ID, "VALUE", JDBC_BIGINT, BIGINT)));
+                "text", new JdbcColumnHandle(CONNECTOR_ID, "TEXT", JDBC_VARCHAR, VARCHAR, true),
+                "text_short", new JdbcColumnHandle(CONNECTOR_ID, "TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32), true),
+                "value", new JdbcColumnHandle(CONNECTOR_ID, "VALUE", JDBC_BIGINT, BIGINT, true)));
 
         // unknown table
         unknownTableColumnHandle(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("unknown", "unknown"), "unknown", "unknown", "unknown"));
@@ -111,7 +112,7 @@ public class TestJdbcMetadata
         ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(SESSION, tableHandle);
         assertEquals(tableMetadata.getTable(), new SchemaTableName("example", "numbers"));
         assertEquals(tableMetadata.getColumns(), ImmutableList.of(
-                new ColumnMetadata("text", VARCHAR),
+                new ColumnMetadata("text", VARCHAR, false, null, null, false, emptyMap()), // primary key is not null in H2
                 new ColumnMetadata("text_short", createVarcharType(32)),
                 new ColumnMetadata("value", BIGINT)));
 
@@ -120,7 +121,7 @@ public class TestJdbcMetadata
         ConnectorTableMetadata specialTableMetadata = metadata.getTableMetadata(SESSION, specialTableHandle);
         assertEquals(specialTableMetadata.getTable(), new SchemaTableName("exa_ple", "num_ers"));
         assertEquals(specialTableMetadata.getColumns(), ImmutableList.of(
-                new ColumnMetadata("te_t", VARCHAR),
+                new ColumnMetadata("te_t", VARCHAR, false, null, null, false, emptyMap()), // primary key is not null in H2
                 new ColumnMetadata("va%ue", BIGINT)));
 
         // unknown tables should produce null
@@ -172,7 +173,7 @@ public class TestJdbcMetadata
     public void getColumnMetadata()
     {
         assertEquals(
-                metadata.getColumnMetadata(SESSION, tableHandle, new JdbcColumnHandle(CONNECTOR_ID, "text", JDBC_VARCHAR, VARCHAR)),
+                metadata.getColumnMetadata(SESSION, tableHandle, new JdbcColumnHandle(CONNECTOR_ID, "text", JDBC_VARCHAR, VARCHAR, true)),
                 new ColumnMetadata("text", VARCHAR));
     }
 
@@ -195,7 +196,7 @@ public class TestJdbcMetadata
         assertEquals(layout.getColumns().get(0), new ColumnMetadata("text", VARCHAR));
         assertEquals(layout.getColumns().get(1), new ColumnMetadata("x", VARCHAR));
 
-        JdbcColumnHandle columnHandle = new JdbcColumnHandle(CONNECTOR_ID, "x", JDBC_VARCHAR, VARCHAR);
+        JdbcColumnHandle columnHandle = new JdbcColumnHandle(CONNECTOR_ID, "x", JDBC_VARCHAR, VARCHAR, true);
         metadata.dropColumn(SESSION, handle, columnHandle);
         layout = metadata.getTableMetadata(SESSION, handle);
         assertEquals(layout.getColumns().size(), 1);

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -86,18 +86,18 @@ public class TestJdbcQueryBuilder
         CharType charType = CharType.createCharType(0);
 
         columns = ImmutableList.of(
-                new JdbcColumnHandle("test_id", "col_0", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("test_id", "col_1", JDBC_DOUBLE, DOUBLE),
-                new JdbcColumnHandle("test_id", "col_2", JDBC_BOOLEAN, BOOLEAN),
-                new JdbcColumnHandle("test_id", "col_3", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle("test_id", "col_4", JDBC_DATE, DATE),
-                new JdbcColumnHandle("test_id", "col_5", JDBC_TIME, TIME),
-                new JdbcColumnHandle("test_id", "col_6", JDBC_TIMESTAMP, TIMESTAMP),
-                new JdbcColumnHandle("test_id", "col_7", JDBC_TINYINT, TINYINT),
-                new JdbcColumnHandle("test_id", "col_8", JDBC_SMALLINT, SMALLINT),
-                new JdbcColumnHandle("test_id", "col_9", JDBC_INTEGER, INTEGER),
-                new JdbcColumnHandle("test_id", "col_10", JDBC_REAL, REAL),
-                new JdbcColumnHandle("test_id", "col_11", JDBC_CHAR, charType));
+                new JdbcColumnHandle("test_id", "col_0", JDBC_BIGINT, BIGINT, true),
+                new JdbcColumnHandle("test_id", "col_1", JDBC_DOUBLE, DOUBLE, true),
+                new JdbcColumnHandle("test_id", "col_2", JDBC_BOOLEAN, BOOLEAN, true),
+                new JdbcColumnHandle("test_id", "col_3", JDBC_VARCHAR, VARCHAR, true),
+                new JdbcColumnHandle("test_id", "col_4", JDBC_DATE, DATE, true),
+                new JdbcColumnHandle("test_id", "col_5", JDBC_TIME, TIME, true),
+                new JdbcColumnHandle("test_id", "col_6", JDBC_TIMESTAMP, TIMESTAMP, true),
+                new JdbcColumnHandle("test_id", "col_7", JDBC_TINYINT, TINYINT, true),
+                new JdbcColumnHandle("test_id", "col_8", JDBC_SMALLINT, SMALLINT, true),
+                new JdbcColumnHandle("test_id", "col_9", JDBC_INTEGER, INTEGER, true),
+                new JdbcColumnHandle("test_id", "col_10", JDBC_REAL, REAL, true),
+                new JdbcColumnHandle("test_id", "col_11", JDBC_CHAR, charType, true));
 
         Connection connection = database.getConnection();
         try (PreparedStatement preparedStatement = connection.prepareStatement("create table \"test_table\" (" + "" +

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSet.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSet.java
@@ -65,20 +65,20 @@ public class TestJdbcRecordSet
     public void testGetColumnTypes()
     {
         RecordSet recordSet = new JdbcRecordSet(jdbcClient, session, split, ImmutableList.of(
-                new JdbcColumnHandle("test", "text", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle("test", "text_short", JDBC_VARCHAR, createVarcharType(32)),
-                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT)));
+                new JdbcColumnHandle("test", "text", JDBC_VARCHAR, VARCHAR, true),
+                new JdbcColumnHandle("test", "text_short", JDBC_VARCHAR, createVarcharType(32), true),
+                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT, true)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(VARCHAR, createVarcharType(32), BIGINT));
 
         recordSet = new JdbcRecordSet(jdbcClient, session, split, ImmutableList.of(
-                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("test", "text", JDBC_VARCHAR, VARCHAR)));
+                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT, true),
+                new JdbcColumnHandle("test", "text", JDBC_VARCHAR, VARCHAR, true)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, VARCHAR));
 
         recordSet = new JdbcRecordSet(jdbcClient, session, split, ImmutableList.of(
-                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("test", "text", JDBC_VARCHAR, VARCHAR)));
+                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT, true),
+                new JdbcColumnHandle("test", "value", JDBC_BIGINT, BIGINT, true),
+                new JdbcColumnHandle("test", "text", JDBC_VARCHAR, VARCHAR, true)));
         assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, BIGINT, VARCHAR));
 
         recordSet = new JdbcRecordSet(jdbcClient, session, split, ImmutableList.of());

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -39,6 +39,12 @@ public class TestCassandraDistributed
     }
 
     @Override
+    protected boolean supportsNotNullColumns()
+    {
+        return false;
+    }
+
+    @Override
     public void testJoinWithLessThanOnDatesInJoinClause()
     {
         // Cassandra does not support DATE

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -32,6 +32,12 @@ public class TestHiveDistributedQueries
     }
 
     @Override
+    protected boolean supportsNotNullColumns()
+    {
+        return false;
+    }
+
+    @Override
     public void testDelete()
     {
         // Hive connector currently does not support row-by-row delete

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesHivePartitioning.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesHivePartitioning.java
@@ -96,5 +96,11 @@ public class TestHiveDistributedQueriesHivePartitioning
         assertEquals(getOnlyElement(result.getOnlyColumnAsSet()), getExplainPlan(query, LOGICAL));
     }
 
+    @Override
+    protected boolean supportsNotNullColumns()
+    {
+        return false;
+    }
+
     // Hive specific tests should normally go in TestHiveIntegrationSmokeTest
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -36,10 +36,12 @@ import java.util.Optional;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.COLUMN_ALREADY_EXISTS;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.TYPE_MISMATCH;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -85,6 +87,9 @@ public class AddColumnTask
         if (columnHandles.containsKey(element.getName().getValue().toLowerCase(ENGLISH))) {
             throw new SemanticException(COLUMN_ALREADY_EXISTS, statement, "Column '%s' already exists", element.getName());
         }
+        if (!element.isNullable() && !metadata.getConnectorCapabilities(session, connectorId).contains(NOT_NULL_COLUMN_CONSTRAINT)) {
+            throw new SemanticException(NOT_SUPPORTED, element, "Catalog '%s' does not support NOT NULL for column '%s'", connectorId.getCatalogName(), element.getName());
+        }
 
         Map<String, Expression> sqlProperties = mapFromProperties(element.getProperties());
         Map<String, Object> columnProperties = metadata.getColumnPropertyManager().getProperties(
@@ -95,7 +100,13 @@ public class AddColumnTask
                 metadata,
                 parameters);
 
-        ColumnMetadata column = new ColumnMetadata(element.getName().getValue(), type, element.getComment().orElse(null), null, false, columnProperties);
+        ColumnMetadata column = new ColumnMetadata(
+                element.getName().getValue(),
+                type,
+                element.isNullable(), element.getComment().orElse(null),
+                null,
+                false,
+                columnProperties);
 
         metadata.addColumn(session, tableHandle.get(), column);
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/CatalogMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/CatalogMetadata.java
@@ -15,13 +15,16 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.util.Objects.requireNonNull;
 
 public class CatalogMetadata
@@ -39,6 +42,7 @@ public class CatalogMetadata
     private final ConnectorId systemTablesId;
     private final ConnectorMetadata systemTables;
     private final ConnectorTransactionHandle systemTablesTransactionHandle;
+    private final Set<ConnectorCapabilities> connectorCapabilities;
 
     public CatalogMetadata(
             ConnectorId connectorId,
@@ -49,7 +53,8 @@ public class CatalogMetadata
             ConnectorTransactionHandle informationSchemaTransactionHandle,
             ConnectorId systemTablesId,
             ConnectorMetadata systemTables,
-            ConnectorTransactionHandle systemTablesTransactionHandle)
+            ConnectorTransactionHandle systemTablesTransactionHandle,
+            Set<ConnectorCapabilities> connectorCapabilities)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
@@ -60,6 +65,7 @@ public class CatalogMetadata
         this.systemTablesId = requireNonNull(systemTablesId, "systemTablesId is null");
         this.systemTables = requireNonNull(systemTables, "systemTables is null");
         this.systemTablesTransactionHandle = requireNonNull(systemTablesTransactionHandle, "systemTablesTransactionHandle is null");
+        this.connectorCapabilities = immutableEnumSet(requireNonNull(connectorCapabilities, "connectorCapabilities is null"));
     }
 
     public ConnectorId getConnectorId()
@@ -116,6 +122,11 @@ public class CatalogMetadata
     public List<ConnectorId> listConnectorIds()
     {
         return ImmutableList.of(informationSchemaId, systemTablesId, connectorId);
+    }
+
+    public Set<ConnectorCapabilities> getConnectorCapabilities()
+    {
+        return connectorCapabilities;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
@@ -385,4 +386,6 @@ public interface Metadata
     ColumnPropertyManager getColumnPropertyManager();
 
     AnalyzePropertyManager getAnalyzePropertyManager();
+
+    Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId catalogName);
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
@@ -1133,6 +1134,12 @@ public class MetadataManager
     public AnalyzePropertyManager getAnalyzePropertyManager()
     {
         return analyzePropertyManager;
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId connectorId)
+    {
+        return getCatalogMetadata(session, connectorId).getConnectorCapabilities();
     }
 
     private ViewDefinition deserializeView(String data)

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -454,7 +454,7 @@ final class ShowQueriesRewrite
                         .filter(column -> !column.isHidden())
                         .map(column -> {
                             List<Property> propertyNodes = buildProperties(objectName, Optional.of(column.getName()), INVALID_COLUMN_PROPERTY, column.getProperties(), allColumnProperties);
-                            return new ColumnDefinition(new Identifier(column.getName()), column.getType().getDisplayName(), propertyNodes, Optional.ofNullable(column.getComment()));
+                            return new ColumnDefinition(new Identifier(column.getName()), column.getType().getDisplayName(), column.isNullable(), propertyNodes, Optional.ofNullable(column.getComment()));
                         })
                         .collect(toImmutableList());
 

--- a/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
@@ -412,15 +412,23 @@ public class InMemoryTransactionManager
             if (catalogMetadata == null) {
                 Catalog catalog = catalogsByConnectorId.get(connectorId);
                 verify(catalog != null, "Unknown connectorId: %s", connectorId);
+                Connector connector = catalog.getConnector(connectorId);
 
                 ConnectorTransactionMetadata metadata = createConnectorTransactionMetadata(catalog.getConnectorId(), catalog);
                 ConnectorTransactionMetadata informationSchema = createConnectorTransactionMetadata(catalog.getInformationSchemaId(), catalog);
                 ConnectorTransactionMetadata systemTables = createConnectorTransactionMetadata(catalog.getSystemTablesId(), catalog);
 
                 catalogMetadata = new CatalogMetadata(
-                        metadata.getConnectorId(), metadata.getConnectorMetadata(), metadata.getTransactionHandle(),
-                        informationSchema.getConnectorId(), informationSchema.getConnectorMetadata(), informationSchema.getTransactionHandle(),
-                        systemTables.getConnectorId(), systemTables.getConnectorMetadata(), systemTables.getTransactionHandle());
+                        metadata.getConnectorId(),
+                        metadata.getConnectorMetadata(),
+                        metadata.getTransactionHandle(),
+                        informationSchema.getConnectorId(),
+                        informationSchema.getConnectorMetadata(),
+                        informationSchema.getTransactionHandle(),
+                        systemTables.getConnectorId(),
+                        systemTables.getConnectorMetadata(),
+                        systemTables.getTransactionHandle(),
+                        connector.getCapabilities());
 
                 this.catalogMetadata.put(catalog.getConnectorId(), catalogMetadata);
                 this.catalogMetadata.put(catalog.getInformationSchemaId(), catalogMetadata);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestCreateTableTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestCreateTableTask.java
@@ -25,33 +25,44 @@ import com.facebook.presto.metadata.TableHandle;
 import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.ColumnDefinition;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.TableElement;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
+import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static com.google.common.collect.Sets.immutableEnumSet;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -87,14 +98,15 @@ public class TestCreateTableTask
         metadata = new MockMetadata(typeManager,
                 tablePropertyManager,
                 columnPropertyManager,
-                testCatalog.getConnectorId());
+                testCatalog.getConnectorId(),
+                emptySet());
     }
 
     @Test
     public void testCreateTableNotExistsTrue()
     {
         CreateTable statement = new CreateTable(QualifiedName.of("test_table"),
-                ImmutableList.of(new ColumnDefinition(identifier("a"), "BIGINT", emptyList(), Optional.empty())),
+                ImmutableList.of(new ColumnDefinition(identifier("a"), "BIGINT", true, emptyList(), Optional.empty())),
                 true,
                 ImmutableList.of(),
                 Optional.empty());
@@ -107,7 +119,7 @@ public class TestCreateTableTask
     public void testCreateTableNotExistsFalse()
     {
         CreateTable statement = new CreateTable(QualifiedName.of("test_table"),
-                ImmutableList.of(new ColumnDefinition(identifier("a"), "BIGINT", emptyList(), Optional.empty())),
+                ImmutableList.of(new ColumnDefinition(identifier("a"), "BIGINT", true, emptyList(), Optional.empty())),
                 false,
                 ImmutableList.of(),
                 Optional.empty());
@@ -125,6 +137,51 @@ public class TestCreateTableTask
         assertEquals(metadata.getCreateTableCallCount(), 1);
     }
 
+    @Test
+    public void testCreateWithNotNullColumns()
+    {
+        metadata.setConnectorCapabilities(NOT_NULL_COLUMN_CONSTRAINT);
+        List<TableElement> inputColumns = ImmutableList.of(
+                new ColumnDefinition(identifier("a"), "DATE", true, emptyList(), Optional.empty()),
+                new ColumnDefinition(identifier("b"), "VARCHAR", false, emptyList(), Optional.empty()),
+                new ColumnDefinition(identifier("c"), "VARBINARY", false, emptyList(), Optional.empty()));
+        CreateTable statement = new CreateTable(QualifiedName.of("test_table"), inputColumns, true, ImmutableList.of(), Optional.empty());
+
+        getFutureValue(new CreateTableTask().internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, emptyList()));
+        assertEquals(metadata.getCreateTableCallCount(), 1);
+        List<ColumnMetadata> columns = metadata.getReceivedTableMetadata().get(0).getColumns();
+        assertEquals(columns.size(), 3);
+
+        assertEquals(columns.get(0).getName(), "a");
+        assertEquals(columns.get(0).getType().getDisplayName().toUpperCase(ENGLISH), "DATE");
+        assertTrue(columns.get(0).isNullable());
+
+        assertEquals(columns.get(1).getName(), "b");
+        assertEquals(columns.get(1).getType().getDisplayName().toUpperCase(ENGLISH), "VARCHAR");
+        assertFalse(columns.get(1).isNullable());
+
+        assertEquals(columns.get(2).getName(), "c");
+        assertEquals(columns.get(2).getType().getDisplayName().toUpperCase(ENGLISH), "VARBINARY");
+        assertFalse(columns.get(2).isNullable());
+    }
+
+    @Test(expectedExceptions = SemanticException.class, expectedExceptionsMessageRegExp = ".*does not support non-null column for column name 'b'")
+    public void testCreateWithUnsupportedConnectorThrowsWhenNotNull()
+    {
+        List<TableElement> inputColumns = ImmutableList.of(
+                new ColumnDefinition(identifier("a"), "DATE", true, emptyList(), Optional.empty()),
+                new ColumnDefinition(identifier("b"), "VARCHAR", false, emptyList(), Optional.empty()),
+                new ColumnDefinition(identifier("c"), "VARBINARY", false, emptyList(), Optional.empty()));
+        CreateTable statement = new CreateTable(
+                QualifiedName.of("test_table"),
+                inputColumns,
+                true,
+                ImmutableList.of(),
+                Optional.empty());
+
+        getFutureValue(new CreateTableTask().internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, emptyList()));
+    }
+
     private static class MockMetadata
             extends AbstractMockMetadata
     {
@@ -132,24 +189,27 @@ public class TestCreateTableTask
         private final TablePropertyManager tablePropertyManager;
         private final ColumnPropertyManager columnPropertyManager;
         private final ConnectorId catalogHandle;
-        private AtomicInteger createTableCallCount = new AtomicInteger();
+        private final List<ConnectorTableMetadata> tables = new CopyOnWriteArrayList<>();
+        private Set<ConnectorCapabilities> connectorCapabilities;
 
         public MockMetadata(
                 TypeManager typeManager,
                 TablePropertyManager tablePropertyManager,
                 ColumnPropertyManager columnPropertyManager,
-                ConnectorId catalogHandle)
+                ConnectorId catalogHandle,
+                Set<ConnectorCapabilities> connectorCapabilities)
         {
             this.typeManager = requireNonNull(typeManager, "typeManager is null");
             this.tablePropertyManager = requireNonNull(tablePropertyManager, "tablePropertyManager is null");
             this.columnPropertyManager = requireNonNull(columnPropertyManager, "columnPropertyManager is null");
             this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
+            this.connectorCapabilities = requireNonNull(immutableEnumSet(connectorCapabilities), "connectorCapabilities is null");
         }
 
         @Override
         public void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
         {
-            createTableCallCount.incrementAndGet();
+            tables.add(tableMetadata);
             if (!ignoreExisting) {
                 throw new PrestoException(ALREADY_EXISTS, "Table already exists");
             }
@@ -190,13 +250,29 @@ public class TestCreateTableTask
 
         public int getCreateTableCallCount()
         {
-            return createTableCallCount.get();
+            return tables.size();
+        }
+
+        public List<ConnectorTableMetadata> getReceivedTableMetadata()
+        {
+            return tables;
         }
 
         @Override
         public void dropColumn(Session session, TableHandle tableHandle, ColumnHandle column)
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId catalogName)
+        {
+            return connectorCapabilities;
+        }
+
+        public void setConnectorCapabilities(ConnectorCapabilities... connectorCapabilities)
+        {
+            this.connectorCapabilities = immutableEnumSet(ImmutableList.copyOf(connectorCapabilities));
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
@@ -511,6 +512,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public boolean catalogExists(Session session, String catalogName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId catalogName)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.plugin.mysql;
 
 import com.facebook.presto.testing.MaterializedResult;
-import com.facebook.presto.tests.AbstractTestQueries;
+import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import io.airlift.testing.mysql.TestingMySqlServer;
 import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
@@ -27,7 +27,7 @@ import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 
 @Test
 public class TestMySqlDistributedQueries
-        extends AbstractTestQueries
+        extends AbstractTestDistributedQueries
 {
     private final TestingMySqlServer mysqlServer;
 
@@ -41,6 +41,12 @@ public class TestMySqlDistributedQueries
     {
         super(() -> createMySqlQueryRunner(mysqlServer, TpchTable.getTables()));
         this.mysqlServer = mysqlServer;
+    }
+
+    @Override
+    protected boolean supportsViews()
+    {
+        return false;
     }
 
     @AfterClass(alwaysRun = true)
@@ -79,6 +85,19 @@ public class TestMySqlDistributedQueries
     public void testDescribeOutputNamedAndUnnamed()
     {
         // this connector uses a non-canonical type for varchar columns in tpch
+    }
+
+    @Override
+    public void testInsert()
+    {
+        // no op -- test not supported due to lack of support for array types.  See
+        // TestMySqlIntegrationSmokeTest for insertion tests.
+    }
+
+    @Override
+    public void testDelete()
+    {
+        // Delete is currently unsupported
     }
 
     // MySQL specific tests should normally go in TestMySqlIntegrationSmokeTest

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
@@ -117,7 +117,7 @@ public class TestMySqlTypeMapping
                 .addRoundTrip(stringDataType("mediumtext", createVarcharType(16777215)), "c")
                 .addRoundTrip(stringDataType("longtext", createUnboundedVarcharType()), "d")
                 .addRoundTrip(varcharDataType(32), "e")
-                .addRoundTrip(varcharDataType(20000), "f")
+                .addRoundTrip(varcharDataType(15000), "f")
                 .execute(getQueryRunner(), mysqlCreateAndInsert("tpch.mysql_test_parameterized_varchar"));
     }
 

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -129,7 +129,7 @@ tableElement
     ;
 
 columnDefinition
-    : identifier type (COMMENT string)? (WITH properties)?
+    : identifier type (NOT NULL)? (COMMENT string)? (WITH properties)?
     ;
 
 likeClause

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -870,11 +870,16 @@ public final class SqlFormatter
 
         private String formatColumnDefinition(ColumnDefinition column)
         {
-            return formatExpression(column.getName(), parameters) + " " + column.getType() +
-                    column.getComment()
-                            .map(comment -> " COMMENT " + formatStringLiteral(comment))
-                            .orElse("") +
-                    formatPropertiesSingleLine(column.getProperties());
+            StringBuilder sb = new StringBuilder()
+                    .append(formatExpression(column.getName(), parameters))
+                    .append(" ").append(column.getType());
+            if (!column.isNullable()) {
+                sb.append(" NOT NULL");
+            }
+            column.getComment().ifPresent(comment ->
+                    sb.append(" COMMENT ").append(formatStringLiteral(comment)));
+            sb.append(formatPropertiesSingleLine(column.getProperties()));
+            return sb.toString();
         }
 
         private static String formatGrantor(GrantorSpecification grantor)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1552,11 +1552,13 @@ class AstBuilder
             properties = visit(context.properties().property(), Property.class);
         }
 
+        boolean nullable = context.NOT() == null;
+
         return new ColumnDefinition(
                 getLocation(context),
                 (Identifier) visit(context.identifier()),
                 getType(context.type()),
-                properties,
+                nullable, properties,
                 comment);
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/testing/TreeAssertions.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/testing/TreeAssertions.java
@@ -63,9 +63,7 @@ public final class TreeAssertions
             return sqlParser.createStatement(sql, parsingOptions);
         }
         catch (ParsingException e) {
-            throw new AssertionError(format(
-                    "failed to parse formatted SQL: %s\nerror: %s\ntree: %s",
-                    sql, e.getMessage(), tree));
+            throw new AssertionError(format("failed to parse formatted SQL: %s\nerror: %s\ntree: %s", sql, e.getMessage(), tree), e);
         }
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ColumnDefinition.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ColumnDefinition.java
@@ -27,24 +27,25 @@ public final class ColumnDefinition
 {
     private final Identifier name;
     private final String type;
+    private final boolean nullable;
     private final List<Property> properties;
     private final Optional<String> comment;
 
-    public ColumnDefinition(Identifier name, String type, List<Property> properties, Optional<String> comment)
+    public ColumnDefinition(Identifier name, String type, boolean nullable, List<Property> properties, Optional<String> comment)
     {
-        this(Optional.empty(), name, type, properties, comment);
+        this(Optional.empty(), name, type, nullable, properties, comment);
     }
 
-    public ColumnDefinition(NodeLocation location, Identifier name, String type, List<Property> properties, Optional<String> comment)
+    public ColumnDefinition(NodeLocation location, Identifier name, String type, boolean nullable, List<Property> properties, Optional<String> comment)
     {
-        this(Optional.of(location), name, type, properties, comment);
+        this(Optional.of(location), name, type, nullable, properties, comment);
     }
-
-    private ColumnDefinition(Optional<NodeLocation> location, Identifier name, String type, List<Property> properties, Optional<String> comment)
+    private ColumnDefinition(Optional<NodeLocation> location, Identifier name, String type, boolean nullable, List<Property> properties, Optional<String> comment)
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
         this.type = requireNonNull(type, "type is null");
+        this.nullable = nullable;
         this.properties = requireNonNull(properties, "properties is null");
         this.comment = requireNonNull(comment, "comment is null");
     }
@@ -57,6 +58,11 @@ public final class ColumnDefinition
     public String getType()
     {
         return type;
+    }
+
+    public boolean isNullable()
+    {
+        return nullable;
     }
 
     public List<Property> getProperties()
@@ -93,6 +99,7 @@ public final class ColumnDefinition
         ColumnDefinition o = (ColumnDefinition) obj;
         return Objects.equals(this.name, o.name) &&
                 Objects.equals(this.type, o.type) &&
+                this.nullable == o.nullable &&
                 Objects.equals(properties, o.properties) &&
                 Objects.equals(this.comment, o.comment);
     }
@@ -100,7 +107,7 @@ public final class ColumnDefinition
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, type, properties, comment);
+        return Objects.hash(name, type, properties, comment, nullable);
     }
 
     @Override
@@ -109,6 +116,7 @@ public final class ColumnDefinition
         return toStringHelper(this)
                 .add("name", name)
                 .add("type", type)
+                .add("nullable", nullable)
                 .add("properties", properties)
                 .add("comment", comment)
                 .toString();

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1061,15 +1061,15 @@ public class TestSqlParser
         assertStatement("CREATE TABLE foo (a VARCHAR, b BIGINT COMMENT 'hello world', c IPADDRESS)",
                 new CreateTable(QualifiedName.of("foo"),
                         ImmutableList.of(
-                                new ColumnDefinition(identifier("a"), "VARCHAR", emptyList(), Optional.empty()),
-                                new ColumnDefinition(identifier("b"), "BIGINT", emptyList(), Optional.of("hello world")),
-                                new ColumnDefinition(identifier("c"), "IPADDRESS", emptyList(), Optional.empty())),
+                                new ColumnDefinition(identifier("a"), "VARCHAR", true, emptyList(), Optional.empty()),
+                                new ColumnDefinition(identifier("b"), "BIGINT", true, emptyList(), Optional.of("hello world")),
+                                new ColumnDefinition(identifier("c"), "IPADDRESS", true, emptyList(), Optional.empty())),
                         false,
                         ImmutableList.of(),
                         Optional.empty()));
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP)",
                 new CreateTable(QualifiedName.of("bar"),
-                        ImmutableList.of(new ColumnDefinition(identifier("c"), "TIMESTAMP", emptyList(), Optional.empty())),
+                        ImmutableList.of(new ColumnDefinition(identifier("c"), "TIMESTAMP", true, emptyList(), Optional.empty())),
                         true,
                         ImmutableList.of(),
                         Optional.empty()));
@@ -1077,7 +1077,7 @@ public class TestSqlParser
         // with properties
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP WITH (nullable = true, compression = 'LZ4'))",
                 new CreateTable(QualifiedName.of("bar"),
-                        ImmutableList.of(new ColumnDefinition(identifier("c"), "TIMESTAMP", ImmutableList.of(
+                        ImmutableList.of(new ColumnDefinition(identifier("c"), "TIMESTAMP", true, ImmutableList.of(
                                 new Property(new Identifier("nullable"), BooleanLiteral.TRUE_LITERAL),
                                 new Property(new Identifier("compression"), new StringLiteral("LZ4"))
                         ), Optional.empty())),
@@ -1097,7 +1097,7 @@ public class TestSqlParser
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP, LIKE like_table)",
                 new CreateTable(QualifiedName.of("bar"),
                         ImmutableList.of(
-                                new ColumnDefinition(identifier("c"), "TIMESTAMP", emptyList(), Optional.empty()),
+                                new ColumnDefinition(identifier("c"), "TIMESTAMP", true, emptyList(), Optional.empty()),
                                 new LikeClause(QualifiedName.of("like_table"),
                                         Optional.empty())),
                         true,
@@ -1106,10 +1106,10 @@ public class TestSqlParser
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP, LIKE like_table, d DATE)",
                 new CreateTable(QualifiedName.of("bar"),
                         ImmutableList.of(
-                                new ColumnDefinition(identifier("c"), "TIMESTAMP", emptyList(), Optional.empty()),
+                                new ColumnDefinition(identifier("c"), "TIMESTAMP", true, emptyList(), Optional.empty()),
                                 new LikeClause(QualifiedName.of("like_table"),
                                         Optional.empty()),
-                                new ColumnDefinition(identifier("d"), "DATE", emptyList(), Optional.empty())),
+                                new ColumnDefinition(identifier("d"), "DATE", true, emptyList(), Optional.empty())),
                         true,
                         ImmutableList.of(),
                         Optional.empty()));
@@ -1124,7 +1124,7 @@ public class TestSqlParser
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP, LIKE like_table EXCLUDING PROPERTIES)",
                 new CreateTable(QualifiedName.of("bar"),
                         ImmutableList.of(
-                                new ColumnDefinition(identifier("c"), "TIMESTAMP", emptyList(), Optional.empty()),
+                                new ColumnDefinition(identifier("c"), "TIMESTAMP", true, emptyList(), Optional.empty()),
                                 new LikeClause(QualifiedName.of("like_table"),
                                         Optional.of(LikeClause.PropertiesOption.EXCLUDING))),
                         true,
@@ -1133,12 +1133,33 @@ public class TestSqlParser
         assertStatement("CREATE TABLE IF NOT EXISTS bar (c TIMESTAMP, LIKE like_table EXCLUDING PROPERTIES) COMMENT 'test'",
                 new CreateTable(QualifiedName.of("bar"),
                         ImmutableList.of(
-                                new ColumnDefinition(identifier("c"), "TIMESTAMP", emptyList(), Optional.empty()),
+                                new ColumnDefinition(identifier("c"), "TIMESTAMP", true, emptyList(), Optional.empty()),
                                 new LikeClause(QualifiedName.of("like_table"),
                                         Optional.of(LikeClause.PropertiesOption.EXCLUDING))),
                         true,
                         ImmutableList.of(),
                         Optional.of("test")));
+    }
+
+    @Test
+    public void testCreateTableWithNotNull()
+    {
+        assertStatement(
+                "CREATE TABLE foo (" +
+                        "a VARCHAR NOT NULL COMMENT 'column a', " +
+                        "b BIGINT COMMENT 'hello world', " +
+                        "c IPADDRESS, " +
+                        "d DATE NOT NULL)",
+                new CreateTable(
+                        QualifiedName.of("foo"),
+                        ImmutableList.of(
+                                new ColumnDefinition(identifier("a"), "VARCHAR", false, emptyList(), Optional.of("column a")),
+                                new ColumnDefinition(identifier("b"), "BIGINT", true, emptyList(), Optional.of("hello world")),
+                                new ColumnDefinition(identifier("c"), "IPADDRESS", true, emptyList(), Optional.empty()),
+                                new ColumnDefinition(identifier("d"), "DATE", false, emptyList(), Optional.empty())),
+                        false,
+                        ImmutableList.of(),
+                        Optional.empty()));
     }
 
     @Test
@@ -1362,7 +1383,9 @@ public class TestSqlParser
     public void testAddColumn()
     {
         assertStatement("ALTER TABLE foo.t ADD COLUMN c bigint", new AddColumn(QualifiedName.of("foo", "t"),
-                new ColumnDefinition(identifier("c"), "bigint", emptyList(), Optional.empty())));
+                new ColumnDefinition(identifier("c"), "bigint", true, emptyList(), Optional.empty())));
+        assertStatement("ALTER TABLE foo.t ADD COLUMN d double NOT NULL", new AddColumn(QualifiedName.of("foo", "t"),
+                new ColumnDefinition(identifier("d"), "double", false, emptyList(), Optional.empty())));
     }
 
     @Test

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -17,7 +17,9 @@ import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
 import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
-import com.facebook.presto.plugin.jdbc.JdbcOutputTableHandle;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.Type;
 import org.postgresql.Driver;
 
@@ -29,33 +31,20 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static java.lang.String.format;
 
 public class PostgreSqlClient
         extends BaseJdbcClient
 {
+    private static final String DUPLICATE_TABLE_SQLSTATE = "42P07";
+
     @Inject
     public PostgreSqlClient(JdbcConnectorId connectorId, BaseJdbcConfig config)
     {
         super(connectorId, config, "\"", new DriverConnectionFactory(new Driver(), config));
-    }
-
-    @Override
-    public void commitCreateTable(JdbcOutputTableHandle handle)
-    {
-        // PostgreSQL does not allow qualifying the target of a rename
-        StringBuilder sql = new StringBuilder()
-                .append("ALTER TABLE ")
-                .append(quoted(handle.getCatalogName(), handle.getSchemaName(), handle.getTemporaryTableName()))
-                .append(" RENAME TO ")
-                .append(quoted(handle.getTableName()));
-
-        try (Connection connection = getConnection(handle)) {
-            execute(connection, sql.toString());
-        }
-        catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @Override
@@ -89,5 +78,35 @@ public class PostgreSqlClient
         }
 
         return super.toSqlType(type);
+    }
+
+    @Override
+    public void createTable(ConnectorTableMetadata tableMetadata)
+    {
+        try {
+            createTable(tableMetadata, tableMetadata.getTable().getTableName());
+        }
+        catch (SQLException e) {
+            if (DUPLICATE_TABLE_SQLSTATE.equals(e.getSQLState())) {
+                throw new PrestoException(ALREADY_EXISTS, e);
+            }
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
+    protected void renameTable(String catalogName, SchemaTableName oldTable, SchemaTableName newTable)
+    {
+        // PostgreSQL does not allow qualifying the target of a rename
+        try (Connection connection = connectionFactory.openConnection()) {
+            String sql = format(
+                    "ALTER TABLE %s RENAME TO %s",
+                    quoted(catalogName, oldTable.getSchemaName(), oldTable.getTableName()),
+                    quoted(newTable.getTableName()));
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
     }
 }

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.plugin.postgresql;
 
-import com.facebook.presto.tests.AbstractTestQueries;
+import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
 import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
@@ -25,7 +25,7 @@ import static com.facebook.presto.plugin.postgresql.PostgreSqlQueryRunner.create
 
 @Test
 public class TestPostgreSqlDistributedQueries
-        extends AbstractTestQueries
+        extends AbstractTestDistributedQueries
 {
     private final TestingPostgreSqlServer postgreSqlServer;
 
@@ -41,11 +41,30 @@ public class TestPostgreSqlDistributedQueries
         this.postgreSqlServer = postgreSqlServer;
     }
 
+    @Override
+    protected boolean supportsViews()
+    {
+        return false;
+    }
+
     @AfterClass(alwaysRun = true)
     public final void destroy()
             throws IOException
     {
         postgreSqlServer.close();
+    }
+
+    @Override
+    public void testInsert()
+    {
+        // no op -- test not supported due to lack of support for array types.  See
+        // TestPostgreSqlIntegrationSmokeTest for insertion tests.
+    }
+
+    @Override
+    public void testDelete()
+    {
+        // Delete is currently unsupported
     }
 
     // PostgreSQL specific tests should normally go in TestPostgreSqlIntegrationSmokeTest

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorDistributedQueries.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorDistributedQueries.java
@@ -31,4 +31,10 @@ public class TestRaptorDistributedQueries
     {
         super(supplier);
     }
+
+    @Override
+    protected boolean supportsNotNullColumns()
+    {
+        return false;
+    }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorDistributedQueriesBucketed.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorDistributedQueriesBucketed.java
@@ -24,4 +24,10 @@ public class TestRaptorDistributedQueriesBucketed
     {
         super(() -> createRaptorQueryRunner(ImmutableMap.of(), true, true));
     }
+
+    @Override
+    protected boolean supportsNotNullColumns()
+    {
+        return false;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ColumnMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ColumnMetadata.java
@@ -29,6 +29,7 @@ public class ColumnMetadata
 {
     private final String name;
     private final Type type;
+    private final boolean nullable;
     private final String comment;
     private final String extraInfo;
     private final boolean hidden;
@@ -36,20 +37,25 @@ public class ColumnMetadata
 
     public ColumnMetadata(String name, Type type)
     {
-        this(name, type, null, null, false, emptyMap());
+        this(name, type, true, null, null, false, emptyMap());
     }
 
     public ColumnMetadata(String name, Type type, String comment, boolean hidden)
     {
-        this(name, type, comment, null, hidden, emptyMap());
+        this(name, type, true, comment, null, hidden, emptyMap());
     }
 
     public ColumnMetadata(String name, Type type, String comment, String extraInfo, boolean hidden)
     {
-        this(name, type, comment, extraInfo, hidden, emptyMap());
+        this(name, type, true, comment, extraInfo, hidden, emptyMap());
     }
 
     public ColumnMetadata(String name, Type type, String comment, String extraInfo, boolean hidden, Map<String, Object> properties)
+    {
+        this(name, type, true, comment, extraInfo, hidden, properties);
+    }
+
+    public ColumnMetadata(String name, Type type, boolean nullable, String comment, String extraInfo, boolean hidden, Map<String, Object> properties)
     {
         checkNotEmpty(name, "name");
         requireNonNull(type, "type is null");
@@ -61,6 +67,7 @@ public class ColumnMetadata
         this.extraInfo = extraInfo;
         this.hidden = hidden;
         this.properties = properties.isEmpty() ? emptyMap() : unmodifiableMap(new LinkedHashMap<>(properties));
+        this.nullable = nullable;
     }
 
     public String getName()
@@ -71,6 +78,11 @@ public class ColumnMetadata
     public Type getType()
     {
         return type;
+    }
+
+    public boolean isNullable()
+    {
+        return nullable;
     }
 
     public String getComment()
@@ -99,6 +111,7 @@ public class ColumnMetadata
         StringBuilder sb = new StringBuilder("ColumnMetadata{");
         sb.append("name='").append(name).append('\'');
         sb.append(", type=").append(type);
+        sb.append(", ").append(nullable ? "nullable" : "nonnull");
         if (comment != null) {
             sb.append(", comment='").append(comment).append('\'');
         }
@@ -118,7 +131,7 @@ public class ColumnMetadata
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, type, comment, extraInfo, hidden);
+        return Objects.hash(name, type, nullable, comment, extraInfo, hidden);
     }
 
     @Override
@@ -133,6 +146,7 @@ public class ColumnMetadata
         ColumnMetadata other = (ColumnMetadata) obj;
         return Objects.equals(this.name, other.name) &&
                 Objects.equals(this.type, other.type) &&
+                Objects.equals(this.nullable, other.nullable) &&
                 Objects.equals(this.comment, other.comment) &&
                 Objects.equals(this.extraInfo, other.extraInfo) &&
                 Objects.equals(this.hidden, other.hidden);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
@@ -173,4 +173,9 @@ public interface Connector
      * have been returned from the connector.
      */
     default void shutdown() {}
+
+    default Set<ConnectorCapabilities> getCapabilities()
+    {
+        return emptySet();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCapabilities.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCapabilities.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.connector;
+
+public enum ConnectorCapabilities
+{
+    NOT_NULL_COLUMN_CONSTRAINT,
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -193,7 +193,7 @@ public class H2QueryRunner
                     throws SQLException
             {
                 int count = resultSet.getMetaData().getColumnCount();
-                checkArgument(types.size() == count, "type does not match result");
+                checkArgument(types.size() == count, "expected types count (%s) does not match actual column count (%s)", types.size(), count);
                 List<Object> row = new ArrayList<>(count);
                 for (int i = 1; i <= count; i++) {
                     Type type = types.get(i - 1);

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -286,7 +286,7 @@ public class TpchMetadata
     {
         ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
         for (TpchColumn<? extends TpchEntity> column : tpchTable.getColumns()) {
-            columns.add(new ColumnMetadata(columnNaming.getName(column), getPrestoType(column)));
+            columns.add(new ColumnMetadata(columnNaming.getName(column), getPrestoType(column), false, null, null, false, emptyMap()));
         }
         columns.add(new ColumnMetadata(ROW_NUMBER_COLUMN_NAME, BIGINT, null, true));
 


### PR DESCRIPTION
Split out from #11490

* Introduce support for `NOT NULL` in DDL.  Connectors can opt-in to this by turning on `ConnectorMetadata#supportsNotNullColumns`.
* Add support for `CREATE TABLE`, `ADD COLUMN`, `DROP COLUMN`, `RENAME COLUMN`, `RENAME TABLE` in JDBC connectors
* Enable `NOT NULL` for JDBC connectors

