### PR TITLE
Avoid making wild guesses in FILTER and JOIN estimates

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculator.java
@@ -243,9 +243,9 @@ public class TestFilterStatsCalculator
     public void testUnsupportedExpression()
     {
         assertExpression("sin(x)")
-                .outputRowsCount(900);
+                .outputRowsCountUnknown();
         assertExpression("x = sin(x)")
-                .outputRowsCount(900);
+                .outputRowsCountUnknown();
     }
 
     @Test
@@ -286,12 +286,7 @@ public class TestFilterStatsCalculator
 
         // both arguments unknown
         assertExpression("json_array_contains(JSON '[11]', x) AND json_array_contains(JSON '[13]', x)")
-                .outputRowsCount(900)
-                .symbolStats(new Symbol("x"), symbolAssert ->
-                        symbolAssert.lowValue(-10)
-                                .highValue(10)
-                                .distinctValuesCount(40)
-                                .nullsFraction(0.25));
+                .outputRowsCountUnknown();
 
         assertExpression("'a' IN ('b', 'c') AND unknownRange = 3e0")
                 .outputRowsCount(0);
@@ -310,16 +305,6 @@ public class TestFilterStatsCalculator
                                 .nullsFraction(0.4)) // FIXME - nulls shouldn't be restored
                 .symbolStats(new Symbol("y"), symbolAssert -> symbolAssert.isEqualTo(yStats));
 
-        assertExpression("NOT(json_array_contains(JSON '[]', x))")
-                .outputRowsCount(900)
-                .symbolStats(new Symbol("x"), symbolAssert ->
-                        symbolAssert.averageRowSize(4.0)
-                                .lowValue(-10.0)
-                                .highValue(10.0)
-                                .distinctValuesCount(40.0)
-                                .nullsFraction(0.25))
-                .symbolStats(new Symbol("y"), symbolAssert -> symbolAssert.isEqualTo(yStats));
-
         assertExpression("NOT(x IS NULL)")
                 .outputRowsCount(750)
                 .symbolStats(new Symbol("x"), symbolAssert ->
@@ -329,6 +314,9 @@ public class TestFilterStatsCalculator
                                 .distinctValuesCount(40.0)
                                 .nullsFraction(0))
                 .symbolStats(new Symbol("y"), symbolAssert -> symbolAssert.isEqualTo(yStats));
+
+        assertExpression("NOT(json_array_contains(JSON '[]', x))")
+                .outputRowsCountUnknown();
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
@@ -257,7 +257,7 @@ public class TestJoinStatsRule
                 0,
                 new SymbolStatistics(RIGHT_JOIN_COLUMN, SymbolStatsEstimate.unknown()),
                 new SymbolStatistics(RIGHT_OTHER_COLUMN, SymbolStatsEstimate.unknown()));
-        assertJoinStats(LEFT, leftStats, rightStats, leftStats);
+        assertJoinStats(LEFT, leftStats, rightStats, PlanNodeStatsEstimate.unknown());
     }
 
     @Test

--- a/presto-main/src/test/resources/sql/presto/tpcds/q16.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q16.plan.txt
@@ -2,31 +2,30 @@ final aggregation over ()
     local exchange (GATHER, SINGLE, [])
         remote exchange (GATHER, SINGLE, [])
             partial aggregation over ()
-                local exchange (GATHER, SINGLE, [])
-                    join (RIGHT, PARTITIONED):
-                        final aggregation over (cr_order_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["cr_order_number"])
-                                    partial aggregation over (cr_order_number)
-                                        scan tpcds:catalog_returns:sf3000.0
-                        final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                            local exchange (GATHER, SINGLE, [])
-                                partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
-                                    join (RIGHT, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["cs_order_number_17"])
-                                            scan tpcds:catalog_sales:sf3000.0
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["cs_order_number"])
+                join (LEFT, PARTITIONED):
+                    final aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                        local exchange (GATHER, SINGLE, [])
+                            partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
+                                join (RIGHT, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["cs_order_number_17"])
+                                        scan tpcds:catalog_sales:sf3000.0
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["cs_order_number"])
+                                            join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            scan tpcds:catalog_sales:sf3000.0
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:customer_address:sf3000.0
+                                                        scan tpcds:catalog_sales:sf3000.0
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan tpcds:customer_address:sf3000.0
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:call_center:sf3000.0
+                                                            scan tpcds:date_dim:sf3000.0
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan tpcds:call_center:sf3000.0
+                    final aggregation over (cr_order_number)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["cr_order_number"])
+                                partial aggregation over (cr_order_number)
+                                    scan tpcds:catalog_returns:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpcds/q24_1.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q24_1.plan.txt
@@ -8,28 +8,29 @@ remote exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["c_first_name", "c_last_name", "ca_state", "i_color", "i_current_price", "i_manager_id", "i_size", "i_units", "s_state", "s_store_name"])
                                     partial aggregation over (c_first_name, c_last_name, ca_state, i_color, i_current_price, i_manager_id, i_size, i_units, s_state, s_store_name)
