### PR TITLE
Move statistics aggregations on write to system memory pool

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/CountAggregationBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/CountAggregationBenchmark.java
@@ -43,7 +43,7 @@ public class CountAggregationBenchmark
         OperatorFactory tableScanOperator = createTableScanOperator(0, new PlanNodeId("test"), "orders", "orderkey");
         InternalAggregationFunction countFunction = localQueryRunner.getMetadata().getFunctionRegistry().getAggregateFunctionImplementation(
                 new Signature("count", AGGREGATE, BIGINT.getTypeSignature()));
-        AggregationOperatorFactory aggregationOperator = new AggregationOperatorFactory(1, new PlanNodeId("test"), Step.SINGLE, ImmutableList.of(countFunction.bind(ImmutableList.of(0), Optional.empty())));
+        AggregationOperatorFactory aggregationOperator = new AggregationOperatorFactory(1, new PlanNodeId("test"), Step.SINGLE, ImmutableList.of(countFunction.bind(ImmutableList.of(0), Optional.empty())), false);
         return ImmutableList.of(tableScanOperator, aggregationOperator);
     }
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/DoubleSumAggregationBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/DoubleSumAggregationBenchmark.java
@@ -44,7 +44,7 @@ public class DoubleSumAggregationBenchmark
         OperatorFactory tableScanOperator = createTableScanOperator(0, new PlanNodeId("test"), "orders", "totalprice");
         InternalAggregationFunction doubleSum = MetadataManager.createTestMetadataManager().getFunctionRegistry().getAggregateFunctionImplementation(
                 new Signature("sum", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
-        AggregationOperatorFactory aggregationOperator = new AggregationOperatorFactory(1, new PlanNodeId("test"), Step.SINGLE, ImmutableList.of(doubleSum.bind(ImmutableList.of(0), Optional.empty())));
+        AggregationOperatorFactory aggregationOperator = new AggregationOperatorFactory(1, new PlanNodeId("test"), Step.SINGLE, ImmutableList.of(doubleSum.bind(ImmutableList.of(0), Optional.empty())), false);
         return ImmutableList.of(tableScanOperator, aggregationOperator);
     }
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery1.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery1.java
@@ -125,7 +125,8 @@ public class HandTpchQuery1
                 Optional.empty(),
                 10_000,
                 Optional.of(new DataSize(16, MEGABYTE)),
-                JOIN_COMPILER);
+                JOIN_COMPILER,
+                false);
 
         return ImmutableList.of(tableScanOperator, tpchQuery1Operator, aggregationOperator);
     }

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
@@ -86,7 +86,8 @@ public class HandTpchQuery6
                 new PlanNodeId("test"),
                 Step.SINGLE,
                 ImmutableList.of(
-                        doubleSum.bind(ImmutableList.of(0), Optional.empty())));
+                        doubleSum.bind(ImmutableList.of(0), Optional.empty())),
+                false);
 
         return ImmutableList.of(tableScanOperator, tpchQuery6Operator, aggregationOperator);
     }

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashAggregationBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashAggregationBenchmark.java
@@ -63,7 +63,8 @@ public class HashAggregationBenchmark
                 Optional.empty(),
                 100_000,
                 Optional.of(new DataSize(16, MEGABYTE)),
-                JOIN_COMPILER);
+                JOIN_COMPILER,
+                false);
         return ImmutableList.of(tableScanOperator, aggregationOperator);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
@@ -35,8 +35,6 @@ import static java.util.Objects.requireNonNull;
 public class AggregationOperator
         implements Operator
 {
-    private final boolean partial;
-
     public static class AggregationOperatorFactory
             implements OperatorFactory
     {
@@ -44,14 +42,16 @@ public class AggregationOperator
         private final PlanNodeId planNodeId;
         private final Step step;
         private final List<AccumulatorFactory> accumulatorFactories;
+        private final boolean useSystemMemory;
         private boolean closed;
 
-        public AggregationOperatorFactory(int operatorId, PlanNodeId planNodeId, Step step, List<AccumulatorFactory> accumulatorFactories)
+        public AggregationOperatorFactory(int operatorId, PlanNodeId planNodeId, Step step, List<AccumulatorFactory> accumulatorFactories, boolean useSystemMemory)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.step = step;
             this.accumulatorFactories = ImmutableList.copyOf(accumulatorFactories);
+            this.useSystemMemory = useSystemMemory;
         }
 
         @Override
@@ -59,7 +59,7 @@ public class AggregationOperator
         {
             checkState(!closed, "Factory is already closed");
             OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, AggregationOperator.class.getSimpleName());
-            return new AggregationOperator(operatorContext, step, accumulatorFactories);
+            return new AggregationOperator(operatorContext, step, accumulatorFactories, useSystemMemory);
         }
 
         @Override
@@ -71,7 +71,7 @@ public class AggregationOperator
         @Override
         public OperatorFactory duplicate()
         {
-            return new AggregationOperatorFactory(operatorId, planNodeId, step, accumulatorFactories);
+            return new AggregationOperatorFactory(operatorId, planNodeId, step, accumulatorFactories, useSystemMemory);
         }
     }
 
@@ -86,17 +86,18 @@ public class AggregationOperator
     private final LocalMemoryContext systemMemoryContext;
     private final LocalMemoryContext userMemoryContext;
     private final List<Aggregator> aggregates;
+    private final boolean useSystemMemory;
 
     private State state = State.NEEDS_INPUT;
 
