### PR TITLE
Implement qdigest type and associated functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions.rst
+++ b/presto-docs/src/main/sphinx/functions.rst
@@ -25,6 +25,7 @@ Functions and Operators
     functions/url
     functions/geospatial
     functions/hyperloglog
+    functions/qdigest
     functions/color
     functions/session
     functions/teradata

--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -216,6 +216,26 @@ Approximate Aggregate Functions
 
     See :doc:`hyperloglog`.
 
+.. function:: merge(qdigest(T)) -> qdigest(T)
+    :noindex:
+
+    See :doc:`qdigest`.
+
+.. function:: qdigest_agg(x) -> qdigest<[same as x]>
+    :noindex:
+
+    See :doc:`qdigest`.
+
+.. function:: qdigest_agg(x, w) -> qdigest<[same as x]>
+    :noindex:
+
+    See :doc:`qdigest`.
+
+.. function:: qdigest_agg(x, w, accuracy) -> qdigest<[same as x]>
+    :noindex:
+
+    See :doc:`qdigest`.
+
 .. function:: numeric_histogram(buckets, value, weight) -> map<double, double>
 
     Computes an approximate histogram with up to ``buckets`` number of buckets

--- a/presto-docs/src/main/sphinx/functions/qdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/qdigest.rst
@@ -1,0 +1,53 @@
+=========================
+Quantile Digest Functions
+=========================
+
+Presto implements the ``approx_percentile``  function with the quantile digest
+data structure.  The underlying data structure, :ref:`qdigest <qdigest_type>`,
+is exposed as a data type in Presto, and can be created, queried and stored
+separately from ``approx_percentile``.
+
+Data Structures
+---------------
+
+A quantile digest is a data sketch which stores approximate percentile
+information.  The presto type for this data structure is called ``qdigest``,
+and it takes a parameter which must be one of ``bigint``, ``double`` or
+``real`` which represent the set of numbers that may be ingested by the
+``qdigest``.  They may be merged without losing precision, and for storage
+and retrieval they may be cast to/from ``VARBINARY``.
+
+Functions
+---------
+
+.. function:: merge(qdigest) -> qdigest
+    :noindex:
+
+    Merges all input ``qdigest``\ s into a single ``qdigest``.
+
+.. function:: value_at_quantile(qdigest(T), quantile) -> T
+
+    Returns the approximate percentile values from the quantile digest given
+    the number ``quantile`` between 0 and 1.
+
+.. function:: values_at_quantiles(qdigest(T), quantiles) -> T
+
+    Returns the approximate percentile values as an array given the input
+    quantile digest and array of values between 0 and 1 which
+    represent the quantiles to return.
+
+.. function:: qdigest_agg(x) -> qdigest<[same as x]>
+
+    Returns the ``qdigest`` which is composed of  all input values of ``x``.
+
+.. function:: qdigest_agg(x, w) -> qdigest<[same as x]>
+
+    Returns the ``qdigest`` which is composed of  all input values of ``x`` using
+    the per-item weight ``w``.
+
+.. function:: qdigest_agg(x, w, accuracy) -> qdigest<[same as x]>
+
+    Returns the ``qdigest`` which is composed of  all input values of ``x`` using
+    the per-item weight ``w`` and maximum error of ``accuracy``. ``accuracy``
+    must be a value greater than zero and less than one, and it must be constant
+    for all input rows.

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -256,3 +256,26 @@ Calculating the approximate distinct count can be done much more cheaply than an
 
     A P4HyperLogLog sketch is similar to :ref:`hyperloglog_type`, but it starts (and remains)
     in the dense representation.
+
+Quantile Digest
+---------------
+
+.. _qdigest_type:
+
+``QDigest``
+^^^^^^^^^^^
+
+    A quantile digest (qdigest) is a summary structure which captures the approximate
+    distribution of data for a given input set, and can be queried to retrieve approximate
+    quantile values from the distribution.  The level of accuracy for a qdigest
+    is tunable, allowing for more precise results at the expense of space.
+
+    A qdigest can be used to give approximate answer to queries asking for what value
+    belongs at a certain quantile.  A useful property of qdigests is that they are
+    additive, meaning they can be merged together without losing precision.
+
+    A qdigest may be helpful whenever the partial results of ``approx_percentile``
+    can be reused.  For example, one may be interested in a daily reading of the 99th
+    percentile values that are read over the course of a week.  Instead of calculating
+    the past week of data with ``approx_percentile``, ``qdigest``\ s could be stored
+    daily, and quickly merged to retrieve the 99th percentile value.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -45,6 +45,7 @@ import com.facebook.presto.operator.aggregation.IntervalYearToMonthSumAggregatio
 import com.facebook.presto.operator.aggregation.LongSumAggregation;
 import com.facebook.presto.operator.aggregation.MaxDataSizeForStats;
 import com.facebook.presto.operator.aggregation.MergeHyperLogLogAggregation;
+import com.facebook.presto.operator.aggregation.MergeQuantileDigestFunction;
 import com.facebook.presto.operator.aggregation.RealCorrelationAggregation;
 import com.facebook.presto.operator.aggregation.RealCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.RealGeometricMeanAggregations;
@@ -112,6 +113,7 @@ import com.facebook.presto.operator.scalar.MapValues;
 import com.facebook.presto.operator.scalar.MathFunctions;
 import com.facebook.presto.operator.scalar.MathFunctions.LegacyLogFunction;
 import com.facebook.presto.operator.scalar.MultimapFromEntriesFunction;
+import com.facebook.presto.operator.scalar.QuantileDigestFunctions;
 import com.facebook.presto.operator.scalar.Re2JRegexpFunctions;
 import com.facebook.presto.operator.scalar.Re2JRegexpReplaceLambdaFunction;
 import com.facebook.presto.operator.scalar.RepeatFunction;
@@ -165,6 +167,7 @@ import com.facebook.presto.type.IntervalDayTimeOperators;
 import com.facebook.presto.type.IntervalYearMonthOperators;
 import com.facebook.presto.type.IpAddressOperators;
 import com.facebook.presto.type.LikeFunctions;
+import com.facebook.presto.type.QuantileDigestOperators;
 import com.facebook.presto.type.RealOperators;
 import com.facebook.presto.type.SmallintOperators;
 import com.facebook.presto.type.TimeOperators;
@@ -225,6 +228,9 @@ import static com.facebook.presto.operator.aggregation.MaxAggregationFunction.MA
 import static com.facebook.presto.operator.aggregation.MaxNAggregationFunction.MAX_N_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.MinAggregationFunction.MIN_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.MinNAggregationFunction.MIN_N_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.QuantileDigestAggregationFunction.QDIGEST_AGG;
