### PR TITLE
Add SphericalGeography type and ST_Distance support for points on a sphere

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -9,7 +9,7 @@ geometries that are operated on are both simple and valid. For example, it does 
 make sense to calculate the area of a polygon that has a hole defined outside of the
 polygon, or to construct a polygon from a non-simple boundary line.
 
-Presto Geospatial functions support the Well-Known Text (WKT) form of spatial objects:
+Presto Geospatial functions support the Well-Known Text (WKT) and Well-Known Binary (WKB) form of spatial objects:
 
 * ``POINT (0 0)``
 * ``LINESTRING (0 0, 1 1, 1 2)``
@@ -18,6 +18,26 @@ Presto Geospatial functions support the Well-Known Text (WKT) form of spatial ob
 * ``MULTILINESTRING ((0 0, 1 1, 1 2), (2 3, 3 2, 5 4))``
 * ``MULTIPOLYGON (((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1)), ((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)))``
 * ``GEOMETRYCOLLECTION (POINT(2 3), LINESTRING (2 3, 3 4))``
+
+Use ST_GeometryFromText and ST_GeomFromBinary functions to create geometry objects from WKT or WKB.
+
+The SphericalGeography type provides native support for spatial features represented on "geographic" coordinates (sometimes called "geodetic" coordinates,
+or "lat/lon", or "lon/lat"). Geographic coordinates are spherical coordinates expressed in angular units (degrees).
+
+The basis for the Geometry type is a plane. The shortest path between two points on the plane is a straight line. That means calculations on geometries (areas, distances, lengths,
+intersections, etc) can be calculated using cartesian mathematics and straight line vectors.
+
+The basis for the SphericalGeography type is a sphere. The shortest path between two points on the sphere is a great circle arc. That means that calculations on geographies
+(areas, distances, lengths, intersections, etc) must be calculated on the sphere, using more complicated mathematics. More accurate measurements that take the actual spheroidal
+shape of the world into account are not supported.
+
+Values returned by the measurement functions ST_Distance and ST_Length are in the unit of meters; values returned by ST_Area are in square meters.
+
+Use ``to_spherical_geography()`` function to convert a geometry object to geography object.
+
+For example, ``ST_Distance(ST_Point(-71.0882, 42.3607), ST_Point(-74.1197, 40.6976))`` returns 3.4577 in the unit of the passed-in values on the euclidean plane, while
+``ST_Distance(to_spherical_geography(ST_Point(-71.0882, 42.3607)), to_spherical_geography(ST_Point(-74.1197, 40.6976)))`` returns 312822.179 in meters.
+
 
 Constructors
 ------------
@@ -65,6 +85,17 @@ Constructors
 .. function:: ST_Polygon(varchar) -> Polygon
 
     Returns a geometry type polygon object from WKT representation.
+
+.. function:: to_spherical_geography(Geometry) -> SphericalGeography
+
+    Converts a Geometry object to a SphericalGeography object on the sphere of the Earth's radius. This function is only applicable to ``POINT``,
+    ``MULTIPOINT``, ``LINESTRING``, ``MULTILINESTRING``, ``POLYGON``, ``MULTIPOLYGON`` geometries defined in 2D space, or ``GEOMETRYCOLLECTION``
+    of such geometries. For each point of the input geometry, it verifies that point.x is within [-180.0, 180.0] and point.y is within [-90.0, 90.0],
+    and uses them as (longitude, latitude) degrees to construct the shape of the SphericalGeography result.
+
+.. function:: to_geometry(SphericalGeography) -> Geometry
+
+    Converts a SphericalGeography object to a Geometry object.
 
 Relationship Tests
 ------------------
@@ -193,6 +224,10 @@ Accessors
 
     Returns the 2-dimensional cartesian minimum distance (based on spatial ref)
     between two geometries in projected units.
