### PR TITLE
Add session property to overwrite configured min/max drivers per task

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -37,12 +37,14 @@ import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.PARTITIONED;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.NONE;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -106,6 +108,7 @@ public final class SystemSessionProperties
     public static final String LEGACY_UNNEST = "legacy_unnest";
     public static final String STATISTICS_CPU_TIMER_ENABLED = "statistics_cpu_timer_enabled";
     public static final String ENABLE_STATS_CALCULATOR = "enable_stats_calculator";
+    public static final String MAX_DRIVERS_PER_TASK = "max_drivers_per_task";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -490,7 +493,16 @@ public final class SystemSessionProperties
                         ENABLE_STATS_CALCULATOR,
                         "Experimental: Enable statistics calculator",
                         featuresConfig.isEnableStatsCalculator(),
-                        false));
+                        false),
+                new PropertyMetadata<>(
+                        MAX_DRIVERS_PER_TASK,
+                        "Maximum number of drivers per task",
+                        INTEGER,
+                        Integer.class,
+                        null,
+                        false,
+                        value -> min(taskManagerConfig.getMaxDriversPerTask(), validateNullablePositiveIntegerValue(value, MAX_DRIVERS_PER_TASK)),
+                        object -> object));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -791,6 +803,14 @@ public final class SystemSessionProperties
         return session.getSystemProperty(LEGACY_UNNEST, Boolean.class);
     }
 
