### PR TITLE
Redirects from root include host name

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/WebUiResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/WebUiResource.java
@@ -23,7 +23,6 @@ import javax.ws.rs.core.UriInfo;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static javax.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
-import static javax.ws.rs.core.UriBuilder.fromPath;
 
 @Path("/")
 public class WebUiResource
@@ -38,7 +37,7 @@ public class WebUiResource
         }
 
         return Response.status(MOVED_PERMANENTLY)
-                .location(fromPath("/ui/").scheme(proto).build())
+                .location(uriInfo.getRequestUriBuilder().scheme(proto).path("/ui/").build())
                 .build();
     }
 }


### PR DESCRIPTION
In the common case that a user visits `/`, we want to redirect them to `/ui/`. Before we added the protocol explicitly (here: https://github.com/prestodb/presto/commit/656c2fcd3eddb27dde890ce28eb371333bd0ce25), this would be achieved with a relative redirect:

```
17754 $ curl -v localhost:8080
* Rebuilt URL to: localhost:8080/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.61.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Date: Fri, 12 Oct 2018 20:48:14 GMT
< Location: /ui/
< Content-Length: 0
<
```

Since adding the schema we now get a mangled URI (`http:/ui/`), which Chrome seems to tolerate on localhost due to some special-casing, but it breaks in most cases:
```
17760 $ curl -v http://localhost:8080/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.61.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Date: Fri, 12 Oct 2018 20:54:10 GMT
< Location: http:/ui/
< Content-Length: 0
<
```

This PR fixes the URI by using the host and forwarded protocol to create an absolute redirect:
```
17754 $ curl -v localhost:8080
* Rebuilt URL to: localhost:8080/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.61.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Date: Fri, 12 Oct 2018 20:48:14 GMT
< Location: http://localhost:8080/ui/
< Content-Length: 0
<
```

It's not clear what the motivation for adding the scheme was in the first place - relative redirects should always work, regardless of whether they're proxied. I would be open to just reverting 656c2fcd3eddb27dde890ce28eb371333bd0ce25, I don't understand the motivation behind this change?