### PR TITLE
Add a config to queue queries when number of  active workers is insufficient

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -59,7 +59,7 @@ public class QueryManagerConfig
 
     private int initializationRequiredWorkers = 1;
     private Duration initializationTimeout = new Duration(5, TimeUnit.MINUTES);
-    private boolean queueQueriesWithInsufficientWorkers;
+    private boolean shouldQueuePendingQueries;
 
     @Min(1)
     public int getScheduleSplitBatchSize()
@@ -333,16 +333,16 @@ public class QueryManagerConfig
     }
 
     @NotNull
-    public boolean getQueueQueriesWithInsufficientWorkers()
+    public boolean getShouldQueuePendingQueries()
     {
-        return queueQueriesWithInsufficientWorkers;
+        return shouldQueuePendingQueries;
     }
 
-    @Config("query-manager.queue-queries.insufficient-workers")
+    @Config("query-manager.queue-pending-queries")
     @ConfigDescription("Whether to queue or reject queries when the number of workers are less than query-manager.initialization-required-workers")
-    public QueryManagerConfig setQueueQueriesWithInsufficientWorkers(boolean queueQueriesWithInsufficientWorkers)
+    public QueryManagerConfig setShouldQueuePendingQueries(boolean shouldQueuePendingQueries)
     {
-        this.queueQueriesWithInsufficientWorkers = queueQueriesWithInsufficientWorkers;
+        this.shouldQueuePendingQueries = shouldQueuePendingQueries;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -59,6 +59,7 @@ public class QueryManagerConfig
 
     private int initializationRequiredWorkers = 1;
     private Duration initializationTimeout = new Duration(5, TimeUnit.MINUTES);
+    private boolean queueQueriesWithInsufficientWorkers;
 
     @Min(1)
     public int getScheduleSplitBatchSize()
@@ -328,6 +329,20 @@ public class QueryManagerConfig
     public QueryManagerConfig setInitializationTimeout(Duration initializationTimeout)
     {
         this.initializationTimeout = initializationTimeout;
+        return this;
+    }
+
+    @NotNull
+    public boolean getQueueQueriesWithInsufficientWorkers()
+    {
+        return queueQueriesWithInsufficientWorkers;
+    }
+
+    @Config("query-manager.queue-queries.insufficient-workers")
+    @ConfigDescription("Whether to queue or reject queries when the number of workers are less than query-manager.initialization-required-workers")
+    public QueryManagerConfig setQueueQueriesWithInsufficientWorkers(boolean queueQueriesWithInsufficientWorkers)
+    {
+        this.queueQueriesWithInsufficientWorkers = queueQueriesWithInsufficientWorkers;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -578,7 +578,7 @@ public class InternalResourceGroup
         }
     }
 
-    public void run(ManagedQueryExecution query)
+    public void run(ManagedQueryExecution query, boolean shouldQueueQueries)
     {
         synchronized (root) {
             checkState(subGroups.isEmpty(), "Cannot add queries to %s. It is not a leaf group.", id);
@@ -599,7 +599,7 @@ public class InternalResourceGroup
                 query.fail(new QueryQueueFullException(id));
                 return;
             }
-            if (canRun) {
+            if (canRun && !shouldQueueQueries) {
                 startInBackground(query);
             }
             else {

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -578,7 +578,7 @@ public class InternalResourceGroup
         }
     }
 
-    public void run(ManagedQueryExecution query, boolean shouldQueueQueries)
+    public void run(ManagedQueryExecution query, boolean shouldPendQueriesUntilScaleout)
     {
         synchronized (root) {
             checkState(subGroups.isEmpty(), "Cannot add queries to %s. It is not a leaf group.", id);
@@ -599,7 +599,7 @@ public class InternalResourceGroup
                 query.fail(new QueryQueueFullException(id));
                 return;
             }
-            if (canRun && !shouldQueueQueries) {
+            if (canRun && !shouldPendQueriesUntilScaleout) {
                 startInBackground(query);
             }
             else {

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -47,7 +47,7 @@ public class TestQueryManagerConfig
                 .setQueryMaxCpuTime(new Duration(1_000_000_000, TimeUnit.DAYS))
                 .setInitializationRequiredWorkers(1)
                 .setInitializationTimeout(new Duration(5, TimeUnit.MINUTES))
-                .setQueueQueriesWithInsufficientWorkers(false));
+                .setShouldQueuePendingQueries(false));
     }
 
     @Test
@@ -98,7 +98,7 @@ public class TestQueryManagerConfig
                 .setQueryMaxCpuTime(new Duration(2, TimeUnit.DAYS))
                 .setInitializationRequiredWorkers(200)
                 .setInitializationTimeout(new Duration(1, TimeUnit.MINUTES))
-                .setQueueQueriesWithInsufficientWorkers(true);
+                .setShouldQueuePendingQueries(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -46,7 +46,8 @@ public class TestQueryManagerConfig
                 .setQueryMaxExecutionTime(new Duration(100, TimeUnit.DAYS))
                 .setQueryMaxCpuTime(new Duration(1_000_000_000, TimeUnit.DAYS))
                 .setInitializationRequiredWorkers(1)
-                .setInitializationTimeout(new Duration(5, TimeUnit.MINUTES)));
+                .setInitializationTimeout(new Duration(5, TimeUnit.MINUTES))
+                .setQueueQueriesWithInsufficientWorkers(false));
     }
 
     @Test