+
+.. function:: ST_Distance(SphericalGeography, SphericalGeography) -> double
+
+    Returns the great-circle distance in meters between two SphericalGeography points.
 
 .. function:: ST_GeometryN(Geometry, index) -> Geometry
 

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -67,6 +67,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 
+import static com.esri.core.geometry.Geometry.Type;
 import static com.esri.core.geometry.NonSimpleResult.Reason.Clustering;
 import static com.esri.core.geometry.NonSimpleResult.Reason.Cracking;
 import static com.esri.core.geometry.NonSimpleResult.Reason.CrossOver;
@@ -88,6 +89,7 @@ import static com.facebook.presto.geospatial.serde.GeometrySerde.deserializeType
 import static com.facebook.presto.geospatial.serde.GeometrySerde.serialize;
 import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY;
 import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY_TYPE_NAME;
+import static com.facebook.presto.plugin.geospatial.SphericalGeographyType.SPHERICAL_GEOGRAPHY_TYPE_NAME;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.StandardTypes.BIGINT;
 import static com.facebook.presto.spi.type.StandardTypes.BOOLEAN;
@@ -129,6 +131,14 @@ public final class GeoFunctions
             .build();
     private static final int NUMBER_OF_DIMENSIONS = 3;
     private static final Block EMPTY_ARRAY_OF_INTS = IntegerType.INTEGER.createFixedSizeBlockBuilder(0).build();
+
+    private static final float MIN_LATITUDE = -90;
+    private static final float MAX_LATITUDE = 90;
+    private static final float MIN_LONGITUDE = -180;
+    private static final float MAX_LONGITUDE = 180;
+
+    private static final EnumSet<Type> GEOMETRY_TYPES_FOR_SPHERICAL_GEOGRAPHY = EnumSet.of(
+            Type.Point, Type.Polyline, Type.Polygon, Type.MultiPoint);
 
     private GeoFunctions() {}
 
@@ -270,6 +280,48 @@ public final class GeoFunctions
     public static Slice stGeomFromBinary(@SqlType(VARBINARY) Slice input)
     {
         return serialize(geomFromBinary(input));
+    }
+
+    @Description("Converts a Geometry object to a SphericalGeography object")
+    @ScalarFunction("to_spherical_geography")
+    @SqlType(SPHERICAL_GEOGRAPHY_TYPE_NAME)
+    public static Slice toSphericalGeography(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
+    {
+        // "every point in input is in range" <=> "the envelope of input is in range"
+        Envelope envelope = deserializeEnvelope(input);
+        if (envelope != null) {
+            checkLatitude(envelope.getYMin());
+            checkLatitude(envelope.getYMax());
+            checkLongitude(envelope.getXMin());
+            checkLongitude(envelope.getXMax());
+        }
+        OGCGeometry geometry = deserialize(input);
+        if (geometry.is3D()) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Cannot convert 3D geometry to a spherical geography");
+        }
+
+        GeometryCursor cursor = geometry.getEsriGeometryCursor();
+        while (true) {
+            com.esri.core.geometry.Geometry subGeometry = cursor.next();
+            if (subGeometry == null) {
+                break;
+            }
+
+            if (!GEOMETRY_TYPES_FOR_SPHERICAL_GEOGRAPHY.contains(subGeometry.getType())) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Cannot convert geometry of this type to spherical geography: " + subGeometry.getType());
+            }
+        }
+
+        return input;
+    }
+
+    @Description("Converts a SphericalGeography object to a Geometry object.")
+    @ScalarFunction("to_geometry")
+    @SqlType(GEOMETRY_TYPE_NAME)
+    public static Slice toGeometry(@SqlType(SPHERICAL_GEOGRAPHY_TYPE_NAME) Slice input)
+    {
+        // Every SphericalGeography object is a valid geometry object
+        return input;
     }
 
     @Description("Returns the Well-Known Text (WKT) representation of the geometry")
