### PR TITLE
Adds Block.getLogicalSize and limits size of response to client.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -416,7 +416,7 @@ class Query
                 }
 
                 Page page = serde.deserialize(serializedPage);
-                bytes += page.getLogicalSizeInBytes();
+                bytes += page.getSizeInBytes();
                 rows += page.getPositionCount();
                 pages.add(new RowIterable(session.toConnectorSession(), types, page));
             }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -416,7 +416,7 @@ class Query
                 }
 
                 Page page = serde.deserialize(serializedPage);
-                bytes += page.getSizeInBytes();
+                bytes += page.getLogicalSizeInBytes();
                 rows += page.getPositionCount();
                 pages.add(new RowIterable(session.toConnectorSession(), types, page));
             }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
@@ -42,6 +42,22 @@ public class TestDictionaryBlock
     }
 
     @Test
+    public void testLogicalSizeInBytes()
+    {
+        // The 10 Slices in the array will be of lengths 0 to 9.
+        Slice[] expectedValues = createExpectedValues(10);
+
+        // The dictionary within the dictionary block is expected to be a VariableWidthBlock of size 95 bytes.
+        // 45 bytes for the expectedValues Slices (sum of seq(0,9)) and 50 bytes for the position and isNull array (total 10 positions).
+        DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, 100);
+
+        // The 100 positions in the dictionary block index to 10 positions in the underlying dictionary (10 each).
+        // Logical size calculation accounts for 4 bytes of offset and 1 byte of isNull. Therefore the expected unoptimized
+        // size is 10 times the size of the underlying dictionary (VariableWidthBlock).
+        assertEquals(dictionaryBlock.getLogicalSizeInBytes(), dictionaryBlock.getDictionary().getSizeInBytes() * 10);
+    }
+
+    @Test
     public void testCopyRegionCreatesCompactBlock()
     {
         Slice[] expectedValues = createExpectedValues(10);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
@@ -42,6 +42,22 @@ public class TestDictionaryBlock
     }
 
     @Test
+    public void testLogicalSizeInBytes()
+    {
+        // The 10 Slices in the array will be of lengths 0 to 9.
+        Slice[] expectedValues = createExpectedValues(10);
+
+        // The dictionary within the dictionary block is expected to be a VariableWidthBlock of size 95bytes.
+        // 45bytes for the expectValue Slices (sum of seq(0,9)) and 50bytes for the position and isNull array (total 10 positions)
+        DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, 100);
+
+        // The 100 positions in the dictionary block index to 10 positions in the underlying dictionary (10 each).
+        // Logical size calculation accounts for 4bytes of offset and 1byte of isNull. Therefore the expected unoptimized
+        // size is 10 times the size of the underlying dictionary (VariableWidthBlock).
+        assertEquals(dictionaryBlock.getLogicalSizeInBytes(), dictionaryBlock.getDictionary().getSizeInBytes() * 10);
+    }
+
+    @Test
     public void testCopyRegionCreatesCompactBlock()
     {
         Slice[] expectedValues = createExpectedValues(10);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
@@ -42,22 +42,6 @@ public class TestDictionaryBlock
     }
 
     @Test
