### PR TITLE
Support LDAP with anonymous bind disabled

### DIFF
--- a/presto-password-authenticators/src/main/java/com/facebook/presto/password/LdapAuthenticator.java
+++ b/presto-password-authenticators/src/main/java/com/facebook/presto/password/LdapAuthenticator.java
@@ -76,7 +76,6 @@ public class LdapAuthenticator
                 .put(INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
                 .put(PROVIDER_URL, ldapUrl)
                 .build();
-        checkEnvironment(environment);
         this.basicEnvironment = environment;
         this.authenticationCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(serverConfig.getLdapCacheTtl().toMillis(), MILLISECONDS)
@@ -173,16 +172,6 @@ public class LdapAuthenticator
     private static String replaceUser(String pattern, String user)
     {
         return pattern.replaceAll("\\$\\{USER}", user);
-    }
-
-    private static void checkEnvironment(Map<String, String> environment)
-    {
-        try {
-            closeContext(createDirContext(environment));
-        }
-        catch (NamingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private static void closeContext(DirContext context)

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -18,4 +18,4 @@ services:
       - CLI_ARGUMENTS=--server https://presto-master:8443 --keystore-path /etc/openldap/certs/coordinator.jks --keystore-password testldap
 
   ldapserver:
-    image: 'prestodb/centos6-oj8-openldap:${DOCKER_IMAGES_VERSION}'
+    image: 'prestodb/centos6-oj8-openldap:4fc1925'


### PR DESCRIPTION
For many users, enabling anonymous bind is not an option from security
perspective.

When anonymous bind is disabled, Presto would fail with
```
1) Error injecting constructor, java.lang.RuntimeException: javax.naming.AuthenticationNotSupportedException: [LDAP: error code 48 - anonymous bind disallowed]
  at com.facebook.presto.password.LdapAuthenticator.<init>(LdapAuthenticator.java:66)
  at com.facebook.presto.password.LdapAuthenticatorFactory.lambda$create$0(LdapAuthenticatorFactory.java:43)
  while locating com.facebook.presto.password.LdapAuthenticator

1 error
	at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:543)
	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:186)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:109)
	at com.google.inject.Guice.createInjector(Guice.java:87)
	at io.airlift.bootstrap.Bootstrap.initialize(Bootstrap.java:240)
	at com.facebook.presto.password.LdapAuthenticatorFactory.create(LdapAuthenticatorFactory.java:50)
	at com.facebook.presto.server.security.PasswordAuthenticatorManager.loadPasswordAuthenticator(PasswordAuthenticatorManager.java:75)
	at com.facebook.presto.server.PrestoServer.run(PrestoServer.java:131)
	at com.facebook.presto.server.PrestoServer.main(PrestoServer.java:67)
Caused by: java.lang.RuntimeException: javax.naming.AuthenticationNotSupportedException: [LDAP: error code 48 - anonymous bind disallowed]
	at com.facebook.presto.password.LdapAuthenticator.checkEnvironment(LdapAuthenticator.java:184)
	at com.facebook.presto.password.LdapAuthenticator.<init>(LdapAuthenticator.java:79)
	at com.facebook.presto.password.LdapAuthenticator$$FastClassByGuice$$ca2e0ce1.newInstance(<generated>)
	at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:89)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:114)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:91)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:306)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:148)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:39)
	at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:211)
	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:182)
	... 7 more
Caused by: javax.naming.AuthenticationNotSupportedException: [LDAP: error code 48 - anonymous bind disallowed]
	at com.sun.jndi.ldap.LdapCtx.mapErrorCode(LdapCtx.java:3145)
	at com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:3100)
	at com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:2886)
	at com.sun.jndi.ldap.LdapCtx.connect(LdapCtx.java:2800)
	at com.sun.jndi.ldap.LdapCtx.<init>(LdapCtx.java:319)
	at com.sun.jndi.ldap.LdapCtxFactory.getUsingURL(LdapCtxFactory.java:192)
	at com.sun.jndi.ldap.LdapCtxFactory.getUsingURLs(LdapCtxFactory.java:210)
	at com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxInstance(LdapCtxFactory.java:153)
	at com.sun.jndi.ldap.LdapCtxFactory.getInitialContext(LdapCtxFactory.java:83)
	at javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:684)
	at javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:313)
	at javax.naming.InitialContext.init(InitialContext.java:244)
	at javax.naming.InitialContext.<init>(InitialContext.java:216)
	at javax.naming.directory.InitialDirContext.<init>(InitialDirContext.java:101)
	at com.facebook.presto.password.jndi.JndiUtils.createDirContext(JndiUtils.java:30)
	at com.facebook.presto.password.LdapAuthenticator.checkEnvironment(LdapAuthenticator.java:181)
	... 18 more
```

Fixes #8569