-    public AggregationOperator(OperatorContext operatorContext, Step step, List<AccumulatorFactory> accumulatorFactories)
+    public AggregationOperator(OperatorContext operatorContext, Step step, List<AccumulatorFactory> accumulatorFactories, boolean useSystemMemory)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(AggregationOperator.class.getSimpleName());
         this.userMemoryContext = operatorContext.localUserMemoryContext();
+        this.useSystemMemory = useSystemMemory;
 
         requireNonNull(step, "step is null");
-        this.partial = step.isOutputPartial();
 
         // wrapper each function with an aggregator
         requireNonNull(accumulatorFactories, "accumulatorFactories is null");
@@ -151,7 +152,7 @@ public class AggregationOperator
             aggregate.processPage(page);
             memorySize += aggregate.getEstimatedSize();
         }
-        if (partial) {
+        if (useSystemMemory) {
             systemMemoryContext.setBytes(memorySize);
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/MergingHashAggregationBuilder.java
@@ -147,6 +147,7 @@ public class MergingHashAggregationBuilder
                 Optional.of(DataSize.succinctBytes(0)),
                 Optional.of(overwriteIntermediateChannelOffset),
                 joinCompiler,
+                false,
                 false);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -301,6 +301,7 @@ public class SpillableHashAggregationBuilder
                 operatorContext,
                 Optional.of(DataSize.succinctBytes(0)),
                 joinCompiler,
+                false,
                 false);
         emptyHashAggregationBuilderSize = hashAggregationBuilder.getSizeInMemory();
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndStreamingAggregationOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndStreamingAggregationOperators.java
@@ -170,7 +170,8 @@ public class BenchmarkHashAndStreamingAggregationOperators
                     succinctBytes(8),
                     succinctBytes(Integer.MAX_VALUE),
                     spillerFactory,
-                    joinCompiler);
+                    joinCompiler,
+                    false);
         }
 
         private static void repeatToStringBlock(String value, int count, BlockBuilder blockBuilder)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAggregationOperator.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
+import static com.facebook.presto.operator.OperatorAssertion.toPages;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -43,9 +44,14 @@ import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Collections.emptyIterator;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestAggregationOperator
@@ -65,17 +71,12 @@ public class TestAggregationOperator
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
-    private DriverContext driverContext;
 
     @BeforeMethod
     public void setUp()
     {
         executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
-
-        driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
-                .addPipelineContext(0, true, true)
-                .addDriverContext();
     }
 
     @AfterMethod
@@ -109,12 +110,63 @@ public class TestAggregationOperator
                         LONG_SUM.bind(ImmutableList.of(3), Optional.empty()),
                         REAL_SUM.bind(ImmutableList.of(4), Optional.empty()),
                         DOUBLE_SUM.bind(ImmutableList.of(5), Optional.empty()),
-                        maxVarcharColumn.bind(ImmutableList.of(6), Optional.empty())));
+                        maxVarcharColumn.bind(ImmutableList.of(6), Optional.empty())),
+                false);
+
+        DriverContext driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
+                .addPipelineContext(0, true, true)
+                .addDriverContext();
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT, BIGINT, DOUBLE, VARCHAR, BIGINT, BIGINT, REAL, DOUBLE, VARCHAR)
                 .row(100L, 4950L, 49.5, "399", 100L, 54950L, 44950.0f, 54950.0, "599")
                 .build();
 
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
+        assertEquals(driverContext.getSystemMemoryUsage(), 0);
+        assertEquals(driverContext.getMemoryUsage(), 0);
+    }
+
+    @Test
+    public void testMemoryTracking()
+            throws Exception
+    {
+        testMemoryTracking(false);
+        testMemoryTracking(true);
+    }
+
+    private void testMemoryTracking(boolean useSystemMemory)
+            throws Exception
+    {
+        Page input = getOnlyElement(rowPagesBuilder(BIGINT).addSequencePage(100, 0).build());
+
+        OperatorFactory operatorFactory = new AggregationOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                Step.SINGLE,
+                ImmutableList.of(LONG_SUM.bind(ImmutableList.of(0), Optional.empty())),
+                useSystemMemory);
+
+        DriverContext driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
+                .addPipelineContext(0, true, true)
+                .addDriverContext();
+
+        try (Operator operator = operatorFactory.createOperator(driverContext)) {
+            assertTrue(operator.needsInput());
+            operator.addInput(input);
+
+            if (useSystemMemory) {
+                assertThat(driverContext.getSystemMemoryUsage()).isGreaterThan(0);
+                assertEquals(driverContext.getMemoryUsage(), 0);
+            }
+            else {
+                assertEquals(driverContext.getSystemMemoryUsage(), 0);
+                assertThat(driverContext.getMemoryUsage()).isGreaterThan(0);
+            }
+
+            toPages(operator, emptyIterator());
+        }
+
+        assertEquals(driverContext.getSystemMemoryUsage(), 0);
+        assertEquals(driverContext.getMemoryUsage(), 0);
     }
 }


### PR DESCRIPTION
With the change that removes the memory limit for partial aggregations the
statistics aggregations were updated to use user memory instead of system memory.

Statistics aggregations is an implicit process that the query doesn't
have much control over. It is very similar to implicit buffer allocations required
when writing ORC files. Although the amount of memory used depends on the user input
(number of columns in the table) the user may not even be aware that stats will be
collected. Therefore, it sounds like it is more suitable to use system memory
for stats collecting aggregations.

This change introduces a "useSystemMemory" parameter that sets the type of
memory that aggregation operators should use. The existing rule of using
system memory for partial aggregations is also removed. The type of memory to use is
now explicitly set in LocalExecutionPlanner based on the type of aggregation --
system memory is used for partial aggregations and for column statistics aggregations
used during writes.