-                                        join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                join (INNER, REPLICATED):
-                                                                    scan tpcds:store_returns:sf3000.0
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:item:sf3000.0
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                        scan tpcds:customer:sf3000.0
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["c_birth_country", "s_zip"])
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                                        join (INNER, REPLICATED):
+                                                            join (INNER, REPLICATED):
+                                                                scan tpcds:store_sales:sf3000.0
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        join (INNER, REPLICATED):
+                                                                            scan tpcds:store_returns:sf3000.0
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan tpcds:item:sf3000.0
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan tpcds:store:sf3000.0
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                                            scan tpcds:customer:sf3000.0
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    join (INNER, REPLICATED):
-                                                        scan tpcds:customer_address:sf3000.0
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:store:sf3000.0
+                                                remote exchange (REPARTITION, HASH, ["ca_zip", "upper"])
+                                                    scan tpcds:customer_address:sf3000.0
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()

--- a/presto-main/src/test/resources/sql/presto/tpcds/q24_2.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q24_2.plan.txt
@@ -8,28 +8,29 @@ remote exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["c_first_name", "c_last_name", "ca_state", "i_color", "i_current_price", "i_manager_id", "i_size", "i_units", "s_state", "s_store_name"])
                                     partial aggregation over (c_first_name, c_last_name, ca_state, i_color, i_current_price, i_manager_id, i_size, i_units, s_state, s_store_name)
-                                        join (INNER, REPLICATED):
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                join (INNER, REPLICATED):
-                                                                    scan tpcds:store_returns:sf3000.0
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:item:sf3000.0
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                        scan tpcds:customer:sf3000.0
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["c_birth_country", "s_zip"])
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                                        join (INNER, REPLICATED):
+                                                            join (INNER, REPLICATED):
+                                                                scan tpcds:store_sales:sf3000.0
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        join (INNER, REPLICATED):
+                                                                            scan tpcds:store_returns:sf3000.0
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan tpcds:item:sf3000.0
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan tpcds:store:sf3000.0
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                                            scan tpcds:customer:sf3000.0
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    join (INNER, REPLICATED):
-                                                        scan tpcds:customer_address:sf3000.0
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:store:sf3000.0
+                                                remote exchange (REPARTITION, HASH, ["ca_zip", "upper"])
+                                                    scan tpcds:customer_address:sf3000.0
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()

--- a/presto-main/src/test/resources/sql/presto/tpcds/q34.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q34.plan.txt
@@ -2,24 +2,24 @@ remote exchange (GATHER, SINGLE, [])
     local exchange (GATHER, UNKNOWN, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                    scan tpcds:customer:sf3000.0
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                    final aggregation over (ss_customer_sk, ss_ticket_number)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
+                                partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:store:sf3000.0
+                                                scan tpcds:store_sales:sf3000.0
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan tpcds:store:sf3000.0
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:household_demographics:sf3000.0
+                                                    scan tpcds:date_dim:sf3000.0
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan tpcds:household_demographics:sf3000.0
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                        scan tpcds:customer:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpcds/q64.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q64.plan.txt
@@ -2,174 +2,193 @@ remote exchange (GATHER, SINGLE, [])
     local exchange (GATHER, UNKNOWN, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["i_item_sk", "s_store_name", "s_zip"])
-                    final aggregation over (ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["ca_city", "ca_city_98", "ca_street_name", "ca_street_name_95", "ca_street_number", "ca_street_number_94", "ca_zip", "ca_zip_101", "d_year", "d_year_28", "d_year_56", "i_item_sk", "i_product_name", "s_store_name", "s_zip"])
-                                partial aggregation over (ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip)
+                final aggregation over (ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip)
+                    local exchange (GATHER, SINGLE, [])
+                        partial aggregation over (ca_city, ca_city_98, ca_street_name, ca_street_name_95, ca_street_number, ca_street_number_94, ca_zip, ca_zip_101, d_year, d_year_28, d_year_56, i_item_sk, i_product_name, s_store_name, s_zip)
+                            join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, ["sr_item_sk"])
                                     join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
+                                        remote exchange (REPARTITION, HASH, ["hd_income_band_sk_88"])
                                             join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
-                                                    join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            join (INNER, REPLICATED):
-                                                                                join (INNER, REPLICATED):
-                                                                                    join (INNER, REPLICATED):
-                                                                                        join (INNER, REPLICATED):
-                                                                                            scan tpcds:store_sales:sf3000.0
-                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                    scan tpcds:date_dim:sf3000.0
-                                                                                        local exchange (GATHER, SINGLE, [])
-                                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                join (INNER, REPLICATED):
-                                                                                                    scan tpcds:store_returns:sf3000.0
-                                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                            final aggregation over (cs_item_sk)
-                                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                                    remote exchange (REPARTITION, HASH, ["cs_item_sk"])
-                                                                                                                        partial aggregation over (cs_item_sk)
+                                                remote exchange (REPARTITION, HASH, ["hd_income_band_sk"])
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
+                                                            join (INNER, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, ["c_current_hdemo_sk"])
+                                                                            join (INNER, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, ["ss_hdemo_sk"])
+                                                                                    join (INNER, PARTITIONED):
+                                                                                        remote exchange (REPARTITION, HASH, ["ss_promo_sk"])
+                                                                                            join (INNER, PARTITIONED):
+                                                                                                remote exchange (REPARTITION, HASH, ["c_current_cdemo_sk"])
+                                                                                                    join (INNER, PARTITIONED):
+                                                                                                        remote exchange (REPARTITION, HASH, ["ss_cdemo_sk"])
+                                                                                                            join (INNER, PARTITIONED):
+                                                                                                                remote exchange (REPARTITION, HASH, ["c_first_shipto_date_sk"])
+                                                                                                                    join (INNER, PARTITIONED):
+                                                                                                                        remote exchange (REPARTITION, HASH, ["c_first_sales_date_sk"])
                                                                                                                             join (INNER, PARTITIONED):
