### PR TITLE
Refreshing file-based authZ

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
@@ -78,9 +78,13 @@ public class FileBasedSystemAccessControl
             checkState(
                     configFileName != null,
                     "Security configuration must contain the '%s' property", CONFIG_FILE_NAME);
+            Path path = Paths.get(configFileName);
+            return RefreshingSystemAccessControl.optionallyRefresh(config, previousControl -> load(path));
+        }
 
+        private FileBasedSystemAccessControl load(Path path)
+        {
             try {
-                Path path = Paths.get(configFileName);
                 if (!path.isAbsolute()) {
                     path = path.toAbsolutePath();
                 }
@@ -98,7 +102,8 @@ public class FileBasedSystemAccessControl
                         Optional.of(Pattern.compile(".*")),
                         Optional.of(Pattern.compile("system"))));
 
-                return new FileBasedSystemAccessControl(catalogRulesBuilder.build(), rules.getPrincipalUserMatchRules());
+                return new FileBasedSystemAccessControl(catalogRulesBuilder.build(),
+                        rules.getPrincipalUserMatchRules());
             }
             catch (SecurityException | IOException | InvalidPathException e) {
                 throw new RuntimeException(e);

--- a/presto-main/src/main/java/com/facebook/presto/security/RefreshingSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/RefreshingSystemAccessControl.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.security;
+
+import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.CatalogSchemaTableName;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.SystemAccessControl;
+import com.google.common.base.Preconditions;
+import io.airlift.log.Logger;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+public class RefreshingSystemAccessControl
+        implements SystemAccessControl
+{
+    private static final Logger LOG = Logger.get(RefreshingSystemAccessControl.class);
+
+    static final String REFRESH_PERIOD_SEC = "security.refresh-sec";
+    private static final String DEFAULT_REFRESH_PERIOD_SEC = "300"; // 5 mins
+    static final String REFRESH_ENABLED = "security.refresh-enabled";
+    private static final String DEFAULT_REFRESH = "false";
+    private final ScheduledThreadPoolExecutor service;
+
+    private AtomicReference<SystemAccessControl> delegate = new AtomicReference<>();
+
+    /**
+     * Add optional refreshing to the {@link SystemAccessControl} provided by the factory function. The previous
+     * {@link SystemAccessControl} is provided as an {@link Optional} input - null, when there is no previous element
+     * (as with the first time). If refreshing is not enabled, then the factory function is just used to create the
+     * {@link SystemAccessControl} and returned.
+     *
+     * @param config access control configuration from
+     *         {@link com.facebook.presto.spi.security.SystemAccessControlFactory#create(Map)}
+     * @param factory create the next {@link SystemAccessControl}, optionally informed by the previous
+     * @return a {@link SystemAccessControl} that might be able to refresh itself
+     */
+    public static SystemAccessControl optionallyRefresh(Map<String, String> config,
+            Function<Optional<SystemAccessControl>, SystemAccessControl> factory)
+    {
+        if (Boolean.valueOf(config.getOrDefault(REFRESH_ENABLED, DEFAULT_REFRESH))) {
+            long period = Long.valueOf(config.getOrDefault(REFRESH_PERIOD_SEC, DEFAULT_REFRESH_PERIOD_SEC));
+            return new RefreshingSystemAccessControl(factory, period);
+        }
+        return factory.apply(Optional.empty());
+    }
+
+    public RefreshingSystemAccessControl(
+            Function<Optional<SystemAccessControl>, SystemAccessControl> factory, long refreshPeriodSec)
+    {
+        Runnable command = () -> {
+            try {
+                delegate.set(factory.apply(Optional.ofNullable(delegate.get())));
+            }
+            catch (Exception e) {
+                LOG.error("Failed to reload configuration", e);
+            }
+        };
+        // run it the first time to ensure we have an access control
+        command.run();
+        Preconditions.checkState(this.delegate.get() != null, "No initial system control loaded!");
+        this.service = new ScheduledThreadPoolExecutor(1, new DaemonFactory());
+        service.scheduleWithFixedDelay(command, refreshPeriodSec, refreshPeriodSec, TimeUnit.SECONDS);
+    }
+
+    AtomicReference<SystemAccessControl> getDelegateForTesting()
+    {
+        return delegate;
+    }
+
+    @Override
+    public void checkCanSetUser(Optional<Principal> principal, String userName)
+    {
+        delegate.get().checkCanSetUser(principal, userName);
+    }
+
+    @Override
+    public void checkCanSetSystemSessionProperty(Identity identity,
+            String propertyName)
+    {
+        delegate.get().checkCanSetSystemSessionProperty(identity, propertyName);
+    }
+
+    @Override
+    public void checkCanAccessCatalog(Identity identity, String catalogName)
+    {
+        delegate.get().checkCanAccessCatalog(identity, catalogName);
+    }
+
+    @Override
+    public Set<String> filterCatalogs(Identity identity,
+            Set<String> catalogs)
+    {
+        return delegate.get().filterCatalogs(identity, catalogs);
+    }
+
+    @Override
+    public void checkCanCreateSchema(Identity identity,
+            CatalogSchemaName schema)
+    {
+        delegate.get().checkCanCreateSchema(identity, schema);
+    }
+
+    @Override
+    public void checkCanDropSchema(Identity identity,
+            CatalogSchemaName schema)
+    {
+        delegate.get().checkCanDropSchema(identity, schema);
+    }
+
+    @Override
+    public void checkCanRenameSchema(Identity identity,
+            CatalogSchemaName schema, String newSchemaName)
+    {
+        delegate.get().checkCanRenameSchema(identity, schema, newSchemaName);
+    }
+
+    @Override
+    public void checkCanShowSchemas(Identity identity, String catalogName)
+    {
+        delegate.get().checkCanShowSchemas(identity, catalogName);
+    }
+
+    @Override
+    public Set<String> filterSchemas(Identity identity,
+            String catalogName, Set<String> schemaNames)
+    {
+        return delegate.get().filterSchemas(identity, catalogName, schemaNames);
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity,
+            CatalogSchemaTableName table)
+    {
+        delegate.get().checkCanCreateTable(identity, table);
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity,
+            CatalogSchemaTableName table)
+    {
+        delegate.get().checkCanDropTable(identity, table);
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity,
+            CatalogSchemaTableName table, CatalogSchemaTableName newTable)
+    {
+        delegate.get().checkCanRenameTable(identity, table, newTable);
+    }
+
+    @Override
+    public void checkCanShowTablesMetadata(Identity identity,
+            CatalogSchemaName schema)
+    {
+        delegate.get().checkCanShowTablesMetadata(identity, schema);
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(
+            Identity identity, String catalogName,
+            Set<SchemaTableName> tableNames)
+    {
+        return delegate.get().filterTables(identity, catalogName, tableNames);
+    }
+
+    @Override
+    public void checkCanAddColumn(Identity identity,
+            CatalogSchemaTableName table)
+    {
+        delegate.get().checkCanAddColumn(identity, table);
+    }
+
+    @Override
+    public void checkCanDropColumn(Identity identity,
+            CatalogSchemaTableName table)
+    {
+        delegate.get().checkCanDropColumn(identity, table);
+    }
+
+    @Override
+    public void checkCanRenameColumn(Identity identity,
+            CatalogSchemaTableName table)
+    {
+        delegate.get().checkCanRenameColumn(identity, table);
+    }
+
+    @Override
+    public void checkCanSelectFromColumns(Identity identity,
+            CatalogSchemaTableName table, Set<String> columns)
+    {
+        delegate.get().checkCanSelectFromColumns(identity, table, columns);
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity,
+            CatalogSchemaTableName table)
+    {
+        delegate.get().checkCanInsertIntoTable(identity, table);
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity,
+            CatalogSchemaTableName table)
+    {
+        delegate.get().checkCanDeleteFromTable(identity, table);
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity,
+            CatalogSchemaTableName view)
+    {
+        delegate.get().checkCanCreateView(identity, view);
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity,
+            CatalogSchemaTableName view)
+    {
+        delegate.get().checkCanDropView(identity, view);
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(Identity identity,
+            CatalogSchemaTableName table, Set<String> columns)
+    {
+        delegate.get().checkCanCreateViewWithSelectFromColumns(identity, table, columns);
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity,
+            String catalogName, String propertyName)
+    {
+        delegate.get().checkCanSetCatalogSessionProperty(identity, catalogName, propertyName);
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(Identity identity,
+            Privilege privilege, CatalogSchemaTableName table,
+            String grantee, boolean withGrantOption)
+    {
+        delegate.get().checkCanGrantTablePrivilege(identity, privilege, table, grantee, withGrantOption);
+    }
+
+    @Override
+    public void checkCanRevokeTablePrivilege(Identity identity,
+            Privilege privilege, CatalogSchemaTableName table,
+            String revokee, boolean grantOptionFor)
+    {
+        delegate.get().checkCanRevokeTablePrivilege(identity, privilege, table, revokee, grantOptionFor);
+    }
+
+    public static class Daemon
+            extends Thread
+    {
+        Runnable runnable;
+
+        public Daemon()
+        {
+            this.setDaemon(true);
+            this.runnable = null;
+        }
+
+        public Daemon(Runnable runnable)
+        {
+            super(runnable);
+            this.setDaemon(true);
+            this.runnable = null;
+            this.runnable = runnable;
+            this.setName(runnable.toString());
+        }
+
+        public Daemon(ThreadGroup group, Runnable runnable)
+        {
+            super(group, runnable);
+            this.setDaemon(true);
+            this.runnable = null;
+            this.runnable = runnable;
+            this.setName(runnable.toString());
+        }
+
+        public Runnable getRunnable()
+        {
+            return this.runnable;
+        }
+    }
+
+    public static class DaemonFactory
+            extends Daemon
+            implements ThreadFactory
+    {
+        DaemonFactory()
+        {
+        }
+
+        public Thread newThread(Runnable runnable)
+        {
+            return new Daemon(runnable);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/security/TestRefreshSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestRefreshSystemAccessControl.java
@@ -43,7 +43,7 @@ public class TestRefreshSystemAccessControl
     {
         Map<String, String> config = new HashMap<>();
         config.put(RefreshingSystemAccessControl.REFRESH_ENABLED, "true");
-        final MockAccessControl mock = new MockAccessControl();
+        final AccessControlForTesting mock = new AccessControlForTesting();
         SystemAccessControl ref = RefreshingSystemAccessControl.optionallyRefresh(config, previous -> mock);
         assertNotEquals(mock, ref);
         ref.checkCanSetUser(null, null);
@@ -57,7 +57,7 @@ public class TestRefreshSystemAccessControl
         config.put(RefreshingSystemAccessControl.REFRESH_ENABLED, "true");
         config.put(RefreshingSystemAccessControl.REFRESH_PERIOD_SEC, "1");
         RefreshingSystemAccessControl ref = (RefreshingSystemAccessControl) RefreshingSystemAccessControl
-                .optionallyRefresh(config, previous -> new MockAccessControl());
+                .optionallyRefresh(config, previous -> new AccessControlForTesting());
         Instant start = Instant.now();
         SystemAccessControl mock = ref.getDelegateForTesting().get();
         // wait until we get a new mock or its been 10 seconds
@@ -68,7 +68,7 @@ public class TestRefreshSystemAccessControl
         assertNotEquals(ref.getDelegateForTesting().get(), mock, "Did not load a new reference");
     }
 
-    private static class MockAccessControl
+    private static class AccessControlForTesting
             implements SystemAccessControl
     {
         private boolean calledCheckCanSetUser;

--- a/presto-main/src/test/java/com/facebook/presto/security/TestRefreshSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestRefreshSystemAccessControl.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.security;
+
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.SystemAccessControl;
+import org.testng.annotations.Test;
+
+import java.security.Principal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestRefreshSystemAccessControl
+{
+    @Test
+    public void testDefaultNoRefresh() throws Exception
+    {
+        Map<String, String> config = new HashMap<>();
+        assertNull(RefreshingSystemAccessControl.optionallyRefresh(config, previous -> null));
+    }
+
+    @Test
+    public void testCallDelegate() throws Exception
+    {
+        Map<String, String> config = new HashMap<>();
+        config.put(RefreshingSystemAccessControl.REFRESH_ENABLED, "true");
+        final MockAccessControl mock = new MockAccessControl();
+        SystemAccessControl ref = RefreshingSystemAccessControl.optionallyRefresh(config, previous -> mock);
+        assertNotEquals(mock, ref);
+        ref.checkCanSetUser(null, null);
+        assertTrue(mock.calledCheckCanSetUser);
+    }
+
+    @Test
+    public void testRefreshAfterPeriod() throws Exception
+    {
+        Map<String, String> config = new HashMap<>();
+        config.put(RefreshingSystemAccessControl.REFRESH_ENABLED, "true");
+        config.put(RefreshingSystemAccessControl.REFRESH_PERIOD_SEC, "1");
+        RefreshingSystemAccessControl ref = (RefreshingSystemAccessControl) RefreshingSystemAccessControl
+                .optionallyRefresh(config, previous -> new MockAccessControl());
+        Instant start = Instant.now();
+        SystemAccessControl mock = ref.getDelegateForTesting().get();
+        // wait until we get a new mock or its been 10 seconds
+        while (ref.getDelegateForTesting().get() == mock &&
+                !Duration.ofSeconds(10).minus(Duration.between(start, Instant.now())).isNegative()) {
+            Thread.sleep(1000);
+        }
+        assertNotEquals(ref.getDelegateForTesting().get(), mock, "Did not load a new reference");
+    }
+
+    private static class MockAccessControl
+            implements SystemAccessControl
+    {
+        private boolean calledCheckCanSetUser;
+
+        @Override
+        public void checkCanSetUser(Optional<Principal> principal, String userName)
+        {
+            calledCheckCanSetUser = true;
+        }
+
+        @Override
+        public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Adds an optional hook for the file-based authZ
that periodically refreshes the authZ and atomically
swaps out the existing authZ access control.

The initial implementation is added to the file-based
authZ mechanism but was implemented with the intention
that it can easily be added to any factory with a
few small code changes.

Using the refreshing authentication is as easy as
adding "security.refresh-enabled=true". This is currently
only supported for the file-based authorization.

Fixes #11687