### PR TITLE
Remove usage of javax.annotation.Nonnull

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/ColumnCardinalityCache.java
@@ -39,7 +39,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.io.Text;
 
-import javax.annotation.Nonnull;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
@@ -334,7 +333,7 @@ public class ColumnCardinalityCache
          * @return The cardinality of the column, which would be zero if the value does not exist
          */
         @Override
-        public Long load(@Nonnull CacheKey key)
+        public Long load(CacheKey key)
                 throws Exception
         {
             LOG.debug("Loading a non-exact range from Accumulo: %s", key);
@@ -360,7 +359,7 @@ public class ColumnCardinalityCache
         }
 
         @Override
-        public Map<CacheKey, Long> loadAll(@Nonnull Iterable<? extends CacheKey> keys)
+        public Map<CacheKey, Long> loadAll(Iterable<? extends CacheKey> keys)
                 throws Exception
         {
             int size = Iterables.size(keys);

--- a/presto-client/src/main/java/com/facebook/presto/client/FailureInfo.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/FailureInfo.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -60,7 +59,6 @@ public class FailureInfo
         this.errorLocation = errorLocation;
     }
 
-    @Nonnull
     @JsonProperty
     public String getType()
     {
@@ -81,14 +79,12 @@ public class FailureInfo
         return cause;
     }
 
-    @Nonnull
     @JsonProperty
     public List<FailureInfo> getSuppressed()
     {
         return suppressed;
     }
 
-    @Nonnull
     @JsonProperty
     public List<String> getStack()
     {

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryError.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryError.java
@@ -16,7 +16,6 @@ package com.facebook.presto.client;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -52,7 +51,6 @@ public class QueryError
         this.failureInfo = failureInfo;
     }
 
-    @Nonnull
     @JsonProperty
     public String getMessage()
     {
@@ -72,14 +70,12 @@ public class QueryError
         return errorCode;
     }
 
-    @Nonnull
     @JsonProperty
     public String getErrorName()
     {
         return errorName;
     }
 
-    @Nonnull
     @JsonProperty
     public String getErrorType()
     {

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -103,7 +102,6 @@ public class QueryResults
         this.updateCount = updateCount;
     }
 
-    @Nonnull
     @JsonProperty
     @Override
     public String getId()
@@ -111,7 +109,6 @@ public class QueryResults
         return id;
     }
 
-    @Nonnull
     @JsonProperty
     @Override
     public URI getInfoUri()
@@ -151,7 +148,6 @@ public class QueryResults
         return data;
     }
 
-    @Nonnull
     @JsonProperty
     @Override
     public StatementStats getStats()

--- a/presto-client/src/main/java/com/facebook/presto/client/StageStats.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StageStats.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
@@ -79,7 +78,6 @@ public class StageStats
         return stageId;
     }
 
-    @Nonnull
     @JsonProperty
     public String getState()
     {
@@ -146,7 +144,6 @@ public class StageStats
         return processedBytes;
     }
 
-    @Nonnull
     @JsonProperty
     public List<StageStats> getSubStages()
     {

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementStats.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementStats.java
@@ -16,7 +16,6 @@ package com.facebook.presto.client;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -83,7 +82,6 @@ public class StatementStats
         this.rootStage = rootStage;
     }
 
-    @Nonnull
     @JsonProperty
     public String getState()
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -29,7 +29,6 @@ import io.airlift.units.MinDataSize;
 import io.airlift.units.MinDuration;
 import org.joda.time.DateTimeZone;
 
-import javax.annotation.Nonnull;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
@@ -464,7 +463,7 @@ public class HiveClientConfig
         return this;
     }
 
-    @Nonnull
+    @NotNull
     public List<String> getResourceConfigFiles()
     {
         return resourceConfigFiles;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -33,8 +33,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
 
-import javax.annotation.Nonnull;
-
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -178,14 +176,12 @@ public final class HiveType
     }
 
     @JsonCreator
-    @Nonnull
     public static HiveType valueOf(String hiveTypeName)
     {
         requireNonNull(hiveTypeName, "hiveTypeName is null");
         return toHiveType(getTypeInfoFromTypeString(hiveTypeName));
     }
 
-    @Nonnull
     public static List<HiveType> toHiveTypes(String hiveTypes)
     {
         requireNonNull(hiveTypes, "hiveTypes is null");
@@ -194,14 +190,12 @@ public final class HiveType
                 .collect(toList()));
     }
 