-                                                                                                                                remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
-                                                                                                                                    scan tpcds:catalog_sales:sf3000.0
+                                                                                                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                                                                                                                    join (INNER, PARTITIONED):
+                                                                                                                                        remote exchange (REPARTITION, HASH, ["ss_store_sk"])
+                                                                                                                                            join (INNER, PARTITIONED):
+                                                                                                                                                remote exchange (REPARTITION, HASH, ["ss_sold_date_sk"])
+                                                                                                                                                    join (INNER, PARTITIONED):
+                                                                                                                                                        remote exchange (REPARTITION, HASH, ["sr_item_sk"])
+                                                                                                                                                            join (INNER, REPLICATED):
+                                                                                                                                                                scan tpcds:store_sales:sf3000.0
+                                                                                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                                                                        scan tpcds:store_returns:sf3000.0
+                                                                                                                                                        final aggregation over (cs_item_sk)
+                                                                                                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                                                                                                remote exchange (REPARTITION, HASH, ["cs_item_sk"])
+                                                                                                                                                                    partial aggregation over (cs_item_sk)
+                                                                                                                                                                        join (INNER, PARTITIONED):
+                                                                                                                                                                            remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
+                                                                                                                                                                                scan tpcds:catalog_sales:sf3000.0
+                                                                                                                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                                                                                                                remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
+                                                                                                                                                                                    scan tpcds:catalog_returns:sf3000.0
+                                                                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                                                                    remote exchange (REPARTITION, HASH, ["d_date_sk"])
+                                                                                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                                                            remote exchange (REPARTITION, HASH, ["s_store_sk"])
+                                                                                                                                                scan tpcds:store:sf3000.0
                                                                                                                                 local exchange (GATHER, SINGLE, [])
-                                                                                                                                    remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
-                                                                                                                                        scan tpcds:catalog_returns:sf3000.0
-                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:customer_demographics:sf3000.0
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        scan tpcds:store:sf3000.0
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    join (INNER, REPLICATED):
-                                                                                        join (INNER, REPLICATED):
-                                                                                            scan tpcds:customer:sf3000.0
-                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                    scan tpcds:date_dim:sf3000.0
-                                                                                        local exchange (GATHER, SINGLE, [])
-                                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:item:sf3000.0
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_demographics:sf3000.0
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        join (INNER, REPLICATED):
-                                                                            scan tpcds:household_demographics:sf3000.0
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:income_band:sf3000.0
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    join (INNER, REPLICATED):
-                                                                        scan tpcds:household_demographics:sf3000.0
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:income_band:sf3000.0
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:promotion:sf3000.0
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                        scan tpcds:customer_address:sf3000.0
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_92"])
-                                                scan tpcds:customer_address:sf3000.0
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["i_item_sk_573", "s_store_name_452", "s_zip_472"])
-                        final aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_369, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_city_547", "ca_city_560", "ca_street_name_544", "ca_street_name_557", "ca_street_number_543", "ca_street_number_556", "ca_zip_550", "ca_zip_563", "d_year_369", "d_year_397", "d_year_425", "i_item_sk_573", "i_product_name_594", "s_store_name_452", "s_zip_472"])
-                                    partial aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_369, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
-                                        join (INNER, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["c_current_addr_sk_480"])
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, ["ss_addr_sk_240"])
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        join (INNER, REPLICATED):
-                                                                            join (INNER, REPLICATED):
-                                                                                join (INNER, REPLICATED):
-                                                                                    join (INNER, REPLICATED):
-                                                                                        join (INNER, REPLICATED):
-                                                                                            join (INNER, REPLICATED):
-                                                                                                scan tpcds:store_sales:sf3000.0
-                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                        scan tpcds:date_dim:sf3000.0
-                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                    join (INNER, REPLICATED):
-                                                                                                        scan tpcds:store_returns:sf3000.0
+                                                                                                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                                                                                                                        scan tpcds:customer:sf3000.0
+                                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                                            remote exchange (REPARTITION, HASH, ["d_date_sk_22"])
+                                                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                                    remote exchange (REPARTITION, HASH, ["d_date_sk_50"])
+                                                                                                                        scan tpcds:date_dim:sf3000.0
                                                                                                         local exchange (GATHER, SINGLE, [])
-                                                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                final aggregation over (cs_item_sk_292)
-                                                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                                                        remote exchange (REPARTITION, HASH, ["cs_item_sk_292"])
-                                                                                                                            partial aggregation over (cs_item_sk_292)
-                                                                                                                                join (INNER, PARTITIONED):
-                                                                                                                                    remote exchange (REPARTITION, HASH, ["cs_item_sk_292", "cs_order_number_294"])
-                                                                                                                                        scan tpcds:catalog_sales:sf3000.0
-                                                                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                                                                        remote exchange (REPARTITION, HASH, ["cr_item_sk_313", "cr_order_number_327"])
-                                                                                                                                            scan tpcds:catalog_returns:sf3000.0
-                                                                                        local exchange (GATHER, SINGLE, [])
-                                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:customer_demographics:sf3000.0
-                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:store:sf3000.0
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        join (INNER, REPLICATED):
-                                                                                            join (INNER, REPLICATED):
-                                                                                                scan tpcds:customer:sf3000.0
+                                                                                                            remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
+                                                                                                                scan tpcds:customer_demographics:sf3000.0
                                                                                                 local exchange (GATHER, SINGLE, [])