-    public void testLogicalSizeInBytes()
-    {
-        // The 10 Slices in the array will be of lengths 0 to 9.
-        Slice[] expectedValues = createExpectedValues(10);
-
-        // The dictionary within the dictionary block is expected to be a VariableWidthBlock of size 95bytes.
-        // 45bytes for the expectValue Slices (sum of seq(0,9)) and 50bytes for the position and isNull array (total 10 positions)
-        DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, 100);
-
-        // The 100 positions in the dictionary block index to 10 positions in the underlying dictionary (10 each).
-        // Logical size calculation accounts for 4bytes of offset and 1byte of isNull. Therefore the expected unoptimized
-        // size is 10 times the size of the underlying dictionary (VariableWidthBlock).
-        assertEquals(dictionaryBlock.getLogicalSizeInBytes(), dictionaryBlock.getDictionary().getSizeInBytes() * 10);
-    }
-
-    @Test
     public void testCopyRegionCreatesCompactBlock()
     {
         Slice[] expectedValues = createExpectedValues(10);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
@@ -40,7 +40,6 @@ public class Page
     private final int positionCount;
     private final AtomicLong sizeInBytes = new AtomicLong(-1);
     private final AtomicLong retainedSizeInBytes = new AtomicLong(-1);
-    private final AtomicLong logicalSizeInBytes = new AtomicLong(-1);
 
     public Page(Block... blocks)
     {
@@ -75,19 +74,6 @@ public class Page
             this.sizeInBytes.set(sizeInBytes);
         }
         return sizeInBytes;
-    }
-
-    public long getLogicalSizeInBytes()
-    {
-        long logicalSizeInBytes = this.logicalSizeInBytes.get();
-        if (logicalSizeInBytes < 0) {
-            logicalSizeInBytes = 0;
-            for (Block block : blocks) {
-                logicalSizeInBytes += block.getLogicalSizeInBytes();
-            }
-            this.logicalSizeInBytes.set(logicalSizeInBytes);
-        }
-        return logicalSizeInBytes;
     }
 
     public long getRetainedSizeInBytes()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Page.java
@@ -40,6 +40,7 @@ public class Page
     private final int positionCount;
     private final AtomicLong sizeInBytes = new AtomicLong(-1);
     private final AtomicLong retainedSizeInBytes = new AtomicLong(-1);
+    private final AtomicLong logicalSizeInBytes = new AtomicLong(-1);
 
     public Page(Block... blocks)
     {
@@ -74,6 +75,19 @@ public class Page
             this.sizeInBytes.set(sizeInBytes);
         }
         return sizeInBytes;
+    }
+
+    public long getLogicalSizeInBytes()
+    {
+        long logicalSizeInBytes = this.logicalSizeInBytes.get();
+        if (logicalSizeInBytes < 0) {
+            logicalSizeInBytes = 0;
+            for (Block block : blocks) {
+                logicalSizeInBytes += block.getLogicalSizeInBytes();
+            }
+            this.logicalSizeInBytes.set(logicalSizeInBytes);
+        }
+        return logicalSizeInBytes;
     }
 
     public long getRetainedSizeInBytes()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -163,18 +163,34 @@ public interface Block
     int getPositionCount();
 
     /**
-     * Returns the logical size of this block in memory.
+     * Returns the size of this block as if it was compacted, ignoring any over-allocations.
+     * For example, in dictionary blocks, this only counts each dictionary entry once,
+     * rather than each time a value is referenced.
      */
     long getSizeInBytes();
 
     /**
-     * Returns the logical size of {@code block.getRegion(position, length)} in memory.
+     * Returns the size of the block contents, regardless of internal representation.
+     * The same logical data values should always have the same size, no matter
+     * what block type is used or how they are represented within a specific block.
+     *
+     * This can differ substantially from {@link #getSizeInBytes} for certain block
+     * types. For RLE, it will be {@code N} times larger. For dictionary, it will be
+     * larger based on how many times dictionary entries are reused.
+     */
+    default long getLogicalSizeInBytes()
+    {
+        return getSizeInBytes();
+    }
+
+    /**
+     * Returns the size of {@code block.getRegion(position, length)}.
      * The method can be expensive. Do not use it outside an implementation of Block.
      */
     long getRegionSizeInBytes(int position, int length);
 
     /**
-     * Returns the retained size of this block in memory.
+     * Returns the retained size of this block in memory, including over-allocations.
      * This method is called from the inner most execution loop and must be fast.
      */
     long getRetainedSizeInBytes();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -163,18 +163,28 @@ public interface Block
     int getPositionCount();
 
     /**
-     * Returns the logical size of this block in memory.
+     * Returns the size of this block as if it was compacted, ignoring any over-allocations.
      */
     long getSizeInBytes();
 
     /**
-     * Returns the logical size of {@code block.getRegion(position, length)} in memory.
+     * Returns the size of this block's contents as if no optimizations were applied to it.
+     * As example, for RLE and Dictionary blocks this can differ significantly from
+     * {@code block.getSizeInBytes()}.
+     */
+    default long getLogicalSizeInBytes()
+    {
+        return getSizeInBytes();
+    }
+
+    /**
+     * Returns the size of {@code block.getRegion(position, length)}.
      * The method can be expensive. Do not use it outside an implementation of Block.
      */
     long getRegionSizeInBytes(int position, int length);
 
     /**
-     * Returns the retained size of this block in memory.
+     * Returns the retained size of this block in memory, including over-allocations.
      * This method is called from the inner most execution loop and must be fast.
      */
     long getRetainedSizeInBytes();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -163,28 +163,18 @@ public interface Block
     int getPositionCount();
 
     /**
-     * Returns the size of this block as if it was compacted, ignoring any over-allocations.
+     * Returns the logical size of this block in memory.
      */
     long getSizeInBytes();
 
     /**
-     * Returns the size of this block's contents as if no optimizations were applied to it.
-     * As example, for RLE and Dictionary blocks this can differ significantly from
-     * {@code block.getSizeInBytes()}.
-     */
-    default long getLogicalSizeInBytes()
-    {
-        return getSizeInBytes();
-    }
-
-    /**
-     * Returns the size of {@code block.getRegion(position, length)}.
+     * Returns the logical size of {@code block.getRegion(position, length)} in memory.
      * The method can be expensive. Do not use it outside an implementation of Block.
      */
     long getRegionSizeInBytes(int position, int length);
 
     /**
-     * Returns the retained size of this block in memory, including over-allocations.
+     * Returns the retained size of this block in memory.
      * This method is called from the inner most execution loop and must be fast.
      */
     long getRetainedSizeInBytes();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -41,7 +41,6 @@ public class DictionaryBlock
     private final int[] ids;
     private final long retainedSizeInBytes;
     private volatile long sizeInBytes = -1;