@@ -73,6 +74,7 @@ public class TestQueryManagerConfig
                 .put("query.max-cpu-time", "2d")
                 .put("query-manager.initialization-required-workers", "200")
                 .put("query-manager.initialization-timeout", "1m")
+                .put("query-manager.queue-queries.insufficient-workers", "true")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -95,7 +97,8 @@ public class TestQueryManagerConfig
                 .setQueryMaxExecutionTime(new Duration(3, TimeUnit.HOURS))
                 .setQueryMaxCpuTime(new Duration(2, TimeUnit.DAYS))
                 .setInitializationRequiredWorkers(200)
-                .setInitializationTimeout(new Duration(1, TimeUnit.MINUTES));
+                .setInitializationTimeout(new Duration(1, TimeUnit.MINUTES))
+                .setQueueQueriesWithInsufficientWorkers(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
@@ -83,7 +83,7 @@ public class BenchmarkResourceGroup
                 group.setHardConcurrencyLimit(queries);
             }
             for (int i = 0; i < queries; i++) {
-                group.run(new MockQueryExecution(10));
+                group.run(new MockQueryExecution(10), false);
             }
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
@@ -83,6 +83,7 @@ public class BenchmarkResourceGroup
                 group.setHardConcurrencyLimit(queries);
             }
             for (int i = 0; i < queries; i++) {
+                // Setting shouldPendQueriesUntilScaleout to false as query-manager.queue-pending-queries is disabled by default
                 group.run(new MockQueryExecution(10), false);
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -65,13 +65,13 @@ public class TestResourceGroups
         root.setMaxQueuedQueries(1);
         root.setHardConcurrencyLimit(1);
         MockQueryExecution query1 = new MockQueryExecution(0);
-        root.run(query1);
+        root.run(query1, false);
         assertEquals(query1.getState(), RUNNING);
         MockQueryExecution query2 = new MockQueryExecution(0);
-        root.run(query2);
+        root.run(query2, false);
         assertEquals(query2.getState(), QUEUED);
         MockQueryExecution query3 = new MockQueryExecution(0);
-        root.run(query3);
+        root.run(query3, false);
         assertEquals(query3.getState(), FAILED);
         assertEquals(query3.getThrowable().getMessage(), "Too many queued queries for \"root\"");
     }
@@ -96,19 +96,19 @@ public class TestResourceGroups
         group3.setMaxQueuedQueries(4);
         group3.setHardConcurrencyLimit(1);
         MockQueryExecution query1a = new MockQueryExecution(0);
-        group1.run(query1a);
+        group1.run(query1a, false);
         assertEquals(query1a.getState(), RUNNING);
         MockQueryExecution query1b = new MockQueryExecution(0);
-        group1.run(query1b);
+        group1.run(query1b, false);
         assertEquals(query1b.getState(), QUEUED);
         MockQueryExecution query2a = new MockQueryExecution(0);
-        group2.run(query2a);
+        group2.run(query2a, false);
         assertEquals(query2a.getState(), QUEUED);
         MockQueryExecution query2b = new MockQueryExecution(0);
-        group2.run(query2b);
+        group2.run(query2b, false);
         assertEquals(query2b.getState(), QUEUED);
         MockQueryExecution query3a = new MockQueryExecution(0);
-        group3.run(query3a);
+        group3.run(query3a, false);
         assertEquals(query3a.getState(), QUEUED);
 
         query1a.complete();
@@ -147,16 +147,16 @@ public class TestResourceGroups
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(2);
         MockQueryExecution query1a = new MockQueryExecution(0);
-        group1.run(query1a);
+        group1.run(query1a, false);
         assertEquals(query1a.getState(), RUNNING);
         MockQueryExecution query1b = new MockQueryExecution(0);
-        group1.run(query1b);
+        group1.run(query1b, false);
         assertEquals(query1b.getState(), QUEUED);
         MockQueryExecution query1c = new MockQueryExecution(0);
-        group1.run(query1c);
+        group1.run(query1c, false);
         assertEquals(query1c.getState(), QUEUED);
         MockQueryExecution query2a = new MockQueryExecution(0);
-        group2.run(query2a);
+        group2.run(query2a, false);
         assertEquals(query2a.getState(), QUEUED);
 
         assertEquals(root.getInfo().getNumEligibleSubGroups(), 2);
@@ -189,16 +189,16 @@ public class TestResourceGroups
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(2);
         MockQueryExecution query1a = new MockQueryExecution(0);
-        group1.run(query1a);
+        group1.run(query1a, false);
         assertEquals(query1a.getState(), RUNNING);
         MockQueryExecution query1b = new MockQueryExecution(0);
