### PR TITLE
Always compact pages in memory connector

### DIFF
--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryPagesStore.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryPagesStore.java
@@ -63,6 +63,8 @@ public class MemoryPagesStore
             throw new PrestoException(MISSING_DATA, "Failed to find table on a worker.");
         }
 
+        page.compact();
+
         long newSize = currentBytes + page.getRetainedSizeInBytes();
         if (maxBytes < newSize) {
             throw new PrestoException(MEMORY_LIMIT_EXCEEDED, format("Memory limit [%d] for memory connector exceeded", maxBytes));


### PR DESCRIPTION
Memory connector might receive pages directly
from exchange. Such pages are composed from
blocks that refer to the same byte array.
It causes overaccounting of Page memory