-                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                        scan tpcds:date_dim:sf3000.0
-                                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                    scan tpcds:date_dim:sf3000.0
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:item:sf3000.0
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:customer_demographics:sf3000.0
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                            join (INNER, REPLICATED):
-                                                                                scan tpcds:household_demographics:sf3000.0
+                                                                                                    remote exchange (REPARTITION, HASH, ["cd_demo_sk_78"])
+                                                                                                        scan tpcds:customer_demographics:sf3000.0
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPARTITION, HASH, ["p_promo_sk"])
+                                                                                                scan tpcds:promotion:sf3000.0
                                                                                 local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        scan tpcds:income_band:sf3000.0
+                                                                                    remote exchange (REPARTITION, HASH, ["hd_demo_sk"])
+                                                                                        scan tpcds:household_demographics:sf3000.0
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["hd_demo_sk_87"])
+                                                                                scan tpcds:household_demographics:sf3000.0
                                                                 local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        join (INNER, REPLICATED):
-                                                                            scan tpcds:household_demographics:sf3000.0
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:income_band:sf3000.0
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:promotion:sf3000.0
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, ["ca_address_sk_541"])
-                                                            scan tpcds:customer_address:sf3000.0
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["ca_address_sk_554"])
-                                                    scan tpcds:customer_address:sf3000.0
+                                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk"])
+                                                                        scan tpcds:customer_address:sf3000.0
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_92"])
+                                                                scan tpcds:customer_address:sf3000.0
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["ib_income_band_sk"])
+                                                        scan tpcds:income_band:sf3000.0
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ib_income_band_sk_105"])
+                                                scan tpcds:income_band:sf3000.0
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["i_item_sk"])
+                                        scan tpcds:item:sf3000.0
+                final aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_369, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
+                    local exchange (GATHER, SINGLE, [])
+                        partial aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_369, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
+                            join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, ["sr_item_sk_259"])
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["hd_income_band_sk_537"])
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["hd_income_band_sk_532"])
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, ["c_current_addr_sk_480"])
+                                                            join (INNER, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, ["ss_addr_sk_240"])
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, ["c_current_hdemo_sk_479"])
+                                                                            join (INNER, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, ["ss_hdemo_sk_239"])
+                                                                                    join (INNER, PARTITIONED):
+                                                                                        remote exchange (REPARTITION, HASH, ["ss_promo_sk_242"])
+                                                                                            join (INNER, PARTITIONED):
+                                                                                                remote exchange (REPARTITION, HASH, ["c_current_cdemo_sk_478"])
+                                                                                                    join (INNER, PARTITIONED):
+                                                                                                        remote exchange (REPARTITION, HASH, ["ss_cdemo_sk_238"])
+                                                                                                            join (INNER, PARTITIONED):
+                                                                                                                remote exchange (REPARTITION, HASH, ["c_first_shipto_date_sk_481"])
+                                                                                                                    join (INNER, PARTITIONED):
+                                                                                                                        remote exchange (REPARTITION, HASH, ["c_first_sales_date_sk_482"])
+                                                                                                                            join (INNER, PARTITIONED):
+                                                                                                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk_237"])
+                                                                                                                                    join (INNER, PARTITIONED):
+                                                                                                                                        remote exchange (REPARTITION, HASH, ["ss_store_sk_241"])
+                                                                                                                                            join (INNER, PARTITIONED):
+                                                                                                                                                remote exchange (REPARTITION, HASH, ["ss_sold_date_sk_234"])
+                                                                                                                                                    join (INNER, PARTITIONED):
+                                                                                                                                                        remote exchange (REPARTITION, HASH, ["sr_item_sk_259"])
+                                                                                                                                                            join (INNER, REPLICATED):
+                                                                                                                                                                scan tpcds:store_sales:sf3000.0
+                                                                                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                                                                        scan tpcds:store_returns:sf3000.0
+                                                                                                                                                        final aggregation over (cs_item_sk_292)
+                                                                                                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                                                                                                remote exchange (REPARTITION, HASH, ["cs_item_sk_292"])
+                                                                                                                                                                    partial aggregation over (cs_item_sk_292)
+                                                                                                                                                                        join (INNER, PARTITIONED):
+                                                                                                                                                                            remote exchange (REPARTITION, HASH, ["cs_item_sk_292", "cs_order_number_294"])
+                                                                                                                                                                                scan tpcds:catalog_sales:sf3000.0
+                                                                                                                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                                                                                                                remote exchange (REPARTITION, HASH, ["cr_item_sk_313", "cr_order_number_327"])
+                                                                                                                                                                                    scan tpcds:catalog_returns:sf3000.0
+                                                                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                                                                    remote exchange (REPARTITION, HASH, ["d_date_sk_363"])
+                                                                                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                                                            remote exchange (REPARTITION, HASH, ["s_store_sk_447"])
+                                                                                                                                                scan tpcds:store:sf3000.0
+                                                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                                                    remote exchange (REPARTITION, HASH, ["c_customer_sk_476"])
+                                                                                                                                        scan tpcds:customer:sf3000.0
+                                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                                            remote exchange (REPARTITION, HASH, ["d_date_sk_391"])
+                                                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                                    remote exchange (REPARTITION, HASH, ["d_date_sk_419"])
+                                                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                            remote exchange (REPARTITION, HASH, ["cd_demo_sk_494"])
+                                                                                                                scan tpcds:customer_demographics:sf3000.0
+                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                    remote exchange (REPARTITION, HASH, ["cd_demo_sk_503"])
+                                                                                                        scan tpcds:customer_demographics:sf3000.0
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPARTITION, HASH, ["p_promo_sk_512"])
+                                                                                                scan tpcds:promotion:sf3000.0
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPARTITION, HASH, ["hd_demo_sk_531"])
+                                                                                        scan tpcds:household_demographics:sf3000.0
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["hd_demo_sk_536"])
+                                                                                scan tpcds:household_demographics:sf3000.0
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPARTITION, HASH, ["ca_address_sk_541"])
+                                                                        scan tpcds:customer_address:sf3000.0
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["ca_address_sk_554"])
+                                                                scan tpcds:customer_address:sf3000.0
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["ib_income_band_sk_567"])
+                                                        scan tpcds:income_band:sf3000.0
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["ib_income_band_sk_570"])
+                                                scan tpcds:income_band:sf3000.0
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["i_item_sk_573"])
+                                        scan tpcds:item:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpcds/q69.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q69.plan.txt
@@ -4,7 +4,41 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["cd_credit_rating", "cd_education_status", "cd_gender", "cd_marital_status", "cd_purchase_estimate"])
                     partial aggregation over (cd_credit_rating, cd_education_status, cd_gender, cd_marital_status, cd_purchase_estimate)
