### PR TITLE
Verify Connection returned from driver

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/DriverConnectionFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/DriverConnectionFactory.java
@@ -18,6 +18,7 @@ import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class DriverConnectionFactory
@@ -56,6 +57,8 @@ public class DriverConnectionFactory
     public Connection openConnection()
             throws SQLException
     {
-        return driver.connect(connectionUrl, connectionProperties);
+        Connection connection = driver.connect(connectionUrl, connectionProperties);
+        checkState(connection != null, "Driver returned null connection");
+        return connection;
     }
 }


### PR DESCRIPTION
A `Driver` can return `null` connection when e.g. it does not recognize
the connection URL.