### PR TITLE
Fix behavior and add validation to ORC writer validation percentage

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -30,6 +30,8 @@ import io.airlift.units.MinDuration;
 import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nonnull;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -829,6 +831,8 @@ public class HiveClientConfig
         return this;
     }
 
+    @DecimalMin("0.0")
+    @DecimalMax("100.0")
     public double getOrcWriterValidationPercentage()
     {
         return orcWriterValidationPercentage;


### PR DESCRIPTION
It is very unintuitive that setting the config property or session property
to 0.0 results in 100% validation. This commit fixes that.
This commit also adds validation to the properties to require that they be
between 0 and 100 inclusive.