### PR TITLE
Support multiple conventions in PolymorphicScalarFunction

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/PolymorphicScalarFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/PolymorphicScalarFunction.java
@@ -13,15 +13,18 @@
  */
 package com.facebook.presto.metadata;
 
+import com.facebook.presto.metadata.PolymorphicScalarFunctionBuilder.MethodAndNativeContainerTypes;
 import com.facebook.presto.metadata.PolymorphicScalarFunctionBuilder.MethodsGroup;
 import com.facebook.presto.metadata.PolymorphicScalarFunctionBuilder.SpecializeContext;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ArgumentProperty;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention;
+import com.facebook.presto.operator.scalar.ScalarFunctionImplementation.ScalarImplementationChoice;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.util.Reflection;
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 
 import java.lang.invoke.MethodHandle;
@@ -31,7 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
-import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_BOXED_TYPE;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.BLOCK_AND_POSITION;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_NULL_FLAG;
 import static com.facebook.presto.type.TypeUtils.resolveTypes;
 import static com.google.common.base.Preconditions.checkState;
@@ -44,27 +47,21 @@ class PolymorphicScalarFunction
     private final String description;
     private final boolean hidden;
     private final boolean deterministic;
-    private final boolean nullableResult;
-    private final List<ArgumentProperty> argumentProperties;
-    private final List<MethodsGroup> methodsGroups;
+    private final List<PolymorphicScalarFunctionChoice> choices;
 
     PolymorphicScalarFunction(
             Signature signature,
             String description,
             boolean hidden,
             boolean deterministic,
-            boolean nullableResult,
-            List<ArgumentProperty> argumentProperties,
-            List<MethodsGroup> methodsGroups)
+            List<PolymorphicScalarFunctionChoice> choices)
     {
         super(signature);
 
         this.description = description;
         this.hidden = hidden;
         this.deterministic = deterministic;
-        this.nullableResult = nullableResult;
-        this.argumentProperties = requireNonNull(argumentProperties, "argumentProperties is null");
-        this.methodsGroups = requireNonNull(methodsGroups, "methodsWithExtraParametersFunctions is null");
+        this.choices = requireNonNull(choices, "choices is null");
     }
 
     @Override