-                        join (RIGHT, PARTITIONED):
+                        join (LEFT, PARTITIONED):
+                            join (RIGHT, PARTITIONED):
+                                final aggregation over (ws_bill_customer_sk)
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
+                                            partial aggregation over (ws_bill_customer_sk)
+                                                join (INNER, REPLICATED):
+                                                    scan tpcds:web_sales:sf3000.0
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan tpcds:date_dim:sf3000.0
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
+                                                scan tpcds:customer_demographics:sf3000.0
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["c_current_cdemo_sk"])
+                                                    join (INNER, PARTITIONED):
+                                                        final aggregation over (ss_customer_sk)
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                                                                    partial aggregation over (ss_customer_sk)
+                                                                        join (INNER, REPLICATED):
+                                                                            scan tpcds:store_sales:sf3000.0
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan tpcds:date_dim:sf3000.0
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                                                                join (INNER, REPLICATED):
+                                                                    scan tpcds:customer:sf3000.0
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan tpcds:customer_address:sf3000.0
                             final aggregation over (cs_ship_customer_sk)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["cs_ship_customer_sk"])
@@ -14,38 +48,3 @@ local exchange (GATHER, SINGLE, [])
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         scan tpcds:date_dim:sf3000.0
-                            local exchange (GATHER, SINGLE, [])
-                                join (RIGHT, PARTITIONED):
-                                    final aggregation over (ws_bill_customer_sk)
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
-                                                partial aggregation over (ws_bill_customer_sk)
-                                                    join (INNER, REPLICATED):
-                                                        scan tpcds:web_sales:sf3000.0
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                                    scan tpcds:customer_demographics:sf3000.0
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["c_current_cdemo_sk"])
-                                                        join (INNER, PARTITIONED):
-                                                            final aggregation over (ss_customer_sk)
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                                        partial aggregation over (ss_customer_sk)
-                                                                            join (INNER, REPLICATED):
-                                                                                scan tpcds:store_sales:sf3000.0
-                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        scan tpcds:date_dim:sf3000.0
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                                    join (INNER, REPLICATED):
-                                                                        scan tpcds:customer:sf3000.0
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:customer_address:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpcds/q73.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q73.plan.txt
@@ -2,24 +2,24 @@ remote exchange (GATHER, SINGLE, [])
     local exchange (GATHER, UNKNOWN, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
             join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                    scan tpcds:customer:sf3000.0
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                        final aggregation over (ss_customer_sk, ss_ticket_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
-                                    partial aggregation over (ss_customer_sk, ss_ticket_number)
+                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                    final aggregation over (ss_customer_sk, ss_ticket_number)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_ticket_number"])
+                                partial aggregation over (ss_customer_sk, ss_ticket_number)
+                                    join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                scan tpcds:store_sales:sf3000.0
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:store:sf3000.0
+                                                        scan tpcds:date_dim:sf3000.0
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:household_demographics:sf3000.0
+                                                    scan tpcds:store:sf3000.0
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan tpcds:household_demographics:sf3000.0
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPARTITION, HASH, ["c_customer_sk"])
+                        scan tpcds:customer:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpcds/q78.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q78.plan.txt
@@ -1,7 +1,35 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, PARTITIONED):
-            join (INNER, PARTITIONED):
+            remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
+                join (INNER, PARTITIONED):
+                    final aggregation over (d_year, ss_customer_sk, ss_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["d_year", "ss_customer_sk", "ss_item_sk"])
+                                partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
+                                    join (INNER, REPLICATED):
+                                        join (LEFT, REPLICATED):
+                                            scan tpcds:store_sales:sf3000.0
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan tpcds:store_returns:sf3000.0
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan tpcds:date_dim:sf3000.0
+                    final aggregation over (d_year_53, ws_bill_customer_sk, ws_item_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["d_year_53", "ws_bill_customer_sk", "ws_item_sk"])
+                                partial aggregation over (d_year_53, ws_bill_customer_sk, ws_item_sk)
+                                    join (INNER, REPLICATED):
+                                        join (LEFT, REPLICATED):
+                                            scan tpcds:web_sales:sf3000.0
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan tpcds:web_returns:sf3000.0
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan tpcds:date_dim:sf3000.0
+            local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                     final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_130)
                         local exchange (GATHER, SINGLE, [])
