### PR TITLE
Display real cpu time in explain analyze

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -41,9 +41,9 @@ import java.util.concurrent.TimeUnit;
         "task.level-absolute-priority"})
 public class TaskManagerConfig
 {
-    private boolean perOperatorCpuTimerEnabled;
+    private boolean perOperatorCpuTimerEnabled = true;
     private boolean taskCpuTimerEnabled = true;
-    private boolean statisticsCpuTimerEnabled;
+    private boolean statisticsCpuTimerEnabled = true;
     private DataSize maxPartialAggregationMemoryUsage = new DataSize(16, Unit.MEGABYTE);
     private DataSize maxLocalExchangeBufferSize = new DataSize(32, Unit.MEGABYTE);
     private DataSize maxIndexMemoryUsage = new DataSize(64, Unit.MEGABYTE);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
@@ -38,7 +38,7 @@ public class PlanNodeStats
 {
     private final PlanNodeId planNodeId;
 
-    private final Duration planNodeWallTime;
+    private final Duration planNodeScheduledTime;
     private final long planNodeInputPositions;
     private final DataSize planNodeInputDataSize;
     private final long planNodeOutputPositions;
@@ -50,7 +50,7 @@ public class PlanNodeStats
 
     PlanNodeStats(
             PlanNodeId planNodeId,
-            Duration planNodeWallTime,
+            Duration planNodeScheduledTime,
             long planNodeInputPositions,
             DataSize planNodeInputDataSize,
             long planNodeOutputPositions,
@@ -61,7 +61,7 @@ public class PlanNodeStats
     {
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
 
-        this.planNodeWallTime = requireNonNull(planNodeWallTime, "planNodeWallTime is null");
+        this.planNodeScheduledTime = requireNonNull(planNodeScheduledTime, "planNodeScheduledTime is null");
         this.planNodeInputPositions = planNodeInputPositions;
         this.planNodeInputDataSize = planNodeInputDataSize;
         this.planNodeOutputPositions = planNodeOutputPositions;
@@ -85,9 +85,9 @@ public class PlanNodeStats
         return planNodeId;
     }
 
-    public Duration getPlanNodeWallTime()
+    public Duration getPlanNodeScheduledTime()
     {
-        return planNodeWallTime;
+        return planNodeScheduledTime;
     }
 
     public Set<String> getOperatorTypes()
@@ -190,7 +190,7 @@ public class PlanNodeStats
 
         return new PlanNodeStats(
                 planNodeId,
-                new Duration(planNodeWallTime.toMillis() + other.getPlanNodeWallTime().toMillis(), MILLISECONDS),
+                new Duration(planNodeScheduledTime.toMillis() + other.getPlanNodeScheduledTime().toMillis(), MILLISECONDS),
                 planNodeInputPositions, planNodeInputDataSize,
                 planNodeOutputPositions, planNodeOutputDataSize,
                 operatorInputStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStats.java
@@ -39,6 +39,7 @@ public class PlanNodeStats
     private final PlanNodeId planNodeId;
 
     private final Duration planNodeScheduledTime;
+    private final Duration planNodeCpuTime;
     private final long planNodeInputPositions;
     private final DataSize planNodeInputDataSize;
     private final long planNodeOutputPositions;
@@ -51,6 +52,7 @@ public class PlanNodeStats
     PlanNodeStats(
             PlanNodeId planNodeId,
             Duration planNodeScheduledTime,
+            Duration planNodeCpuTime,
             long planNodeInputPositions,
             DataSize planNodeInputDataSize,
             long planNodeOutputPositions,
@@ -62,6 +64,7 @@ public class PlanNodeStats
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
 
         this.planNodeScheduledTime = requireNonNull(planNodeScheduledTime, "planNodeScheduledTime is null");
+        this.planNodeCpuTime = requireNonNull(planNodeCpuTime, "planNodeCpuTime is null");
         this.planNodeInputPositions = planNodeInputPositions;
         this.planNodeInputDataSize = planNodeInputDataSize;
         this.planNodeOutputPositions = planNodeOutputPositions;
@@ -88,6 +91,11 @@ public class PlanNodeStats
     public Duration getPlanNodeScheduledTime()
     {
         return planNodeScheduledTime;
+    }
+
+    public Duration getPlanNodeCpuTime()
+    {
+        return planNodeCpuTime;
     }
 
     public Set<String> getOperatorTypes()
@@ -191,6 +199,7 @@ public class PlanNodeStats
         return new PlanNodeStats(
                 planNodeId,
                 new Duration(planNodeScheduledTime.toMillis() + other.getPlanNodeScheduledTime().toMillis(), MILLISECONDS),
+                new Duration(planNodeCpuTime.toMillis() + other.getPlanNodeCpuTime().toMillis(), MILLISECONDS),
                 planNodeInputPositions, planNodeInputDataSize,
                 planNodeOutputPositions, planNodeOutputDataSize,
                 operatorInputStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -45,10 +45,11 @@ public class PlanNodeStatsSummarizer
 {
     private PlanNodeStatsSummarizer() {}
 
-    public static Map<PlanNodeId, PlanNodeStats> aggregatePlanNodeStats(StageInfo stageInfo)
+    public static Map<PlanNodeId, PlanNodeStats> aggregatePlanNodeStats(List<StageInfo> stageInfos)
     {
         Map<PlanNodeId, PlanNodeStats> aggregatedStats = new HashMap<>();
-        List<PlanNodeStats> planNodeStats = stageInfo.getTasks().stream()
+        List<PlanNodeStats> planNodeStats = stageInfos.stream()
+                .flatMap(stageInfo -> stageInfo.getTasks().stream())
                 .map(TaskInfo::getStats)
                 .flatMap(taskStats -> getPlanNodeStats(taskStats).stream())
                 .collect(toList());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -66,6 +66,8 @@ public class PlanNodeStatsSummarizer
         // it's possible that some or all of them are missing or out of date.
         // For example, a LIMIT clause can cause a query to finish before stats
         // are collected from the leaf stages.
+        Set<PlanNodeId> planNodeIds = new HashSet<>();
+
         Map<PlanNodeId, Long> planNodeInputPositions = new HashMap<>();
         Map<PlanNodeId, Long> planNodeInputBytes = new HashMap<>();
         Map<PlanNodeId, Long> planNodeOutputPositions = new HashMap<>();
@@ -90,6 +92,7 @@ public class PlanNodeStatsSummarizer
             // Gather input statistics
             for (OperatorStats operatorStats : pipelineStats.getOperatorSummaries()) {
                 PlanNodeId planNodeId = operatorStats.getPlanNodeId();
+                planNodeIds.add(planNodeId);
 
                 long scheduledMillis = operatorStats.getAddInputWall().toMillis() + operatorStats.getGetOutputWall().toMillis() + operatorStats.getFinishWall().toMillis();
                 planNodeScheduledMillis.merge(planNodeId, scheduledMillis, Long::sum);
@@ -157,8 +160,7 @@ public class PlanNodeStatsSummarizer
         }
 
         List<PlanNodeStats> stats = new ArrayList<>();
-        for (Map.Entry<PlanNodeId, Long> entry : planNodeScheduledMillis.entrySet()) {
-            PlanNodeId planNodeId = entry.getKey();
+        for (PlanNodeId planNodeId : planNodeIds) {
             if (!planNodeInputPositions.containsKey(planNodeId)) {
                 continue;
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -194,8 +194,8 @@ public class PlanPrinter
         List<PlanFragment> allFragments = allStages.stream()
                 .map(StageInfo::getPlan)
                 .collect(toImmutableList());
+        Map<PlanNodeId, PlanNodeStats> aggregatedStats = aggregatePlanNodeStats(allStages);
         for (StageInfo stageInfo : allStages) {
-            Map<PlanNodeId, PlanNodeStats> aggregatedStats = aggregatePlanNodeStats(stageInfo);
             builder.append(formatFragment(functionRegistry, session, stageInfo.getPlan(), Optional.of(stageInfo), Optional.of(aggregatedStats), verbose, allFragments));
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -354,7 +354,13 @@ public class PlanPrinter
         double cpuTimeFraction = 100.0d * nodeStats.getPlanNodeCpuTime().toMillis() / totalCpuMillis;
 
         output.append(indentString(indent));
-        output.append("CPU fraction: " + formatDouble(cpuTimeFraction) + "%, Scheduled fraction: " + formatDouble(scheduledTimeFraction) + "%");
+        output.append(format(
+                "CPU: %s (%s%%), Scheduled: %s (%s%%)",
+                nodeStats.getPlanNodeCpuTime(),
+                formatDouble(cpuTimeFraction),
+                nodeStats.getPlanNodeScheduledTime(),
+                formatDouble(scheduledTimeFraction)));
+
         if (printInput) {
             output.append(format(", Input: %s (%s)",
                     formatPositions(nodeStats.getPlanNodeInputPositions()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -227,8 +227,9 @@ public class PlanPrinter
             double sdAmongTasks = Math.sqrt(squaredDifferences / stageInfo.get().getTasks().size());
 
             builder.append(indentString(1))
-                    .append(format("CPU: %s, Input: %s (%s); per task: avg.: %s std.dev.: %s, Output: %s (%s)\n",
+                    .append(format("CPU: %s, Scheduled: %s, Input: %s (%s); per task: avg.: %s std.dev.: %s, Output: %s (%s)\n",
                             stageStats.getTotalCpuTime(),
+                            stageStats.getTotalScheduledTime(),
                             formatPositions(stageStats.getProcessedInputPositions()),
                             stageStats.getProcessedInputDataSize(),
                             formatDouble(avgPositionsPerTask),
@@ -326,8 +327,8 @@ public class PlanPrinter
             return;
         }
 
-        long totalMillis = stats.get().values().stream()
-                .mapToLong(node -> node.getPlanNodeWallTime().toMillis())
+        long totalScheduledMillis = stats.get().values().stream()
+                .mapToLong(node -> node.getPlanNodeScheduledTime().toMillis())
                 .sum();
 
         PlanNodeStats nodeStats = stats.get().get(planNodeId);
@@ -345,10 +346,10 @@ public class PlanPrinter
             return;
         }
 
-        double fraction = 100.0d * nodeStats.getPlanNodeWallTime().toMillis() / totalMillis;
+        double scheduledTimeFraction = 100.0d * nodeStats.getPlanNodeScheduledTime().toMillis() / totalScheduledMillis;
 
         output.append(indentString(indent));
-        output.append("CPU fraction: " + formatDouble(fraction) + "%");
+        output.append("Scheduled fraction: " + formatDouble(scheduledTimeFraction) + "%");
         if (printInput) {
             output.append(format(", Input: %s (%s)",
                     formatPositions(nodeStats.getPlanNodeInputPositions()),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -228,8 +228,8 @@ public class PlanPrinter
 
             builder.append(indentString(1))
                     .append(format("CPU: %s, Scheduled: %s, Input: %s (%s); per task: avg.: %s std.dev.: %s, Output: %s (%s)\n",
-                            stageStats.getTotalCpuTime(),
-                            stageStats.getTotalScheduledTime(),
+                            stageStats.getTotalCpuTime().convertToMostSuccinctTimeUnit(),
+                            stageStats.getTotalScheduledTime().convertToMostSuccinctTimeUnit(),
                             formatPositions(stageStats.getProcessedInputPositions()),
                             stageStats.getProcessedInputDataSize(),
                             formatDouble(avgPositionsPerTask),
@@ -356,9 +356,9 @@ public class PlanPrinter
         output.append(indentString(indent));
         output.append(format(
                 "CPU: %s (%s%%), Scheduled: %s (%s%%)",
-                nodeStats.getPlanNodeCpuTime(),
+                nodeStats.getPlanNodeCpuTime().convertToMostSuccinctTimeUnit(),
                 formatDouble(cpuTimeFraction),
-                nodeStats.getPlanNodeScheduledTime(),
+                nodeStats.getPlanNodeScheduledTime().convertToMostSuccinctTimeUnit(),
                 formatDouble(scheduledTimeFraction)));
 
         if (printInput) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -331,6 +331,10 @@ public class PlanPrinter
                 .mapToLong(node -> node.getPlanNodeScheduledTime().toMillis())
                 .sum();
 
+        long totalCpuMillis = stats.get().values().stream()
+                .mapToLong(node -> node.getPlanNodeCpuTime().toMillis())
+                .sum();
+
         PlanNodeStats nodeStats = stats.get().get(planNodeId);
         if (nodeStats == null) {
             output.append(indentString(indent));
@@ -347,9 +351,10 @@ public class PlanPrinter
         }
 
         double scheduledTimeFraction = 100.0d * nodeStats.getPlanNodeScheduledTime().toMillis() / totalScheduledMillis;
+        double cpuTimeFraction = 100.0d * nodeStats.getPlanNodeCpuTime().toMillis() / totalCpuMillis;
 
         output.append(indentString(indent));
-        output.append("Scheduled fraction: " + formatDouble(scheduledTimeFraction) + "%");
+        output.append("CPU fraction: " + formatDouble(cpuTimeFraction) + "%, Scheduled fraction: " + formatDouble(scheduledTimeFraction) + "%");
         if (printInput) {
             output.append(format(", Input: %s (%s)",
                     formatPositions(nodeStats.getPlanNodeInputPositions()),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -37,7 +37,7 @@ public class TestTaskManagerConfig
                 .setSplitConcurrencyAdjustmentInterval(new Duration(100, TimeUnit.MILLISECONDS))
                 .setStatusRefreshMaxWait(new Duration(1, TimeUnit.SECONDS))
                 .setInfoUpdateInterval(new Duration(3, TimeUnit.SECONDS))
-                .setPerOperatorCpuTimerEnabled(false)
+                .setPerOperatorCpuTimerEnabled(true)
                 .setTaskCpuTimerEnabled(true)
                 .setMaxWorkerThreads(Runtime.getRuntime().availableProcessors() * 2)
                 .setMinDrivers(Runtime.getRuntime().availableProcessors() * 2 * 2)
@@ -58,7 +58,7 @@ public class TestTaskManagerConfig
                 .setTaskNotificationThreads(5)
                 .setTaskYieldThreads(3)
                 .setLevelTimeMultiplier(new BigDecimal("2"))
-                .setStatisticsCpuTimerEnabled(false));
+                .setStatisticsCpuTimerEnabled(true));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class TestTaskManagerConfig
                 .put("task.split-concurrency-adjustment-interval", "1s")
                 .put("task.status-refresh-max-wait", "2s")
                 .put("task.info-update-interval", "2s")
-                .put("task.per-operator-cpu-timer-enabled", "true")
+                .put("task.per-operator-cpu-timer-enabled", "false")
                 .put("task.cpu-timer-enabled", "false")
                 .put("task.max-index-memory", "512MB")
                 .put("task.share-index-loading", "true")
@@ -90,7 +90,7 @@ public class TestTaskManagerConfig
                 .put("task.task-notification-threads", "13")
                 .put("task.task-yield-threads", "8")
                 .put("task.level-time-multiplier", "2.1")
-                .put("task.statistics-cpu-timer-enabled", "true")
+                .put("task.statistics-cpu-timer-enabled", "false")
                 .build();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -98,7 +98,7 @@ public class TestTaskManagerConfig
                 .setSplitConcurrencyAdjustmentInterval(new Duration(1, TimeUnit.SECONDS))
                 .setStatusRefreshMaxWait(new Duration(2, TimeUnit.SECONDS))
                 .setInfoUpdateInterval(new Duration(2, TimeUnit.SECONDS))
-                .setPerOperatorCpuTimerEnabled(true)
+                .setPerOperatorCpuTimerEnabled(false)
                 .setTaskCpuTimerEnabled(false)
                 .setMaxIndexMemoryUsage(new DataSize(512, Unit.MEGABYTE))
                 .setShareIndexLoading(true)
@@ -119,7 +119,7 @@ public class TestTaskManagerConfig
                 .setTaskNotificationThreads(13)
                 .setTaskYieldThreads(8)
                 .setLevelTimeMultiplier(new BigDecimal("2.1"))
-                .setStatisticsCpuTimerEnabled(true);
+                .setStatisticsCpuTimerEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
```
presto:default> explain analyze select linestatus, count(orderkey) from lineitem group by 1;
                                                                                Query Plan                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Fragment 1 [HASH]                                                                                                                                                         
     CPU: 31.86ms, Scheduled: 140.80ms, Input: 10 rows (240B); per task: avg.: 10.00 std.dev.: 0.00, Output: 2 rows (30B)                                                  
     Output layout: [linestatus, count]                                                                                                                                    
     Output partitioning: SINGLE []                                                                                                                                        
     Grouped Execution: false                                                                                                                                              
     - Project[] => [linestatus:varchar(1), count:bigint]                                                                                                                  
             CPU: 2.00ms (0.10%), Scheduled: 5.00ms (0.04%), Input: 2 rows (48B), Output: 2 rows (30B), Filtered: 0.00%                                                    
             Input avg.: 0.13 rows, Input std.dev.: 264.58%                                                                                                                
         - Aggregate(FINAL)[linestatus][$hashvalue] => [linestatus:varchar(1), $hashvalue:bigint, count:bigint]                                                            
                 CPU: 4.00ms (0.20%), Scheduled: 7.00ms (0.06%), Output: 2 rows (48B)                                                                                      
                 Input avg.: 0.63 rows, Input std.dev.: 264.58%                                                                                                            
                 count := "count"("count_9")                                                                                                                               
             - LocalExchange[HASH][$hashvalue] ("linestatus") => linestatus:varchar(1), count_9:bigint, $hashvalue:bigint                                                  
                     CPU: 5.00ms (0.24%), Scheduled: 23.00ms (0.18%), Output: 10 rows (240B)                                                                               
                     Input avg.: 0.63 rows, Input std.dev.: 186.55%                                                                                                        
                 - RemoteSource[2] => [linestatus:varchar(1), count_9:bigint, $hashvalue_10:bigint]                                                                        
                         CPU: 1.00ms (0.05%), Scheduled: 5.00ms (0.04%), Output: 10 rows (240B)                                                                            
                         Input avg.: 0.63 rows, Input std.dev.: 186.55%                                                                                                    
                                                                                                                                                                           
 Fragment 2 [SOURCE]                                                                                                                                                       
     CPU: 2.03s, Scheduled: 7.08s, Input: 6001215 rows (137.36MB); per task: avg.: 6001215.00 std.dev.: 0.00, Output: 10 rows (240B)                                       
     Output layout: [linestatus, count_9, $hashvalue_11]                                                                                                                   
     Output partitioning: HASH [linestatus][$hashvalue_11]                                                                                                                 
     Grouped Execution: false                                                                                                                                              
     - Aggregate(PARTIAL)[linestatus][$hashvalue_11] => [linestatus:varchar(1), $hashvalue_11:bigint, count_9:bigint]                                                      
             CPU: 392.00ms (19.18%), Scheduled: 436.00ms (3.47%), Output: 10 rows (240B)                                                                                   
             Input avg.: 1200243.00 rows, Input std.dev.: 11.99%                                                                                                           
             count_9 := "count"("orderkey")                                                                                                                                
         - ScanProject[table = hive:default:lineitem, grouped = false] => [orderkey:bigint, linestatus:varchar(1), $hashvalue_11:bigint]                                   
                 Cost: {rows: 6001215 (85.85MB), cpu: 90018225.00, memory: 0.00, network: 0.00}/{rows: 6001215 (137.36MB), cpu: 234047385.00, memory: 0.00, network: 0.00} 
                 CPU: 1.64s (80.23%), Scheduled: 12.10s (96.22%), Input: 6001215 rows (215.05MB), Output: 6001215 rows (137.36MB), Filtered: 0.00%                         
                 Input avg.: 1200243.00 rows, Input std.dev.: 11.99%                                                                                                       
                 $hashvalue_11 := "combine_hash"(bigint '0', COALESCE("$operator$hash_code"("linestatus"), 0))                                                             
                 LAYOUT: default.lineitem                                                                                                                                  
                 orderkey := orderkey:bigint:0:REGULAR                                                                                                                     
                 linestatus := linestatus:varchar(1):9:REGULAR                                                                                                             
                                                                                                                                                                           
                                                                                                                                                                           
(1 row)
```