@@ -88,20 +85,34 @@ class PolymorphicScalarFunction
     @Override
     public ScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
     {
+        ImmutableList.Builder<ScalarImplementationChoice> implementationChoices = ImmutableList.builder();
+
+        for (PolymorphicScalarFunctionChoice choice : choices) {
+            implementationChoices.add(getScalarFunctionImplementationChoice(boundVariables, typeManager, functionRegistry, choice));
+        }
+
+        return new ScalarFunctionImplementation(implementationChoices.build(), deterministic);
+    }
+
+    private ScalarImplementationChoice getScalarFunctionImplementationChoice(
+            BoundVariables boundVariables,
+            TypeManager typeManager,
+            FunctionRegistry functionRegistry,
+            PolymorphicScalarFunctionChoice choice)
+    {
         List<TypeSignature> resolvedParameterTypeSignatures = applyBoundVariables(getSignature().getArgumentTypes(), boundVariables);
         List<Type> resolvedParameterTypes = resolveTypes(resolvedParameterTypeSignatures, typeManager);
         TypeSignature resolvedReturnTypeSignature = applyBoundVariables(getSignature().getReturnType(), boundVariables);
         Type resolvedReturnType = typeManager.getType(resolvedReturnTypeSignature);
-
         SpecializeContext context = new SpecializeContext(boundVariables, resolvedParameterTypes, resolvedReturnType, typeManager, functionRegistry);
-        Optional<Method> matchingMethod = Optional.empty();
+        Optional<MethodAndNativeContainerTypes> matchingMethod = Optional.empty();
 
         Optional<MethodsGroup> matchingMethodsGroup = Optional.empty();
-        for (MethodsGroup candidateMethodsGroup : methodsGroups) {
-            for (Method candidateMethod : candidateMethodsGroup.getMethods()) {
-                if (matchesParameterAndReturnTypes(candidateMethod, resolvedParameterTypes, resolvedReturnType)) {
+        for (MethodsGroup candidateMethodsGroup : choice.getMethodsGroups()) {
+            for (MethodAndNativeContainerTypes candidateMethod : candidateMethodsGroup.getMethods()) {
+                if (matchesParameterAndReturnTypes(candidateMethod, resolvedParameterTypes, resolvedReturnType, choice.getArgumentProperties(), choice.isNullableResult())) {
                     if (matchingMethod.isPresent()) {
-                        throw new IllegalStateException("two matching methods (" + matchingMethod.get().getName() + " and " + candidateMethod.getName() + ") for parameter types " + resolvedParameterTypeSignatures);
+                        throw new IllegalStateException("two matching methods (" + matchingMethod.get().getMethod().getName() + " and " + candidateMethod.getMethod().getName() + ") for parameter types " + resolvedParameterTypeSignatures);
                     }
 
                     matchingMethod = Optional.of(candidateMethod);
@@ -112,25 +123,47 @@ class PolymorphicScalarFunction
         checkState(matchingMethod.isPresent(), "no matching method for parameter types %s", resolvedParameterTypes);
 
         List<Object> extraParameters = computeExtraParameters(matchingMethodsGroup.get(), context);
-        MethodHandle matchingMethodHandle = applyExtraParameters(matchingMethod.get(), extraParameters);
-
-        return new ScalarFunctionImplementation(
-                nullableResult,
-                argumentProperties,
-                matchingMethodHandle,
-                deterministic);
+        MethodHandle methodHandle = applyExtraParameters(matchingMethod.get().getMethod(), extraParameters, choice.getArgumentProperties());
+        return new ScalarImplementationChoice(choice.isNullableResult(), choice.getArgumentProperties(), methodHandle, Optional.empty());
     }
 
-    private boolean matchesParameterAndReturnTypes(Method method, List<Type> resolvedTypes, Type returnType)
+    private static boolean matchesParameterAndReturnTypes(
+            MethodAndNativeContainerTypes methodAndNativeContainerTypes,
+            List<Type> resolvedTypes,
+            Type returnType,
+            List<ArgumentProperty> argumentProperties,
+            boolean nullableResult)
     {
+        Method method = methodAndNativeContainerTypes.getMethod();
         checkState(method.getParameterCount() >= resolvedTypes.size(),
                 "method %s has not enough arguments: %s (should have at least %s)", method.getName(), method.getParameterCount(), resolvedTypes.size());
 
         Class<?>[] methodParameterJavaTypes = method.getParameterTypes();
         for (int i = 0, methodParameterIndex = 0; i < resolvedTypes.size(); i++) {
             NullConvention nullConvention = argumentProperties.get(i).getNullConvention();
-            Class<?> type = getNullAwareContainerType(resolvedTypes.get(i).getJavaType(), nullConvention == USE_BOXED_TYPE);
-            if (!methodParameterJavaTypes[methodParameterIndex].equals(type)) {
+            Class<?> expectedType = null;
+            Class<?> actualType;
+            switch (nullConvention) {
+                case RETURN_NULL_ON_NULL:
+                case USE_NULL_FLAG:
+                    expectedType = methodParameterJavaTypes[methodParameterIndex];
+                    actualType = getNullAwareContainerType(resolvedTypes.get(i).getJavaType(), false);
+                    break;
+                case USE_BOXED_TYPE:
+                    expectedType = methodParameterJavaTypes[methodParameterIndex];
+                    actualType = getNullAwareContainerType(resolvedTypes.get(i).getJavaType(), true);
+                    break;
+                case BLOCK_AND_POSITION:
+                    Optional<Class<?>> explicitNativeContainerTypes = methodAndNativeContainerTypes.getExplicitNativeContainerTypes().get(i);
+                    if (explicitNativeContainerTypes.isPresent()) {
+                        expectedType = explicitNativeContainerTypes.get();
+                    }
+                    actualType = getNullAwareContainerType(resolvedTypes.get(i).getJavaType(), false);
+                    break;
+                default:
+                    throw new UnsupportedOperationException("unknown NullConvention");
+            }
+            if (!actualType.equals(expectedType)) {
                 return false;
             }
             methodParameterIndex += nullConvention.getParameterCount();
@@ -143,17 +176,24 @@ class PolymorphicScalarFunction
         return methodsGroup.getExtraParametersFunction().map(function -> function.apply(context)).orElse(emptyList());
     }
 
-    private int getNullFlagsCount()
+    private static int getNullFlagsCount(List<ArgumentProperty> argumentProperties)
     {
         return (int) argumentProperties.stream()
                 .filter(argumentProperty -> argumentProperty.getNullConvention() == USE_NULL_FLAG)
                 .count();
     }
 
-    private MethodHandle applyExtraParameters(Method matchingMethod, List<Object> extraParameters)
+    private static int getBlockPositionCount(List<ArgumentProperty> argumentProperties)
+    {
+        return (int) argumentProperties.stream()
+                .filter(argumentProperty -> argumentProperty.getNullConvention() == BLOCK_AND_POSITION)
+                .count();
+    }
+
+    private MethodHandle applyExtraParameters(Method matchingMethod, List<Object> extraParameters, List<ArgumentProperty> argumentProperties)
     {
         Signature signature = getSignature();
-        int expectedArgumentsCount = signature.getArgumentTypes().size() + getNullFlagsCount() + extraParameters.size();
+        int expectedArgumentsCount = signature.getArgumentTypes().size() + getNullFlagsCount(argumentProperties) + getBlockPositionCount(argumentProperties) + extraParameters.size();
         int matchingMethodArgumentCount = matchingMethod.getParameterCount();
         checkState(matchingMethodArgumentCount == expectedArgumentsCount,
                 "method %s has invalid number of arguments: %s (should have %s)", matchingMethod.getName(), matchingMethodArgumentCount, expectedArgumentsCount);
@@ -172,5 +212,37 @@ class PolymorphicScalarFunction
             return Primitives.wrap(clazz);
         }
         return clazz;
+    }
+
+    static final class PolymorphicScalarFunctionChoice
+    {
+        private final boolean nullableResult;
+        private final List<ArgumentProperty> argumentProperties;
+        private final List<MethodsGroup> methodsGroups;
+
+        PolymorphicScalarFunctionChoice(
+                boolean nullableResult,
+                List<ArgumentProperty> argumentProperties,
+                List<MethodsGroup> methodsGroups)
+        {
+            this.nullableResult = nullableResult;
+            this.argumentProperties = ImmutableList.copyOf(requireNonNull(argumentProperties, "argumentProperties is null"));
+            this.methodsGroups = ImmutableList.copyOf(requireNonNull(methodsGroups, "methodsWithExtraParametersFunctions is null"));
+        }
+
+        boolean isNullableResult()
+        {
+            return nullableResult;
+        }
+
+        List<MethodsGroup> getMethodsGroups()
+        {
+            return methodsGroups;
+        }
+
+        List<ArgumentProperty> getArgumentProperties()
+        {
+            return argumentProperties;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalOperators.java
@@ -96,12 +96,13 @@ public final class DecimalOperators
         return SqlScalarFunction.builder(DecimalOperators.class)
                 .signature(signature)
                 .deterministic(true)
-                .implementation(b -> b
-                        .methods("addShortShortShort")
-                        .withExtraParameters(DecimalOperators::calculateShortRescaleParameters))
-                .implementation(b -> b
-                        .methods("addShortShortLong", "addLongLongLong", "addShortLongLong", "addLongShortLong")
-                        .withExtraParameters(DecimalOperators::calculateLongRescaleParameters))
+                .choice(choice -> choice
+                        .implementation(methodsGroup -> methodsGroup
+                                .methods("addShortShortShort")
+                                .withExtraParameters(DecimalOperators::calculateShortRescaleParameters))
+                        .implementation(methodsGroup -> methodsGroup
+                                .methods("addShortShortLong", "addLongLongLong", "addShortLongLong", "addLongShortLong")
+                                .withExtraParameters(DecimalOperators::calculateLongRescaleParameters)))
                 .build();
     }
 
@@ -177,12 +178,13 @@ public final class DecimalOperators
         return SqlScalarFunction.builder(DecimalOperators.class)
                 .signature(signature)
                 .deterministic(true)
-                .implementation(b -> b
-                        .methods("subtractShortShortShort")
-                        .withExtraParameters(DecimalOperators::calculateShortRescaleParameters))
-                .implementation(b -> b
-                        .methods("subtractShortShortLong", "subtractLongLongLong", "subtractShortLongLong", "subtractLongShortLong")
-                        .withExtraParameters(DecimalOperators::calculateLongRescaleParameters))
+                .choice(choice -> choice
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("subtractShortShortShort")
+                            .withExtraParameters(DecimalOperators::calculateShortRescaleParameters))
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("subtractShortShortLong", "subtractLongLongLong", "subtractShortLongLong", "subtractLongShortLong")
+                            .withExtraParameters(DecimalOperators::calculateLongRescaleParameters)))
                 .build();
     }
 
@@ -254,7 +256,9 @@ public final class DecimalOperators
         return SqlScalarFunction.builder(DecimalOperators.class)
                 .signature(signature)
                 .deterministic(true)
-                .implementation(b -> b.methods("multiplyShortShortShort", "multiplyShortShortLong", "multiplyLongLongLong", "multiplyShortLongLong", "multiplyLongShortLong"))
+                .choice(choice -> choice
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("multiplyShortShortShort", "multiplyShortShortLong", "multiplyLongLongLong", "multiplyShortLongLong", "multiplyLongShortLong")))
                 .build();
     }
 
@@ -317,9 +321,10 @@ public final class DecimalOperators
         return SqlScalarFunction.builder(DecimalOperators.class)
                 .signature(signature)
                 .deterministic(true)
-                .implementation(b -> b
-                        .methods("divideShortShortShort", "divideShortLongShort", "divideLongShortShort", "divideShortShortLong", "divideLongLongLong", "divideShortLongLong", "divideLongShortLong")
-                        .withExtraParameters(DecimalOperators::divideRescaleFactor))
+                .choice(choice -> choice
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("divideShortShortShort", "divideShortLongShort", "divideLongShortShort", "divideShortShortLong", "divideLongLongLong", "divideShortLongLong", "divideLongShortLong")
+                            .withExtraParameters(DecimalOperators::divideRescaleFactor)))
                 .build();
     }
 
@@ -457,9 +462,10 @@ public final class DecimalOperators
         return SqlScalarFunction.builder(DecimalOperators.class)
                 .signature(signature)
                 .deterministic(true)
-                .implementation(b -> b
-                        .methods("modulusShortShortShort", "modulusLongLongLong", "modulusShortLongLong", "modulusShortLongShort", "modulusLongShortShort", "modulusLongShortLong")
-                        .withExtraParameters(DecimalOperators::modulusRescaleParameters))
+                .choice(choice -> choice
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("modulusShortShortShort", "modulusLongLongLong", "modulusShortLongLong", "modulusShortLongShort", "modulusLongShortShort", "modulusLongShortLong")
+                            .withExtraParameters(DecimalOperators::modulusRescaleParameters)))
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalSaturatedFloorCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalSaturatedFloorCasts.java
@@ -50,15 +50,16 @@ public final class DecimalSaturatedFloorCasts
                     .returnType(parseTypeSignature("decimal(result_precision,result_scale)", ImmutableSet.of("result_precision", "result_scale")))
                     .build())
             .deterministic(true)
