### PR TITLE
Add Spill To Disk For ORDER BY

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OrderByBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/OrderByBenchmark.java
@@ -23,6 +23,7 @@ import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_LAST;
@@ -53,7 +54,9 @@ public class OrderByBenchmark
                 ROWS,
                 ImmutableList.of(0),
                 ImmutableList.of(ASC_NULLS_LAST),
-                new PagesIndex.TestingFactory(false));
+                new PagesIndex.TestingFactory(false),
+                false,
+                Optional.empty());
 
         return ImmutableList.of(tableScanOperator, limitOperator, orderByOperator);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -974,6 +974,8 @@ public class LocalExecutionPlanner
                 outputChannels.add(i);
             }
 
+            boolean spillEnabled = isSpillEnabled(context.getSession());
+
             OperatorFactory operator = new OrderByOperatorFactory(
                     context.getNextOperatorId(),
                     node.getId(),
@@ -982,7 +984,9 @@ public class LocalExecutionPlanner
                     10_000,
                     orderByChannels,
                     sortOrder.build(),
-                    pagesIndexFactory);
+                    pagesIndexFactory,
+                    spillEnabled,
+                    Optional.of(spillerFactory));
 
             return new PhysicalOperation(operator, source.getLayout(), context, source);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/DummySpillerFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/DummySpillerFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spiller.Spiller;
+import com.facebook.presto.spiller.SpillerFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+
+public class DummySpillerFactory
+        implements SpillerFactory
+{
+    private long spillsCount;
+
+    @Override
+    public Spiller create(List<Type> types, SpillContext spillContext, AggregatedMemoryContext memoryContext)
+    {
+        return new Spiller()
+        {
+            private final List<Iterable<Page>> spills = new ArrayList<>();
+
+            @Override
+            public ListenableFuture<?> spill(Iterator<Page> pageIterator)
+            {
+                spillsCount++;
+                spills.add(ImmutableList.copyOf(pageIterator));
+                return immediateFuture(null);
+            }
+
+            @Override
+            public List<Iterator<Page>> getSpills()
+            {
+                return spills.stream()
+                        .map(Iterable::iterator)
+                        .collect(toImmutableList());
+            }
+
+            @Override
+            public void close()
+            {
+            }
+        };
+    }
+
+    public long getSpillsCount()
+    {
+        return spillsCount;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -72,10 +72,8 @@ import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static com.google.common.base.Strings.nullToEmpty;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
@@ -752,47 +750,6 @@ public class TestHashAggregationOperator
         }
         assertTrue(aggregationBuilder instanceof InMemoryHashAggregationBuilder);
         return ((InMemoryHashAggregationBuilder) aggregationBuilder).getCapacity();
-    }
-
-    private static class DummySpillerFactory
-            implements SpillerFactory
-    {
-        private long spillsCount;
-
-        @Override
-        public Spiller create(List<Type> types, SpillContext spillContext, AggregatedMemoryContext memoryContext)
-        {
-            return new Spiller()
-            {
-                private final List<Iterable<Page>> spills = new ArrayList<>();
-
-                @Override
-                public ListenableFuture<?> spill(Iterator<Page> pageIterator)
-                {
-                    spillsCount++;
-                    spills.add(ImmutableList.copyOf(pageIterator));
-                    return immediateFuture(null);
-                }
-
-                @Override
-                public List<Iterator<Page>> getSpills()
-                {
-                    return spills.stream()
-                            .map(Iterable::iterator)
-                            .collect(toImmutableList());
-                }
-
-                @Override
-                public void close()
-                {
-                }
-            };
-        }
-
-        public long getSpillsCount()
-        {
-            return spillsCount;
-        }
     }
 
     private static class FailingSpillerFactory

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
@@ -23,9 +23,11 @@ import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -51,6 +53,14 @@ public class TestOrderByOperator
     private ScheduledExecutorService scheduledExecutor;
     private DriverContext driverContext;
 
+    @DataProvider(name = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public static Object[][] testWithoutSpillEnabledAndSpillEnabled()
+    {
+        return new Object[][] {
+                {false},
+                {true}};
+    }
+
     @BeforeMethod
     public void setUp()
     {
@@ -68,8 +78,8 @@ public class TestOrderByOperator
         scheduledExecutor.shutdownNow();
     }
 
-    @Test
-    public void testSingleFieldKey()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testSingleFieldKey(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)
                 .row(1L, 0.1)
@@ -87,7 +97,9 @@ public class TestOrderByOperator
                 10,
                 ImmutableList.of(0),
                 ImmutableList.of(ASC_NULLS_LAST),
-                new PagesIndex.TestingFactory(false));
+                new PagesIndex.TestingFactory(false),
+                spillEnabled,
+                Optional.of(new DummySpillerFactory()));
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), DOUBLE)
                 .row(-0.1)
@@ -99,8 +111,8 @@ public class TestOrderByOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testMultiFieldKey()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testMultiFieldKey(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(VARCHAR, BIGINT)
                 .row("a", 1L)
@@ -118,7 +130,9 @@ public class TestOrderByOperator
                 10,
                 ImmutableList.of(0, 1),
                 ImmutableList.of(ASC_NULLS_LAST, DESC_NULLS_LAST),
-                new PagesIndex.TestingFactory(false));
+                new PagesIndex.TestingFactory(false),
+                spillEnabled,
+                Optional.of(new DummySpillerFactory()));
 
         MaterializedResult expected = MaterializedResult.resultBuilder(driverContext.getSession(), VARCHAR, BIGINT)
                 .row("a", 4L)
@@ -130,8 +144,8 @@ public class TestOrderByOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test
-    public void testReverseOrder()
+    @Test(dataProvider = "testWithoutSpillEnabledAndWithSpillEnabled")
+    public void testReverseOrder(boolean spillEnabled)
     {
         List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)
                 .row(1L, 0.1)
@@ -149,7 +163,9 @@ public class TestOrderByOperator
                 10,
                 ImmutableList.of(0),
                 ImmutableList.of(DESC_NULLS_LAST),
-                new PagesIndex.TestingFactory(false));
+                new PagesIndex.TestingFactory(false),
+                spillEnabled,
+                Optional.of(new DummySpillerFactory()));
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), BIGINT)
                 .row(4L)
@@ -184,7 +200,9 @@ public class TestOrderByOperator
                 10,
                 ImmutableList.of(0),
                 ImmutableList.of(ASC_NULLS_LAST),
-                new PagesIndex.TestingFactory(false));
+                new PagesIndex.TestingFactory(false),
+                true,
+                Optional.of(new DummySpillerFactory()));
 
         toPages(operatorFactory, driverContext, input);
     }


### PR DESCRIPTION
ORDER BY currently will error out if the data being processed exceeds
query memory limit. The PR introduces paging from disk and ensures
that ORDER BY is limited only by the amount of disk present