### PR TITLE
Add support for writing DWRF files with ZSTD compression

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -319,6 +319,8 @@ public class DwrfMetadataWriter
                 return DwrfProto.CompressionKind.SNAPPY;
             case LZ4:
                 return DwrfProto.CompressionKind.LZ4;
+            case ZSTD:
+                return DwrfProto.CompressionKind.ZSTD;
         }
         throw new IllegalArgumentException("Unsupported compression kind: " + compressionKind);
     }


### PR DESCRIPTION
This fixes `TestFullOrcReader`, which broke after adding ZSTD for ORC.