### PR TITLE
Remove unnecessary byte[] allocation in block builders

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/FixedWidthBlockBuilder.java
@@ -127,7 +127,7 @@ public class FixedWidthBlockBuilder
             if (hasNullValue) {
                 newValueIsNull.appendByte(valueIsNull.getUnderlyingSlice().getByte(position));
             }
-            newSlice.appendBytes(getRawSlice().getBytes(position * fixedSize, fixedSize));
+            newSlice.writeBytes(getRawSlice(), position * fixedSize, fixedSize);
         }
         return new FixedWidthBlock(fixedSize, length, newSlice.slice(), newValueIsNull == null ? null : newValueIsNull.slice());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -157,7 +157,7 @@ public class VariableWidthBlockBuilder
                 newValueIsNull[i] = true;
             }
             else {
-                newSlice.appendBytes(sliceOutput.getUnderlyingSlice().getBytes(getPositionOffset(position), getSliceLength(position)));
+                newSlice.writeBytes(sliceOutput.getUnderlyingSlice(), getPositionOffset(position), getSliceLength(position));
             }
             newOffsets[i + 1] = newSlice.size();
         }


### PR DESCRIPTION
This is a follow up PR of #11709. Slice.getBytes is allocating a redundant 
byte[] which can be avoided by using SliceOutput.writeBytes in 
FixedWidthBlockBuilder.copyPositions and VariableWidthBlockBuilder.copyPositions. 

