### PR TITLE
[POC] Track completion of lifespan in OutputBuffer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -221,6 +221,7 @@ public class SqlTaskExecution
                     .collect(toImmutableMap(identity(), ignore -> new PendingSplitsForPlanNode()));
             this.status = new Status(
                     taskContext,
+                    outputBuffer,
                     localExecutionPlan.getDriverFactories().stream()
                             .collect(toImmutableMap(DriverFactory::getPipelineId, DriverFactory::getPipelineExecutionStrategy)));
             this.schedulingLifespanManager = new SchedulingLifespanManager(localExecutionPlan.getPartitionedSourceOrder(), localExecutionPlan.getStageExecutionStrategy(), this.status);
@@ -260,6 +261,7 @@ public class SqlTaskExecution
             }
 
             outputBuffer.addStateChangeListener(new CheckTaskCompletionOnBufferFinish(SqlTaskExecution.this));
+            outputBuffer.registerLifespanFinishCallback(status::checkLifespanCompletion);
         }
     }
 
@@ -1117,6 +1119,7 @@ public class SqlTaskExecution
         // remaining driver: number of created Drivers that haven't yet finished.
 
         private final TaskContext taskContext;
+        private final OutputBuffer outputBuffer;
 
         @GuardedBy("this")
         private final int pipelineWithTaskLifeCycleCount;
@@ -1140,9 +1143,11 @@ public class SqlTaskExecution
         @GuardedBy("this")
         private boolean noMoreLifespans;
 
-        public Status(TaskContext taskContext, Map<Integer, PipelineExecutionStrategy> pipelineToExecutionStrategy)
+        public Status(TaskContext taskContext, OutputBuffer outputBuffer, Map<Integer, PipelineExecutionStrategy> pipelineToExecutionStrategy)
         {
             this.taskContext = requireNonNull(taskContext, "taskContext is null");
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+
             int pipelineWithTaskLifeCycleCount = 0;
             int pipelineWithDriverGroupLifeCycleCount = 0;
             ImmutableMap.Builder<Integer, Map<Lifespan, PerPipelineAndLifespanStatus>> perPipelineAndLifespan = ImmutableMap.builder();
@@ -1301,12 +1306,25 @@ public class SqlTaskExecution
             if (lifespan.isTaskWide()) {
                 return; // not a driver group
             }
+
             if (!isNoMoreDriverRunners(lifespan)) {
                 return;
             }
+
+            // do we still have running tasks?
             if (getRemainingDriver(lifespan) != 0) {
                 return;
             }
+
+            // no more output will be created
+            outputBuffer.setNoMorePagesForLifespan(lifespan);
+
+            // are there still pages in the output buffer
+            if (!outputBuffer.isLifespanFinished(lifespan)) {
+                return;
+            }
+
+            // Cool! All done!
             taskContext.addCompletedDriverGroup(lifespan);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/LazyOutputBuffer.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution.buffer;
 
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.OutputBuffers.OutputBufferId;
+import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.TaskId;
@@ -32,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.execution.buffer.BufferResult.emptyResults;
@@ -245,25 +247,25 @@ public class LazyOutputBuffer
     }
 
     @Override
-    public void enqueue(List<SerializedPage> pages)
+    public void enqueue(Lifespan lifespan, List<SerializedPage> pages)
     {
         OutputBuffer outputBuffer;
         synchronized (this) {
             checkState(delegate != null, "Buffer has not been initialized");
             outputBuffer = delegate;
         }
-        outputBuffer.enqueue(pages);
+        outputBuffer.enqueue(lifespan, pages);
     }
 
     @Override
-    public void enqueue(int partition, List<SerializedPage> pages)
+    public void enqueue(Lifespan lifespan, int partition, List<SerializedPage> pages)
     {
         OutputBuffer outputBuffer;
         synchronized (this) {
             checkState(delegate != null, "Buffer has not been initialized");
             outputBuffer = delegate;
         }
-        outputBuffer.enqueue(partition, pages);
+        outputBuffer.enqueue(lifespan, partition, pages);
     }
 
     @Override
@@ -321,6 +323,39 @@ public class LazyOutputBuffer
             outputBuffer = delegate;
         }
         outputBuffer.fail();
