### PR TITLE
Test EXPLAIN for all queries [WIP]

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -774,8 +774,8 @@ public abstract class AbstractTestDistributedQueries
             long beforeCompletedQueriesCount = waitUntilStable(() -> queryManager.getStats().getCompletedQueries().getTotalCount(), new Duration(5, SECONDS));
             long beforeSubmittedQueriesCount = queryManager.getStats().getSubmittedQueries().getTotalCount();
             assertUpdate("CREATE TABLE test_query_logging_count AS SELECT 1 foo_1, 2 foo_2_4", 1);
-            assertQuery("SELECT foo_1, foo_2_4 FROM test_query_logging_count", "SELECT 1, 2");
-            assertUpdate("DROP TABLE test_query_logging_count");
+            assertQuery("SELECT foo_1, foo_2_4 FROM test_query_logging_count -- SKIP EXPLAIN", "SELECT 1, 2");
+            assertUpdate("DROP TABLE test_query_logging_count -- SKIP EXPLAIN");
             assertQueryFails("SELECT * FROM test_query_logging_count", ".*Table .* does not exist");
 
             // TODO: Figure out a better way of synchronization


### PR DESCRIPTION
Apparently, we don't have full coverage for EXPLAIN just yet.

By running EXPLAIN on every query in TestLocalQueries, i was able to reproduce https://github.com/prestodb/presto/issues/11484

cc @sopel39 