### PR TITLE
Fix JDBC connectors to clean up temp table after exception

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -200,7 +200,9 @@ public class JdbcMetadata
     @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        return jdbcClient.beginInsertTable(getTableMetadata(session, tableHandle));
+        JdbcOutputTableHandle handle = jdbcClient.beginInsertTable(getTableMetadata(session, tableHandle));
+        setRollback(() -> jdbcClient.rollbackCreateTable(handle));
+        return handle;
     }
 
     @Override


### PR DESCRIPTION
JDBC based connectors use the following strategy to insert into the
destination table:

* Create a temp table which has the same columns as the destination
table
* Direct JdbcPageSink to write to this temp table
* Select into the destination table from the temp table

If an exception occurs during the write, then no attempt is made to
clean up this temp table.  This commit adds code to attempt this clean
up during the phases where we could receive errors from the destination
database and which may result in orphaned tables.