+import static com.facebook.presto.operator.aggregation.QuantileDigestAggregationFunction.QDIGEST_AGG_WITH_WEIGHT;
+import static com.facebook.presto.operator.aggregation.QuantileDigestAggregationFunction.QDIGEST_AGG_WITH_WEIGHT_AND_ERROR;
 import static com.facebook.presto.operator.aggregation.RealAverageAggregation.REAL_AVERAGE_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.minmaxby.MaxByAggregationFunction.MAX_BY;
 import static com.facebook.presto.operator.aggregation.minmaxby.MaxByNAggregationFunction.MAX_BY_N_AGGREGATION;
@@ -448,6 +454,8 @@ public class FunctionRegistry
                 .aggregates(RealGeometricMeanAggregations.class)
                 .aggregates(MergeHyperLogLogAggregation.class)
                 .aggregates(ApproximateSetAggregation.class)
+                .functions(QDIGEST_AGG, QDIGEST_AGG_WITH_WEIGHT, QDIGEST_AGG_WITH_WEIGHT_AND_ERROR)
+                .function(MergeQuantileDigestFunction.MERGE)
                 .aggregates(DoubleHistogramAggregation.class)
                 .aggregates(RealHistogramAggregation.class)
                 .aggregates(DoubleCovarianceAggregation.class)
@@ -482,6 +490,7 @@ public class FunctionRegistry
                 .scalars(ColorFunctions.class)
                 .scalars(ColorOperators.class)
                 .scalars(HyperLogLogFunctions.class)
+                .scalars(QuantileDigestFunctions.class)
                 .scalars(UnknownOperators.class)
                 .scalars(BooleanOperators.class)
                 .scalars(BigintOperators.class)
@@ -501,6 +510,7 @@ public class FunctionRegistry
                 .scalars(TimestampWithTimeZoneOperators.class)
                 .scalars(DateTimeOperators.class)
                 .scalars(HyperLogLogOperators.class)