-        group1.run(query1b);
+        group1.run(query1b, false);
         assertEquals(query1b.getState(), QUEUED);
         MockQueryExecution query1c = new MockQueryExecution(0);
-        group1.run(query1c);
+        group1.run(query1c, false);
         assertEquals(query1c.getState(), QUEUED);
         MockQueryExecution query2a = new MockQueryExecution(0);
-        group2.run(query2a);
+        group2.run(query2a, false);
         assertEquals(query2a.getState(), QUEUED);
 
         query1a.complete();
@@ -223,15 +223,15 @@ public class TestResourceGroups
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(3);
         MockQueryExecution query1 = new MockQueryExecution(2);
-        root.run(query1);
+        root.run(query1, false);
         // Process the group to refresh stats
         root.processQueuedQueries();
         assertEquals(query1.getState(), RUNNING);
         MockQueryExecution query2 = new MockQueryExecution(0);
-        root.run(query2);
+        root.run(query2, false);
         assertEquals(query2.getState(), QUEUED);
         MockQueryExecution query3 = new MockQueryExecution(0);
-        root.run(query3);
+        root.run(query3, false);
         assertEquals(query3.getState(), QUEUED);
 
         query1.complete();
@@ -253,15 +253,15 @@ public class TestResourceGroups
         subgroup.setHardConcurrencyLimit(3);
 
         MockQueryExecution query1 = new MockQueryExecution(2);
-        subgroup.run(query1);
+        subgroup.run(query1, false);
         // Process the group to refresh stats
         root.processQueuedQueries();
         assertEquals(query1.getState(), RUNNING);
         MockQueryExecution query2 = new MockQueryExecution(0);
-        subgroup.run(query2);
+        subgroup.run(query2, false);
         assertEquals(query2.getState(), QUEUED);
         MockQueryExecution query3 = new MockQueryExecution(0);
-        subgroup.run(query3);
+        subgroup.run(query3, false);
         assertEquals(query3.getState(), QUEUED);
 
         query1.complete();
@@ -282,15 +282,15 @@ public class TestResourceGroups
         root.setHardConcurrencyLimit(2);
 
         MockQueryExecution query1 = new MockQueryExecution(1, "query_id", 1, new Duration(1, SECONDS));
-        root.run(query1);
+        root.run(query1, false);
         assertEquals(query1.getState(), RUNNING);
 
         MockQueryExecution query2 = new MockQueryExecution(0);
-        root.run(query2);
+        root.run(query2, false);
         assertEquals(query2.getState(), RUNNING);
 
         MockQueryExecution query3 = new MockQueryExecution(0);
-        root.run(query3);
+        root.run(query3, false);
         assertEquals(query3.getState(), QUEUED);
 
         query1.complete();
@@ -314,10 +314,10 @@ public class TestResourceGroups
         root.setMaxQueuedQueries(1);
         root.setHardConcurrencyLimit(1);
         MockQueryExecution query1 = new MockQueryExecution(1, "query_id", 1, new Duration(2, SECONDS));
-        root.run(query1);
+        root.run(query1, false);
         assertEquals(query1.getState(), RUNNING);
         MockQueryExecution query2 = new MockQueryExecution(0);
-        root.run(query2);
+        root.run(query2, false);
         assertEquals(query2.getState(), QUEUED);
 
         query1.complete();
@@ -359,10 +359,10 @@ public class TestResourceGroups
 
             MockQueryExecution query = new MockQueryExecution(0, "query_id", priority);
             if (random.nextBoolean()) {
-                group1.run(query);
+                group1.run(query, false);
             }
             else {
-                group2.run(query);
+                group2.run(query, false);
             }
             queries.put(priority, query);
         }
@@ -819,7 +819,7 @@ public class TestResourceGroups
         for (int i = 0; i < count - existingCount; i++) {
             MockQueryExecution query = new MockQueryExecution(0, group.getId().toString().replace(".", "") + Integer.toString(i), queryPriority ? i + 1 : 1);
             queries.add(query);
-            group.run(query);
+            group.run(query, false);
         }
         return queries;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -57,6 +57,7 @@ import static org.testng.Assert.assertTrue;
 
 public class TestResourceGroups
 {
+    // Setting shouldPendQueriesUntilScaleout to false  while invoking InternalResourceGroup.run() in these tests as query-manager.queue-pending-queries is disabled by default
     @Test(timeOut = 10_000)
     public void testQueueFull()
     {


### PR DESCRIPTION
We have clusters that scale based on load. We scale down to a configured number of worker nodes when the cluster is in idle state. It would be good to scale down to zero workers without rejecting queries. 

We could set the minimum workers required on the cluster to 1 to avoid rejecting queries. However, since number of nodes during planning affects the parallelism of exchange and aggregation stages, the query may take a long time to complete despite the cluster scaling up in response to the load. 

So it would be good to queue the query until we scale up to the configured number of workers. 
Eventually we could even set the minimum required workers based on the size of the query instead of it being a global config.