@@ -1229,14 +1281,14 @@ public final class GeoFunctions
 
     private static void checkLatitude(double latitude)
     {
-        if (isNaN(latitude) || isInfinite(latitude) || latitude < -90 || latitude > 90) {
+        if (Double.isNaN(latitude) || Double.isInfinite(latitude) || latitude < MIN_LATITUDE || latitude > MAX_LATITUDE) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Latitude must be between -90 and 90");
         }
     }
 
     private static void checkLongitude(double longitude)
     {
-        if (isNaN(longitude) || isInfinite(longitude) || longitude < -180 || longitude > 180) {
+        if (Double.isNaN(longitude) || Double.isInfinite(longitude) || longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Longitude must be between -180 and 180");
         }
     }
@@ -1407,6 +1459,36 @@ public final class GeoFunctions
     private interface EnvelopesPredicate
     {
         boolean apply(Envelope left, Envelope right);
+    }
+
+    @SqlNullable
+    @Description("Returns the great-circle distance in meters between two SphericalGeography points.")
+    @ScalarFunction("ST_Distance")
+    @SqlType(DOUBLE)
+    public static Double stSphericalDistance(@SqlType(SPHERICAL_GEOGRAPHY_TYPE_NAME) Slice left, @SqlType(SPHERICAL_GEOGRAPHY_TYPE_NAME) Slice right)
+    {
+        OGCGeometry leftGeometry = deserialize(left);
+        OGCGeometry rightGeometry = deserialize(right);
+        if (leftGeometry.isEmpty() || rightGeometry.isEmpty()) {
+            return null;
+        }
+
+        // TODO: support more SphericalGeography types.
+        validateSphericalType("ST_Distance", leftGeometry, EnumSet.of(POINT));
+        validateSphericalType("ST_Distance", rightGeometry, EnumSet.of(POINT));
+        Point leftPoint = (Point) leftGeometry.getEsriGeometry();
+        Point rightPoint = (Point) rightGeometry.getEsriGeometry();
+
+        // greatCircleDistance returns distance in KM.
+        return greatCircleDistance(leftPoint.getY(), leftPoint.getX(), rightPoint.getY(), rightPoint.getX()) * 1000;
+    }
+
+    private static void validateSphericalType(String function, OGCGeometry geometry, Set<GeometryType> validTypes)
+    {
+        GeometryType type = GeometryType.getForEsriGeometryType(geometry.geometryType());
+        if (!validTypes.contains(type)) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("When applied to SphericalGeography inputs, %s only supports %s. Input type is: %s", function, OR_JOINER.join(validTypes), type));
+        }
     }
 
     private static Iterable<Slice> getGeometrySlicesFromBlock(Block block)

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoPlugin.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoPlugin.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import static com.facebook.presto.plugin.geospatial.BingTileType.BING_TILE;
 import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY;
 import static com.facebook.presto.plugin.geospatial.KdbTreeType.KDB_TREE;
+import static com.facebook.presto.plugin.geospatial.SphericalGeographyType.SPHERICAL_GEOGRAPHY;
 
 public class GeoPlugin
         implements Plugin