+                .scalars(QuantileDigestOperators.class)
                 .scalars(IpAddressOperators.class)
                 .scalars(LikeFunctions.class)
                 .scalars(ArrayFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FloatingPointBitsConverterUtil.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.operator.aggregation;
 
-final class FloatingPointBitsConverterUtil
+public final class FloatingPointBitsConverterUtil
 {
     private FloatingPointBitsConverterUtil() {}
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MergeQuantileDigestFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MergeQuantileDigestFunction.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.state.QuantileDigestState;
+import com.facebook.presto.operator.aggregation.state.QuantileDigestStateFactory;
+import com.facebook.presto.operator.aggregation.state.QuantileDigestStateSerializer;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.type.QuantileDigestType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.DynamicClassLoader;
+import io.airlift.stats.QuantileDigest;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.MoreMath.nearlyEqual;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.base.Preconditions.checkArgument;
+
+@AggregationFunction("merge")
+public final class MergeQuantileDigestFunction
+        extends SqlAggregationFunction
+{
+    public static final MergeQuantileDigestFunction MERGE = new MergeQuantileDigestFunction();
+    public static final String NAME = "merge";
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(MergeQuantileDigestFunction.class, "input", Type.class, QuantileDigestState.class, Block.class, int.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(MergeQuantileDigestFunction.class, "combine", QuantileDigestState.class, QuantileDigestState.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(MergeQuantileDigestFunction.class, "output", QuantileDigestStateSerializer.class, QuantileDigestState.class, BlockBuilder.class);
+    private static final double COMPARISON_EPSILON = 1E-6;
+
+    public MergeQuantileDigestFunction()
+    {
+        super(NAME,
+                ImmutableList.of(comparableTypeParameter("T")),
+                ImmutableList.of(),
+                parseTypeSignature("qdigest(T)"),
+                ImmutableList.of(parseTypeSignature("qdigest(T)")));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Merges the input quantile digests into a single quantile digest";
+    }
+
+    @Override
+    public InternalAggregationFunction specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type valueType = boundVariables.getTypeVariable("T");
+        QuantileDigestType outputType = (QuantileDigestType) typeManager.getParameterizedType(StandardTypes.QDIGEST,
+                ImmutableList.of(TypeSignatureParameter.of(valueType.getTypeSignature())));
+        return generateAggregation(valueType, outputType);
+    }
+
+    private static InternalAggregationFunction generateAggregation(Type valueType, QuantileDigestType type)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(MapAggregationFunction.class.getClassLoader());
+        QuantileDigestStateSerializer stateSerializer = new QuantileDigestStateSerializer(valueType);
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, type.getTypeSignature(), ImmutableList.of(type.getTypeSignature())),
+                createInputParameterMetadata(type),
+                INPUT_FUNCTION.bindTo(type),
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION.bindTo(stateSerializer),
+                ImmutableList.of(new AccumulatorStateDescriptor(
+                    QuantileDigestState.class,
+                    stateSerializer,
+                    new QuantileDigestStateFactory())),
+                type);
+
+        GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
+        return new InternalAggregationFunction(NAME, ImmutableList.of(type), ImmutableList.of(intermediateType), type, true, true, factory);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type valueType)
+    {
+        return ImmutableList.of(
+                new ParameterMetadata(STATE),
+                new ParameterMetadata(BLOCK_INPUT_CHANNEL, valueType),
+                new ParameterMetadata(BLOCK_INDEX));
+    }
+
+    @InputFunction
+    public static void input(Type type, QuantileDigestState state, Block value, int index)
+    {
+        merge(state, new QuantileDigest(type.getSlice(value, index)));
+    }
+
+    @CombineFunction
+    public static void combine(QuantileDigestState state, QuantileDigestState otherState)
+    {
+        merge(state, otherState.getQuantileDigest());
+    }
+
+    private static void merge(QuantileDigestState state, QuantileDigest input)
+    {
+        if (input == null) {
+            return;
+        }
+        QuantileDigest previous = state.getQuantileDigest();
+        if (previous == null) {
+            state.setQuantileDigest(input);
+            state.addMemoryUsage(input.estimatedInMemorySizeInBytes());
+        }
+        else {
+            checkArgument(nearlyEqual(previous.getMaxError(), input.getMaxError(), COMPARISON_EPSILON),
+                    "Cannot merge qdigests with different accuracies (%s vs. %s)", state.getQuantileDigest().getMaxError(), input.getMaxError());
+            checkArgument(nearlyEqual(previous.getAlpha(), input.getAlpha(), COMPARISON_EPSILON),
+                    "Cannot merge qdigests with different alpha values (%s vs. %s)", state.getQuantileDigest().getAlpha(), input.getAlpha());
+            state.addMemoryUsage(-previous.estimatedInMemorySizeInBytes());
+            previous.merge(input);
+            state.addMemoryUsage(previous.estimatedInMemorySizeInBytes());
+        }
+    }
+
+    public static void output(QuantileDigestStateSerializer serializer, QuantileDigestState state, BlockBuilder out)
+    {
+        serializer.serialize(state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/QuantileDigestAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/QuantileDigestAggregationFunction.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.state.QuantileDigestState;
+import com.facebook.presto.operator.aggregation.state.QuantileDigestStateFactory;
+import com.facebook.presto.operator.aggregation.state.QuantileDigestStateSerializer;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.QuantileDigestType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.DynamicClassLoader;
+import io.airlift.stats.QuantileDigest;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.metadata.Signature.comparableTypeParameter;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.doubleToSortableLong;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.floatToSortableInt;
+import static com.facebook.presto.operator.scalar.QuantileDigestFunctions.DEFAULT_ACCURACY;
+import static com.facebook.presto.operator.scalar.QuantileDigestFunctions.DEFAULT_WEIGHT;
+import static com.facebook.presto.operator.scalar.QuantileDigestFunctions.verifyAccuracy;
+import static com.facebook.presto.operator.scalar.QuantileDigestFunctions.verifyWeight;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.insertArguments;
+
+public final class QuantileDigestAggregationFunction
+        extends SqlAggregationFunction
+{
+    public static final QuantileDigestAggregationFunction QDIGEST_AGG = new QuantileDigestAggregationFunction(parseTypeSignature("V"));
+    public static final QuantileDigestAggregationFunction QDIGEST_AGG_WITH_WEIGHT = new QuantileDigestAggregationFunction(parseTypeSignature("V"), parseTypeSignature(StandardTypes.BIGINT));
+    public static final QuantileDigestAggregationFunction QDIGEST_AGG_WITH_WEIGHT_AND_ERROR = new QuantileDigestAggregationFunction(parseTypeSignature("V"), parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.DOUBLE));
+    public static final String NAME = "qdigest_agg";
+
+    private static final MethodHandle INPUT_DOUBLE = methodHandle(QuantileDigestAggregationFunction.class, "inputDouble", QuantileDigestState.class, double.class, long.class, double.class);
+    private static final MethodHandle INPUT_REAL = methodHandle(QuantileDigestAggregationFunction.class, "inputReal", QuantileDigestState.class, long.class, long.class, double.class);
+    private static final MethodHandle INPUT_BIGINT = methodHandle(QuantileDigestAggregationFunction.class, "inputBigint", QuantileDigestState.class, long.class, long.class, double.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(QuantileDigestAggregationFunction.class, "combineState", QuantileDigestState.class, QuantileDigestState.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(QuantileDigestAggregationFunction.class, "evaluateFinal", QuantileDigestStateSerializer.class, QuantileDigestState.class, BlockBuilder.class);
+
+    private QuantileDigestAggregationFunction(TypeSignature... typeSignatures)
+    {
+        super(
+                NAME,
+                ImmutableList.of(comparableTypeParameter("V")),
+                ImmutableList.of(),
+                parseTypeSignature("qdigest(V)"),
+                ImmutableList.copyOf(typeSignatures));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Returns a qdigest from the set of reals, bigints or doubles";
+    }
+
+    @Override
+    public InternalAggregationFunction specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type valueType = boundVariables.getTypeVariable("V");
+        QuantileDigestType outputType = (QuantileDigestType) typeManager.getParameterizedType(
+                StandardTypes.QDIGEST,
+                ImmutableList.of(TypeSignatureParameter.of(valueType.getTypeSignature())));
+        return generateAggregation(valueType, outputType, arity);
+    }
+
+    private static InternalAggregationFunction generateAggregation(Type valueType, QuantileDigestType outputType, int arity)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(QuantileDigestAggregationFunction.class.getClassLoader());
+        List<Type> inputTypes = getInputTypes(valueType, arity);
+        QuantileDigestStateSerializer stateSerializer = new QuantileDigestStateSerializer(valueType);
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                createInputParameterMetadata(inputTypes),
+                getMethodHandle(valueType, arity),
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION.bindTo(stateSerializer),
+                ImmutableList.of(new AccumulatorStateDescriptor(
+                        QuantileDigestState.class,
+                        stateSerializer,
+                        new QuantileDigestStateFactory())),
+                outputType);
+
+        GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
+        return new InternalAggregationFunction(NAME, inputTypes, ImmutableList.of(intermediateType), outputType, true, true, factory);
+    }
+
+    private static List<Type> getInputTypes(Type valueType, int arity)
+    {
+        switch (arity) {
+            case 1:
+                // weight and accuracy unspecified
+                return ImmutableList.of(valueType);
+            case 2:
+                // weight specified, accuracy unspecified
+                return ImmutableList.of(valueType, BIGINT);
+            case 3:
+                // weight and accuracy specified
+                return ImmutableList.of(valueType, BIGINT, DOUBLE);
+            default:
+                throw new IllegalArgumentException(format("Unsupported number of arguments: %s", arity));
+        }
+    }
+
+    private static MethodHandle getMethodHandle(Type valueType, int arity)
+    {
+        final MethodHandle inputFunction;
+        switch (valueType.getDisplayName()) {
+            case StandardTypes.DOUBLE:
+                inputFunction = INPUT_DOUBLE;
+                break;
+            case StandardTypes.REAL:
+                inputFunction = INPUT_REAL;
+                break;
+            case StandardTypes.BIGINT:
+                inputFunction = INPUT_BIGINT;
+                break;
+            default:
+                throw new IllegalArgumentException(format("Unsupported type %s supplied", valueType.getDisplayName()));
+        }
+
+        switch (arity) {
+            case 1:
+                // weight and accuracy unspecified
+                return insertArguments(inputFunction, 2, DEFAULT_WEIGHT, DEFAULT_ACCURACY);
+            case 2:
+                // weight specified, accuracy unspecified
+                return insertArguments(inputFunction, 3, DEFAULT_ACCURACY);
+            case 3:
+                // weight and accuracy specified
+                return inputFunction;
+            default:
+                throw new IllegalArgumentException(format("Unsupported number of arguments: %s", arity));
+        }
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(List<Type> valueTypes)
+    {
+        return ImmutableList.<ParameterMetadata>builder()
+                .add(new ParameterMetadata(STATE))
+                .addAll(valueTypes.stream().map(valueType -> new ParameterMetadata(INPUT_CHANNEL, valueType)).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static void inputDouble(QuantileDigestState state, double value, long weight, double accuracy)
+    {
+        inputBigint(state, doubleToSortableLong(value), weight, accuracy);
+    }
+
+    public static void inputReal(QuantileDigestState state, long value, long weight, double accuracy)
+    {
+        inputBigint(state, floatToSortableInt(intBitsToFloat((int) value)), weight, accuracy);
+    }
+
+    public static void inputBigint(QuantileDigestState state, long value, long weight, double accuracy)
+    {
+        QuantileDigest qdigest = getOrCreateQuantileDigest(state, verifyAccuracy(accuracy));
+        state.addMemoryUsage(-qdigest.estimatedInMemorySizeInBytes());
+        qdigest.add(value, verifyWeight(weight));
+        state.addMemoryUsage(qdigest.estimatedInMemorySizeInBytes());
+    }
+
+    private static QuantileDigest getOrCreateQuantileDigest(QuantileDigestState state, double accuracy)
+    {
+        QuantileDigest qdigest = state.getQuantileDigest();
+        if (qdigest == null) {
+            qdigest = new QuantileDigest(accuracy);
+            state.setQuantileDigest(qdigest);
+            state.addMemoryUsage(qdigest.estimatedInMemorySizeInBytes());
+        }
+        return qdigest;
+    }
+
+    public static void combineState(QuantileDigestState state, QuantileDigestState otherState)
+    {
+        QuantileDigest input = otherState.getQuantileDigest();
+
+        QuantileDigest previous = state.getQuantileDigest();
+        if (previous == null) {
+            state.setQuantileDigest(input);
+            state.addMemoryUsage(input.estimatedInMemorySizeInBytes());
+        }
+        else {
+            state.addMemoryUsage(-previous.estimatedInMemorySizeInBytes());
+            previous.merge(input);
+            state.addMemoryUsage(previous.estimatedInMemorySizeInBytes());
+        }
+    }
+
+    public static void evaluateFinal(QuantileDigestStateSerializer serializer, QuantileDigestState state, BlockBuilder out)
+    {
+        serializer.serialize(state, out);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/QuantileDigestState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/QuantileDigestState.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+import io.airlift.stats.QuantileDigest;
+
+public interface QuantileDigestState
+        extends AccumulatorState
+{
+    QuantileDigest getQuantileDigest();
+
+    void setQuantileDigest(QuantileDigest value);
+
+    void addMemoryUsage(int value);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/QuantileDigestStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/QuantileDigestStateFactory.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import io.airlift.stats.QuantileDigest;
+import org.openjdk.jol.info.ClassLayout;
+
+import static java.util.Objects.requireNonNull;
+
+public class QuantileDigestStateFactory
+        implements AccumulatorStateFactory<QuantileDigestState>
+{
+    @Override
+    public QuantileDigestState createSingleState()
+    {
+        return new SingleQuantileDigestState();
+    }
+
+    @Override
+    public Class<? extends QuantileDigestState> getSingleStateClass()
+    {
+        return SingleQuantileDigestState.class;
+    }
+
+    @Override
+    public QuantileDigestState createGroupedState()
+    {
+        return new GroupedQuantileDigestState();
+    }
+
+    @Override
+    public Class<? extends QuantileDigestState> getGroupedStateClass()
+    {
+        return GroupedQuantileDigestState.class;
+    }
+
+    public static class GroupedQuantileDigestState
+            extends AbstractGroupedAccumulatorState
+            implements QuantileDigestState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedQuantileDigestState.class).instanceSize();
+        private final ObjectBigArray<QuantileDigest> qdigests = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            qdigests.ensureCapacity(size);
+        }
+
+        @Override
+        public QuantileDigest getQuantileDigest()
+        {
+            return qdigests.get(getGroupId());
+        }
+
+        @Override
+        public void setQuantileDigest(QuantileDigest value)
+        {
+            requireNonNull(value, "value is null");
+            qdigests.set(getGroupId(), value);
+        }
+
+        @Override
+        public void addMemoryUsage(int value)
+        {
+            size += value;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return INSTANCE_SIZE + size + qdigests.sizeOf();
+        }
+    }
+
+    public static class SingleQuantileDigestState
+            implements QuantileDigestState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleQuantileDigestState.class).instanceSize();
+        private QuantileDigest qdigest;
+
+        @Override
+        public QuantileDigest getQuantileDigest()
+        {
+            return qdigest;
+        }
+
+        @Override
+        public void setQuantileDigest(QuantileDigest value)
+        {
+            qdigest = value;
+        }
+
+        @Override
+        public void addMemoryUsage(int value)
+        {
+            // noop
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            long estimatedSize = INSTANCE_SIZE;
+            if (qdigest != null) {
+                estimatedSize += qdigest.estimatedInMemorySizeInBytes();
+            }
+            return estimatedSize;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/QuantileDigestStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/QuantileDigestStateSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.QuantileDigestType;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.stats.QuantileDigest;
+
+public class QuantileDigestStateSerializer
+        implements AccumulatorStateSerializer<QuantileDigestState>
+{
+    private final QuantileDigestType type;
+
+    public QuantileDigestStateSerializer(Type elementType)
+    {
+        this.type = new QuantileDigestType(elementType);
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return type;
+    }
+
+    @Override
+    public void serialize(QuantileDigestState state, BlockBuilder out)
+    {
+        if (state.getQuantileDigest() == null) {
+            out.appendNull();
+        }
+        else {
+            type.writeSlice(out, state.getQuantileDigest().serialize());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, QuantileDigestState state)
+    {
+        state.setQuantileDigest(new QuantileDigest(type.getSlice(block, index)));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/QuantileDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/QuantileDigestFunctions.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import io.airlift.slice.Slice;
+import io.airlift.stats.QuantileDigest;
+
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableIntToFloat;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.sortableLongToDouble;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static java.lang.Float.floatToRawIntBits;
+
+public final class QuantileDigestFunctions
+{
+    public static final double DEFAULT_ACCURACY = 0.01;
+    public static final long DEFAULT_WEIGHT = 1L;
+
+    private QuantileDigestFunctions() {}
+
+    @ScalarFunction("value_at_quantile")
+    @Description("Given an input q between [0, 1], find the value whose rank in the sorted sequence of the n values represented by the qdigest is qn.")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double valueAtQuantileDouble(@SqlType("qdigest(double)") Slice input, @SqlType(StandardTypes.DOUBLE) double quantile)
+    {
+        return sortableLongToDouble(valueAtQuantileBigint(input, quantile));
+    }
+
+    @ScalarFunction("value_at_quantile")
+    @Description("Given an input q between [0, 1], find the value whose rank in the sorted sequence of the n values represented by the qdigest is qn.")
+    @SqlType(StandardTypes.REAL)
+    public static long valueAtQuantileReal(@SqlType("qdigest(real)") Slice input, @SqlType(StandardTypes.DOUBLE) double quantile)
+    {
+        return floatToRawIntBits(sortableIntToFloat((int) valueAtQuantileBigint(input, quantile)));
+    }
+
+    @ScalarFunction("value_at_quantile")
+    @Description("Given an input q between [0, 1], find the value whose rank in the sorted sequence of the n values represented by the qdigest is qn.")
+    @SqlType(StandardTypes.BIGINT)
+    public static long valueAtQuantileBigint(@SqlType("qdigest(bigint)") Slice input, @SqlType(StandardTypes.DOUBLE) double quantile)
+    {
+        return new QuantileDigest(input).getQuantile(quantile);
+    }
+
+    @ScalarFunction("values_at_quantiles")
+    @Description("For each input q between [0, 1], find the value whose rank in the sorted sequence of the n values represented by the qdigest is qn.")
+    @SqlType("array(double)")
+    public static Block valuesAtQuantilesDouble(@SqlType("qdigest(double)") Slice input, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        QuantileDigest digest = new QuantileDigest(input);
+        BlockBuilder output = DOUBLE.createBlockBuilder(null, percentilesArrayBlock.getPositionCount());
+        for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+            DOUBLE.writeDouble(output, sortableLongToDouble(digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i))));
+        }
+        return output.build();
+    }
+
+    @ScalarFunction("values_at_quantiles")
+    @Description("For each input q between [0, 1], find the value whose rank in the sorted sequence of the n values represented by the qdigest is qn.")
+    @SqlType("array(real)")
+    public static Block valuesAtQuantilesReal(@SqlType("qdigest(real)") Slice input, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        QuantileDigest digest = new QuantileDigest(input);
+        BlockBuilder output = REAL.createBlockBuilder(null, percentilesArrayBlock.getPositionCount());
+        for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+            REAL.writeLong(output, floatToRawIntBits(sortableIntToFloat((int) digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i)))));
+        }
+        return output.build();
+    }
+
+    @ScalarFunction("values_at_quantiles")
+    @Description("For each input q between [0, 1], find the value whose rank in the sorted sequence of the n values represented by the qdigest is qn.")
+    @SqlType("array(bigint)")
+    public static Block valuesAtQuantilesBigint(@SqlType("qdigest(bigint)") Slice input, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        QuantileDigest digest = new QuantileDigest(input);
+        BlockBuilder output = BIGINT.createBlockBuilder(null, percentilesArrayBlock.getPositionCount());
+        for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+            BIGINT.writeLong(output, digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i)));
+        }
+        return output.build();
+    }
+
+    public static double verifyAccuracy(double accuracy)
+    {
+        checkCondition(accuracy > 0 && accuracy < 1, INVALID_FUNCTION_ARGUMENT, "Percentile accuracy must be exclusively between 0 and 1, was %s", accuracy);
+        return accuracy;
+    }
+
+    public static long verifyWeight(long weight)
+    {
+        checkCondition(weight > 0, INVALID_FUNCTION_ARGUMENT, "Percentile weight must be > 0, was %s", weight);
+        return weight;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/QuantileDigestOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/QuantileDigestOperators.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.spi.function.OperatorType.CAST;
+
+public final class QuantileDigestOperators
+{
+    private QuantileDigestOperators() {}
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice castToBinaryDouble(@SqlType("qdigest(double)") Slice slice)
+    {
+        return slice;
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice castToBinaryBigint(@SqlType("qdigest(bigint)") Slice slice)
+    {
+        return slice;
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice castToBinaryReal(@SqlType("qdigest(real)") Slice slice)
+    {
+        return slice;
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType("qdigest(double)")
+    public static Slice castFromVarbinaryDouble(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return slice;
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType("qdigest(bigint)")
+    public static Slice castFromVarbinaryBigint(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return slice;
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType("qdigest(real)")
+    public static Slice castFromVarbinaryReal(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return slice;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -60,6 +60,7 @@ import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.P4HyperLogLogType.P4_HYPER_LOG_LOG;
+import static com.facebook.presto.spi.type.QuantileDigestParametricType.QDIGEST;
 import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.RowType.Field;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
@@ -153,6 +154,7 @@ public final class TypeRegistry
         addParametricType(ARRAY);
         addParametricType(MAP);
         addParametricType(FUNCTION);
+        addParametricType(QDIGEST);
 
         for (Type type : types) {
             addType(type);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeQuantileDigestFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeQuantileDigestFunction.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.SqlVarbinary;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeParameter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.stats.QuantileDigest;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.spi.type.QuantileDigestParametricType.QDIGEST;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.util.Objects.requireNonNull;
+
+public class TestMergeQuantileDigestFunction
+        extends AbstractTestAggregationFunction
+{
+    public static final BiFunction<Object, Object, Boolean> QDIGEST_EQUALITY = (actualBinary, expectedBinary) -> {
+        if (actualBinary == null && expectedBinary == null) {
+            return true;
+        }
+        requireNonNull(actualBinary, "actual value was null");
+        requireNonNull(expectedBinary, "expected value was null");
+
+        QuantileDigest actual = new QuantileDigest(wrappedBuffer(((SqlVarbinary) actualBinary).getBytes()));
+        QuantileDigest expected = new QuantileDigest(wrappedBuffer(((SqlVarbinary) expectedBinary).getBytes()));
+        return actual.getCount() == expected.getCount() &&
+                actual.getMin() == expected.getMin() &&
+                actual.getMax() == expected.getMax() &&
+                actual.getAlpha() == expected.getAlpha() &&
+                actual.getMaxError() == expected.getMaxError();
+    };
+
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        Type type = QDIGEST.createType(typeRegistry, ImmutableList.of(TypeParameter.of(DoubleType.DOUBLE)));
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, length);
+        for (int i = start; i < start + length; i++) {
+            QuantileDigest qdigest = new QuantileDigest(0.0);
+            qdigest.add(i);
+            type.writeSlice(blockBuilder, qdigest.serialize());
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "merge";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of("qdigest(double)");
+    }
+
+    @Override
+    public Object getExpectedValue(int start, int length)
+    {
+        if (length == 0) {
+            return null;
+        }
+
+        QuantileDigest qdigest = new QuantileDigest(0.00);
+        for (int i = start; i < start + length; i++) {
+            qdigest.add(i);
+        }
+        return new SqlVarbinary(qdigest.serialize().getBytes());
+    }
+
+    // The following tests are overridden because by default simple equality checks are done, which often won't work with
+    // qdigests due to the way they are serialized.  I am instead overridding these methods and using the QDIGEST_EQUALITY
+    // function to perform equality checks.
+    @Test
+    @Override
+    public void testMultiplePositions()
+    {
+        assertAggregation(getFunction(),
+                QDIGEST_EQUALITY,
+                "test multiple positions",
+                new Page(getSequenceBlocks(0, 5)),
+                getExpectedValue(0, 5));
+    }
+
+    @Test
+    @Override
+    public void testMixedNullAndNonNullPositions()
+    {
+        assertAggregation(getFunction(),
+                QDIGEST_EQUALITY,
+                "test mixed null and nonnull position",
+                new Page(createAlternatingNullsBlock(getFunction().getParameterTypes(), getSequenceBlocks(0, 10))),
+                getExpectedValueIncludingNulls(0, 10, 20));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestQuantileDigestAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestQuantileDigestAggregationFunction.java
@@ -1,0 +1,390 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.SqlVarbinary;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.base.Joiner;
+import com.google.common.primitives.Floats;
+import io.airlift.stats.QuantileDigest;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static com.facebook.presto.block.BlockAssertions.createBlockOfReals;
+import static com.facebook.presto.block.BlockAssertions.createDoubleSequenceBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongSequenceBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.block.BlockAssertions.createSequenceBlockOfReal;
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.doubleToSortableLong;
+import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.floatToSortableInt;
+import static com.facebook.presto.operator.aggregation.TestMergeQuantileDigestFunction.QDIGEST_EQUALITY;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Double.NaN;
+import static java.lang.Integer.max;
+import static java.lang.Integer.min;
+import static java.lang.String.format;
+
+public class TestQuantileDigestAggregationFunction
+        extends AbstractTestFunctions
+{
+    private static final Joiner ARRAY_JOINER = Joiner.on(",");
+    private static final MetadataManager METADATA = MetadataManager.createTestMetadataManager();
+
+    @Test
+    public void testDoublesWithWeights()
+    {
+        testAggregationDouble(
+                createDoublesBlock(1.0, null, 2.0, null, 3.0, null, 4.0, null, 5.0, null),
+                createRLEBlock(1, 10),
+                0.01, 1.0, 2.0, 3.0, 4.0, 5.0);
+        testAggregationDouble(
+                createDoublesBlock(null, null, null, null, null),
+                createRLEBlock(1, 5),
+                NaN);
+        testAggregationDouble(
+                createDoublesBlock(-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0, -10.0),
+                createRLEBlock(1, 10),
+                0.01, -1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0, -10.0);
+        testAggregationDouble(
+                createDoublesBlock(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0),
+                createRLEBlock(1, 10),
+                0.01, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0);
+        testAggregationDouble(
+                createDoublesBlock(),
+                createRLEBlock(1, 0),
+                NaN);
+        testAggregationDouble(
+                createDoublesBlock(1.0),
+                createRLEBlock(1, 1),
+                0.01, 1.0);
+        testAggregationDouble(
+                createDoubleSequenceBlock(-1000, 1000),
+                createRLEBlock(1, 2000),
+                0.01,
+                LongStream.range(-1000, 1000).asDoubleStream().toArray());
+    }
+
+    @Test
+    public void testRealsWithWeights()
+    {
+        testAggregationReal(
+                createBlockOfReals(1.0F, null, 2.0F, null, 3.0F, null, 4.0F, null, 5.0F, null),
+                createRLEBlock(1, 10),
+                0.01, 1.0F, 2.0F, 3.0F, 4.0F, 5.0F);
+        testAggregationReal(
+                createBlockOfReals(null, null, null, null, null),
+                createRLEBlock(1, 5),
+                NaN);
+        testAggregationReal(
+                createBlockOfReals(-1.0F, -2.0F, -3.0F, -4.0F, -5.0F, -6.0F, -7.0F, -8.0F, -9.0F, -10.0F),
+                createRLEBlock(1, 10),
+                0.01, -1.0F, -2.0F, -3.0F, -4.0F, -5.0F, -6.0F, -7.0F, -8.0F, -9.0F, -10.0F);
+        testAggregationReal(
+                createBlockOfReals(1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F),
+                createRLEBlock(1, 10),
+                0.01, 1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F);
+        testAggregationReal(
+                createBlockOfReals(),
+                createRLEBlock(1, 0),
+                NaN);
+        testAggregationReal(
+                createBlockOfReals(1.0F),
+                createRLEBlock(1, 1),
+                0.01, 1.0F);
+        testAggregationReal(
+                createSequenceBlockOfReal(-1000, 1000),
+                createRLEBlock(1, 2000),
+                0.01,
+                Floats.toArray(LongStream.range(-1000, 1000).mapToObj(Float::new).collect(toImmutableList())));
+    }
+
+    @Test
+    public void testBigintsWithWeight()
+    {
+        testAggregationBigint(
+                createLongsBlock(1L, null, 2L, null, 3L, null, 4L, null, 5L, null),
+                createRLEBlock(1, 10),
+                0.01, 1, 2, 3, 4, 5);
+        testAggregationBigint(
+                createLongsBlock(null, null, null, null, null),
+                createRLEBlock(1, 5),
+                NaN);
+        testAggregationBigint(
+                createLongsBlock(-1, -2, -3, -4, -5, -6, -7, -8, -9, -10),
+                createRLEBlock(1, 10),
+                0.01, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10);
+        testAggregationBigint(
+                createLongsBlock(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+                createRLEBlock(1, 10),
+                0.01, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        testAggregationBigint(
+                createLongsBlock(new int[] {}),
+                createRLEBlock(1, 0),
+                NaN);
+        testAggregationBigint(
+                createLongsBlock(1),
+                createRLEBlock(1, 1),
+                0.01, 1);
+        testAggregationBigint(
+                createLongSequenceBlock(-1000, 1000),
+                createRLEBlock(1, 2000),
+                0.01,
+                LongStream.range(-1000, 1000).toArray());
+    }
+
+    private InternalAggregationFunction getAggregationFunction(String... type)
+    {
+        TypeSignature[] typeSignatures = Arrays.stream(type).map(TypeSignature::parseTypeSignature).toArray(TypeSignature[]::new);
+        return METADATA.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("qdigest_agg",
+                        AGGREGATE,
+                        parseTypeSignature(format("qdigest(%s)", type[0])),
+                        typeSignatures));
+    }
+
+    private void testAggregationBigint(Block inputBlock, Block weightsBlock, double maxError, long... inputs)
+    {
+        // Test without weights and accuracy
+        testAggregationBigints(
+                getAggregationFunction(StandardTypes.BIGINT),
+                new Page(inputBlock),
+                maxError,
+                inputs);
+
+        // Test with weights and without accuracy
+        testAggregationBigints(
+                getAggregationFunction(StandardTypes.BIGINT, StandardTypes.BIGINT),
+                new Page(inputBlock, weightsBlock),
+                maxError,
+                inputs);
+        // Test with weights and accuracy
+        testAggregationBigints(
+                getAggregationFunction(StandardTypes.BIGINT, StandardTypes.BIGINT, StandardTypes.DOUBLE),
+                new Page(inputBlock, weightsBlock, createRLEBlock(maxError, inputBlock.getPositionCount())),
+                maxError,
+                inputs);
+    }
+
+    private void testAggregationReal(Block longsBlock, Block weightsBlock, double maxError, float... inputs)
+    {
+        // Test without weights and accuracy
+        testAggregationReal(
+                getAggregationFunction(StandardTypes.REAL),
+                new Page(longsBlock),
+                maxError,
+                inputs);
+        // Test with weights and without accuracy
+        testAggregationReal(
+                getAggregationFunction(StandardTypes.REAL, StandardTypes.BIGINT),
+                new Page(longsBlock, weightsBlock),
+                maxError,
+                inputs);
+        // Test with weights and accuracy
+        testAggregationReal(
+                getAggregationFunction(StandardTypes.REAL, StandardTypes.BIGINT, StandardTypes.DOUBLE),
+                new Page(longsBlock, weightsBlock, createRLEBlock(maxError, longsBlock.getPositionCount())),
+                maxError,
+                inputs);
+    }
+
+    private void testAggregationDouble(Block longsBlock, Block weightsBlock, double maxError, double... inputs)
+    {
+        // Test without weights and accuracy
+        testAggregationDoubles(
+                getAggregationFunction(StandardTypes.DOUBLE),
+                new Page(longsBlock),
+                maxError,
+                inputs);
+        // Test with weights and without accuracy
+        testAggregationDoubles(
+                getAggregationFunction(StandardTypes.DOUBLE, StandardTypes.BIGINT),
+                new Page(longsBlock, weightsBlock),
+                maxError,
+                inputs);
+        // Test with weights and accuracy
+        testAggregationDoubles(
+                getAggregationFunction(StandardTypes.DOUBLE, StandardTypes.BIGINT, StandardTypes.DOUBLE),
+                new Page(longsBlock, weightsBlock, createRLEBlock(maxError, longsBlock.getPositionCount())),
+                maxError,
+                inputs);
+    }
+
+    private void testAggregationBigints(InternalAggregationFunction function, Page page, double maxError, long... inputs)
+    {
+        // aggregate level
+        assertAggregation(function,
+                QDIGEST_EQUALITY,
+                "test multiple positions",
+                page,
+                getExpectedValueLongs(maxError, inputs));
+
+        // test scalars
+        List<Long> rows = Arrays.stream(inputs).sorted().boxed().collect(Collectors.toList());
+
+        SqlVarbinary returned = (SqlVarbinary) AggregationTestUtils.aggregation(function, page);
+        assertPercentileWithinError(StandardTypes.BIGINT, returned, maxError, rows, 0.1, 0.5, 0.9, 0.99);
+    }
+
+    private void testAggregationDoubles(InternalAggregationFunction function, Page page, double maxError, double... inputs)
+    {
+        assertAggregation(function,
+                QDIGEST_EQUALITY,
+                "test multiple positions",
+                page,
+                getExpectedValueDoubles(maxError, inputs));
+
+        // test scalars
+        List<Double> rows = Arrays.stream(inputs).sorted().boxed().collect(Collectors.toList());
+
+        SqlVarbinary returned = (SqlVarbinary) AggregationTestUtils.aggregation(function, page);
+        assertPercentileWithinError(StandardTypes.DOUBLE, returned, maxError, rows, 0.1, 0.5, 0.9, 0.99);
+    }
+
+    private void testAggregationReal(InternalAggregationFunction function, Page page, double maxError, float... inputs)
+    {
+        assertAggregation(function,
+                QDIGEST_EQUALITY,
+                "test multiple positions",
+                page,
+                getExpectedValuesFloats(maxError, inputs));
+
+        // test scalars
+        List<Double> rows = Floats.asList(inputs).stream().sorted().map(Float::doubleValue).collect(Collectors.toList());
+
+        SqlVarbinary returned = (SqlVarbinary) AggregationTestUtils.aggregation(function, page);
+        assertPercentileWithinError(StandardTypes.REAL, returned, maxError, rows, 0.1, 0.5, 0.9, 0.99);
+    }
+
+    private Object getExpectedValueLongs(double maxError, long... values)
+    {
+        if (values.length == 0) {
+            return null;
+        }
+        QuantileDigest qdigest = new QuantileDigest(maxError);
+        Arrays.stream(values).forEach(qdigest::add);
+        return new SqlVarbinary(qdigest.serialize().getBytes());
+    }
+
+    private Object getExpectedValueDoubles(double maxError, double... values)
+    {
+        if (values.length == 0) {
+            return null;
+        }
+        QuantileDigest qdigest = new QuantileDigest(maxError);
+        Arrays.stream(values).forEach(value -> qdigest.add(doubleToSortableLong(value)));
+        return new SqlVarbinary(qdigest.serialize().getBytes());
+    }
+
+    private Object getExpectedValuesFloats(double maxError, float... values)
+    {
+        if (values.length == 0) {
+            return null;
+        }
+        QuantileDigest qdigest = new QuantileDigest(maxError);
+        Floats.asList(values).forEach(value -> qdigest.add(floatToSortableInt(value)));
+        return new SqlVarbinary(qdigest.serialize().getBytes());
+    }
+
+    private void assertPercentileWithinError(String type, SqlVarbinary binary, double error, List<? extends Number> rows, double... percentiles)
+    {
+        if (rows.isEmpty()) {
+            // Nothing to assert except that the qdigest is empty
+            return;
+        }
+
+        // Test each quantile individually (value_at_quantile)
+        for (double percentile : percentiles) {
+            assertPercentileWithinError(type, binary, error, rows, percentile);
+        }
+
+        // Test all the quantiles (values_at_quantiles)
+        assertPercentilesWithinError(type, binary, error, rows, percentiles);
+    }
+
+    private void assertPercentileWithinError(String type, SqlVarbinary binary, double error, List<? extends Number> rows, double percentile)
+    {
+        Number lowerBound = getLowerBound(error, rows, percentile);
+        Number upperBound = getUpperBound(error, rows, percentile);
+
+        // Check that the chosen quantile is within the upper and lower bound of the error
+        functionAssertions.assertFunction(
+                format("value_at_quantile(CAST(X'%s' AS qdigest(%s)), %s) >= %s", binary.toString().replaceAll("\\s+", " "), type, percentile, lowerBound),
+                BOOLEAN,
+                true);
+        functionAssertions.assertFunction(
+                format("value_at_quantile(CAST(X'%s' AS qdigest(%s)), %s) <= %s", binary.toString().replaceAll("\\s+", " "), type, percentile, upperBound),
+                BOOLEAN,
+                true);
+    }
+
+    private void assertPercentilesWithinError(String type, SqlVarbinary binary, double error, List<? extends Number> rows, double[] percentiles)
+    {
+        List<Double> boxedPercentiles = Arrays.stream(percentiles).sorted().boxed().collect(toImmutableList());
+        List<Number> lowerBounds = boxedPercentiles.stream().map(percentile -> getLowerBound(error, rows, percentile)).collect(toImmutableList());
+        List<Number> upperBounds = boxedPercentiles.stream().map(percentile -> getUpperBound(error, rows, percentile)).collect(toImmutableList());
+
+        // Ensure that the lower bound of each item in the distribution is not greater than the chosen quantiles
+        functionAssertions.assertFunction(
+                format(
+                        "zip_with(values_at_quantiles(CAST(X'%s' AS qdigest(%s)), ARRAY[%s]), ARRAY[%s], (value, lowerbound) -> value >= lowerbound)",
+                        binary.toString().replaceAll("\\s+", " "),
+                        type,
+                        ARRAY_JOINER.join(boxedPercentiles),
+                        ARRAY_JOINER.join(lowerBounds)),
+                METADATA.getType(parseTypeSignature("array(boolean)")),
+                Collections.nCopies(percentiles.length, true));
+
+        // Ensure that the upper bound of each item in the distribution is not less than the chosen quantiles
+        functionAssertions.assertFunction(
+                format(
+                        "zip_with(values_at_quantiles(CAST(X'%s' AS qdigest(%s)), ARRAY[%s]), ARRAY[%s], (value, upperbound) -> value <= upperbound)",
+                        binary.toString().replaceAll("\\s+", " "),
+                        type,
+                        ARRAY_JOINER.join(boxedPercentiles),
+                        ARRAY_JOINER.join(upperBounds)),
+                METADATA.getType(parseTypeSignature("array(boolean)")),
+                Collections.nCopies(percentiles.length, true));
+    }
+
+    private Number getLowerBound(double error, List<? extends Number> rows, double percentile)
+    {
+        int medianIndex = (int) (rows.size() * percentile);
+        int marginOfError = (int) (rows.size() * error / 2);
+        return rows.get(max(medianIndex - marginOfError, 0));
+    }
+
+    private Number getUpperBound(double error, List<? extends Number> rows, double percentile)
+    {
+        int medianIndex = (int) (rows.size() * percentile);
+        int marginOfError = (int) (rows.size() * error / 2);
+        return rows.get(min(medianIndex + marginOfError, rows.size() - 1));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1460,6 +1460,10 @@ public class TestAnalyzer
         // HLL is neither orderable nor comparable
         assertFails(TYPE_MISMATCH, "SELECT cast(NULL AS HyperLogLog) < ALL (VALUES cast(NULL AS HyperLogLog))");
         assertFails(TYPE_MISMATCH, "SELECT cast(NULL AS HyperLogLog) = ANY (VALUES cast(NULL AS HyperLogLog))");
+
+        // qdigest is neither orderable nor comparable
+        assertFails(TYPE_MISMATCH, "SELECT cast(NULL AS qdigest(double)) < ALL (VALUES cast(NULL AS qdigest(double)))");
+        assertFails(TYPE_MISMATCH, "SELECT cast(NULL AS qdigest(double)) = ANY (VALUES cast(NULL AS qdigest(double)))");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -503,6 +503,11 @@ public class TestRowOperators
         assertInvalidFunction("cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog)) > cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog))",
                 SemanticErrorCode.TYPE_MISMATCH, "line 1:81: '>' cannot be applied to row(col0 HyperLogLog), row(col0 HyperLogLog)");
 
+        assertInvalidFunction("cast(row(cast(cast ('' as varbinary) as qdigest(double))) as row(col0 qdigest(double))) = cast(row(cast(cast ('' as varbinary) as qdigest(double))) as row(col0 qdigest(double)))",
+                SemanticErrorCode.TYPE_MISMATCH, "line 1:89: '=' cannot be applied to row(col0 qdigest(double)), row(col0 qdigest(double))");
+        assertInvalidFunction("cast(row(cast(cast ('' as varbinary) as qdigest(double))) as row(col0 qdigest(double))) > cast(row(cast(cast ('' as varbinary) as qdigest(double))) as row(col0 qdigest(double)))",
+                SemanticErrorCode.TYPE_MISMATCH, "line 1:89: '>' cannot be applied to row(col0 qdigest(double)), row(col0 qdigest(double))");
+
         assertFunction("row(TRUE, ARRAY [1], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0])) = row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0]))", BOOLEAN, false);
         assertFunction("row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0])) = row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0]))", BOOLEAN, true);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/QuantileDigestParametricType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/QuantileDigestParametricType.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+public class QuantileDigestParametricType
+        implements ParametricType
+{
+    public static final QuantileDigestParametricType QDIGEST = new QuantileDigestParametricType();
+
+    @Override
+    public String getName()
+    {
+        return StandardTypes.QDIGEST;
+    }
+
+    @Override
+    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    {
+        checkArgument(parameters.size() == 1, "QDIGEST type expects exactly one type as a parameter, got %s", parameters);
+        checkArgument(
+                parameters.get(0).getKind() == ParameterKind.TYPE,
+                "QDIGEST expects type as a parameter, got %s",
+                parameters);
+        // Validation check on the acceptable type (bigint, real, double) intentionally omitted
+        // because this is validated in each function and to allow for consistent error messaging
+        return new QuantileDigestType(parameters.get(0).getType());
+    }
+
+    private static void checkArgument(boolean argument, String format, Object... args)
+    {
+        if (!argument) {
+            throw new IllegalArgumentException(format(format, args));
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/QuantileDigestType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/QuantileDigestType.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.airlift.slice.Slice;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+public class QuantileDigestType
+        extends AbstractVariableWidthType
+{
+    private final Type type;
+
+    @JsonCreator
+    public QuantileDigestType(Type type)
+    {
+        super(new TypeSignature(StandardTypes.QDIGEST, TypeSignatureParameter.of(type.getTypeSignature())), Slice.class);
+        this.type = type;
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else {
+            block.writeBytesTo(position, 0, block.getSliceLength(position), blockBuilder);
+            blockBuilder.closeEntry();
+        }
+    }
+
+    @Override
+    public Slice getSlice(Block block, int position)
+    {
+        return block.getSlice(position, 0, block.getSliceLength(position));
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value)
+    {
+        writeSlice(blockBuilder, value, 0, value.length());
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        blockBuilder.writeBytes(value, offset, length).closeEntry();
+    }
+
+    @Override
+    public Object getObjectValue(ConnectorSession session, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+
+        return new SqlVarbinary(block.getSlice(position, 0, block.getSliceLength(position)).getBytes());
+    }
+
+    @Override
+    public List<Type> getTypeParameters()
+    {
+        return singletonList(type);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/StandardTypes.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/StandardTypes.java
@@ -25,6 +25,7 @@ public final class StandardTypes
     public static final String REAL = "real";
     public static final String DOUBLE = "double";
     public static final String HYPER_LOG_LOG = "HyperLogLog";
+    public static final String QDIGEST = "qdigest";
     public static final String P4_HYPER_LOG_LOG = "P4HyperLogLog";
     public static final String INTERVAL_DAY_TO_SECOND = "interval day to second";
     public static final String INTERVAL_YEAR_TO_MONTH = "interval year to month";

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7128,7 +7128,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testMergeHyperLogLogOnlyNulls()
     {
-        MaterializedResult actual = computeActual("SELECT cardinality(merge(null)) FROM orders");
+        MaterializedResult actual = computeActual("SELECT cardinality(merge(CAST (null AS HyperLogLog))) FROM orders");
 
         MaterializedResult expected = resultBuilder(getSession(), BIGINT)
                 .row(new Object[] {null})


### PR DESCRIPTION
Adds the following functions for creating and manipulating qdigests:
- `qdigest_agg`: aggregation function to create qdigest from real, bigint or double
  values
- `merge`: aggregation function to merge multiple qdigests
- `value_at_quantile`: scalar function that retrieves a given quantile from a
  qdigest
- `values_at_quantiles`: scalar function that retrieves a list of quantiles from a
  qdigest

Weights and accuracy specifications can be set to `qdigest_agg` in the same way they can be set on `approx_percentile`.  `qdigest`s support casting to and from `varbinary`.

Fixes #8695 

The serialization format still needs to be agreed on and documented, so this should not be merged until that is done.  airlift/airlift#678