### PR TITLE
Provide log.properties in RPM

### DIFF
--- a/presto-server-rpm/src/main/resources/dist/config/log.properties
+++ b/presto-server-rpm/src/main/resources/dist/config/log.properties
@@ -1,0 +1,2 @@
+# Enable verbose logging from Presto
+#com.facebook.presto=DEBUG


### PR DESCRIPTION
For convenience of administrators, provide `log.properties` as part of
an RPM install. That way, people do not have to think where the file
should be put. Later, we can provide useful logging configuration:
- suppress overly verbose logging from Hive, see
  https://github.com/prestodb/presto-hive-apache/pull/33
- logging configuration for troubleshooting problems ("uncomment ...
  when diagnosing ..."), see e.g.
  https://github.com/prestodb/presto/wiki/Security-Troubleshooting-Guide#before-you-begin