### PR TITLE
Make JoinUtils public

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinUtils.java
@@ -19,7 +19,10 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
-final class JoinUtils
+/**
+ * This class must be public as it is accessed via join compiler reflection.
+ */
+public final class JoinUtils
 {
     private JoinUtils() {}
 


### PR DESCRIPTION
JoinHashSupplier can be isolated via
JoinCompiler#internalCompileLookupSourceFactory.
In such case it cannot access package private
JoinUtils. We get errors like:

com.facebook.presto.sql.gen.JoinCompiler$LookupSourceSupplierFactory.createLookupSourceSupplier(JoinCompiler.java:926)
	... 32 more
Caused by: java.lang.IllegalAccessError: com/facebook/presto/operator/JoinUtils
	at com.facebook.presto.operator.JoinHashSupplier.<init>(JoinHashSupplier.java:72)

Therefore JoinUtils needs to be public