@@ -13,36 +41,6 @@ local exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     scan tpcds:catalog_returns:sf3000.0
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
-                        final aggregation over (d_year_53, ws_bill_customer_sk, ws_item_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["d_year_53", "ws_bill_customer_sk", "ws_item_sk"])
-                                    partial aggregation over (d_year_53, ws_bill_customer_sk, ws_item_sk)
-                                        join (INNER, REPLICATED):
-                                            join (LEFT, REPLICATED):
-                                                scan tpcds:web_sales:sf3000.0
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:web_returns:sf3000.0
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                    final aggregation over (d_year, ss_customer_sk, ss_item_sk)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, ["d_year", "ss_customer_sk", "ss_item_sk"])
-                                partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
-                                    join (INNER, REPLICATED):
-                                        join (LEFT, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:store_returns:sf3000.0
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 scan tpcds:date_dim:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpcds/q94.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q94.plan.txt
@@ -2,31 +2,30 @@ final aggregation over ()
     local exchange (GATHER, SINGLE, [])
         remote exchange (GATHER, SINGLE, [])
             partial aggregation over ()
-                local exchange (GATHER, SINGLE, [])
-                    join (RIGHT, PARTITIONED):
-                        final aggregation over (wr_order_number)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["wr_order_number"])
-                                    partial aggregation over (wr_order_number)
-                                        scan tpcds:web_returns:sf3000.0
-                        final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                            local exchange (GATHER, SINGLE, [])
-                                partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
-                                    join (RIGHT, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, ["ws_order_number_17"])
-                                            scan tpcds:web_sales:sf3000.0
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, ["ws_order_number"])
+                join (LEFT, PARTITIONED):
+                    final aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                        local exchange (GATHER, SINGLE, [])
+                            partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
+                                join (RIGHT, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["ws_order_number_17"])
+                                        scan tpcds:web_sales:sf3000.0
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, ["ws_order_number"])
+                                            join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            scan tpcds:web_sales:sf3000.0
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:customer_address:sf3000.0
+                                                        scan tpcds:web_sales:sf3000.0
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan tpcds:customer_address:sf3000.0
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:web_site:sf3000.0
+                                                            scan tpcds:date_dim:sf3000.0
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan tpcds:web_site:sf3000.0
+                    final aggregation over (wr_order_number)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["wr_order_number"])
+                                partial aggregation over (wr_order_number)
+                                    scan tpcds:web_returns:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpch/q04.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpch/q04.plan.txt
@@ -6,11 +6,10 @@ remote exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["orderpriority"])
                         partial aggregation over (orderpriority)
                             join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, ["orderkey"])
+                                    scan tpch:orders:sf3000.0
                                 final aggregation over (orderkey_0)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["orderkey_0"])
                                             partial aggregation over (orderkey_0)
                                                 scan tpch:lineitem:sf3000.0
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["orderkey"])
-                                        scan tpch:orders:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpch/q09.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpch/q09.plan.txt
@@ -5,24 +5,28 @@ remote exchange (GATHER, SINGLE, [])
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr_18", "name_15"])
                         partial aggregation over (expr_18, name_15)
-                            join (INNER, REPLICATED):
-                                join (INNER, REPLICATED):
-                                    scan tpch:lineitem:sf3000.0
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpch:orders:sf3000.0
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                scan tpch:partsupp:sf3000.0
+                            join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, ["nationkey"])
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, ["orderkey"])
+                                            join (INNER, PARTITIONED):
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, ["suppkey_4"])
+                                                        join (INNER, PARTITIONED):
+                                                            remote exchange (REPARTITION, HASH, ["partkey"])
+                                                                scan tpch:part:sf3000.0
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPARTITION, HASH, ["partkey_3"])
+                                                                    scan tpch:lineitem:sf3000.0
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, ["suppkey"])
+                                                            scan tpch:supplier:sf3000.0
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpch:part:sf3000.0
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    join (INNER, REPLICATED):
-                                                        scan tpch:supplier:sf3000.0
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpch:nation:sf3000.0
+                                                    remote exchange (REPARTITION, HASH, ["suppkey_8"])
+                                                        scan tpch:partsupp:sf3000.0
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, ["orderkey_11"])
+                                                scan tpch:orders:sf3000.0
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPARTITION, HASH, ["nationkey_14"])
+                                        scan tpch:nation:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpch/q13.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpch/q13.plan.txt
@@ -8,9 +8,9 @@ remote exchange (GATHER, SINGLE, [])
                             final aggregation over (custkey)
                                 local exchange (GATHER, SINGLE, [])
                                     partial aggregation over (custkey)
