### PR TITLE
Add experimental config for disabling the reserved pool

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryAwareQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryAwareQueryExecution.java
@@ -168,7 +168,9 @@ public class MemoryAwareQueryExecution
                     startedWaiting = true;
                     delegate.startWaitingForResources();
                     memoryManager.addChangeListener(GENERAL_POOL, none -> start());
-                    memoryManager.addChangeListener(RESERVED_POOL, none -> start());
+                    if (memoryManager.memoryPoolExists(RESERVED_POOL)) {
+                        memoryManager.addChangeListener(RESERVED_POOL, none -> start());
+                    }
                 }
             }
             catch (Throwable e) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
@@ -105,7 +105,10 @@ public class MemoryRevokingScheduler
     private static List<MemoryPool> getMemoryPools(LocalMemoryManager localMemoryManager)
     {
         requireNonNull(localMemoryManager, "localMemoryManager can not be null");
-        return ImmutableList.of(localMemoryManager.getPool(LocalMemoryManager.GENERAL_POOL), localMemoryManager.getPool(LocalMemoryManager.RESERVED_POOL));
+        ImmutableList.Builder<MemoryPool> builder = new ImmutableList.Builder<>();
+        builder.add(localMemoryManager.getGeneralPool());
+        localMemoryManager.getReservedPool().ifPresent(builder::add);
+        return builder.build();
     }
 
     @PostConstruct

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -24,6 +24,7 @@ import com.facebook.presto.execution.executor.TaskExecutor;
 import com.facebook.presto.memory.DefaultQueryContext;
 import com.facebook.presto.memory.LegacyQueryContext;
 import com.facebook.presto.memory.LocalMemoryManager;
+import com.facebook.presto.memory.MemoryPool;
 import com.facebook.presto.memory.MemoryPoolAssignment;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
 import com.facebook.presto.memory.NodeMemoryConfig;
@@ -67,10 +68,13 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.SystemSessionProperties.resourceOvercommit;
+import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
+import static com.facebook.presto.memory.LocalMemoryManager.RESERVED_POOL;
 import static com.facebook.presto.spi.StandardErrorCode.ABANDONED_TASK;
 import static com.facebook.presto.spi.StandardErrorCode.SERVER_SHUTTING_DOWN;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.notNull;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.transform;
 import static io.airlift.concurrent.Threads.threadsNamed;