-    private volatile long logicalSizeInBytes = -1;
     private volatile int uniqueIds = -1;
     private final DictionaryId dictionarySourceId;
 
@@ -218,30 +217,6 @@ public class DictionaryBlock
         }
         this.sizeInBytes = sizeInBytes + (Integer.BYTES * (long) positionCount);
         this.uniqueIds = uniqueIds;
-    }
-
-    @Override
-    public long getLogicalSizeInBytes()
-    {
-        // Calculation of logical size can be performed as part of calculateCompactSize() with minor modifications.
-        // Keeping this calculation separate as this is a little more expensive and may not be called as often.
-        if (logicalSizeInBytes >= 0) {
-            return logicalSizeInBytes;
-        }
-        logicalSizeInBytes = 0;
-
-        long[] seenSizes = new long[dictionary.getPositionCount()];
-        Arrays.fill(seenSizes, -1L);
-        for (int i = 0; i < getPositionCount(); i++) {
-            int position = getId(i);
-            if (!dictionary.isNull(position)) {
-                if (seenSizes[position] < 0) {
-                    seenSizes[position] = dictionary.getRegionSizeInBytes(position, 1);
-                }
-                logicalSizeInBytes += seenSizes[position];
-            }
-        }
-        return logicalSizeInBytes;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -82,6 +82,12 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public long getLogicalSizeInBytes()
+    {
+        return positionCount * value.getLogicalSizeInBytes();
+    }
+
+    @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + value.getRetainedSizeInBytes();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -82,12 +82,6 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public long getLogicalSizeInBytes()
-    {
-        return positionCount * value.getLogicalSizeInBytes();
-    }
-
-    @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE + value.getRetainedSizeInBytes();


### PR DESCRIPTION
Resolves #11332
The change adds a method getLogicalSizeInBytes to the Block interface for
getting the size of a block's contents as if no optimizations (such as RLE or
Dictionary encoding) were applied to it.
This provides a more accurate estimate of the data size sent to the client when
Query::getNextResult is invoked.
For blocks other than RLE and Dictionary encoded the method returns getSizeInBytes().
More details at: https://github.com/prestodb/presto/issues/11332