-            .implementation(b -> b
-                    .methods("shortDecimalToShortDecimal", "shortDecimalToLongDecimal", "longDecimalToShortDecimal", "longDecimalToLongDecimal")
-                    .withExtraParameters((context) -> {
-                        int sourcePrecision = toIntExact(context.getLiteral("source_precision"));
-                        int sourceScale = toIntExact(context.getLiteral("source_scale"));
-                        int resultPrecision = toIntExact(context.getLiteral("result_precision"));
-                        int resultScale = toIntExact(context.getLiteral("result_scale"));
-                        return ImmutableList.of(sourcePrecision, sourceScale, resultPrecision, resultScale);
-                    }))
+            .choice(choice -> choice
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("shortDecimalToShortDecimal", "shortDecimalToLongDecimal", "longDecimalToShortDecimal", "longDecimalToLongDecimal")
+                            .withExtraParameters((context) -> {
+                                int sourcePrecision = toIntExact(context.getLiteral("source_precision"));
+                                int sourceScale = toIntExact(context.getLiteral("source_scale"));
+                                int resultPrecision = toIntExact(context.getLiteral("result_precision"));
+                                int resultScale = toIntExact(context.getLiteral("result_scale"));
+                                return ImmutableList.of(sourcePrecision, sourceScale, resultPrecision, resultScale);
+                            })))
             .build();
 
     @UsedByGeneratedCode
