### PR TITLE
Add support for writing ORC files with ZSTD compression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -892,6 +892,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>1.3.5-4</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>3.4.9</version>

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -92,6 +92,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.checkpoint.InputStreamCheckpoint;
 import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.zstd.ZstdJniCompressor;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.compress.Compressor;
 import io.airlift.compress.lz4.Lz4Compressor;
@@ -96,6 +97,9 @@ public class OrcOutputBuffer
         }
         else if (compression == CompressionKind.LZ4) {
             this.compressor = new Lz4Compressor();
+        }
+        else if (compression == CompressionKind.ZSTD) {
+            this.compressor = new ZstdJniCompressor();
         }
         else {
             throw new IllegalArgumentException("Unsupported compression " + compression);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
@@ -365,6 +365,8 @@ public class OrcMetadataWriter
                 return OrcProto.CompressionKind.SNAPPY;
             case LZ4:
                 return OrcProto.CompressionKind.LZ4;
+            case ZSTD:
+                return OrcProto.CompressionKind.ZSTD;
         }
         throw new IllegalArgumentException("Unsupported compression kind: " + compressionKind);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdJniCompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdJniCompressor.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.zstd;
+
+import com.github.luben.zstd.Zstd;
+import io.airlift.compress.Compressor;
+
+import java.nio.ByteBuffer;
+
+import static java.lang.Math.toIntExact;
+
+public class ZstdJniCompressor
+        implements Compressor
+{
+    private static final int COMPRESSION_LEVEL = 3; // default level
+
+    @Override
+    public int maxCompressedLength(int uncompressedSize)
+    {
+        return toIntExact(Zstd.compressBound(uncompressedSize));
+    }
+
+    @Override
+    public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+    {
+        long size = Zstd.compressByteArray(output, outputOffset, maxOutputLength, input, inputOffset, inputLength, COMPRESSION_LEVEL);
+        if (Zstd.isError(size)) {
+            throw new RuntimeException(Zstd.getErrorName(size));
+        }
+        return toIntExact(size);
+    }
+
+    @Override
+    public void compress(ByteBuffer input, ByteBuffer output)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -118,6 +118,7 @@ import static com.facebook.presto.orc.metadata.CompressionKind.LZ4;
 import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
+import static com.facebook.presto.orc.metadata.CompressionKind.ZSTD;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
@@ -273,7 +274,7 @@ public class OrcTester
         orcTester.skipBatchTestsEnabled = true;
         orcTester.skipStripeTestsEnabled = true;
         orcTester.formats = ImmutableSet.copyOf(Format.values());
-        orcTester.compressions = ImmutableSet.of(NONE, SNAPPY, ZLIB, LZ4);
+        orcTester.compressions = ImmutableSet.of(NONE, SNAPPY, ZLIB, LZ4, ZSTD);
         return orcTester;
     }
 
@@ -473,7 +474,7 @@ public class OrcTester
 
             OrcEncoding orcEncoding = format.getOrcEncoding();
             for (CompressionKind compression : compressions) {
-                boolean hiveSupported = (compression != LZ4);
+                boolean hiveSupported = (compression != LZ4) && (compression != ZSTD);
 
                 // write Hive, read Presto
                 if (hiveSupported) {


### PR DESCRIPTION
This will allow Raptor v2 to use ZSTD.