### PR TITLE
Convert Block and Type from interface to abstract class

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -25,7 +25,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class GroupByIdBlock
-        implements Block
+        extends Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupByIdBlock.class).instanceSize();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
@@ -464,7 +464,7 @@ public class AccumulatorCompiler
                         .condition(new BytecodeBlock()
                                 .getVariable(variableDefinition)
                                 .getVariable(positionVariable)
-                                .invokeInterface(Block.class, "isNull", boolean.class, int.class))
+                                .invokeVirtual(Block.class, "isNull", boolean.class, int.class))
                         .ifFalse(loopBody);
             }
         }
@@ -711,14 +711,14 @@ public class AccumulatorCompiler
 
         BytecodeBlock block = new BytecodeBlock()
                 .append(blockVariable)
-                .invokeInterface(Block.class, "getPositionCount", int.class)
+                .invokeVirtual(Block.class, "getPositionCount", int.class)
                 .putVariable(rowsVariable);
 
         IfStatement ifStatement = new IfStatement("if(!block.isNull(position))")
                 .condition(new BytecodeBlock()
                         .append(blockVariable)
                         .append(positionVariable)
-                        .invokeInterface(Block.class, "isNull", boolean.class, int.class))
+                        .invokeVirtual(Block.class, "isNull", boolean.class, int.class))
                 .ifFalse(loopBody);
 
         block.append(new ForLoop()

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
@@ -548,35 +548,35 @@ public class AccumulatorCompiler
                     .append(constantType(callSiteBinder, sqlType))
                     .append(getBlockBytecode)
                     .append(position)
-                    .invokeInterface(Type.class, "getLong", long.class, Block.class, int.class);
+                    .invokeVirtual(Type.class, "getLong", long.class, Block.class, int.class);
         }
         else if (parameter == double.class) {
             block.comment("%s.getDouble(block, position)", sqlType.getTypeSignature())
                     .append(constantType(callSiteBinder, sqlType))
                     .append(getBlockBytecode)
                     .append(position)
-                    .invokeInterface(Type.class, "getDouble", double.class, Block.class, int.class);
+                    .invokeVirtual(Type.class, "getDouble", double.class, Block.class, int.class);
         }
         else if (parameter == boolean.class) {
             block.comment("%s.getBoolean(block, position)", sqlType.getTypeSignature())
                     .append(constantType(callSiteBinder, sqlType))
                     .append(getBlockBytecode)
                     .append(position)
-                    .invokeInterface(Type.class, "getBoolean", boolean.class, Block.class, int.class);
+                    .invokeVirtual(Type.class, "getBoolean", boolean.class, Block.class, int.class);
         }
         else if (parameter == Slice.class) {
             block.comment("%s.getSlice(block, position)", sqlType.getTypeSignature())
                     .append(constantType(callSiteBinder, sqlType))
                     .append(getBlockBytecode)
                     .append(position)
-                    .invokeInterface(Type.class, "getSlice", Slice.class, Block.class, int.class);
+                    .invokeVirtual(Type.class, "getSlice", Slice.class, Block.class, int.class);
         }
         else {
             block.comment("%s.getObject(block, position)", sqlType.getTypeSignature())
                     .append(constantType(callSiteBinder, sqlType))
                     .append(getBlockBytecode)
                     .append(position)
-                    .invokeInterface(Type.class, "getObject", Object.class, Block.class, int.class);
+                    .invokeVirtual(Type.class, "getObject", Object.class, Block.class, int.class);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
@@ -368,7 +368,7 @@ public final class BytecodeUtils
                         .ifTrue(new BytecodeBlock()
                                 .comment("output.appendNull();")
                                 .pop(valueJavaType)
-                                .invokeInterface(BlockBuilder.class, "appendNull", BlockBuilder.class)
+                                .invokeVirtual(BlockBuilder.class, "appendNull", BlockBuilder.class)
                                 .pop())
                         .ifFalse(new BytecodeBlock()
                                 .comment("%s.%s(output, %s)", type.getTypeSignature(), methodName, valueJavaType.getSimpleName())

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
@@ -377,6 +377,6 @@ public final class BytecodeUtils
                                 .append(loadConstant(callSiteBinder.bind(type, Type.class)))
                                 .getVariable(tempOutput)
                                 .getVariable(tempValue)
-                                .invokeInterface(Type.class, methodName, void.class, BlockBuilder.class, valueJavaType)));
+                                .invokeVirtual(Type.class, methodName, void.class, BlockBuilder.class, valueJavaType)));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/DereferenceCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/DereferenceCodeGenerator.java
@@ -67,7 +67,7 @@ public class DereferenceCodeGenerator
                 .comment("call rowBlock.isNull(index)")
                 .append(rowBlock)
                 .push(index)