+    }
+
+    @Override
+    public void setNoMorePagesForLifespan(Lifespan lifespan)
+    {
+        OutputBuffer outputBuffer;
+        synchronized (this) {
+            checkState(delegate != null, "Buffer has not been initialized");
+            outputBuffer = delegate;
+        }
+        outputBuffer.setNoMorePagesForLifespan(lifespan);
+    }
+
+    @Override
+    public void registerLifespanFinishCallback(Consumer<Lifespan> callback)
+    {
+        OutputBuffer outputBuffer;
+        synchronized (this) {
+            checkState(delegate != null, "Buffer has not been initialized");
+            outputBuffer = delegate;
+        }
+        outputBuffer.registerLifespanFinishCallback(callback);
+    }
+
+    @Override
+    public boolean isLifespanFinished(Lifespan lifespan)
+    {
+        OutputBuffer outputBuffer;
+        synchronized (this) {
+            checkState(delegate != null, "Buffer has not been initialized");
+            outputBuffer = delegate;
+        }
+        return outputBuffer.isLifespanFinished(lifespan);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskOutputOperator.java
@@ -146,7 +146,9 @@ public class TaskOutputOperator
                 .map(serde::serialize)
                 .collect(toImmutableList());
 
-        outputBuffer.enqueue(serializedPages);
+        outputBuffer.enqueue(
+                operatorContext.getDriverContext().getLifespan(),
+                serializedPages);
         operatorContext.recordGeneratedOutput(page.getSizeInBytes(), page.getPositionCount());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/BufferTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/BufferTestUtils.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution.buffer;
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.OutputBuffers.OutputBufferId;
 import com.facebook.presto.block.BlockAssertions;
+import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.operator.PageAssertions;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.type.Type;
@@ -105,7 +106,7 @@ public final class BufferTestUtils
 
     static ListenableFuture<?> enqueuePage(OutputBuffer buffer, Page page)
     {
-        buffer.enqueue(ImmutableList.of(PAGES_SERDE.serialize(page)));
+        buffer.enqueue(Lifespan.taskWide(), ImmutableList.of(PAGES_SERDE.serialize(page)));
         ListenableFuture<?> future = buffer.isFull();
         assertFalse(future.isDone());
         return future;
@@ -113,7 +114,7 @@ public final class BufferTestUtils
 
     static ListenableFuture<?> enqueuePage(OutputBuffer buffer, Page page, int partition)
     {
-        buffer.enqueue(partition, ImmutableList.of(PAGES_SERDE.serialize(page)));
+        buffer.enqueue(Lifespan.taskWide(), partition, ImmutableList.of(PAGES_SERDE.serialize(page)));
         ListenableFuture<?> future = buffer.isFull();
         assertFalse(future.isDone());
         return future;
@@ -121,13 +122,13 @@ public final class BufferTestUtils
 
     public static void addPage(OutputBuffer buffer, Page page)
     {
-        buffer.enqueue(ImmutableList.of(PAGES_SERDE.serialize(page)));
+        buffer.enqueue(Lifespan.taskWide(), ImmutableList.of(PAGES_SERDE.serialize(page)));
         assertTrue(buffer.isFull().isDone(), "Expected add page to not block");
     }
 
     public static void addPage(OutputBuffer buffer, Page page, int partition)
     {
-        buffer.enqueue(partition, ImmutableList.of(PAGES_SERDE.serialize(page)));
+        buffer.enqueue(Lifespan.taskWide(), partition, ImmutableList.of(PAGES_SERDE.serialize(page)));
         assertTrue(buffer.isFull().isDone(), "Expected add page to not block");
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution.buffer;
 
 import com.facebook.presto.OutputBuffers;
 import com.facebook.presto.OutputBuffers.OutputBufferId;
+import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
 import com.facebook.presto.spi.Page;
@@ -950,7 +951,7 @@ public class TestArbitraryOutputBuffer
 
     private static ListenableFuture<?> enqueuePage(OutputBuffer buffer, Page page)
     {
-        buffer.enqueue(ImmutableList.of(PAGES_SERDE.serialize(page)));
+        buffer.enqueue(Lifespan.taskWide(), ImmutableList.of(PAGES_SERDE.serialize(page)));
         ListenableFuture<?> future = buffer.isFull();
         assertFalse(future.isDone());
         return future;
@@ -958,7 +959,7 @@ public class TestArbitraryOutputBuffer
 
     private static void addPage(OutputBuffer buffer, Page page)
     {
-        buffer.enqueue(ImmutableList.of(PAGES_SERDE.serialize(page)));
+        buffer.enqueue(Lifespan.taskWide(), ImmutableList.of(PAGES_SERDE.serialize(page)));
         assertTrue(buffer.isFull().isDone(), "Expected add page to not block");
     }
 


### PR DESCRIPTION
Currently, a lifepsan reported to be completed might still have
pending data in OutputBuffer. This makes it difficult to decide
lifespans to be rerun in the scenario of failure recovery. Since even
"completed" lifespan from a failed task might not finish flushing
data in OutputBuffer.

This is an POC and request for comment.
- Is this the way we want to go? Note this approach is basically to confirm data is delivered from sender side. An alternative way would be to confirm it from the receiver side, which requires communication between `TableCommitOperator` and `SqlStageScheduler / SqlStageExecution`, which I found more weird to do so... 


- Need to think about API. 