-    @Nonnull
     private static HiveType toHiveType(TypeInfo typeInfo)
     {
         requireNonNull(typeInfo, "typeInfo is null");
         return new HiveType(typeInfo);
     }
 
-    @Nonnull
     public static HiveType toHiveType(TypeTranslator typeTranslator, Type type)
     {
         requireNonNull(typeTranslator, "typeTranslator is null");
@@ -209,7 +203,6 @@ public final class HiveType
         return new HiveType(typeTranslator.translate(type));
     }
 
-    @Nonnull
     private static TypeSignature getTypeSignature(TypeInfo typeInfo)
     {
         switch (typeInfo.getCategory()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
-import javax.validation.constraints.NotNull;
 
 import java.util.List;
 import java.util.regex.Matcher;
@@ -72,7 +71,6 @@ public class ExecutionFailureInfo
         this.remoteHost = remoteHost;
     }
 
-    @NotNull
     @JsonProperty
     public String getType()
     {
@@ -93,14 +91,12 @@ public class ExecutionFailureInfo
         return cause;
     }
 
-    @NotNull
     @JsonProperty
     public List<ExecutionFailureInfo> getSuppressed()
     {
         return suppressed;
     }
 
-    @NotNull
     @JsonProperty
     public List<String> getStack()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/StateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StateMachine.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.log.Logger;
 
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -87,7 +86,6 @@ public class StateMachine<T>
         this.terminalStates = ImmutableSet.copyOf(requireNonNull(terminalStates, "terminalStates is null"));
     }
 
