### PR TITLE
Embed Presto version in stacktraces

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -124,6 +124,7 @@ import com.facebook.presto.transaction.TransactionManagerConfig;
 import com.facebook.presto.type.TypeDeserializer;
 import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.util.FinalizerService;
+import com.facebook.presto.version.EmbedVersion;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Key;
@@ -291,6 +292,7 @@ public class ServerMainModule
         configBinder(binder).bindConfig(ReservedSystemMemoryConfig.class);
         binder.bind(LocalMemoryManager.class).in(Scopes.SINGLETON);
         binder.bind(LocalMemoryManagerExporter.class).in(Scopes.SINGLETON);
+        binder.bind(EmbedVersion.class).in(Scopes.SINGLETON);
         newExporter(binder).export(TaskManager.class).withGeneratedName();
         binder.bind(TaskExecutor.class).in(Scopes.SINGLETON);
         newExporter(binder).export(TaskExecutor.class).withGeneratedName();

--- a/presto-main/src/main/java/com/facebook/presto/version/EmbedVersion.java
+++ b/presto-main/src/main/java/com/facebook/presto/version/EmbedVersion.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.version;
+
+import com.facebook.presto.server.ServerConfig;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.bytecode.ClassDefinition;
+import io.airlift.bytecode.FieldDefinition;
+import io.airlift.bytecode.MethodDefinition;
+import io.airlift.bytecode.Parameter;
+
+import javax.inject.Inject;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Objects;
+
+import static com.facebook.presto.util.CompilerUtils.defineClass;
+import static com.facebook.presto.util.CompilerUtils.makeClassName;
+import static com.facebook.presto.util.Reflection.constructorMethodHandle;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.airlift.bytecode.Access.FINAL;
+import static io.airlift.bytecode.Access.PRIVATE;
+import static io.airlift.bytecode.Access.PUBLIC;
+import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.Parameter.arg;
+import static io.airlift.bytecode.ParameterizedType.type;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class EmbedVersion
+{
+    private final MethodHandle runnableConstructor;
+
+    @Inject
+    public EmbedVersion(ServerConfig serverConfig)
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName(baseClassName(serverConfig)),
+                type(Object.class),
+                type(Runnable.class));
+
+        FieldDefinition field = classDefinition.declareField(a(PRIVATE), "runnable", Runnable.class);
+
+        Parameter parameter = arg("runnable", type(Runnable.class));
+        MethodDefinition constructor = classDefinition.declareConstructor(a(PUBLIC), parameter);
+        constructor.getBody()
+                .comment("super(runnable);")
+                .append(constructor.getThis())
+                .invokeConstructor(Object.class)
+                .append(constructor.getThis())
+                .append(parameter)
+                .putField(field)
+                .ret();
+
+        MethodDefinition run = classDefinition.declareMethod(a(PUBLIC), "run", type(void.class));
+        run.getBody()
+                .comment("runnable.run();")
+                .append(run.getThis())
+                .getField(field)
+                .invokeInterface(Runnable.class, "run", void.class)
+                .ret();
+
+        Class<? extends Runnable> generatedClass = defineClass(classDefinition, Runnable.class, ImmutableMap.of(), getClass().getClassLoader());
+        this.runnableConstructor = constructorMethodHandle(generatedClass, Runnable.class);
+    }
+
+    private static String baseClassName(ServerConfig serverConfig)
+    {
+        String builtInVersion = new ServerConfig().getPrestoVersion();
+        String configuredVersion = serverConfig.getPrestoVersion();
+
+        String version = configuredVersion;
+        if (Objects.equals(builtInVersion, configuredVersion)) {
+            version = format("%s__%s", builtInVersion, configuredVersion);
+        }
+        return format("Presto_%s___", version);
+    }
+
+    public Runnable embedVersion(Runnable runnable)
+    {
+        requireNonNull(runnable, "runnable is null");
+        try {
+            return (Runnable) runnableConstructor.invoke(runnable);
+        }
+        catch (Throwable throwable) {
+            throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
+        }
+    }
+}


### PR DESCRIPTION
Sometimes, users will just report a stacktrace, without telling which
Presto version it is for. Embed version information in exceptions
produced by Presto, so that the version is immediately know.

Example output
```
$ ./presto-product-tests/conf/docker/singlenode/compose.sh run application-runner /docker/volumes/conf/docker/files/presto-cli.sh --debug --catalog hive --schema default --user hive
+ java -jar /docker/volumes/presto-cli/presto-cli-executable.jar --server presto-master:8080 --debug --catalog hive --schema default --user hive
presto:default> select * from x;
Query 20181012_121120_00002_k4ata failed: line 1:15: Table hive.default.x does not exist
com.facebook.presto.sql.analyzer.SemanticException: line 1:15: Table hive.default.x does not exist
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:848)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:258)
	at com.facebook.presto.sql.tree.Table.accept(Table.java:53)
	at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:270)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom(StatementAnalyzer.java:1772)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:954)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:258)
	at com.facebook.presto.sql.tree.QuerySpecification.accept(QuerySpecification.java:127)
	at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:270)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:280)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:676)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:258)
	at com.facebook.presto.sql.tree.Query.accept(Query.java:94)
	at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:270)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:244)
	at com.facebook.presto.sql.analyzer.Analyzer.analyze(Analyzer.java:72)
	at com.facebook.presto.sql.analyzer.Analyzer.analyze(Analyzer.java:64)
	at com.facebook.presto.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:184)
	at com.facebook.presto.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:721)
	at com.facebook.presto.execution.SqlQueryManager.createQueryInternal(SqlQueryManager.java:453)
	at com.facebook.presto.execution.SqlQueryManager.lambda$createQuery$3(SqlQueryManager.java:386)
	at com.facebook.presto.$gen.Presto_0_212_94_g1fabb82____20181012_121051_1.run(Unknown Source)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```