### PR TITLE
Add UDF Ngrams

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -129,6 +129,16 @@ Array Functions
 
     Flattens an ``array(array(T))`` to an ``array(T)`` by concatenating the contained arrays.
 
+.. function:: ngrams(array(T), n) -> array(array(T))
+
+    Returns ``n``-grams for the ``array``::
+
+        SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 2); --[['foo', 'bar'], ['bar', 'baz'], ['baz', 'foo']]
+        SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 3); -- [['foo', 'bar', 'baz'], ['bar', 'baz', 'foo']]
+        SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 4); -- [['foo', 'bar', 'baz', 'foo']]
+        SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 5); -- [['foo', 'bar', 'baz', 'foo']]
+        SELECT ngrams(ARRAY[1, 2, 3, 4], 2); --[[1, 2], [2, 3], [3, 4]]
+
 .. function:: reduce(array(T), initialState S, inputFunction(S,T,S), outputFunction(S,R)) -> R
 
     Returns a single value reduced from ``array``. ``inputFunction`` will

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -74,6 +74,7 @@ import com.facebook.presto.operator.scalar.ArrayLessThanOperator;
 import com.facebook.presto.operator.scalar.ArrayLessThanOrEqualOperator;
 import com.facebook.presto.operator.scalar.ArrayMaxFunction;
 import com.facebook.presto.operator.scalar.ArrayMinFunction;
+import com.facebook.presto.operator.scalar.ArrayNgramsFunction;
 import com.facebook.presto.operator.scalar.ArrayNotEqualOperator;
 import com.facebook.presto.operator.scalar.ArrayPositionFunction;
 import com.facebook.presto.operator.scalar.ArrayRemoveFunction;
@@ -542,6 +543,7 @@ public class FunctionRegistry
                 .scalar(ArrayExceptFunction.class)
                 .scalar(ArraySliceFunction.class)
                 .scalar(ArrayIndeterminateOperator.class)
