### PR TITLE
Remove Optional from FilterStatsCalculator and ComparisonStatsCalculator method signatures

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -48,8 +48,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
-import static com.facebook.presto.cost.ComparisonStatsCalculator.comparisonExpressionToExpressionStats;
-import static com.facebook.presto.cost.ComparisonStatsCalculator.comparisonExpressionToLiteralStats;
+import static com.facebook.presto.cost.ComparisonStatsCalculator.estimateExpressionToExpressionComparison;
+import static com.facebook.presto.cost.ComparisonStatsCalculator.estimateExpressionToLiteralComparison;
 import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStatsAndSumDistinctValues;
 import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.differenceInNonRangeStats;
 import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.differenceInStats;
@@ -359,7 +359,7 @@ public class FilterStatsCalculator
 
             if (right instanceof Literal) {
                 OptionalDouble literal = doubleValueFromLiteral(getType(left), (Literal) right);
-                return comparisonExpressionToLiteralStats(input, leftSymbol, leftStats, literal, operator);
+                return estimateExpressionToLiteralComparison(input, leftStats, leftSymbol, literal, operator);
             }
 
             Optional<Symbol> rightSymbol = asSymbol(right);
@@ -375,10 +375,10 @@ public class FilterStatsCalculator
 
             if (isSingleValue(rightStats)) {
                 OptionalDouble value = isNaN(rightStats.getLowValue()) ? OptionalDouble.empty() : OptionalDouble.of(rightStats.getLowValue());
-                return comparisonExpressionToLiteralStats(input, leftSymbol, leftStats, value, operator);
+                return estimateExpressionToLiteralComparison(input, leftStats, leftSymbol, value, operator);
             }
 
-            return comparisonExpressionToExpressionStats(input, leftSymbol, leftStats, rightSymbol, rightStats, operator);
+            return estimateExpressionToExpressionComparison(input, leftStats, leftSymbol, rightStats, rightSymbol, operator);
         }
 
         private Optional<Symbol> asSymbol(Expression expression)

--- a/presto-main/src/main/java/com/facebook/presto/cost/SymbolStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/SymbolStatsEstimate.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 import static java.lang.String.format;
 
@@ -148,6 +149,13 @@ public class SymbolStatsEstimate
     public boolean isUnknown()
     {
         return this.equals(UNKNOWN);
+    }
+
+    public boolean isSingleValue()
+    {
+        return distinctValuesCount == 1.0
+                && Double.compare(lowValue, highValue) == 0
+                && !isInfinite(lowValue);
     }
 
     @Override


### PR DESCRIPTION
Having Optional in these interfaces makes code messy. `Optional.empty()` indicates an absence of the estimate. However it doesn't mean that if the result is not empty, the estimate is not unknown. That makes code harder to reason about.