### PR TITLE
Fix planning failure for DistinctLimit with hash generation optimizer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -214,9 +214,12 @@ public class HashGenerationOptimizer
                     parentPreference.withHashComputation(node, hashComputation));
             Symbol hashSymbol = child.getRequiredHashSymbol(hashComputation.get());
 
+            // TODO: we need to reason about how pre-computed hashes from child relate to distinct symbols. We should be able to include any precomputed hash
+            // that's functionally dependent on the distinct field in the set of distinct fields of the new node to be able to propagate it downstream.
+            // Currently, such precomputed hashes will be dropped by this operation.
             return new PlanWithProperties(
                     new DistinctLimitNode(node.getId(), child.getNode(), node.getLimit(), node.isPartial(), node.getDistinctSymbols(), Optional.of(hashSymbol)),
-                    child.getHashSymbols());
+                    ImmutableMap.of(hashComputation.get(), hashSymbol));
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestPrecomputedHashes.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestPrecomputedHashes.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.query;
+
+import com.facebook.presto.Session;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_HASH_GENERATION;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestPrecomputedHashes
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        Session session = testSessionBuilder()
+                .setSystemProperty(OPTIMIZE_HASH_GENERATION, "true")
+                .build();
+
+        assertions = new QueryAssertions(session);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testDistinctLimit()
+    {
+        // issue #11593
+        assertions.assertQuery(
+                "SELECT a " +
+                        "FROM (" +
+                        "    SELECT a, b" +
+                        "    FROM (VALUES (1, 2)) t(a, b)" +
+                        "    WHERE a = 1" +
+                        "    GROUP BY a, b" +
+                        "    LIMIT 1" +
+                        ")" +
+                        "GROUP BY a",
+                "VALUES (1)");
+    }
+}


### PR DESCRIPTION
A recent change (032575a1f2d47de2cc034716de645ce3c1b14281) uncovered a latent bug in
the precomputed hash optimizer for DistinctLimit. The code was declaring that
the subplan rooted at DistinctLimit produced the set of hashes as its source,
which is incorrect given that DistinctLimit propagates only the distinct columns
and a *single* precomputed hash field.

Fixes #11593