@@ -33,7 +34,7 @@ public class GeoPlugin
     @Override
     public Iterable<Type> getTypes()
     {
-        return ImmutableList.of(GEOMETRY, BING_TILE, KDB_TREE);
+        return ImmutableList.of(GEOMETRY, BING_TILE, KDB_TREE, SPHERICAL_GEOGRAPHY);
     }
 
     @Override

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/SphericalGeographyType.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/SphericalGeographyType.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.AbstractVariableWidthType;
+import com.facebook.presto.spi.type.TypeSignature;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.geospatial.serde.GeometrySerde.deserialize;
+
+public class SphericalGeographyType
+        extends AbstractVariableWidthType
+{
+    public static final SphericalGeographyType SPHERICAL_GEOGRAPHY = new SphericalGeographyType();
+    public static final String SPHERICAL_GEOGRAPHY_TYPE_NAME = "SphericalGeography";
+
+    private SphericalGeographyType()
+    {
+        super(new TypeSignature(SPHERICAL_GEOGRAPHY_TYPE_NAME), Slice.class);
+    }
+
+    protected SphericalGeographyType(TypeSignature signature)
+    {
+        super(signature, Slice.class);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else {
+            block.writeBytesTo(position, 0, block.getSliceLength(position), blockBuilder);
+            blockBuilder.closeEntry();
+        }
+    }
+
+    @Override
+    public Slice getSlice(Block block, int position)
+    {
+        return block.getSlice(position, 0, block.getSliceLength(position));
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value)
+    {
+        writeSlice(blockBuilder, value, 0, value.length());
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        blockBuilder.writeBytes(value, offset, length).closeEntry();
+    }
+
+    @Override
+    public Object getObjectValue(ConnectorSession session, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+        Slice slice = block.getSlice(position, 0, block.getSliceLength(position));
+        return deserialize(slice).asText();
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestExtractSpatialInnerJoin.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestExtractSpatialInnerJoin.java
@@ -17,10 +17,12 @@ import com.facebook.presto.sql.planner.iterative.rule.ExtractSpatialJoins.Extrac
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY;
+import static com.facebook.presto.plugin.geospatial.SphericalGeographyType.SPHERICAL_GEOGRAPHY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
@@ -73,6 +75,40 @@ public class TestExtractSpatialInnerJoin
                                 p.join(INNER,
                                         p.values(p.symbol("a", GEOMETRY)),
                                         p.values(p.symbol("b", GEOMETRY)))))
+                .doesNotFire();
+
+        // SphericalGeography operand
+        assertRuleApplication()
+                .on(p ->
+                        p.filter(PlanBuilder.expression("ST_Distance(a, b) < 5"),
+                                p.join(INNER,
+                                        p.values(p.symbol("a", SPHERICAL_GEOGRAPHY)),
+                                        p.values(p.symbol("b", SPHERICAL_GEOGRAPHY)))))
+                .doesNotFire();
+
+        assertRuleApplication()
+                .on(p ->
+                        p.filter(PlanBuilder.expression("ST_Contains(polygon, point)"),
+                                p.join(INNER,
+                                        p.values(p.symbol("polygon", SPHERICAL_GEOGRAPHY)),
+                                        p.values(p.symbol("point", SPHERICAL_GEOGRAPHY)))))
+                .doesNotFire();
+
+        // to_spherical_geography() operand
+        assertRuleApplication()
+                .on(p ->
+                        p.filter(PlanBuilder.expression("ST_Distance(to_spherical_geography(ST_GeometryFromText(wkt)), point) < 5"),
+                                p.join(INNER,
+                                        p.values(p.symbol("wkt", VARCHAR)),
+                                        p.values(p.symbol("point", SPHERICAL_GEOGRAPHY)))))
+                .doesNotFire();
+
+        assertRuleApplication()
+                .on(p ->
+                        p.filter(PlanBuilder.expression("ST_Contains(to_spherical_geography(ST_GeometryFromText(wkt)), point)"),
+                                p.join(INNER,
+                                        p.values(p.symbol("wkt", VARCHAR)),
+                                        p.values(p.symbol("point", SPHERICAL_GEOGRAPHY)))))
                 .doesNotFire();
     }
 
