### PR TITLE
Fix varchar IS DISTINCT FROM coerce

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharOperators.java
@@ -238,13 +238,13 @@ public final class VarcharOperators
         return xxHash64(value);
     }
 
-    @LiteralParameters({"x", "y"})
+    @LiteralParameters("x")
     @ScalarOperator(IS_DISTINCT_FROM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean isDistinctFrom(
             @SqlType("varchar(x)") Slice left,
             @IsNull boolean leftNull,
-            @SqlType("varchar(y)") Slice right,
+            @SqlType("varchar(x)") Slice right,
             @IsNull boolean rightNull)
     {
         if (leftNull != rightNull) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8043,6 +8043,13 @@ public abstract class AbstractTestQueries
                 "WITH small_part AS (SELECT * FROM part WHERE name = 'a') SELECT lineitem.orderkey FROM small_part RIGHT JOIN lineitem ON  small_part.partkey = lineitem.partkey");
     }
 
+    @Test
+    public void testVarcharIsDistinctFrom()
+    {
+        String catalog = getSession().getCatalog().get();
+        assertQueryReturnsEmptyResult(format("SELECT * FROM information_schema.tables WHERE table_catalog IS DISTINCT FROM '%s'", catalog));
+    }
+
     protected Session noJoinReordering()
     {
         return Session.builder(getSession())


### PR DESCRIPTION
varchar `IS DISTINCT FROM` varchar(n) causes a coerce exception at the 0.2x versions of Presto. 
```
presto:current> select * from "com.facebook.presto.execution.executor:name=multilevelsplitqueue" where node is distinct from 'x';
Query 20181015_132239_00000_a2dm9 failed: Mismatched types: varchar(1) vs varchar
```