### PR TITLE
Make CostCalculator to calculate cumulatively

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CachingCostProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CachingCostProvider.java
@@ -88,13 +88,6 @@ public class CachingCostProvider
 
     private PlanNodeCostEstimate calculateCumulativeCost(PlanNode node)
     {
-        PlanNodeCostEstimate localCosts = costCalculator.calculateCost(node, statsProvider, session, types);
-
-        PlanNodeCostEstimate sourcesCost = node.getSources().stream()
-                .map(this::getCumulativeCost)
-                .reduce(PlanNodeCostEstimate.zero(), PlanNodeCostEstimate::add);
-
-        PlanNodeCostEstimate cumulativeCost = localCosts.add(sourcesCost);
-        return cumulativeCost;
+        return costCalculator.calculateCost(node, statsProvider, this, session, types);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculator.java
@@ -31,7 +31,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public interface CostCalculator
 {
     /**
-     * Calculates non-cumulative cost of a node.
+     * Calculates cumulative cost of a node.
      *
      * @param node The node to compute cost for.
      * @param stats The stats provider for node's stats and child nodes' stats, to be used if stats are needed to compute cost for the {@code node}
@@ -39,6 +39,7 @@ public interface CostCalculator
     PlanNodeCostEstimate calculateCost(
             PlanNode node,
             StatsProvider stats,
+            CostProvider costs,
             Session session,
             TypeProvider types);
 

--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
@@ -65,11 +65,11 @@ public class CostCalculatorWithEstimatedExchanges
     }
 
     @Override
-    public PlanNodeCostEstimate calculateCost(PlanNode node, StatsProvider stats, Session session, TypeProvider types)
+    public PlanNodeCostEstimate calculateCost(PlanNode node, StatsProvider stats, CostProvider costs, Session session, TypeProvider types)
     {
         ExchangeCostEstimator exchangeCostEstimator = new ExchangeCostEstimator(numberOfNodes.getAsInt(), stats, types);
         PlanNodeCostEstimate estimatedExchangeCost = node.accept(exchangeCostEstimator, null);
-        return costCalculator.calculateCost(node, stats, session, types).add(estimatedExchangeCost);
+        return costCalculator.calculateCost(node, stats, costs, session, types).add(estimatedExchangeCost);
     }
 
     private static class ExchangeCostEstimator


### PR DESCRIPTION
This enables:
- incorporating peak memory computation as part of CostCalculator
(and not CachingCostProvider which has different responsibility)
- simplifying CostProvider and StatsProvider into single
interface, e.g: `TraitProvider<T>`
- simplifying CachingCostProvider and CachingStatsProvider into
single class, e.g: `CachingTraitProvider<T>`

This should enable cleaner approach for https://github.com/prestodb/presto/pull/11591