@@ -172,11 +176,13 @@ public class SqlTaskManager
             DataSize maxQuerySpillPerNode)
     {
         if (nodeMemoryConfig.isLegacySystemPoolEnabled()) {
+            Optional<MemoryPool> systemPool = localMemoryManager.getSystemPool();
+            verify(systemPool.isPresent(), "systemPool must be present");
             return new LegacyQueryContext(
                     queryId,
                     maxQueryUserMemoryPerNode,
-                    localMemoryManager.getPool(LocalMemoryManager.GENERAL_POOL),
-                    localMemoryManager.getPool(LocalMemoryManager.SYSTEM_POOL),
+                    localMemoryManager.getGeneralPool(),
+                    systemPool.get(),
                     gcMonitor,
                     taskNotificationExecutor,
                     driverYieldExecutor,
@@ -188,7 +194,7 @@ public class SqlTaskManager
                 queryId,
                 maxQueryUserMemoryPerNode,
                 maxQueryTotalMemoryPerNode,
-                localMemoryManager.getPool(LocalMemoryManager.GENERAL_POOL),
+                localMemoryManager.getGeneralPool(),
                 gcMonitor,
                 taskNotificationExecutor,
                 driverYieldExecutor,
@@ -209,7 +215,17 @@ public class SqlTaskManager
         coordinatorId = assignments.getCoordinatorId();
 
         for (MemoryPoolAssignment assignment : assignments.getAssignments()) {
-            queryContexts.getUnchecked(assignment.getQueryId()).setMemoryPool(localMemoryManager.getPool(assignment.getPoolId()));
+            if (assignment.getPoolId().equals(GENERAL_POOL)) {
+                queryContexts.getUnchecked(assignment.getQueryId()).setMemoryPool(localMemoryManager.getGeneralPool());
+            }
+            else if (assignment.getPoolId().equals(RESERVED_POOL)) {
+                MemoryPool reservedPool = localMemoryManager.getReservedPool()
+                        .orElseThrow(() -> new IllegalArgumentException(format("Cannot move %s to the reserved pool as the reserved pool is not enabled", assignment.getQueryId())));
+                queryContexts.getUnchecked(assignment.getQueryId()).setMemoryPool(reservedPool);
+            }
+            else {
+                new IllegalArgumentException(format("Cannot move %s to %s as the target memory pool id is invalid", assignment.getQueryId(), assignment.getPoolId()));
+            }
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
@@ -29,6 +29,7 @@ public class NodeMemoryConfig
     public static final String QUERY_MAX_TOTAL_MEMORY_PER_NODE_CONFIG = "query.max-total-memory-per-node";
 
     private boolean isLegacySystemPoolEnabled;
+    private boolean isReservedPoolEnabled = true;
 
     private DataSize maxQueryMemoryPerNode = new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE);
 
@@ -58,6 +59,18 @@ public class NodeMemoryConfig
     public NodeMemoryConfig setLegacySystemPoolEnabled(boolean legacySystemPoolEnabled)
     {
         isLegacySystemPoolEnabled = legacySystemPoolEnabled;
+        return this;
+    }
+
+    public boolean isReservedPoolEnabled()
+    {
+        return isReservedPoolEnabled;
+    }
+
+    @Config("experimental.reserved-pool-enabled")
+    public NodeMemoryConfig setReservedPoolEnabled(boolean reservedPoolEnabled)
+    {
+        isReservedPoolEnabled = reservedPoolEnabled;
         return this;
     }
 

--- a/presto-main/src/main/resources/webapp/assets/worker.js
+++ b/presto-main/src/main/resources/webapp/assets/worker.js
@@ -78,6 +78,10 @@ let WorkerStatus = React.createClass({
         new Clipboard('.copy-button');
     },
     renderPoolBar: function(name, pool) {
+        if (pool === undefined) {
+             return (<div className="row"><h4>{name} Pool is disabled.</h4></div>)
+        }
+
         const size = pool.maxBytes;
         const reserved = pool.reservedBytes;
         const revocable = pool.reservedRevocableBytes;
@@ -155,6 +159,10 @@ let WorkerStatus = React.createClass({
         )
     },
     renderPoolQueries: function(pool) {
+        if (pool === undefined) {
+             return;
+        }
+
         const queries = {};
         const reservations = pool.queryMemoryReservations;
         const revocableReservations = pool.queryMemoryRevocableReservations;

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
@@ -35,7 +35,8 @@ public class TestNodeMemoryConfig
                 .setLegacySystemPoolEnabled(false)
                 .setMaxQueryMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
-                .setHeapHeadroom(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE)));
+                .setHeapHeadroom(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
+                .setReservedPoolEnabled(true));
     }
 
     @Test
@@ -46,13 +47,15 @@ public class TestNodeMemoryConfig
                 .put("query.max-total-memory-per-node", "3GB")
                 .put("memory.heap-headroom-per-node", "1GB")
                 .put("deprecated.legacy-system-pool-enabled", "true")
+                .put("experimental.reserved-pool-enabled", "false")
                 .build();
 
         NodeMemoryConfig expected = new NodeMemoryConfig()
                 .setLegacySystemPoolEnabled(true)
                 .setMaxQueryMemoryPerNode(new DataSize(1, GIGABYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(3, GIGABYTE))
-                .setHeapHeadroom(new DataSize(1, GIGABYTE));
+                .setHeapHeadroom(new DataSize(1, GIGABYTE))
+                .setReservedPoolEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryAwareExecution.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryAwareExecution.java
@@ -69,7 +69,7 @@ public class TestMemoryAwareExecution
         while (clusterMemoryManager.getClusterMemoryBytes() == 0) {
             Thread.sleep(1000);
         }
-        totalAvailableMemory = localMemoryManager.getPool(LocalMemoryManager.GENERAL_POOL).getMaxBytes();
+        totalAvailableMemory = localMemoryManager.getGeneralPool().getMaxBytes();
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
This PR adds a new experimental config option for disabling the reserved
pool. The reason we have a reserved pool is to prevent deadlocks when
the general pool gets full. However, it's a source of inefficiency as a
good chunk of the heap just stays unused most of the time. Now that the
cluster oom killer works reasonably well (after making it resilient to
memory accounting leaks/bugs) we can run some experiments by disabling
the reserved pool -- when the general pool is full on some worker the
oom killer should just resolve the situation by killing a query. It's
possible that the killed query is retried by the client and cause oom
again, but the existing implementation is also already susceptible to
that issue, so this change doesn't make the situation any worse.