@@ -120,12 +121,13 @@ public final class DecimalSaturatedFloorCasts
                         .returnType(type.getTypeSignature())
                         .build())
                 .deterministic(true)
-                .implementation(b -> b
-                        .methods("shortDecimalToGenericIntegerType", "longDecimalToGenericIntegerType")
-                        .withExtraParameters((context) -> {
-                            int sourceScale = toIntExact(context.getLiteral("source_scale"));
-                            return ImmutableList.of(sourceScale, minValue, maxValue);
-                        }))
+                .choice(choice -> choice
+                        .implementation(methodsGroup -> methodsGroup
+                                .methods("shortDecimalToGenericIntegerType", "longDecimalToGenericIntegerType")
+                                .withExtraParameters((context) -> {
+                                    int sourceScale = toIntExact(context.getLiteral("source_scale"));
+                                    return ImmutableList.of(sourceScale, minValue, maxValue);
+                                })))
                 .build();
     }
 
@@ -169,13 +171,14 @@ public final class DecimalSaturatedFloorCasts
                         .returnType(parseTypeSignature("decimal(result_precision,result_scale)", ImmutableSet.of("result_precision", "result_scale")))
                         .build())
                 .deterministic(true)
-                .implementation(b -> b
-                        .methods("genericIntegerTypeToShortDecimal", "genericIntegerTypeToLongDecimal")
-                        .withExtraParameters((context) -> {
-                            int resultPrecision = toIntExact(context.getLiteral("result_precision"));
-                            int resultScale = toIntExact(context.getLiteral("result_scale"));
-                            return ImmutableList.of(resultPrecision, resultScale);
-                        }))
+                .choice(choice -> choice
+                        .implementation(methodsGroup -> methodsGroup
+                                .methods("genericIntegerTypeToShortDecimal", "genericIntegerTypeToLongDecimal")
+                                .withExtraParameters((context) -> {
+                                    int resultPrecision = toIntExact(context.getLiteral("result_precision"));
+                                    int resultScale = toIntExact(context.getLiteral("result_scale"));
+                                    return ImmutableList.of(resultPrecision, resultScale);
+                                })))
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalToDecimalCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalToDecimalCasts.java
@@ -53,26 +53,27 @@ public final class DecimalToDecimalCasts
     public static final SqlScalarFunction DECIMAL_TO_DECIMAL_CAST = SqlScalarFunction.builder(DecimalToDecimalCasts.class)
             .signature(SIGNATURE)
             .deterministic(true)
