### PR TITLE
Remove redundant byte[] allocation in VariableWidthBlock

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
@@ -159,7 +159,7 @@ public class VariableWidthBlock
         for (int i = 0; i < length; i++) {
             int position = positions[offset + i];
             if (!isEntryNull(position)) {
-                newSlice.appendBytes(slice.getBytes(getPositionOffset(position), getSliceLength(position)));
+                newSlice.writeBytes(slice, getPositionOffset(position), getSliceLength(position));
             }
             else if (newValueIsNull != null) {
                 newValueIsNull[i] = true;


### PR DESCRIPTION
Slice.getBytes is allocating a redundant byte[] which can be avoided
by using SliceOutput.writeBytes in VariableWidthBlock.copyPositions.

From production:

```
 --- 3058697816 bytes (2.02%), 446 samples
[ 0] byte[]
[ 1] io.airlift.slice.Slice.getBytes
[ 2] com.facebook.presto.spi.block.VariableWidthBlock.copyPositions
[ 3] com.facebook.presto.operator.project.InputPageProjection.project
 ```
The fix has been tested with tpch sf100 q10 and got rid of the below 3.6 GB byte[] allocation. 

```
--- 3652861448 bytes (0.26%), 958 samples
  [ 0] byte[]
  [ 1] io.airlift.slice.Slice.getBytes
  [ 2] com.facebook.presto.spi.block.VariableWidthBlock.copyPositions
  [ 3] com.facebook.presto.operator.exchange.PartitioningExchanger.accept
```