@@ -151,8 +187,8 @@ public class TestExtractSpatialInnerJoin
                 .on(p ->
                         p.filter(PlanBuilder.expression(filter),
                                 p.join(INNER,
-                                        p.values(p.symbol("a"), p.symbol("name_a")),
-                                        p.values(p.symbol("b"), p.symbol("name_b"), p.symbol("r")))))
+                                        p.values(p.symbol("a", GEOMETRY), p.symbol("name_a")),
+                                        p.values(p.symbol("b", GEOMETRY), p.symbol("name_b"), p.symbol("r")))))
                 .matches(
                         spatialJoin(newFilter,
                                 values(ImmutableMap.of("a", 0, "name_a", 1)),
@@ -165,8 +201,8 @@ public class TestExtractSpatialInnerJoin
                 .on(p ->
                         p.filter(PlanBuilder.expression(filter),
                                 p.join(INNER,
-                                        p.values(p.symbol("a"), p.symbol("name_a")),
-                                        p.values(p.symbol("b"), p.symbol("name_b"), p.symbol("r")))))
+                                        p.values(p.symbol("a", GEOMETRY), p.symbol("name_a")),
+                                        p.values(p.symbol("b", GEOMETRY), p.symbol("name_b"), p.symbol("r")))))
                 .matches(
                         spatialJoin(newFilter,
                                 values(ImmutableMap.of("a", 0, "name_a", 1)),
@@ -352,6 +388,7 @@ public class TestExtractSpatialInnerJoin
 
     private RuleAssert assertRuleApplication()
     {
-        return tester().assertThat(new ExtractSpatialInnerJoin(tester().getMetadata(), tester().getSplitManager(), tester().getPageSourceManager()));
+        RuleTester tester = tester();
+        return tester.assertThat(new ExtractSpatialInnerJoin(tester.getMetadata(), tester.getSplitManager(), tester.getPageSourceManager(), tester.getSqlParser()));
     }
 }

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.metadata.FunctionExtractor.extractFunctions;
+import static com.facebook.presto.plugin.geospatial.SphericalGeographyType.SPHERICAL_GEOGRAPHY;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestSphericalGeoFunctions
+        extends AbstractTestFunctions
+{
+    @BeforeClass
+    protected void registerFunctions()
+    {
+        GeoPlugin plugin = new GeoPlugin();
+        for (Type type : plugin.getTypes()) {
+            functionAssertions.getTypeRegistry().addType(type);
+        }
+        functionAssertions.getMetadata().addFunctions(extractFunctions(plugin.getFunctions()));
+    }
+
+    @Test
+    public void testGetObjectValue()
+    {
+        List<String> wktList = ImmutableList.of(
+                "POINT EMPTY",
+                "MULTIPOINT EMPTY",
+                "LINESTRING EMPTY",
+                "MULTILINESTRING EMPTY",
+                "POLYGON EMPTY",
+                "MULTIPOLYGON EMPTY",
+                "GEOMETRYCOLLECTION EMPTY",
+                "POINT (-40.2 28.9)",
+                "MULTIPOINT ((-40.2 28.9), (-40.2 31.9))",
+                "LINESTRING (-40.2 28.9, -40.2 31.9, -37.2 31.9)",
+                "MULTILINESTRING ((-40.2 28.9, -40.2 31.9), (-40.2 31.9, -37.2 31.9))",
+                "POLYGON ((-40.2 28.9, -37.2 28.9, -37.2 31.9, -40.2 31.9, -40.2 28.9))",
+                "POLYGON ((-40.2 28.9, -37.2 28.9, -37.2 31.9, -40.2 31.9, -40.2 28.9), (-39.2 29.9, -39.2 30.9, -38.2 30.9, -38.2 29.9, -39.2 29.9))",
+                "MULTIPOLYGON (((-40.2 28.9, -37.2 28.9, -37.2 31.9, -40.2 31.9, -40.2 28.9)), ((-39.2 29.9, -38.2 29.9, -38.2 30.9, -39.2 30.9, -39.2 29.9)))",
+                "GEOMETRYCOLLECTION (POINT (-40.2 28.9), LINESTRING (-40.2 28.9, -40.2 31.9, -37.2 31.9), POLYGON ((-40.2 28.9, -37.2 28.9, -37.2 31.9, -40.2 31.9, -40.2 28.9)))");
+
+        BlockBuilder builder = SPHERICAL_GEOGRAPHY.createBlockBuilder(null, wktList.size());
+        for (String wkt : wktList) {
+            SPHERICAL_GEOGRAPHY.writeSlice(builder, GeoFunctions.toSphericalGeography(GeoFunctions.stGeometryFromText(utf8Slice(wkt))));
+        }
+        Block block = builder.build();
+        for (int i = 0; i < wktList.size(); i++) {
+            assertEquals(wktList.get(i), SPHERICAL_GEOGRAPHY.getObjectValue(null, block, i));
+        }
+    }
+
+    @Test
+    public void testToAndFromSphericalGeography()
+    {
+        // empty geometries
+        assertToAndFromSphericalGeography("POINT EMPTY");
+        assertToAndFromSphericalGeography("MULTIPOINT EMPTY");
+        assertToAndFromSphericalGeography("LINESTRING EMPTY");
+        assertToAndFromSphericalGeography("MULTILINESTRING EMPTY");
+        assertToAndFromSphericalGeography("POLYGON EMPTY");
+        assertToAndFromSphericalGeography("MULTIPOLYGON EMPTY");
+        assertToAndFromSphericalGeography("GEOMETRYCOLLECTION EMPTY");
+
+        // valid nonempty geometries
+        assertToAndFromSphericalGeography("POINT (-40.2 28.9)");
+        assertToAndFromSphericalGeography("MULTIPOINT ((-40.2 28.9), (-40.2 31.9))");
+        assertToAndFromSphericalGeography("LINESTRING (-40.2 28.9, -40.2 31.9, -37.2 31.9)");
+        assertToAndFromSphericalGeography("MULTILINESTRING ((-40.2 28.9, -40.2 31.9), (-40.2 31.9, -37.2 31.9))");
+        assertToAndFromSphericalGeography("POLYGON ((-40.2 28.9, -37.2 28.9, -37.2 31.9, -40.2 31.9, -40.2 28.9))");
+        assertToAndFromSphericalGeography("POLYGON ((-40.2 28.9, -37.2 28.9, -37.2 31.9, -40.2 31.9, -40.2 28.9), " +
+                "(-39.2 29.9, -39.2 30.9, -38.2 30.9, -38.2 29.9, -39.2 29.9))");
+        assertToAndFromSphericalGeography("MULTIPOLYGON (((-40.2 28.9, -37.2 28.9, -37.2 31.9, -40.2 31.9, -40.2 28.9)), " +
+                "((-39.2 29.9, -38.2 29.9, -38.2 30.9, -39.2 30.9, -39.2 29.9)))");
+        assertToAndFromSphericalGeography("GEOMETRYCOLLECTION (POINT (-40.2 28.9), LINESTRING (-40.2 28.9, -40.2 31.9, -37.2 31.9), " +
+                "POLYGON ((-40.2 28.9, -37.2 28.9, -37.2 31.9, -40.2 31.9, -40.2 28.9)))");
+
+        // geometries containing invalid latitude or longitude values
+        assertInvalidLongitude("POINT (-340.2 28.9)");
+        assertInvalidLatitude("MULTIPOINT ((-40.2 128.9), (-40.2 31.9))");
+        assertInvalidLongitude("LINESTRING (-40.2 28.9, -40.2 31.9, 237.2 31.9)");
+        assertInvalidLatitude("MULTILINESTRING ((-40.2 28.9, -40.2 31.9), (-40.2 131.9, -37.2 31.9))");
+        assertInvalidLongitude("POLYGON ((-40.2 28.9, -40.2 31.9, 237.2 31.9, -37.2 28.9, -40.2 28.9))");
+        assertInvalidLatitude("POLYGON ((-40.2 28.9, -40.2 31.9, -37.2 131.9, -37.2 28.9, -40.2 28.9), (-39.2 29.9, -39.2 30.9, -38.2 30.9, -38.2 29.9, -39.2 29.9))");
+        assertInvalidLongitude("MULTIPOLYGON (((-40.2 28.9, -40.2 31.9, -37.2 31.9, -37.2 28.9, -40.2 28.9)), " +
+                "((-39.2 29.9, -39.2 30.9, 238.2 30.9, -38.2 29.9, -39.2 29.9)))");
+        assertInvalidLatitude("GEOMETRYCOLLECTION (POINT (-40.2 28.9), LINESTRING (-40.2 28.9, -40.2 131.9, -37.2 31.9), " +
+                "POLYGON ((-40.2 28.9, -40.2 31.9, -37.2 31.9, -37.2 28.9, -40.2 28.9)))");
+    }
+
+    private void assertToAndFromSphericalGeography(String wkt)
+    {
+        assertFunction(format("ST_AsText(to_geometry(to_spherical_geography(ST_GeometryFromText('%s'))))", wkt), VARCHAR, wkt);
+    }
+
+    private void assertInvalidLongitude(String wkt)
+    {
+        assertInvalidFunction(format("to_spherical_geography(ST_GeometryFromText('%s'))", wkt), "Longitude must be between -180 and 180");
+    }
+
+    private void assertInvalidLatitude(String wkt)
+    {
+        assertInvalidFunction(format("to_spherical_geography(ST_GeometryFromText('%s'))", wkt), "Latitude must be between -90 and 90");
+    }
+
+    @Test
+    public void testDistance()
+    {
+        assertDistance("POINT (-86.67 36.12)", "POINT (-118.40 33.94)", 2886448.973436703);
+        assertDistance("POINT (-118.40 33.94)", "POINT (-86.67 36.12)", 2886448.973436703);
+        assertDistance("POINT (-71.0589 42.3601)", "POINT (-71.2290 42.4430)", 16734.69743457461);
+        assertDistance("POINT (-86.67 36.12)", "POINT (-86.67 36.12)", 0.0);
+
+        assertDistance("POINT EMPTY", "POINT (40 30)", null);
+        assertDistance("POINT (20 10)", "POINT EMPTY", null);
+        assertDistance("POINT EMPTY", "POINT EMPTY", null);
+    }
+
+    private void assertDistance(String wkt, String otherWkt, Double expectedDistance)
+    {
+        assertFunction(format("ST_Distance(to_spherical_geography(ST_GeometryFromText('%s')), to_spherical_geography(ST_GeometryFromText('%s')))", wkt, otherWkt), DOUBLE, expectedDistance);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -428,7 +428,7 @@ public class PlanOptimizers
                 costCalculator,
                 ImmutableSet.<Rule<?>>builder()
                         .add(new RemoveRedundantIdentityProjections())
-                        .addAll(new ExtractSpatialJoins(metadata, splitManager, pageSourceManager).rules())
+                        .addAll(new ExtractSpatialJoins(metadata, splitManager, pageSourceManager, sqlParser).rules())
                         .add(new InlineProjections())
                         .build()));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -20,6 +20,7 @@ import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tpch.TpchConnectorFactory;
@@ -47,6 +48,7 @@ public class RuleTester
     private final SplitManager splitManager;
     private final PageSourceManager pageSourceManager;
     private final AccessControl accessControl;
+    private final SqlParser sqlParser;
 
     public RuleTester()
     {
@@ -89,6 +91,7 @@ public class RuleTester
         this.splitManager = queryRunner.getSplitManager();
         this.pageSourceManager = queryRunner.getPageSourceManager();
         this.accessControl = queryRunner.getAccessControl();
+        this.sqlParser = queryRunner.getSqlParser();
     }
 
     public RuleAssert assertThat(Rule rule)
@@ -115,6 +118,11 @@ public class RuleTester
     public PageSourceManager getPageSourceManager()
     {
         return pageSourceManager;
+    }
+
+    public SqlParser getSqlParser()
+    {
+        return sqlParser;
     }
 
     public ConnectorId getCurrentConnectorId()


### PR DESCRIPTION
This PR covers phase 1 and a small step in phase 2 towards [Issue #11580](https://github.com/prestodb/presto/issues/11580)
1. Add a new SQL type `SphericalGeography` to represent geometry objects in lat/lon space.
1. Add `to_geometry` and `to_spherical_geography` function to convert between `SphericalGeography` and `Geometry` values. The conversion is mainly about validating the range of lat/lon values.
1. Add `ST_Distance` support for SphericalGeography objects. Right now it only supports points and returns the great circle distance between them. Support for other shapes will be added in later PRs.
1. Spatial functions operating on SphericalGeography objects are excluded from spatial joins for now.