-                                        join (RIGHT, PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["custkey_0"])
-                                                scan tpch:orders:sf3000.0
+                                        join (LEFT, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, ["custkey"])
+                                                scan tpch:customer:sf3000.0
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["custkey"])
-                                                    scan tpch:customer:sf3000.0
+                                                remote exchange (REPARTITION, HASH, ["custkey_0"])
+                                                    scan tpch:orders:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpch/q15.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpch/q15.plan.txt
@@ -1,23 +1,23 @@
 remote exchange (GATHER, SINGLE, [])
     local exchange (GATHER, UNKNOWN, [])
         remote exchange (REPARTITION, ROUND_ROBIN, [])
-            join (INNER, PARTITIONED):
-                remote exchange (REPARTITION, HASH, ["suppkey"])
-                    scan tpch:supplier:sf3000.0
-                join (INNER, REPLICATED):
+            join (INNER, REPLICATED):
+                join (INNER, PARTITIONED):
+                    remote exchange (REPARTITION, HASH, ["suppkey"])
+                        scan tpch:supplier:sf3000.0
                     final aggregation over (suppkey_0)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["suppkey_0"])
                                 partial aggregation over (suppkey_0)
                                     scan tpch:lineitem:sf3000.0
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPLICATE, BROADCAST, [])
-                            final aggregation over ()
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (GATHER, SINGLE, [])
-                                        partial aggregation over ()
-                                            final aggregation over (suppkey_16)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, ["suppkey_16"])
-                                                        partial aggregation over (suppkey_16)
-                                                            scan tpch:lineitem:sf3000.0
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPLICATE, BROADCAST, [])
+                        final aggregation over ()
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (GATHER, SINGLE, [])
+                                    partial aggregation over ()
+                                        final aggregation over (suppkey_16)
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, ["suppkey_16"])
+                                                    partial aggregation over (suppkey_16)
+                                                        scan tpch:lineitem:sf3000.0

--- a/presto-main/src/test/resources/sql/presto/tpch/q20.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpch/q20.plan.txt
@@ -11,20 +11,20 @@ remote exchange (GATHER, SINGLE, [])
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["suppkey_4"])
                         cross join:
-                            join (RIGHT, PARTITIONED):
-                                final aggregation over (partkey_18, suppkey_19)
+                            join (LEFT, PARTITIONED):
+                                semijoin (PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, ["partkey"])
+                                        scan tpch:partsupp:sf3000.0
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, ["partkey_18", "suppkey_19"])
-                                            partial aggregation over (partkey_18, suppkey_19)
-                                                scan tpch:lineitem:sf3000.0
+                                        remote exchange (REPARTITION, HASH, ["partkey_8"])
+                                            scan tpch:part:sf3000.0
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, ["partkey", "suppkey_4"])
-                                        semijoin (PARTITIONED):
-                                            remote exchange (REPARTITION, HASH, ["partkey"])
-                                                scan tpch:partsupp:sf3000.0
+                                    remote exchange (REPARTITION, HASH, ["partkey_18"])
+                                        final aggregation over (partkey_18, suppkey_19)
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, ["partkey_8"])
-                                                    scan tpch:part:sf3000.0
+                                                remote exchange (REPARTITION, HASH, ["partkey_18", "suppkey_19"])
+                                                    partial aggregation over (partkey_18, suppkey_19)
+                                                        scan tpch:lineitem:sf3000.0
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     single aggregation over ()

--- a/presto-main/src/test/resources/sql/presto/tpch/q21.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpch/q21.plan.txt
@@ -4,29 +4,32 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["name"])
                     partial aggregation over (name)
-                        single aggregation over (commitdate, exists, name, name_7, nationkey, orderkey, orderstatus, receiptdate, suppkey_0, unique)
+                        single aggregation over (commitdate, exists, name, name_7, nationkey, orderkey, orderstatus, receiptdate, suppkey, unique)
                             join (LEFT, PARTITIONED):
-                                final aggregation over (commitdate, name, name_7, nationkey, orderkey, orderstatus, receiptdate, suppkey_0, unique_189)
+                                final aggregation over (commitdate, name, name_7, nationkey, orderkey, orderstatus, receiptdate, suppkey, unique_189)
                                     local exchange (GATHER, SINGLE, [])
-                                        partial aggregation over (commitdate, name, name_7, nationkey, orderkey, orderstatus, receiptdate, suppkey_0, unique_189)
-                                            join (RIGHT, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, ["orderkey_10"])
-                                                    scan tpch:lineitem:sf3000.0
-                                                local exchange (GATHER, SINGLE, [])
+                                        partial aggregation over (commitdate, name, name_7, nationkey, orderkey, orderstatus, receiptdate, suppkey, unique_189)
+                                            join (LEFT, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, ["orderkey"])
                                                     join (INNER, PARTITIONED):
-                                                        remote exchange (REPARTITION, HASH, ["orderkey"])
-                                                            join (INNER, REPLICATED):
-                                                                scan tpch:lineitem:sf3000.0
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        join (INNER, REPLICATED):
+                                                        remote exchange (REPARTITION, HASH, ["nationkey"])
+                                                            join (INNER, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, ["orderkey"])
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, ["suppkey"])
                                                                             scan tpch:supplier:sf3000.0
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpch:nation:sf3000.0
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, ["suppkey_0"])
+                                                                                scan tpch:lineitem:sf3000.0
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPARTITION, HASH, ["orderkey_3"])
+                                                                        scan tpch:orders:sf3000.0
                                                         local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPARTITION, HASH, ["orderkey_3"])