-                .invokeInterface(Block.class, "isNull", boolean.class, int.class);
+                .invokeVirtual(Block.class, "isNull", boolean.class, int.class);
 
         ifFieldIsNull.ifTrue()
                 .comment("if the field is null, push null to stack")

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -367,7 +367,7 @@ public class JoinCompiler
                     .push(pageBuilderOutputChannel++)
                     .append(OpCode.IADD)
                     .invokeVirtual(PageBuilder.class, "getBlockBuilder", BlockBuilder.class, int.class)
-                    .invokeInterface(Type.class, "appendTo", void.class, Block.class, int.class, BlockBuilder.class);
+                    .invokeVirtual(Type.class, "appendTo", void.class, Block.class, int.class, BlockBuilder.class);
         }
         appendToBody.ret();
     }

--- a/presto-main/src/main/java/com/facebook/presto/type/FunctionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FunctionType.java
@@ -30,7 +30,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class FunctionType
-        implements Type
+        extends Type
 {
     public static final String NAME = "function";
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -20,7 +20,7 @@ import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
 
 public abstract class AbstractArrayBlock
-        implements Block
+        extends BlockBuilder
 {
     protected abstract Block getRawElementBlock();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
@@ -20,7 +20,7 @@ import io.airlift.slice.XxHash64;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 
 public abstract class AbstractFixedWidthBlock
-        implements Block
+        extends BlockBuilder
 {
     protected final int fixedSize;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -28,7 +28,7 @@ import static com.facebook.presto.spi.block.MapBlock.createMapBlockInternal;
 import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractMapBlock
-        implements Block
+        extends BlockBuilder
 {
     // inverse of hash fill ratio, must be integer
     static final int HASH_MULTIPLIER = 2;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -21,7 +21,7 @@ import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
 import static com.facebook.presto.spi.block.RowBlock.createRowBlockInternal;
 
 public abstract class AbstractRowBlock
-        implements Block
+        extends BlockBuilder
 {
     protected final int numFields;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -16,7 +16,7 @@ package com.facebook.presto.spi.block;
 import io.airlift.slice.Slice;
 
 public abstract class AbstractSingleArrayBlock
-        implements Block
+        extends BlockBuilder
 {
     protected final int start;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
@@ -17,7 +17,7 @@ package com.facebook.presto.spi.block;
 import io.airlift.slice.Slice;
 
 public abstract class AbstractSingleMapBlock
-        implements Block
+        extends BlockBuilder
 {
     abstract int getOffset();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
@@ -17,7 +17,7 @@ package com.facebook.presto.spi.block;
 import io.airlift.slice.Slice;
 
 public abstract class AbstractSingleRowBlock
-        implements Block
+        extends BlockBuilder
 {
     protected final int rowIndex;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
@@ -21,7 +21,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkValidPosition;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 
 public abstract class AbstractVariableWidthBlock
-        implements Block
+        extends BlockBuilder
 {
     protected abstract Slice getRawSlice(int position);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -29,7 +29,6 @@ import static java.util.Objects.requireNonNull;
 
 public class ArrayBlockBuilder
         extends AbstractArrayBlock
-        implements BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ArrayBlockBuilder.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -20,13 +20,13 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.DictionaryId.randomDictionaryId;
 
-public interface Block
+public abstract class Block
 {
     /**
      * Gets the length of the value at the {@code position}.
      * This method must be implemented if @{code getSlice} is implemented.
      */
-    default int getSliceLength(int position)
+    public int getSliceLength(int position)
     {
         throw new UnsupportedOperationException();
     }
@@ -34,7 +34,7 @@ public interface Block
     /**
      * Gets a byte at {@code offset} in the value at {@code position}.
      */
-    default byte getByte(int position, int offset)
+    public byte getByte(int position, int offset)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -42,7 +42,7 @@ public interface Block
     /**
      * Gets a little endian short at {@code offset} in the value at {@code position}.
      */
-    default short getShort(int position, int offset)
+    public short getShort(int position, int offset)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -50,7 +50,7 @@ public interface Block
     /**
      * Gets a little endian int at {@code offset} in the value at {@code position}.
      */
-    default int getInt(int position, int offset)
+    public int getInt(int position, int offset)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -58,7 +58,7 @@ public interface Block
     /**
      * Gets a little endian long at {@code offset} in the value at {@code position}.
      */
-    default long getLong(int position, int offset)
+    public long getLong(int position, int offset)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -66,7 +66,7 @@ public interface Block
     /**
      * Gets a slice at {@code offset} in the value at {@code position}.
      */
-    default Slice getSlice(int position, int offset, int length)
+    public Slice getSlice(int position, int offset, int length)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -74,7 +74,7 @@ public interface Block
     /**
      * Gets an object in the value at {@code position}.
      */
-    default <T> T getObject(int position, Class<T> clazz)
+    public <T> T getObject(int position, Class<T> clazz)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -84,7 +84,7 @@ public interface Block
      * to the byte sequence at {@code otherOffset} in {@code otherSlice}.
      * This method must be implemented if @{code getSlice} is implemented.
      */
-    default boolean bytesEqual(int position, int offset, Slice otherSlice, int otherOffset, int length)
+    public boolean bytesEqual(int position, int offset, Slice otherSlice, int otherOffset, int length)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -94,7 +94,7 @@ public interface Block
      * to the byte sequence at {@code otherOffset} in {@code otherSlice}.
      * This method must be implemented if @{code getSlice} is implemented.
      */
-    default int bytesCompare(int position, int offset, int length, Slice otherSlice, int otherOffset, int otherLength)
+    public int bytesCompare(int position, int offset, int length, Slice otherSlice, int otherOffset, int otherLength)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -104,7 +104,7 @@ public interface Block
      * to {@code blockBuilder}.
      * This method must be implemented if @{code getSlice} is implemented.
      */
-    default void writeBytesTo(int position, int offset, int length, BlockBuilder blockBuilder)
+    public void writeBytesTo(int position, int offset, int length, BlockBuilder blockBuilder)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -112,7 +112,7 @@ public interface Block
     /**
      * Appends the value at {@code position} to {@code blockBuilder} and close the entry.
      */
-    void writePositionTo(int position, BlockBuilder blockBuilder);
+    public abstract void writePositionTo(int position, BlockBuilder blockBuilder);
 
     /**
      * Is the byte sequences at {@code offset} in the value at {@code position} equal
@@ -120,7 +120,7 @@ public interface Block
      * in {@code otherBlock}.
      * This method must be implemented if @{code getSlice} is implemented.
      */
-    default boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
+    public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -130,7 +130,7 @@ public interface Block
      * value at {@code position}.
      * This method must be implemented if @{code getSlice} is implemented.
      */
-    default long hash(int position, int offset, int length)
+    public long hash(int position, int offset, int length)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -141,7 +141,7 @@ public interface Block
      * in {@code otherBlock}.
      * This method must be implemented if @{code getSlice} is implemented.
      */
-    default int compareTo(int leftPosition, int leftOffset, int leftLength, Block rightBlock, int rightPosition, int rightOffset, int rightLength)
+    public int compareTo(int leftPosition, int leftOffset, int leftLength, Block rightBlock, int rightPosition, int rightOffset, int rightLength)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -155,35 +155,35 @@ public interface Block
      *
      * @throws IllegalArgumentException if this position is not valid
      */
-    Block getSingleValueBlock(int position);
+    public abstract Block getSingleValueBlock(int position);
 
     /**
      * Returns the number of positions in this block.
      */
-    int getPositionCount();
+    public abstract int getPositionCount();
 
     /**
      * Returns the logical size of this block in memory.
      */
-    long getSizeInBytes();
+    public abstract long getSizeInBytes();
 
     /**
      * Returns the logical size of {@code block.getRegion(position, length)} in memory.
      * The method can be expensive. Do not use it outside an implementation of Block.
      */
-    long getRegionSizeInBytes(int position, int length);
+    public abstract long getRegionSizeInBytes(int position, int length);
 
     /**
      * Returns the retained size of this block in memory.
      * This method is called from the inner most execution loop and must be fast.
      */
-    long getRetainedSizeInBytes();
+    public abstract long getRetainedSizeInBytes();
 
     /**
      * Returns the estimated in memory data size for stats of position.
      * Do not use it for other purpose.
      */
-    long getEstimatedDataSizeForStats(int position);
+    public abstract long getEstimatedDataSizeForStats(int position);
 
     /**
      * {@code consumer} visits each of the internal data container and accepts the size for it.
@@ -193,19 +193,19 @@ public interface Block
      * {@code consumer} should be called at least once with the current block and
      * must include the instance size of the current block
      */
-    void retainedBytesForEachPart(BiConsumer<Object, Long> consumer);
+    public abstract void retainedBytesForEachPart(BiConsumer<Object, Long> consumer);
 
     /**
      * Get the encoding for this block.
      */
-    String getEncodingName();
+    public abstract String getEncodingName();
 
     /**
      * Create a new block from the current block by keeping the same elements
      * only with respect to {@code positions} that starts at {@code offset} and has length of {@code length}.
      * May return a view over the data in this block or may return a copy
      */
-    default Block getPositions(int[] positions, int offset, int length)
+    public Block getPositions(int[] positions, int offset, int length)
     {
         checkArrayRange(positions, offset, length);
 
@@ -220,7 +220,7 @@ public interface Block
      * <p>
      * The returned block must be a compact representation of the original block.
      */
-    Block copyPositions(int[] positions, int offset, int length);
+    public abstract Block copyPositions(int[] positions, int offset, int length);
 
     /**
      * Returns a block starting at the specified position and extends for the
@@ -231,7 +231,7 @@ public interface Block
      * the region block may also be released.  If the region block is released
      * this block may also be released.
      */
-    Block getRegion(int positionOffset, int length);
+    public abstract Block getRegion(int positionOffset, int length);
 
     /**
      * Returns a block starting at the specified position and extends for the
@@ -243,13 +243,13 @@ public interface Block
      * operators that hold on to a range of values without holding on to the
      * entire block.
      */
-    Block copyRegion(int position, int length);
+    public abstract Block copyRegion(int position, int length);
 
     /**
      * Is it possible the block may have a null value?  If false, the block can not contain
      * a null, but if true, the block may or may not have a null.
      */
-    default boolean mayHaveNull()
+    public boolean mayHaveNull()
     {
         return true;
     }
@@ -259,7 +259,7 @@ public interface Block
      *
      * @throws IllegalArgumentException if this position is not valid
      */
-    boolean isNull(int position);
+    public abstract boolean isNull(int position);
 
     /**
      * Returns a block that assures all data is in memory.
@@ -268,7 +268,7 @@ public interface Block
      * This allows streaming data sources to skip sections that are not
      * accessed in a query.
      */
-    default Block getLoadedBlock()
+    public Block getLoadedBlock()
     {
         return this;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockBuilder.java
@@ -15,13 +15,13 @@ package com.facebook.presto.spi.block;
 
 import io.airlift.slice.Slice;
 
-public interface BlockBuilder
+public abstract class BlockBuilder
         extends Block
 {
     /**
      * Write a byte to the current entry;
      */
-    default BlockBuilder writeByte(int value)
+    public BlockBuilder writeByte(int value)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -29,7 +29,7 @@ public interface BlockBuilder
     /**
      * Write a short to the current entry;
      */
-    default BlockBuilder writeShort(int value)
+    public BlockBuilder writeShort(int value)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -37,7 +37,7 @@ public interface BlockBuilder
     /**
      * Write a int to the current entry;
      */
-    default BlockBuilder writeInt(int value)
+    public BlockBuilder writeInt(int value)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -45,7 +45,7 @@ public interface BlockBuilder
     /**
      * Write a long to the current entry;
      */
-    default BlockBuilder writeLong(long value)
+    public BlockBuilder writeLong(long value)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -53,7 +53,7 @@ public interface BlockBuilder
     /**
      * Write a byte sequences to the current entry;
      */
-    default BlockBuilder writeBytes(Slice source, int sourceIndex, int length)
+    public BlockBuilder writeBytes(Slice source, int sourceIndex, int length)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -62,7 +62,7 @@ public interface BlockBuilder
      * Return a writer to the current entry. The caller can operate on the returned caller to incrementally build the object. This is generally more efficient than
      * building the object elsewhere and call writeObject afterwards because a large chunk of memory could potentially be unnecessarily copied in this process.
      */
-    default BlockBuilder beginBlockEntry()
+    public BlockBuilder beginBlockEntry()
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -71,7 +71,7 @@ public interface BlockBuilder
      * Create a new block from the current materialized block by keeping the same elements
      * only with respect to {@code visiblePositions}.
      */
-    default Block getPositions(int[] visiblePositions, int offset, int length)
+    public Block getPositions(int[] visiblePositions, int offset, int length)
     {
         return build().getPositions(visiblePositions, offset, length);
     }
@@ -79,17 +79,23 @@ public interface BlockBuilder
     /**
      * Write a byte to the current entry;
      */
-    BlockBuilder closeEntry();
+    public BlockBuilder closeEntry()
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
 
     /**
      * Appends a null value to the block.
      */
-    BlockBuilder appendNull();
+    public BlockBuilder appendNull()
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
 
     /**
      * Append a struct to the block and close the entry.
      */
-    default BlockBuilder appendStructure(Block value)
+    public BlockBuilder appendStructure(Block value)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -98,7 +104,7 @@ public interface BlockBuilder
      * Do not use this interface outside block package.
      * Instead, use Block.writePositionTo(BlockBuilder, position)
      */
-    default BlockBuilder appendStructureInternal(Block block, int position)
+    public BlockBuilder appendStructureInternal(Block block, int position)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -106,10 +112,16 @@ public interface BlockBuilder
     /**
      * Builds the block. This method can be called multiple times.
      */
-    Block build();
+    public Block build()
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
 
     /**
      * Creates a new block builder of the same type based on the current usage statistics of this block builder.
      */
-    BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus);
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -26,7 +26,7 @@ import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ByteArrayBlock
-        implements Block
+        extends Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteArrayBlock.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -27,7 +27,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
 public class ByteArrayBlockBuilder
-        implements BlockBuilder
+        extends BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteArrayBlockBuilder.class).instanceSize();
     private static final Block NULL_VALUE_BLOCK = new ByteArrayBlock(0, 1, new boolean[] {true}, new byte[1]);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -31,7 +31,7 @@ import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class DictionaryBlock
-        implements Block
+        extends Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(DictionaryBlock.class).instanceSize() + ClassLayout.parseClass(DictionaryId.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -35,7 +35,6 @@ import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 
 public class FixedWidthBlockBuilder
         extends AbstractFixedWidthBlock
-        implements BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(FixedWidthBlockBuilder.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -26,7 +26,7 @@ import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class IntArrayBlock
-        implements Block
+        extends Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntArrayBlock.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -27,7 +27,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
 public class IntArrayBlockBuilder
-        implements BlockBuilder
+        extends BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntArrayBlockBuilder.class).instanceSize();
     private static final Block NULL_VALUE_BLOCK = new IntArrayBlock(0, 1, new boolean[] {true}, new int[1]);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -21,7 +21,7 @@ import java.util.function.BiConsumer;
 import static java.util.Objects.requireNonNull;
 
 public class LazyBlock
-        implements Block
+        extends Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LazyBlock.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -27,7 +27,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.toIntExact;
 
 public class LongArrayBlock
-        implements Block
+        extends Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongArrayBlock.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -28,7 +28,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
 
 public class LongArrayBlockBuilder
-        implements BlockBuilder
+        extends BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongArrayBlockBuilder.class).instanceSize();
     private static final Block NULL_VALUE_BLOCK = new LongArrayBlock(0, 1, new boolean[] {true}, new long[1]);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -34,7 +34,6 @@ import static java.util.Objects.requireNonNull;
 
 public class MapBlockBuilder
         extends AbstractMapBlock
-        implements BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapBlockBuilder.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
@@ -31,7 +31,6 @@ import static java.util.Objects.requireNonNull;
 
 public class RowBlockBuilder
         extends AbstractRowBlock
-        implements BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(RowBlockBuilder.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class RunLengthEncodedBlock
-        implements Block
+        extends Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(RunLengthEncodedBlock.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -26,7 +26,7 @@ import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ShortArrayBlock
-        implements Block
+        extends Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlock.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -27,7 +27,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
 public class ShortArrayBlockBuilder
-        implements BlockBuilder
+        extends BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlockBuilder.class).instanceSize();
     private static final Block NULL_VALUE_BLOCK = new ShortArrayBlock(0, 1, new boolean[] {true}, new short[1]);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleArrayBlockWriter.java
@@ -22,7 +22,6 @@ import static java.lang.String.format;
 
 public class SingleArrayBlockWriter
         extends AbstractSingleArrayBlock
-        implements BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleArrayBlockWriter.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockWriter.java
@@ -22,7 +22,6 @@ import static java.lang.String.format;
 
 public class SingleMapBlockWriter
         extends AbstractSingleMapBlock
-        implements BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleMapBlockWriter.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleRowBlockWriter.java
@@ -22,7 +22,6 @@ import static java.lang.String.format;
 
 public class SingleRowBlockWriter
         extends AbstractSingleRowBlock
-        implements BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleRowBlockWriter.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -42,7 +42,6 @@ import static java.lang.Math.min;
 
 public class VariableWidthBlockBuilder
         extends AbstractVariableWidthBlock
-        implements BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(VariableWidthBlockBuilder.class).instanceSize();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractFixedWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractFixedWidthType.java
@@ -21,8 +21,7 @@ import com.facebook.presto.spi.block.PageBuilderStatus;
 import io.airlift.slice.Slice;
 
 public abstract class AbstractFixedWidthType
-        extends AbstractType
-        implements FixedWidthType
+        extends FixedWidthType
 {
     private final int fixedSize;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
@@ -23,8 +23,7 @@ import io.airlift.slice.Slice;
 import static java.lang.Long.rotateLeft;
 
 public abstract class AbstractIntType
-        extends AbstractType
-        implements FixedWidthType
+        extends FixedWidthType
 {
     protected AbstractIntType(TypeSignature signature)
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
@@ -23,8 +23,7 @@ import io.airlift.slice.Slice;
 import static java.lang.Long.rotateLeft;
 
 public abstract class AbstractLongType
-        extends AbstractType
-        implements FixedWidthType
+        extends FixedWidthType
 {
     public AbstractLongType(TypeSignature signature)
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 public abstract class AbstractType
-        implements Type
+        extends Type
 {
     private final TypeSignature signature;
     private final Class<?> javaType;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractVariableWidthType.java
@@ -21,8 +21,7 @@ import com.facebook.presto.spi.block.VariableWidthBlockBuilder;
 import static java.lang.Math.min;
 
 public abstract class AbstractVariableWidthType
-        extends AbstractType
-        implements VariableWidthType
+        extends VariableWidthType
 {
     private static final int EXPECTED_BYTES_PER_ENTRY = 32;
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
@@ -23,8 +23,7 @@ import com.facebook.presto.spi.block.PageBuilderStatus;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 
 public final class BooleanType
-        extends AbstractType
-        implements FixedWidthType
+        extends FixedWidthType
 {
     public static final BooleanType BOOLEAN = new BooleanType();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DecimalType.java
@@ -24,8 +24,7 @@ import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static java.util.Collections.unmodifiableList;
 
 public abstract class DecimalType
-        extends AbstractType
-        implements FixedWidthType
+        extends FixedWidthType
 {
     public static final int DEFAULT_SCALE = 0;
     public static final int DEFAULT_PRECISION = MAX_PRECISION;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -25,8 +25,7 @@ import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.longBitsToDouble;
 
 public final class DoubleType
-        extends AbstractType
-        implements FixedWidthType
+        extends FixedWidthType
 {
     public static final DoubleType DOUBLE = new DoubleType();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/FixedWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/FixedWidthType.java
@@ -18,18 +18,23 @@ import com.facebook.presto.spi.block.BlockBuilder;
 /**
  * FixedWidthType is a type that has a fixed size for every value.
  */
-public interface FixedWidthType
-        extends Type
+public abstract class FixedWidthType
+        extends AbstractType
 {
+    protected FixedWidthType(TypeSignature signature, Class<?> javaType)
+    {
+        super(signature, javaType);
+    }
+
     /**
      * Gets the size of a value of this type is bytes. All values
      * of a FixedWidthType are the same size.
      */
-    int getFixedSize();
+    public abstract int getFixedSize();
 
     /**
      * Creates a block builder for this type sized to hold the specified number
      * of positions.
      */
-    BlockBuilder createFixedSizeBlockBuilder(int positionCount);
+    public abstract BlockBuilder createFixedSizeBlockBuilder(int positionCount);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
@@ -26,8 +26,7 @@ import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static java.lang.Long.rotateLeft;
 
 public final class SmallintType
-        extends AbstractType
-        implements FixedWidthType
+        extends FixedWidthType
 {
     public static final SmallintType SMALLINT = new SmallintType();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
@@ -26,8 +26,7 @@ import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static java.lang.Long.rotateLeft;
 
 public final class TinyintType
-        extends AbstractType
-        implements FixedWidthType
+        extends FixedWidthType
 {
     public static final TinyintType TINYINT = new TinyintType();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
@@ -22,29 +22,29 @@ import io.airlift.slice.Slice;
 
 import java.util.List;
 
-public interface Type
+public abstract class Type
 {
     /**
      * Gets the name of this type which must be case insensitive globally unique.
      * The name of a user defined type must be a legal identifier in Presto.
      */
     @JsonValue
-    TypeSignature getTypeSignature();
+    public abstract TypeSignature getTypeSignature();
 
     /**
      * Returns the name of this type that should be displayed to end-users.
      */
-    String getDisplayName();
+    public abstract String getDisplayName();
 
     /**
      * True if the type supports equalTo and hash.
      */
-    boolean isComparable();
+    public abstract boolean isComparable();
 
     /**
      * True if the type supports compareTo.
      */
-    boolean isOrderable();
+    public abstract boolean isOrderable();
 
     /**
      * Gets the Java class type used to represent this value on the stack during
@@ -52,107 +52,107 @@ public interface Type
      * <p>
      * Currently, this must be boolean, long, double, Slice or Block.
      */
-    Class<?> getJavaType();
+    public abstract Class<?> getJavaType();
 
     /**
      * For parameterized types returns the list of parameters.
      */
-    List<Type> getTypeParameters();
+    public abstract List<Type> getTypeParameters();
 
     /**
      * Creates the preferred block builder for this type. This is the builder used to
      * store values after an expression projection within the query.
      */
-    BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry);
+    public abstract BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry);
 
     /**
      * Creates the preferred block builder for this type. This is the builder used to
      * store values after an expression projection within the query.
      */
-    BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries);
+    public abstract BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries);
 
     /**
      * Gets an object representation of the type value in the {@code block}
      * {@code position}. This is the value returned to the user via the
      * REST endpoint and therefore must be JSON serializable.
      */
-    Object getObjectValue(ConnectorSession session, Block block, int position);
+    public abstract Object getObjectValue(ConnectorSession session, Block block, int position);
 
     /**
      * Gets the value at the {@code block} {@code position} as a boolean.
      */
-    boolean getBoolean(Block block, int position);
+    public abstract boolean getBoolean(Block block, int position);
 
     /**
      * Gets the value at the {@code block} {@code position} as a long.
      */
-    long getLong(Block block, int position);
+    public abstract long getLong(Block block, int position);
 
     /**
      * Gets the value at the {@code block} {@code position} as a double.
      */
-    double getDouble(Block block, int position);
+    public abstract double getDouble(Block block, int position);
 
     /**
      * Gets the value at the {@code block} {@code position} as a Slice.
      */
-    Slice getSlice(Block block, int position);
+    public abstract Slice getSlice(Block block, int position);
 
     /**
      * Gets the value at the {@code block} {@code position} as an Object.
      */
-    Object getObject(Block block, int position);
+    public abstract Object getObject(Block block, int position);
 
     /**
      * Writes the boolean value into the {@code BlockBuilder}.
      */
-    void writeBoolean(BlockBuilder blockBuilder, boolean value);
+    public abstract void writeBoolean(BlockBuilder blockBuilder, boolean value);
 
     /**
      * Writes the long value into the {@code BlockBuilder}.
      */
-    void writeLong(BlockBuilder blockBuilder, long value);
+    public abstract void writeLong(BlockBuilder blockBuilder, long value);
 
     /**
      * Writes the double value into the {@code BlockBuilder}.
      */
-    void writeDouble(BlockBuilder blockBuilder, double value);
+    public abstract void writeDouble(BlockBuilder blockBuilder, double value);
 
     /**
      * Writes the Slice value into the {@code BlockBuilder}.
      */
-    void writeSlice(BlockBuilder blockBuilder, Slice value);
+    public abstract void writeSlice(BlockBuilder blockBuilder, Slice value);
 
     /**
      * Writes the Slice value into the {@code BlockBuilder}.
      */
-    void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length);
+    public abstract void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length);
 
     /**
      * Writes the Object value into the {@code BlockBuilder}.
      */
-    void writeObject(BlockBuilder blockBuilder, Object value);
+    public abstract void writeObject(BlockBuilder blockBuilder, Object value);
 
     /**
      * Append the value at {@code position} in {@code block} to {@code blockBuilder}.
      */
-    void appendTo(Block block, int position, BlockBuilder blockBuilder);
+    public abstract void appendTo(Block block, int position, BlockBuilder blockBuilder);
 
     /**
      * Are the values in the specified blocks at the specified positions equal?
      *
      * This method assumes input is not null.
      */
-    boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition);
+    public abstract boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition);
 
     /**
      * Calculates the hash code of the value at the specified position in the
      * specified block.
      */
-    long hash(Block block, int position);
+    public abstract long hash(Block block, int position);
 
     /**
      * Compare the values in the specified block at the specified positions equal.
      */
-    int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition);
+    public abstract int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/VariableWidthType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/VariableWidthType.java
@@ -16,7 +16,11 @@ package com.facebook.presto.spi.type;
 /**
  * VariableWidthType is a type that can have a different size for every value.
  */
-public interface VariableWidthType
-        extends Type
+public abstract class VariableWidthType
+        extends AbstractType
 {
+    protected VariableWidthType(TypeSignature signature, Class<?> javaType)
+    {
+        super(signature, javaType);
+    }
 }


### PR DESCRIPTION
Based on @oerling findings.

Interface method dispatch is more expensive than the virtual method dispatch, as it requires additional level of indirection.

Interface / Virtual method dispatch can be optimized by the JVM in call site is monomorphic / bimorphic. Unfortunately our code generation is not ideal, and somethimes JVM ends up executing megamorphic invokations without optimizations by doing ITable traversal + VTable lookups. 

Optimizing our code generation to have all the Block/Type methods invocations as monomorphic is definitely the best long term solution. But for the short term solution we can cut the megamorphic dispatch overhead by the factor of 2 by changing the `Block` and `Type` to be an abstract class instead of an interface. 

Below are the results of running `BenchmarkPageProcessor` before and after this change

```
BEFORE

Benchmark                          Mode  Cnt     Score    Error  Units
BenchmarkPageProcessor.compiled   thrpt   10  6096.074 ± 57.174  ops/s
BenchmarkPageProcessor.handCoded  thrpt   10  6861.199 ± 47.061  ops/s
```

```
AFTER

Benchmark                          Mode  Cnt     Score    Error  Units
BenchmarkPageProcessor.compiled   thrpt   10  6246.534 ± 51.951  ops/s
BenchmarkPageProcessor.handCoded  thrpt   10  6757.921 ± 63.097  ops/s
```

The benchmarks shows an improvement in `~3%`. However the  `BenchmarkPageProcessor` runs comparisons on `VARCHAR`, that takes most of the CPU time. After removing the `VARCHAR` comparisons, but leaving the other three `DOUBLE` comparisons, the benchmark shows `~20%` improvement.


```
BEFORE, WITHOUT VARCHAR

Benchmark                          Mode  Cnt      Score     Error  Units
BenchmarkPageProcessor.compiled   thrpt   10   8981.628 ±  51.715  ops/s
BenchmarkPageProcessor.handCoded  thrpt   10  14339.662 ± 983.400  ops/s
```

```
AFTER, WITHOUT VARCHAR

Benchmark                          Mode  Cnt      Score     Error  Units
BenchmarkPageProcessor.compiled   thrpt   10  11073.608 ± 232.180  ops/s
BenchmarkPageProcessor.handCoded  thrpt   10  14335.648 ± 621.870  ops/s
```

As a follow up we should ensure that `InputReferenceCompiler` generates exact method signatures for the `Type` and `Block`, instead of generic ones:

![selection_038](https://user-images.githubusercontent.com/5570988/46634790-123a4200-cb20-11e8-90d8-37b24991d673.png)