+                .scalar(ArrayNgramsFunction.class)
                 .scalar(MapDistinctFromOperator.class)
                 .scalar(MapEqualOperator.class)
                 .scalar(MapEntriesFunction.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayNgramsFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayNgramsFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.block.ArrayBlock;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.StandardTypes.INTEGER;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static java.lang.Math.min;
+import static java.lang.StrictMath.toIntExact;
+
+@ScalarFunction("ngrams")
+@Description("Return N-grams for the input")
+public final class ArrayNgramsFunction
+{
+    private ArrayNgramsFunction(){}
+
+    @TypeParameter("T")
+    @SqlType("array(array(T))")
+    public static Block ngrams(@SqlType("array(T)") Block array, @SqlType(INTEGER) long n)
+    {
+        checkCondition(n > 0, INVALID_FUNCTION_ARGUMENT, "N must be positive");
+
+        // n should not be larger than the array length
+        int elementsPreRecord = toIntExact(min(array.getPositionCount(), n));
+        int totalRecords = array.getPositionCount() - elementsPreRecord + 1;
+        int[] ids = new int[totalRecords * elementsPreRecord];
+        int[] offset = new int[totalRecords + 1];
+        for (int recordIndex = 0; recordIndex < totalRecords; recordIndex++) {
+            for (int elementIndex = 0; elementIndex < elementsPreRecord; elementIndex++) {
+                ids[recordIndex * elementsPreRecord + elementIndex] = recordIndex + elementIndex;
+            }
+            offset[recordIndex + 1] = (recordIndex + 1) * elementsPreRecord;
+        }
+
+        return ArrayBlock.fromElementBlock(totalRecords, Optional.empty(), offset, array.getPositions(ids, 0, totalRecords * elementsPreRecord));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayNgramsFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayNgramsFunction.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.type.ArrayType;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static java.util.Arrays.asList;
+public class TestArrayNgramsFunction
+
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testBasic()
+    {
+        assertFunction("ngrams(ARRAY['bar', 'foo', 'baz', 'foo'], 1)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
+                ImmutableList.of("bar"),
+                ImmutableList.of("foo"),
+                ImmutableList.of("baz"),
+                ImmutableList.of("foo")));
+        assertFunction("ngrams(ARRAY['bar', 'foo', 'baz', 'foo'], 2)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
+                ImmutableList.of("bar", "foo"),
+                ImmutableList.of("foo", "baz"),
+                ImmutableList.of("baz", "foo")));
+        assertFunction("ngrams(ARRAY['bar', 'foo', 'baz', 'foo'], 3)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
+                ImmutableList.of("bar", "foo", "baz"),
+                ImmutableList.of("foo", "baz", "foo")));
+        assertFunction("ngrams(ARRAY['bar', 'foo', 'baz', 'foo'], 4)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
+                ImmutableList.of("bar", "foo", "baz", "foo")));
+        assertFunction("ngrams(ARRAY['bar', 'foo', 'baz', 'foo'], 5)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
+                ImmutableList.of("bar", "foo", "baz", "foo")));
+        assertFunction("ngrams(ARRAY['bar', 'foo', 'baz', 'foo'], 6)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
+                ImmutableList.of("bar", "foo", "baz", "foo")));
+        assertFunction("ngrams(ARRAY['bar', 'foo', 'baz', 'foo'], 100000000)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
+                ImmutableList.of("bar", "foo", "baz", "foo")));
+        assertFunction("ngrams(ARRAY['a', 'bb', 'ccc', 'dddd'], 2)", new ArrayType(new ArrayType(createVarcharType(4))), ImmutableList.of(
+                ImmutableList.of("a", "bb"),
+                ImmutableList.of("bb", "ccc"),
+                ImmutableList.of("ccc", "dddd")));
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertFunction("ngrams(ARRAY['foo', NULL, 'bar'], 2)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
+                asList("foo", null),
+                asList(null, "bar")));
+
+        assertFunction("ngrams(ARRAY [NULL, NULL, NULL], 2)", new ArrayType(new ArrayType(UNKNOWN)), ImmutableList.of(
+                asList(null, null),
+                asList(null, null)));
+
+        assertFunction("ngrams(ARRAY [NULL, 3, NULL], 2)", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(
+                asList(null, 3),
+                asList(3, null)));
+    }
+
+    @Test
+    public void testTypeCombinations()
+    {
+        assertFunction("ngrams(ARRAY[1, 2, 3], 2)", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(
+                        ImmutableList.of(1, 2),
+                        ImmutableList.of(2, 3)));
+        assertFunction("ngrams(ARRAY[1.1E0, 2.1E0, 3.1E0], 2)", new ArrayType(new ArrayType(DOUBLE)), ImmutableList.of(
+                ImmutableList.of(1.1, 2.1),
+                ImmutableList.of(2.1, 3.1)));
+        assertFunction("ngrams(ARRAY[true, false, true], 2)", new ArrayType(new ArrayType(BOOLEAN)), ImmutableList.of(
+                ImmutableList.of(true, false),
+                ImmutableList.of(false, true)));
+
+        assertFunction("ngrams(ARRAY[ARRAY['A1', 'A2'], ARRAY['B1'], ARRAY['C1', 'C2']], 2)", new ArrayType(new ArrayType(new ArrayType(createVarcharType(2)))), ImmutableList.of(
+                ImmutableList.of(ImmutableList.of("A1", "A2"), ImmutableList.of("B1")),
+                ImmutableList.of(ImmutableList.of("B1"), ImmutableList.of("C1", "C2"))));
+
+        assertFunction("ngrams(ARRAY['\u4FE1\u5FF5\u7231', '\u5E0C\u671B', '\u671B'], 2)", new ArrayType(new ArrayType(createVarcharType(3))), ImmutableList.of(
+                ImmutableList.of("\u4FE1\u5FF5\u7231", "\u5E0C\u671B"),
+                ImmutableList.of("\u5E0C\u671B", "\u671B")));
+
+        assertFunction("ngrams(ARRAY[], 2)", new ArrayType(new ArrayType(UNKNOWN)), ImmutableList.of(
+                asList()));
+        assertFunction("ngrams(ARRAY[''], 2)", new ArrayType(new ArrayType(createVarcharType(0))), ImmutableList.of(
+                ImmutableList.of("")));
+        assertFunction("ngrams(ARRAY['', ''], 2)", new ArrayType(new ArrayType(createVarcharType(0))), ImmutableList.of(
+                ImmutableList.of("", "")));
+
+        assertInvalidFunction("ngrams(ARRAY['foo','bar'], 0)", "N must be positive");
+        assertInvalidFunction("ngrams(ARRAY['foo','bar'], 0)", "N must be positive");
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -321,7 +321,7 @@ public class DictionaryBlock
     public Block getRegion(int positionOffset, int length)
     {
         checkValidRegion(positionCount, positionOffset, length);
-        return new DictionaryBlock(idsOffset + positionOffset, length, getDictionary(), ids, false, getDictionarySourceId());
+        return new DictionaryBlock(idsOffset + positionOffset, length, dictionary, ids, false, dictionarySourceId);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -321,7 +321,7 @@ public class DictionaryBlock
     public Block getRegion(int positionOffset, int length)
     {
         checkValidRegion(positionCount, positionOffset, length);
-        return new DictionaryBlock(idsOffset + positionOffset, length, dictionary, ids, false, randomDictionaryId());
+        return new DictionaryBlock(idsOffset + positionOffset, length, getDictionary(), ids, false, getDictionarySourceId());
     }
 
     @Override


### PR DESCRIPTION
Create a UDF for ngrams

```
 Returns ``n``-grams for the ``array``::
        SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 2); --[['foo', 'bar'], ['bar', 'baz'], ['baz', 'foo']]
        SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 3); -- [['foo', 'bar', 'baz'], ['bar', 'baz', 'foo']]
        SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 4); -- [['foo', 'bar', 'baz', 'foo']]
        SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 5); -- [['foo', 'bar', 'baz', 'foo']]
        SELECT ngrams(ARRAY[1, 2, 3, 4], 2); --[[1, 2], [2, 3], [3, 4]]
```