-                                                                scan tpch:orders:sf3000.0
+                                                            remote exchange (REPARTITION, HASH, ["nationkey_6"])
+                                                                scan tpch:nation:sf3000.0
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, ["orderkey_10"])
+                                                        scan tpch:lineitem:sf3000.0
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["orderkey_92"])
                                         scan tpch:lineitem:sf3000.0

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedStats.java
@@ -106,24 +106,20 @@ public class TestTpchDistributedStats
     public void testIntersect()
     {
         statisticsAssertion.check("SELECT * FROM nation INTERSECT SELECT * FROM nation",
-                // real count is 25, estimation cannot know all rows are duplicate.
-                checks -> checks.estimate(OUTPUT_ROW_COUNT, relativeError(.7, .9)));
+                checks -> checks.noEstimate(OUTPUT_ROW_COUNT));
 
         statisticsAssertion.check("SELECT * FROM orders WHERE o_custkey < 900 INTERSECT SELECT * FROM orders WHERE o_custkey > 600",
-                // TODO fix INTERSECT stats calculation as custkey values distribution is pretty linear
-                checks -> checks.estimate(OUTPUT_ROW_COUNT, relativeError(4, 5)));
+                checks -> checks.noEstimate(OUTPUT_ROW_COUNT));
     }
 
     @Test
     public void testExcept()
     {
         statisticsAssertion.check("SELECT * FROM nation EXCEPT SELECT * FROM nation",
-                // real count is 0, estimation cannot know all rows are eliminated
-                checks -> checks.estimate(OUTPUT_ROW_COUNT, absoluteError(45, 45)));
+                checks -> checks.noEstimate(OUTPUT_ROW_COUNT));
 
         statisticsAssertion.check("SELECT * FROM orders WHERE o_custkey < 900 EXCEPT SELECT * FROM orders WHERE o_custkey > 600",
-                // TODO fix EXCEPT stats calculation as custkey values distribution is pretty linear
-                checks -> checks.estimate(OUTPUT_ROW_COUNT, relativeError(1.5, 2)));
+                checks -> checks.noEstimate(OUTPUT_ROW_COUNT));
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchLocalStats.java
@@ -446,45 +446,20 @@ public class TestTpchLocalStats
     public void testIntersect()
     {
         statisticsAssertion.check("SELECT * FROM nation INTERSECT SELECT * FROM nation",
-                // real count is 25, estimation cannot know all rows are duplicate.
-                checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, relativeError(.7, .9))
-                        .verifyExactColumnStatistics("n_nationkey")
-                        .verifyExactColumnStatistics("n_regionkey"));
+                checks -> checks.noEstimate(OUTPUT_ROW_COUNT));
 
         statisticsAssertion.check("SELECT * FROM orders WHERE o_custkey < 900 INTERSECT SELECT * FROM orders WHERE o_custkey > 600",
-                // TODO fix INTERSECT stats calculation as custkey values distribution is pretty linear
-                checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, relativeError(4, 5))
-                        .estimate(distinctValuesCount("o_orderkey"), relativeError(1.5, 2))
-                        .estimate(nullsFraction("o_orderkey"), relativeError(4, 5))
-                        .estimate(lowValue("o_orderkey"), absoluteError(-1, -1))
-                        .estimate(highValue("o_orderkey"), absoluteError(25, 25))
-                        .estimate(distinctValuesCount("o_custkey"), relativeError(1.5, 2.5))
-                        .estimate(nullsFraction("o_custkey"), relativeError(5, 6))
-                        .estimate(lowValue("o_custkey"), absoluteError(-600, -600))
-                        .estimate(highValue("o_custkey"), relativeError(.5, 1)));
+                checks -> checks.noEstimate(OUTPUT_ROW_COUNT));
     }
 
     @Test
     public void testExcept()
     {
         statisticsAssertion.check("SELECT * FROM nation EXCEPT SELECT * FROM nation",
-                // real count is 0, estimation cannot know all rows are eliminated
-                checks -> checks.estimate(OUTPUT_ROW_COUNT, absoluteError(45, 45)));
+                checks -> checks.noEstimate(OUTPUT_ROW_COUNT));
 
         statisticsAssertion.check("SELECT * FROM orders WHERE o_custkey < 900 EXCEPT SELECT * FROM orders WHERE o_custkey > 600",
-                // TODO fix EXCEPT stats calculation as custkey values distribution is pretty linear
-                checks -> checks
-                        .estimate(OUTPUT_ROW_COUNT, relativeError(1.5, 2))
-                        .estimate(distinctValuesCount("o_orderkey"), relativeError(0.5, 1))
-                        .estimate(nullsFraction("o_orderkey"), relativeError(1.5, 2))
-                        .estimate(lowValue("o_orderkey"), noError())
-                        .estimate(highValue("o_orderkey"), absoluteError(27, 27))
-                        .estimate(distinctValuesCount("o_custkey"), relativeError(0.5, 0.8))
-                        .estimate(nullsFraction("o_custkey"), relativeError(2, 2.5))
-                        .estimate(lowValue("o_custkey"), noError())
-                        .estimate(highValue("o_custkey"), relativeError(1.5, 2)));
+                checks -> checks.noEstimate(OUTPUT_ROW_COUNT));
     }
 
     @Test


### PR DESCRIPTION
Apply 0.9 coefficient for a conjunct that cannot be estimated only if at least a single conjunct was estimated.