### PR TITLE
Fix flakiness in testTableWithNoSupportedColumns

### DIFF
--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -138,8 +138,10 @@ public class TestPostgreSqlIntegrationSmokeTest
             assertQuery("SHOW COLUMNS FROM no_columns", "SELECT 'nothing' WHERE false");
 
             // Other tables should be visible in SHOW TABLES (the no_supported_columns might be included or might be not) and information_schema.tables
-            assertQuery("SHOW TABLES", "VALUES 'orders', 'no_supported_columns', 'supported_columns', 'no_columns'");
-            assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema = 'tpch'", "VALUES 'orders', 'no_supported_columns', 'supported_columns', 'no_columns'");
+            assertThat(computeActual("SHOW TABLES").getOnlyColumn())
+                    .contains("orders", "no_supported_columns", "supported_columns", "no_columns");
+            assertThat(computeActual("SELECT table_name FROM information_schema.tables WHERE table_schema = 'tpch'").getOnlyColumn())
+                    .contains("orders", "no_supported_columns", "supported_columns", "no_columns");
 
             // Other tables should be introspectable with SHOW COLUMNS and information_schema.columns
             assertQuery("SHOW COLUMNS FROM supported_columns", "VALUES ('good', 'varchar(5)', '', '')");


### PR DESCRIPTION
The test failed recently with:
```
For query:
 SHOW TABLES
not equal
Actual rows (up to 100 of 1 extra rows shown, 5 rows in total):
    [tmp_presto_9463216b05bc4223a243554a6933634b]
Expected rows (up to 100 of 0 missing rows shown, 4 rows in total):

	at com.facebook.presto.plugin.postgresql.TestPostgreSqlIntegrationSmokeTest.testTableWithNoSupportedColumns(TestPostgreSqlIntegrationSmokeTest.java:141)
```