### PR TITLE
Improve geometry_to_bing_tiles error message 

### DIFF
--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
@@ -239,7 +239,7 @@ public class TestBingTileFunctions
 
         // Too many tiles
         assertInvalidFunction("bing_tiles_around(30.12, 60.0, 20, 100)",
-                "The number of input tiles is too large (more than 1M) to compute a set of covering Bing tiles.");
+                "The number of tiles covering input rectangle exceeds the limit of 1M. Number of tiles: 36699364. Radius: 100.0 km. Zoom level: 20.");
     }
 
     @Test
@@ -454,7 +454,8 @@ public class TestBingTileFunctions
         assertInvalidFunction("geometry_to_bing_tiles(ST_Point(60, 30.12), 40)", "Zoom level must be <= 23");
 
         // Input rectangle too large
-        assertInvalidFunction("geometry_to_bing_tiles(ST_Envelope(ST_GeometryFromText('LINESTRING (0 0, 80 80)')), 16)", "The number of input tiles is too large (more than 1M) to compute a set of covering Bing tiles.");
+        assertInvalidFunction("geometry_to_bing_tiles(ST_Envelope(ST_GeometryFromText('LINESTRING (0 0, 80 80)')), 16)",
+                "The number of tiles covering input rectangle exceeds the limit of 1M. Number of tiles: 370085804. Rectangle: xMin=0.00, yMin=0.00, xMax=80.00, yMax=80.00. Zoom level: 16.");
         assertFunction("cardinality(geometry_to_bing_tiles(ST_Envelope(ST_GeometryFromText('LINESTRING (0 0, 80 80)')), 5))", BIGINT, 104L);
 
         // Input polygon too complex


### PR DESCRIPTION
Fixes #11599 
1. Improve error message for geo-function geometry_to_bing_tiles with zoom level,  tile number and rectangle geometry in wkt format 
2. Improve error message for converting circle to bing tiles
with zoom level,  tile number and radius in error message 
cc: @mbasmanova 