+    public static OptionalInt getMaxDriversPerTask(Session session)
+    {
+        Integer value = session.getSystemProperty(MAX_DRIVERS_PER_TASK, Integer.class);
+        if (value == null) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(value);
+    }
     private static int validateValueIsPowerOfTwo(Object value, String property)
     {
         int intValue = ((Number) requireNonNull(value, "value is null")).intValue();
@@ -798,6 +818,28 @@ public final class SystemSessionProperties
             throw new PrestoException(
                     INVALID_SESSION_PROPERTY,
                     format("%s must be a power of 2: %s", property, intValue));
+        }
+        return intValue;
+    }
+
+    private static Integer validateNullablePositiveIntegerValue(Object value, String property)
+    {
+        return validateIntegerValue(value, property, 1, true);
+    }
+
+    private static Integer validateIntegerValue(Object value, String property, int lowerBoundIncluded, boolean allowNull)
+    {
+        if (value == null && !allowNull) {
+            throw new PrestoException(INVALID_SESSION_PROPERTY, format("%s must be non-null", property));
+        }
+
+        if (value == null) {
+            return null;
+        }
+
+        int intValue = ((Number) value).intValue();
+        if (intValue < lowerBoundIncluded) {
+            throw new PrestoException(INVALID_SESSION_PROPERTY, format("%s must be equal or greater than %s", property, lowerBoundIncluded));
         }
         return intValue;
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -65,6 +65,7 @@ import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.getInitialSplitsPerNode;
+import static com.facebook.presto.SystemSessionProperties.getMaxDriversPerTask;
 import static com.facebook.presto.SystemSessionProperties.getSplitConcurrencyAdjustmentInterval;
 import static com.facebook.presto.execution.SqlTaskExecution.SplitsState.ADDING_SPLITS;
 import static com.facebook.presto.execution.SqlTaskExecution.SplitsState.FINISHED;
@@ -239,7 +240,12 @@ public class SqlTaskExecution
 
             // don't register the task if it is already completed (most likely failed during planning above)
             if (!taskStateMachine.getState().isDone()) {
-                taskHandle = taskExecutor.addTask(taskId, outputBuffer::getUtilization, getInitialSplitsPerNode(taskContext.getSession()), getSplitConcurrencyAdjustmentInterval(taskContext.getSession()));
+                taskHandle = taskExecutor.addTask(
+                        taskId,
+                        outputBuffer::getUtilization,
+                        getInitialSplitsPerNode(taskContext.getSession()),
+                        getSplitConcurrencyAdjustmentInterval(taskContext.getSession()),
+                        getMaxDriversPerTask(taskContext.getSession()));
                 taskStateMachine.addStateChangeListener(state -> {
                     if (state.isDone()) {
                         taskExecutor.removeTask(taskHandle);

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskHandle.java
@@ -24,6 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -56,12 +57,20 @@ public class TaskHandle
 
     protected final AtomicReference<Priority> priority = new AtomicReference<>(new Priority(0, 0));
     private final MultilevelSplitQueue splitQueue;
+    private final OptionalInt maxDriversPerTask;
 
-    public TaskHandle(TaskId taskId, MultilevelSplitQueue splitQueue, DoubleSupplier utilizationSupplier, int initialSplitConcurrency, Duration splitConcurrencyAdjustFrequency)
+    public TaskHandle(
+            TaskId taskId,
+            MultilevelSplitQueue splitQueue,
+            DoubleSupplier utilizationSupplier,
+            int initialSplitConcurrency,
+            Duration splitConcurrencyAdjustFrequency,
+            OptionalInt maxDriversPerTask)
     {
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.splitQueue = requireNonNull(splitQueue, "splitQueue is null");
         this.utilizationSupplier = requireNonNull(utilizationSupplier, "utilizationSupplier is null");
+        this.maxDriversPerTask = requireNonNull(maxDriversPerTask, "maxDriversPerTask is null");
         this.concurrencyController = new SplitConcurrencyController(
                 initialSplitConcurrency,
                 requireNonNull(splitConcurrencyAdjustFrequency, "splitConcurrencyAdjustFrequency is null"));
@@ -103,6 +112,11 @@ public class TaskHandle
     public TaskId getTaskId()
     {
         return taskId;
+    }
+
+    public OptionalInt getMaxDriversPerTask()
+    {
+        return maxDriversPerTask;
     }
 
     // Returns any remaining splits. The caller must destroy these.

--- a/presto-main/src/test/java/com/facebook/presto/execution/executor/SimulationTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/executor/SimulationTask.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import io.airlift.units.Duration;
 
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -39,7 +40,7 @@ abstract class SimulationTask
     {
         this.specification = specification;
         this.taskId = taskId;
-        taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, SECONDS));
+        taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, SECONDS), OptionalInt.empty());
     }
 
     public void setKilled()

--- a/presto-main/src/test/java/com/facebook/presto/execution/executor/TestTaskExecutor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/executor/TestTaskExecutor.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -55,7 +56,7 @@ public class TestTaskExecutor
 
         try {
             TaskId taskId = new TaskId("test", 0, 0);
-            TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS));
+            TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             Phaser beginPhase = new Phaser();
             beginPhase.register();
@@ -148,8 +149,8 @@ public class TestTaskExecutor
         ticker.increment(20, MILLISECONDS);
 
         try {
-            TaskHandle shortQuantaTaskHandle = taskExecutor.addTask(new TaskId("shortQuanta", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS));
-            TaskHandle longQuantaTaskHandle = taskExecutor.addTask(new TaskId("longQuanta", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS));
+            TaskHandle shortQuantaTaskHandle = taskExecutor.addTask(new TaskId("shortQuanta", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle longQuantaTaskHandle = taskExecutor.addTask(new TaskId("longQuanta", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             Phaser globalPhaser = new Phaser();
 
@@ -182,7 +183,7 @@ public class TestTaskExecutor
         ticker.increment(20, MILLISECONDS);
 
         try {
-            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS));
+            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             Phaser globalPhaser = new Phaser();
             globalPhaser.bulkRegister(3);
@@ -223,9 +224,9 @@ public class TestTaskExecutor
         try {
             for (int i = 0; i < (LEVEL_THRESHOLD_SECONDS.length - 1); i++) {
                 TaskHandle[] taskHandles = {
-                        taskExecutor.addTask(new TaskId("test1", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS)),
-                        taskExecutor.addTask(new TaskId("test2", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS)),
-                        taskExecutor.addTask(new TaskId("test3", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS))
+                        taskExecutor.addTask(new TaskId("test1", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty()),
+                        taskExecutor.addTask(new TaskId("test2", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty()),
+                        taskExecutor.addTask(new TaskId("test3", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty())
                 };
 
                 // move task 0 to next level
@@ -305,7 +306,7 @@ public class TestTaskExecutor
 
         try {
             TaskId taskId = new TaskId("test", 0, 0);
-            TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS));
+            TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             Phaser beginPhase = new Phaser();
             beginPhase.register();
@@ -336,8 +337,8 @@ public class TestTaskExecutor
     public void testLevelContributionCap()
     {
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
-        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS));
-        TaskHandle handle1 = new TaskHandle(new TaskId("test1", 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS));
+        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
+        TaskHandle handle1 = new TaskHandle(new TaskId("test1", 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
 
         for (int i = 0; i < (LEVEL_THRESHOLD_SECONDS.length - 1); i++) {
             long levelAdvanceTime = SECONDS.toNanos(LEVEL_THRESHOLD_SECONDS[i + 1] - LEVEL_THRESHOLD_SECONDS[i]);
@@ -356,7 +357,7 @@ public class TestTaskExecutor
     public void testUpdateLevelWithCap()
     {
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
-        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS));
+        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
 
         long quantaNanos = MINUTES.toNanos(10);
         handle0.addScheduledNanos(quantaNanos);
@@ -378,7 +379,7 @@ public class TestTaskExecutor
         TaskExecutor taskExecutor = new TaskExecutor(4, 16, 1, maxDriversPerTask, splitQueue, ticker);
         taskExecutor.start();
         try {
-            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS));
+            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
 
             // enqueue all batches of splits
             int batchCount = 4;
@@ -400,6 +401,45 @@ public class TestTaskExecutor
                 waitUntilSplitsStart(ImmutableList.of(splits[2 * batch], splits[2 * batch + 1]));
                 // assert that only the splits including and up to the current batch are running and the rest haven't started yet
                 assertSplitStates(2 * batch + 1, splits);
+                // complete the current batch
+                phasers[batch].arriveAndDeregister();
+            }
+        }
+        finally {
+            taskExecutor.stop();
+        }
+    }
+
+    @Test(timeOut = 30_000)
+    public void testUserSpecifiedMaxDriversPerTask()
+    {
+        MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
+        TestingTicker ticker = new TestingTicker();
+        // create a task executor with min/max drivers per task to be 2 and 4
+        TaskExecutor taskExecutor = new TaskExecutor(4, 16, 2, 4, splitQueue, ticker);
+        taskExecutor.start();
+        try {
+            // overwrite the max drivers per task to be 1
+            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.of(1));
+
+            // enqueue all batches of splits
+            int batchCount = 4;
+            TestingJob[] splits = new TestingJob[4];
+            Phaser[] phasers = new Phaser[batchCount];
+            for (int batch = 0; batch < batchCount; batch++) {
+                phasers[batch] = new Phaser();
+                phasers[batch].register();
+                TestingJob split = new TestingJob(ticker, new Phaser(), new Phaser(), phasers[batch], 1, 0);
+                splits[batch] = split;
+                taskExecutor.enqueueSplits(testTaskHandle, false, ImmutableList.of(split));
+            }
+
+            // assert that the splits are processed in batches as expected
+            for (int batch = 0; batch < batchCount; batch++) {
+                // wait until the current batch starts
+                waitUntilSplitsStart(ImmutableList.of(splits[batch]));
+                // assert that only the splits including and up to the current batch are running and the rest haven't started yet
+                assertSplitStates(batch, splits);
                 // complete the current batch
                 phasers[batch].arriveAndDeregister();
             }

--- a/presto-main/src/test/java/com/facebook/presto/execution/executor/TestTaskExecutor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/executor/TestTaskExecutor.java
@@ -387,8 +387,8 @@ public class TestTaskExecutor
             for (int batch = 0; batch < batchCount; batch++) {
                 phasers[batch] = new Phaser();
                 phasers[batch].register();
-                TestingJob split1 = new TestingJob(ticker, new Phaser(), new Phaser(), phasers[batch], maxDriversPerTask, 0);
-                TestingJob split2 = new TestingJob(ticker, new Phaser(), new Phaser(), phasers[batch], maxDriversPerTask, 0);
+                TestingJob split1 = new TestingJob(ticker, new Phaser(), new Phaser(), phasers[batch], 1, 0);
+                TestingJob split2 = new TestingJob(ticker, new Phaser(), new Phaser(), phasers[batch], 1, 0);
                 splits[2 * batch] = split1;
                 splits[2 * batch + 1] = split2;
                 taskExecutor.enqueueSplits(testTaskHandle, false, ImmutableList.of(split1, split2));


### PR DESCRIPTION
[Edited]
By default max number of driver per task will be capped by the configured value in `TaskManagerConfig`. Valid value of this session property is either `NULL` or a positive integer. If the session property is set and it's not `NULL`:

(1) If the session property value is less than `task.min-drivers-per-task`, it overwrites the min drivers count.
(2) If the session property value is greater than `task.max-drivers-per-task`, the session property will be ignored. The actual max driver count per task is still capped by the system configured value.

It basically enforces a cap on the driver count per task based on user specified value. 