-    @Nonnull
     public T get()
     {
         return state;
@@ -99,7 +97,6 @@ public class StateMachine<T>
      *
      * @return the old state
      */
-    @Nonnull
     public T set(T newState)
     {
         checkState(!Thread.holdsLock(lock), "Can not set state while holding the lock");

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NetworkTopology.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NetworkTopology.java
@@ -16,7 +16,6 @@ package com.facebook.presto.execution.scheduler;
 import com.facebook.presto.spi.HostAddress;
 
 import javax.annotation.concurrent.ThreadSafe;
-import javax.validation.constraints.NotNull;
 
 import java.util.List;
 
@@ -26,13 +25,11 @@ import java.util.List;
 @ThreadSafe
 public interface NetworkTopology
 {
-    @NotNull
     NetworkLocation locate(HostAddress address);
 
     /**
      * Strings describing the meaning of each segment of a NetworkLocation returned from locate().
      * This method must return a constant.
      */
-    @NotNull
     List<String> getLocationSegmentNames();
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleHistogramAggregation.java
@@ -25,8 +25,6 @@ import com.facebook.presto.spi.function.OutputFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.DoubleType;
 
-import javax.validation.constraints.NotNull;
-
 import java.util.Map;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -48,7 +46,6 @@ public final class DoubleHistogramAggregation
     public interface State
             extends AccumulatorState
     {
-        @NotNull
         NumericHistogram get();
 
         void set(NumericHistogram value);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/HyperLogLogState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/HyperLogLogState.java
@@ -17,15 +17,12 @@ import com.facebook.presto.spi.function.AccumulatorState;
 import com.facebook.presto.spi.function.AccumulatorStateMetadata;
 import io.airlift.stats.cardinality.HyperLogLog;
 
-import javax.validation.constraints.NotNull;
-
 @AccumulatorStateMetadata(stateSerializerClass = HyperLogLogStateSerializer.class, stateFactoryClass = HyperLogLogStateFactory.class)
 public interface HyperLogLogState
         extends AccumulatorState
 {
     int NUMBER_OF_BUCKETS = 4096;
 
-    @NotNull
     HyperLogLog getHyperLogLog();
 
     void setHyperLogLog(HyperLogLog value);

--- a/presto-ml/pom.xml
+++ b/presto-ml/pom.xml
@@ -27,11 +27,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
         </dependency>

--- a/presto-ml/src/main/java/com/facebook/presto/ml/LearnState.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/LearnState.java
@@ -18,8 +18,6 @@ import com.facebook.presto.spi.function.AccumulatorStateMetadata;
 import com.google.common.collect.BiMap;
 import io.airlift.slice.Slice;
 
-import javax.validation.constraints.NotNull;
-
 import java.util.List;
 
 @AccumulatorStateMetadata(stateSerializerClass = LearnStateSerializer.class, stateFactoryClass = LearnStateFactory.class)
@@ -27,15 +25,12 @@ public interface LearnState
         extends AccumulatorState
 {
     // Mapping of string labels for classifiers that use strings instead of doubles
-    @NotNull
     BiMap<String, Integer> getLabelEnumeration();
 
     int enumerateLabel(String label);
 
-    @NotNull
     List<Double> getLabels();
 
-    @NotNull
     List<FeatureVector> getFeatureVectors();
 
     Slice getParameters();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
@@ -25,7 +25,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -49,13 +48,11 @@ public class BooleanStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
     private boolean[] nullVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> dataStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream dataStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -50,13 +49,11 @@ public class ByteStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
     private boolean[] nullVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<ByteInputStream> dataStreamSource = missingStreamSource(ByteInputStream.class);
     @Nullable
     private ByteInputStream dataStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DecimalStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DecimalStreamReader.java
@@ -31,7 +31,6 @@ import com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -60,17 +59,14 @@ public class DecimalStreamReader
     private boolean[] nullVector = new boolean[0];
     private long[] scaleVector = new long[0];
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
 
-    @Nonnull
     private InputStreamSource<DecimalInputStream> decimalStreamSource = missingStreamSource(DecimalInputStream.class);
     @Nullable
     private DecimalInputStream decimalStream;
 
-    @Nonnull
     private InputStreamSource<LongInputStream> scaleStreamSource = missingStreamSource(LongInputStream.class);
     @Nullable
     private LongInputStream scaleStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -50,13 +49,11 @@ public class DoubleStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
     private boolean[] nullVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<DoubleInputStream> dataStreamSource = missingStreamSource(DoubleInputStream.class);
     @Nullable
     private DoubleInputStream dataStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -51,13 +50,11 @@ public class FloatStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
     private boolean[] nullVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<FloatInputStream> dataStreamSource = missingStreamSource(FloatInputStream.class);
     @Nullable
     private FloatInputStream dataStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListStreamReader.java
@@ -28,7 +28,6 @@ import com.google.common.io.Closer;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -56,12 +55,10 @@ public class ListStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
 
-    @Nonnull
     private InputStreamSource<LongInputStream> lengthStreamSource = missingStreamSource(LongInputStream.class);
     @Nullable
     private LongInputStream lengthStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryStreamReader.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -51,25 +50,20 @@ public class LongDictionaryStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
     private boolean[] nullVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<LongInputStream> dictionaryDataStreamSource = missingStreamSource(LongInputStream.class);
     private int dictionarySize;
-    @Nonnull
     private long[] dictionary = new long[0];
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> inDictionaryStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream inDictionaryStream;
     private boolean[] inDictionaryVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<LongInputStream> dataStreamSource;
     @Nullable
     private LongInputStream dataStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -50,13 +49,11 @@ public class LongDirectStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
     private boolean[] nullVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<LongInputStream> dataStreamSource = missingStreamSource(LongInputStream.class);
     @Nullable
     private LongInputStream dataStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapStreamReader.java
@@ -29,7 +29,6 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -58,12 +57,10 @@ public class MapStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
 
-    @Nonnull
     private InputStreamSource<LongInputStream> lengthStreamSource = missingStreamSource(LongInputStream.class);
     @Nullable
     private LongInputStream lengthStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
@@ -31,7 +31,6 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -68,44 +67,33 @@ public class SliceDictionaryStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
     private boolean[] isNullVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<ByteArrayInputStream> stripeDictionaryDataStreamSource = missingStreamSource(ByteArrayInputStream.class);
     private boolean stripeDictionaryOpen;
     private int stripeDictionarySize;
-    @Nonnull
     private int[] stripeDictionaryLength = new int[0];
-    @Nonnull
     private byte[] stripeDictionaryData = EMPTY_DICTIONARY_DATA;
-    @Nonnull
     private int[] stripeDictionaryOffsetVector = EMPTY_DICTIONARY_OFFSETS;
 
     private VariableWidthBlock dictionaryBlock = new VariableWidthBlock(1, Slices.wrappedBuffer(EMPTY_DICTIONARY_DATA), EMPTY_DICTIONARY_OFFSETS, Optional.of(new boolean[]{true}));
     private byte[] currentDictionaryData = EMPTY_DICTIONARY_DATA;
 
-    @Nonnull
     private InputStreamSource<LongInputStream> stripeDictionaryLengthStreamSource = missingStreamSource(LongInputStream.class);
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> inDictionaryStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream inDictionaryStream;
     private boolean[] inDictionaryVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<ByteArrayInputStream> rowGroupDictionaryDataStreamSource = missingStreamSource(ByteArrayInputStream.class);
 
-    @Nonnull
     private InputStreamSource<RowGroupDictionaryLengthInputStream> rowGroupDictionaryLengthStreamSource = missingStreamSource(RowGroupDictionaryLengthInputStream.class);
-    @Nonnull
     private int[] rowGroupDictionaryLength = new int[0];
 
-    @Nonnull
     private InputStreamSource<LongInputStream> dataStreamSource = missingStreamSource(LongInputStream.class);
     @Nullable
     private LongInputStream dataStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
@@ -30,7 +30,6 @@ import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -63,17 +62,14 @@ public class SliceDirectStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
 
-    @Nonnull
     private InputStreamSource<LongInputStream> lengthStreamSource = missingStreamSource(LongInputStream.class);
     @Nullable
     private LongInputStream lengthStream;
 
-    @Nonnull
     private InputStreamSource<ByteArrayInputStream> dataByteSource = missingStreamSource(ByteArrayInputStream.class);
     @Nullable
     private ByteArrayInputStream dataStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
@@ -28,7 +28,6 @@ import com.google.common.io.Closer;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -59,7 +58,6 @@ public class StructStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampStreamReader.java
@@ -28,7 +28,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -56,18 +55,15 @@ public class TimestampStreamReader
     private int readOffset;
     private int nextBatchSize;
 
-    @Nonnull
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
     private boolean[] nullVector = new boolean[0];
 
-    @Nonnull
     private InputStreamSource<LongInputStream> secondsStreamSource = missingStreamSource(LongInputStream.class);
     @Nullable
     private LongInputStream secondsStream;
 
-    @Nonnull
     private InputStreamSource<LongInputStream> nanosStreamSource = missingStreamSource(LongInputStream.class);
     @Nullable
     private LongInputStream nanosStream;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/InputStreamSources.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/InputStreamSources.java
@@ -18,8 +18,6 @@ import com.facebook.presto.orc.StreamId;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableMap;
 
-import javax.annotation.Nonnull;
-
 import java.util.Map;
 
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
@@ -35,7 +33,6 @@ public class InputStreamSources
         this.streamSources = ImmutableMap.copyOf(requireNonNull(streamSources, "streamSources is null"));
     }
 
-    @Nonnull
     public <S extends ValueInputStream<?>> InputStreamSource<S> getInputStreamSource(StreamDescriptor streamDescriptor, StreamKind streamKind, Class<S> streamType)
     {
         requireNonNull(streamDescriptor, "streamDescriptor is null");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/StreamDataOutput.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/StreamDataOutput.java
@@ -17,8 +17,6 @@ import com.facebook.presto.orc.metadata.Stream;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 
-import javax.annotation.Nonnull;
-
 import java.util.function.ToLongFunction;
 
 import static com.google.common.base.Verify.verify;
@@ -47,7 +45,7 @@ public final class StreamDataOutput
     }
 
     @Override
-    public int compareTo(@Nonnull StreamDataOutput otherStream)
+    public int compareTo(StreamDataOutput otherStream)
     {
         return Long.compare(size(), otherStream.size());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PrestoWarning.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PrestoWarning.java
@@ -16,8 +16,6 @@ package com.facebook.presto.spi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.annotation.Nonnull;
-
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -42,14 +40,12 @@ public final class PrestoWarning
         this(requireNonNull(warningCodeSupplier, "warningCodeSupplier is null").toWarningCode(), message);
     }
 
-    @Nonnull
     @JsonProperty
     public WarningCode getWarningCode()
     {
         return warningCode;
     }
 
-    @Nonnull
     @JsonProperty
     public String getMessage()
     {


### PR DESCRIPTION
Remove usage of javax.annotation.Nonnull

By default fields and parameters are by default non nullable.
There is no need to annotate that.