-            .implementation(b -> b
-                    .methods("shortToShortCast")
-                    .withExtraParameters((context) -> {
-                        DecimalType argumentType = (DecimalType) context.getType("F");
-                        DecimalType resultType = (DecimalType) context.getType("T");
-                        long rescale = longTenToNth(Math.abs(resultType.getScale() - argumentType.getScale()));
-                        return ImmutableList.of(
-                                argumentType.getPrecision(), argumentType.getScale(),
-                                resultType.getPrecision(), resultType.getScale(),
-                                rescale, rescale / 2);
-                    }))
-            .implementation(b -> b
-                    .methods("shortToLongCast", "longToShortCast", "longToLongCast")
-                    .withExtraParameters((context) -> {
-                        DecimalType argumentType = (DecimalType) context.getType("F");
-                        DecimalType resultType = (DecimalType) context.getType("T");
-                        return ImmutableList.of(
-                                argumentType.getPrecision(), argumentType.getScale(),
-                                resultType.getPrecision(), resultType.getScale());
-                    }))
+            .choice(choice -> choice
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("shortToShortCast")
+                            .withExtraParameters((context) -> {
+                                DecimalType argumentType = (DecimalType) context.getType("F");
+                                DecimalType resultType = (DecimalType) context.getType("T");
+                                long rescale = longTenToNth(Math.abs(resultType.getScale() - argumentType.getScale()));
+                                return ImmutableList.of(
+                                        argumentType.getPrecision(), argumentType.getScale(),
+                                        resultType.getPrecision(), resultType.getScale(),
+                                        rescale, rescale / 2);
+                            }))
+                    .implementation(methodsGroup -> methodsGroup
+                            .methods("shortToLongCast", "longToShortCast", "longToLongCast")
+                            .withExtraParameters((context) -> {
+                                DecimalType argumentType = (DecimalType) context.getType("F");
+                                DecimalType resultType = (DecimalType) context.getType("T");
+                                return ImmutableList.of(
+                                        argumentType.getPrecision(), argumentType.getScale(),
+                                        resultType.getPrecision(), resultType.getScale());
+                            })))
             .build();
 
     private DecimalToDecimalCasts() {}


### PR DESCRIPTION
PolymorphicScalarFunction and PolymorphicScalarFunctionBuilder have 
changed to support adding multiple convention choices.
TestPolymorphicScalarFunction.testSelectsMultipleChoice is 
an example of the usage.

This fixes #11723