### PR TITLE
Implement recording metastore

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ForRecordingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ForRecordingHiveMetastore.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForRecordingHiveMetastore
+{
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBasicStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBasicStatistics.java
@@ -13,12 +13,18 @@
  */
 package com.facebook.presto.hive;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
 import java.util.Objects;
 import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class HiveBasicStatistics
 {
     private final OptionalLong fileCount;
@@ -41,11 +47,12 @@ public class HiveBasicStatistics
         this(OptionalLong.of(fileCount), OptionalLong.of(rowCount), OptionalLong.of(inMemoryDataSizeInBytes), OptionalLong.of(onDiskDataSizeInBytes));
     }
 
+    @JsonCreator
     public HiveBasicStatistics(
-            OptionalLong fileCount,
-            OptionalLong rowCount,
-            OptionalLong inMemoryDataSizeInBytes,
-            OptionalLong onDiskDataSizeInBytes)
+            @JsonProperty("fileCount") OptionalLong fileCount,
+            @JsonProperty("rowCount") OptionalLong rowCount,
+            @JsonProperty("inMemoryDataSizeInBytes") OptionalLong inMemoryDataSizeInBytes,
+            @JsonProperty("onDiskDataSizeInBytes") OptionalLong onDiskDataSizeInBytes)
     {
         this.fileCount = requireNonNull(fileCount, "fileCount is null");
         this.rowCount = requireNonNull(rowCount, "rowCount is null");
@@ -53,21 +60,25 @@ public class HiveBasicStatistics
         this.onDiskDataSizeInBytes = requireNonNull(onDiskDataSizeInBytes, "onDiskDataSizeInBytes is null");
     }
 
+    @JsonProperty
     public OptionalLong getFileCount()
     {
         return fileCount;
     }
 
+    @JsonProperty
     public OptionalLong getRowCount()
     {
         return rowCount;
     }
 
+    @JsonProperty
     public OptionalLong getInMemoryDataSizeInBytes()
     {
         return inMemoryDataSizeInBytes;
     }
 
+    @JsonProperty
     public OptionalLong getOnDiskDataSizeInBytes()
     {
         return onDiskDataSizeInBytes;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -40,6 +40,7 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 @DefunctConfig({
         "hive.file-system-cache-ttl",
@@ -138,6 +139,10 @@ public class HiveClientConfig
     private int partitionStatisticsSampleSize = 100;
     private boolean ignoreCorruptedStatistics;
     private boolean collectColumnStatisticsOnWrite;
+
+    private String recordingPath;
+    private boolean replay;
+    private Duration recordingDuration = new Duration(0, MINUTES);
 
     public int getMaxInitialSplits()
     {
@@ -1092,5 +1097,42 @@ public class HiveClientConfig
     {
         this.collectColumnStatisticsOnWrite = collectColumnStatisticsOnWrite;
         return this;
+    }
+
+    @Config("hive.metastore-recording-path")
+    public HiveClientConfig setRecordingPath(String recordingPath)
+    {
+        this.recordingPath = recordingPath;
+        return this;
+    }
+
+    public String getRecordingPath()
+    {
+        return recordingPath;
+    }
+
+    @Config("hive.replay-metastore-recording")
+    public HiveClientConfig setReplay(boolean replay)
+    {
+        this.replay = replay;
+        return this;
+    }
+
+    public boolean isReplay()
+    {
+        return replay;
+    }
+
+    @Config("hive.metastore-recoding-duration")
+    public HiveClientConfig setRecordingDuration(Duration recordingDuration)
+    {
+        this.recordingDuration = recordingDuration;
+        return this;
+    }
+
+    @NotNull
+    public Duration getRecordingDuration()
+    {
+        return recordingDuration;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionStatistics.java
@@ -15,7 +15,11 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.HiveColumnStatistics;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.concurrent.Immutable;
 
 import java.util.Map;
 import java.util.Objects;
@@ -23,6 +27,7 @@ import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class PartitionStatistics
 {
     private static final PartitionStatistics EMPTY = new PartitionStatistics(HiveBasicStatistics.createEmptyStatistics(), ImmutableMap.of());
@@ -35,19 +40,22 @@ public class PartitionStatistics
         return EMPTY;
     }
 
+    @JsonCreator
     public PartitionStatistics(
-            HiveBasicStatistics basicStatistics,
-            Map<String, HiveColumnStatistics> columnStatistics)
+            @JsonProperty("basicStatistics") HiveBasicStatistics basicStatistics,
+            @JsonProperty("columnStatistics") Map<String, HiveColumnStatistics> columnStatistics)
     {
         this.basicStatistics = requireNonNull(basicStatistics, "basicStatistics is null");
         this.columnStatistics = ImmutableMap.copyOf(requireNonNull(columnStatistics, "columnStatistics can not be null"));
     }
 
+    @JsonProperty
     public HiveBasicStatistics getBasicStatistics()
     {
         return basicStatistics;
     }
 
+    @JsonProperty
     public Map<String, HiveColumnStatistics> getColumnStatistics()
     {
         return columnStatistics;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/BooleanStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/BooleanStatistics.java
@@ -16,12 +16,15 @@ package com.facebook.presto.hive.metastore;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.concurrent.Immutable;
+
 import java.util.Objects;
 import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class BooleanStatistics
 {
     private final OptionalLong trueCount;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Column.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Column.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -67,5 +68,27 @@ public class Column
                 .add("name", name)
                 .add("type", type)
                 .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Column column = (Column) o;
+        return Objects.equals(name, column.name) &&
+                Objects.equals(type, column.type) &&
+                Objects.equals(comment, column.comment);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type, comment);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Database.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Database.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.concurrent.Immutable;
@@ -35,12 +37,14 @@ public class Database
     private final Optional<String> comment;
     private final Map<String, String> parameters;
 
-    public Database(String databaseName,
-            Optional<String> location,
-            String ownerName,
-            PrincipalType ownerType,
-            Optional<String> comment,
-            Map<String, String> parameters)
+    @JsonCreator
+    public Database(
+            @JsonProperty("databaseName") String databaseName,
+            @JsonProperty("location") Optional<String> location,
+            @JsonProperty("ownerName") String ownerName,
+            @JsonProperty("ownerType") PrincipalType ownerType,
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("parameters") Map<String, String> parameters)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.location = requireNonNull(location, "location is null");
@@ -50,31 +54,37 @@ public class Database
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
     }
 
+    @JsonProperty
     public String getDatabaseName()
     {
         return databaseName;
     }
 
+    @JsonProperty
     public Optional<String> getLocation()
     {
         return location;
     }
 
+    @JsonProperty
     public String getOwnerName()
     {
         return ownerName;
     }
 
+    @JsonProperty
     public PrincipalType getOwnerType()
     {
         return ownerType;
     }
 
+    @JsonProperty
     public Optional<String> getComment()
     {
         return comment;
     }
 
+    @JsonProperty
     public Map<String, String> getParameters()
     {
         return parameters;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Database.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Database.java
@@ -21,8 +21,10 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -173,5 +175,43 @@ public class Database
                     comment,
                     parameters);
         }
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("databaseName", databaseName)
+                .add("location", location)
+                .add("ownerName", ownerName)
+                .add("ownerType", ownerType)
+                .add("comment", comment)
+                .add("parameters", parameters)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Database database = (Database) o;
+        return Objects.equals(databaseName, database.databaseName) &&
+                Objects.equals(location, database.location) &&
+                Objects.equals(ownerName, database.ownerName) &&
+                ownerType == database.ownerType &&
+                Objects.equals(comment, database.comment) &&
+                Objects.equals(parameters, database.parameters);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(databaseName, location, ownerName, ownerType, comment, parameters);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/DateStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/DateStatistics.java
@@ -16,6 +16,8 @@ package com.facebook.presto.hive.metastore;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.concurrent.Immutable;
+
 import java.time.LocalDate;
 import java.util.Objects;
 import java.util.Optional;
@@ -23,6 +25,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class DateStatistics
 {
     private final Optional<LocalDate> min;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/DecimalStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/DecimalStatistics.java
@@ -16,6 +16,8 @@ package com.facebook.presto.hive.metastore;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.concurrent.Immutable;
+
 import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.Optional;
@@ -23,6 +25,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class DecimalStatistics
 {
     private final Optional<BigDecimal> min;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/DoubleStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/DoubleStatistics.java
@@ -16,12 +16,15 @@ package com.facebook.presto.hive.metastore;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.concurrent.Immutable;
+
 import java.util.Objects;
 import java.util.OptionalDouble;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class DoubleStatistics
 {
     private final OptionalDouble min;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveColumnStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveColumnStatistics.java
@@ -16,6 +16,8 @@ package com.facebook.presto.hive.metastore;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.concurrent.Immutable;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -29,6 +31,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class HiveColumnStatistics
 {
     private static final HiveColumnStatistics EMPTY = HiveColumnStatistics.builder().build();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePartitionName.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePartitionName.java
@@ -21,6 +21,7 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveUtil.toPartitionValues;
 import static com.facebook.presto.hive.metastore.HiveTableName.hiveTableName;
@@ -32,22 +33,22 @@ public class HivePartitionName
 {
     private final HiveTableName hiveTableName;
     private final List<String> partitionValues;
-    private final String partitionName; // does not participate in hashCode/equals
+    private final Optional<String> partitionName; // does not participate in hashCode/equals
 
     @JsonCreator
     public HivePartitionName(
             @JsonProperty("hiveTableName") HiveTableName hiveTableName,
             @JsonProperty("partitionValues") List<String> partitionValues,
-            @JsonProperty("partitionName") String partitionName)
+            @JsonProperty("partitionName") Optional<String> partitionName)
     {
         this.hiveTableName = requireNonNull(hiveTableName, "hiveTableName is null");
         this.partitionValues = ImmutableList.copyOf(requireNonNull(partitionValues, "partitionValues is null"));
-        this.partitionName = partitionName;
+        this.partitionName = requireNonNull(partitionName, "partitionName is null");
     }
 
     public static HivePartitionName hivePartitionName(HiveTableName hiveTableName, String partitionName)
     {
-        return new HivePartitionName(hiveTableName, toPartitionValues(partitionName), partitionName);
+        return new HivePartitionName(hiveTableName, toPartitionValues(partitionName), Optional.of(partitionName));
     }
 
     public static HivePartitionName hivePartitionName(String databaseName, String tableName, String partitionName)
@@ -57,7 +58,7 @@ public class HivePartitionName
 
     public static HivePartitionName hivePartitionName(String databaseName, String tableName, List<String> partitionValues)
     {
-        return new HivePartitionName(hiveTableName(databaseName, tableName), partitionValues, null);
+        return new HivePartitionName(hiveTableName(databaseName, tableName), partitionValues, Optional.empty());
     }
 
     @JsonProperty
@@ -73,9 +74,9 @@ public class HivePartitionName
     }
 
     @JsonProperty
-    public String getPartitionName()
+    public Optional<String> getPartitionName()
     {
-        return requireNonNull(partitionName, "partitionName is null");
+        return partitionName;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePartitionName.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePartitionName.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.facebook.presto.hive.HiveUtil.toPartitionValues;
+import static com.facebook.presto.hive.metastore.HiveTableName.hiveTableName;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class HivePartitionName
+{
+    private final HiveTableName hiveTableName;
+    private final List<String> partitionValues;
+    private final String partitionName; // does not participate in hashCode/equals
+
+    @JsonCreator
+    public HivePartitionName(
+            @JsonProperty("hiveTableName") HiveTableName hiveTableName,
+            @JsonProperty("partitionValues") List<String> partitionValues,
+            @JsonProperty("partitionName") String partitionName)
+    {
+        this.hiveTableName = requireNonNull(hiveTableName, "hiveTableName is null");
+        this.partitionValues = ImmutableList.copyOf(requireNonNull(partitionValues, "partitionValues is null"));
+        this.partitionName = partitionName;
+    }
+
+    public static HivePartitionName hivePartitionName(HiveTableName hiveTableName, String partitionName)
+    {
+        return new HivePartitionName(hiveTableName, toPartitionValues(partitionName), partitionName);
+    }
+
+    public static HivePartitionName hivePartitionName(String databaseName, String tableName, String partitionName)
+    {
+        return hivePartitionName(hiveTableName(databaseName, tableName), partitionName);
+    }
+
+    public static HivePartitionName hivePartitionName(String databaseName, String tableName, List<String> partitionValues)
+    {
+        return new HivePartitionName(hiveTableName(databaseName, tableName), partitionValues, null);
+    }
+
+    @JsonProperty
+    public HiveTableName getHiveTableName()
+    {
+        return hiveTableName;
+    }
+
+    @JsonProperty
+    public List<String> getPartitionValues()
+    {
+        return partitionValues;
+    }
+
+    @JsonProperty
+    public String getPartitionName()
+    {
+        return requireNonNull(partitionName, "partitionName is null");
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("hiveTableName", hiveTableName)
+                .add("partitionValues", partitionValues)
+                .add("partitionName", partitionName)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HivePartitionName other = (HivePartitionName) o;
+        return Objects.equals(hiveTableName, other.hiveTableName) &&
+                Objects.equals(partitionValues, other.partitionValues);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(hiveTableName, partitionValues);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HivePrivilegeInfo.java
@@ -15,8 +15,12 @@ package com.facebook.presto.hive.metastore;
 
 import com.facebook.presto.spi.security.Privilege;
 import com.facebook.presto.spi.security.PrivilegeInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hive.metastore.api.PrivilegeGrantInfo;
+
+import javax.annotation.concurrent.Immutable;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -31,6 +35,7 @@ import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Locale.ENGLISH;
 
+@Immutable
 public class HivePrivilegeInfo
 {
     public enum HivePrivilege
@@ -41,17 +46,22 @@ public class HivePrivilegeInfo
     private final HivePrivilege hivePrivilege;
     private final boolean grantOption;
 
-    public HivePrivilegeInfo(HivePrivilege hivePrivilege, boolean grantOption)
+    @JsonCreator
+    public HivePrivilegeInfo(
+            @JsonProperty("hivePrivilege") HivePrivilege hivePrivilege,
+            @JsonProperty("grantOption") boolean grantOption)
     {
         this.hivePrivilege = hivePrivilege;
         this.grantOption = grantOption;
     }
 
+    @JsonProperty
     public HivePrivilege getHivePrivilege()
     {
         return hivePrivilege;
     }
 
+    @JsonProperty
     public boolean isGrantOption()
     {
         return grantOption;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveTableName.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/HiveTableName.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+@Immutable
+public class HiveTableName
+{
+    private final String databaseName;
+    private final String tableName;
+
+    @JsonCreator
+    public HiveTableName(@JsonProperty("databaseName") String databaseName, @JsonProperty("tableName") String tableName)
+    {
+        this.databaseName = databaseName;
+        this.tableName = tableName;
+    }
+
+    public static HiveTableName hiveTableName(String databaseName, String tableName)
+    {
+        return new HiveTableName(databaseName, tableName);
+    }
+
+    @JsonProperty
+    public String getDatabaseName()
+    {
+        return databaseName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("databaseName", databaseName)
+                .add("tableName", tableName)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HiveTableName other = (HiveTableName) o;
+        return Objects.equals(databaseName, other.databaseName) &&
+                Objects.equals(tableName, other.tableName);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(databaseName, tableName);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/IntegerStatistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/IntegerStatistics.java
@@ -16,12 +16,15 @@ package com.facebook.presto.hive.metastore;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.concurrent.Immutable;
+
 import java.util.Objects;
 import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class IntegerStatistics
 {
     private final OptionalLong min;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Partition.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Partition.java
@@ -22,6 +22,7 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -98,6 +99,31 @@ public class Partition
                 .add("tableName", tableName)
                 .add("values", values)
                 .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Partition partition = (Partition) o;
+        return Objects.equals(databaseName, partition.databaseName) &&
+                Objects.equals(tableName, partition.tableName) &&
+                Objects.equals(values, partition.values) &&
+                Objects.equals(storage, partition.storage) &&
+                Objects.equals(columns, partition.columns) &&
+                Objects.equals(parameters, partition.parameters);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(databaseName, tableName, values, storage, columns, parameters);
     }
 
     public static Builder builder()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/PartitionFilter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/PartitionFilter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.facebook.presto.hive.metastore.HiveTableName.hiveTableName;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class PartitionFilter
+{
+    private final HiveTableName hiveTableName;
+    private final List<String> parts;
+
+    @JsonCreator
+    public PartitionFilter(@JsonProperty("hiveTableName") HiveTableName hiveTableName, @JsonProperty("parts") List<String> parts)
+    {
+        this.hiveTableName = requireNonNull(hiveTableName, "hiveTableName is null");
+        this.parts = ImmutableList.copyOf(requireNonNull(parts, "parts is null"));
+    }
+
+    public static PartitionFilter partitionFilter(String databaseName, String tableName, List<String> parts)
+    {
+        return new PartitionFilter(hiveTableName(databaseName, tableName), parts);
+    }
+
+    @JsonProperty
+    public HiveTableName getHiveTableName()
+    {
+        return hiveTableName;
+    }
+
+    @JsonProperty
+    public List<String> getParts()
+    {
+        return parts;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("hiveTableName", hiveTableName)
+                .add("parts", parts)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PartitionFilter other = (PartitionFilter) o;
+        return Objects.equals(hiveTableName, other.hiveTableName) &&
+                Objects.equals(parts, other.parts);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(hiveTableName, parts);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
@@ -1,0 +1,618 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.hive.ForRecordingHiveMetastore;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.PartitionStatistics;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.json.ObjectMapperProvider;
+import org.weakref.jmx.Managed;
+
+import javax.annotation.concurrent.Immutable;
+import javax.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.hive.metastore.HivePartitionName.hivePartitionName;
+import static com.facebook.presto.hive.metastore.HiveTableName.hiveTableName;
+import static com.facebook.presto.hive.metastore.PartitionFilter.partitionFilter;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class RecordingHiveMetastore
+        implements ExtendedHiveMetastore
+{
+    private final ExtendedHiveMetastore delegate;
+    private final String recordingPath;
+    private final boolean replay;
+
+    private volatile Optional<List<String>> allDatabases = Optional.empty();
+
+    private final Cache<String, Optional<Database>> databaseCache;
+    private final Cache<HiveTableName, Optional<Table>> tableCache;
+    private final Cache<String, Set<ColumnStatisticType>> supportedColumnStatisticsCache;
+    private final Cache<HiveTableName, PartitionStatistics> tableStatisticsCache;
+    private final Cache<Set<HivePartitionName>, Map<String, PartitionStatistics>> partitionStatisticsCache;
+    private final Cache<String, Optional<List<String>>> allTablesCache;
+    private final Cache<String, Optional<List<String>>> allViewsCache;
+    private final Cache<HivePartitionName, Optional<Partition>> partitionCache;
+    private final Cache<HiveTableName, Optional<List<String>>> partitionNamesCache;
+    private final Cache<PartitionFilter, Optional<List<String>>> partitionNamesByPartsCache;
+    private final Cache<Set<HivePartitionName>, Map<String, Optional<Partition>>> partitionsByNamesCache;
+    private final Cache<String, Set<String>> rolesCache;
+    private final Cache<UserDatabaseKey, Set<HivePrivilegeInfo>> databasePrivilegesCache;
+    private final Cache<UserTableKey, Set<HivePrivilegeInfo>> tablePrivilegesCache;
+
+    @Inject
+    public RecordingHiveMetastore(@ForRecordingHiveMetastore ExtendedHiveMetastore delegate, HiveClientConfig hiveClientConfig)
+            throws IOException
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        requireNonNull(hiveClientConfig, "hiveClientConfig is null");
+        this.recordingPath = requireNonNull(hiveClientConfig.getRecordingPath(), "recordingPath is null");
+        this.replay = hiveClientConfig.isReplay();
+
+        databaseCache = createCache(hiveClientConfig);
+        tableCache = createCache(hiveClientConfig);
+        supportedColumnStatisticsCache = createCache(hiveClientConfig);
+        tableStatisticsCache = createCache(hiveClientConfig);
+        partitionStatisticsCache = createCache(hiveClientConfig);
+        allTablesCache = createCache(hiveClientConfig);
+        allViewsCache = createCache(hiveClientConfig);
+        partitionCache = createCache(hiveClientConfig);
+        partitionNamesCache = createCache(hiveClientConfig);
+        partitionNamesByPartsCache = createCache(hiveClientConfig);
+        partitionsByNamesCache = createCache(hiveClientConfig);
+        rolesCache = createCache(hiveClientConfig);
+        databasePrivilegesCache = createCache(hiveClientConfig);
+        tablePrivilegesCache = createCache(hiveClientConfig);
+
+        if (replay) {
+            loadRecording();
+        }
+    }
+
+    @VisibleForTesting
+    void loadRecording()
+            throws IOException
+    {
+        Recording recording = new ObjectMapperProvider().get().readValue(new File(recordingPath), Recording.class);
+
+        allDatabases = recording.getAllDatabases();
+        databaseCache.putAll(toMap(recording.getDatabases()));
+        tableCache.putAll(toMap(recording.getTables()));
+        supportedColumnStatisticsCache.putAll(toMap(recording.getSupportedColumnStatistics()));
+        tableStatisticsCache.putAll(toMap(recording.getTableStatistics()));
+        partitionStatisticsCache.putAll(toMap(recording.getPartitionStatistics()));
+        allTablesCache.putAll(toMap(recording.getAllTables()));
+        allViewsCache.putAll(toMap(recording.getAllViews()));
+        partitionCache.putAll(toMap(recording.getPartitions()));
+        partitionNamesCache.putAll(toMap(recording.getPartitionNames()));
+        partitionNamesByPartsCache.putAll(toMap(recording.getPartitionNamesByParts()));
+        partitionsByNamesCache.putAll(toMap(recording.getPartitionsByNames()));
+        rolesCache.putAll(toMap(recording.getRoles()));
+        databasePrivilegesCache.putAll(toMap(recording.getDatabasePrivileges()));
+        tablePrivilegesCache.putAll(toMap(recording.getTablePrivileges()));
+    }
+
+    private static <K, V> Cache<K, V> createCache(HiveClientConfig hiveClientConfig)
+    {
+        if (hiveClientConfig.isReplay()) {
+            return CacheBuilder.<K, V>newBuilder()
+                    .build();
+        }
+
+        return CacheBuilder.<K, V>newBuilder()
+                .expireAfterWrite(hiveClientConfig.getRecordingDuration().toMillis(), MILLISECONDS)
+                .build();
+    }
+
+    @Managed
+    public void writeRecording()
+            throws IOException
+    {
+        if (replay) {
+            throw new IllegalStateException("Cannot write recording in replay mode");
+        }
+
+        Recording recording = new Recording(
+                allDatabases,
+                toPairs(databaseCache),
+                toPairs(tableCache),
+                toPairs(supportedColumnStatisticsCache),
+                toPairs(tableStatisticsCache),
+                toPairs(partitionStatisticsCache),
+                toPairs(allTablesCache),
+                toPairs(allViewsCache),
+                toPairs(partitionCache),
+                toPairs(partitionNamesCache),
+                toPairs(partitionNamesByPartsCache),
+                toPairs(partitionsByNamesCache),
+                toPairs(rolesCache),
+                toPairs(databasePrivilegesCache),
+                toPairs(tablePrivilegesCache));
+        new ObjectMapperProvider().get()
+                .writerWithDefaultPrettyPrinter()
+                .writeValue(new File(recordingPath), recording);
+    }
+
+    private static <K, V> Map<K, V> toMap(List<Pair<K, V>> pairs)
+    {
+        return pairs.stream()
+                .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
+    }
+
+    private static <K, V> List<Pair<K, V>> toPairs(Cache<K, V> cache)
+    {
+        return cache.asMap().entrySet().stream()
+                .map(entry -> new Pair<>(entry.getKey(), entry.getValue()))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public Optional<Database> getDatabase(String databaseName)
+    {
+        return loadValue(databaseCache, databaseName, () -> delegate.getDatabase(databaseName));
+    }
+
+    @Override
+    public List<String> getAllDatabases()
+    {
+        if (replay) {
+            return allDatabases.orElseThrow(() -> new PrestoException(NOT_FOUND, "Missing entry for all databases"));
+        }
+
+        List<String> result = delegate.getAllDatabases();
+        allDatabases = Optional.of(result);
+        return result;
+    }
+
+    @Override
+    public Optional<Table> getTable(String databaseName, String tableName)
+    {
+        return loadValue(tableCache, hiveTableName(databaseName, tableName), () -> delegate.getTable(databaseName, tableName));
+    }
+
+    @Override
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
+    {
+        return loadValue(supportedColumnStatisticsCache, type.getTypeSignature().toString(), () -> delegate.getSupportedColumnStatistics(type));
+    }
+
+    @Override
+    public PartitionStatistics getTableStatistics(String databaseName, String tableName)
+    {
+        return loadValue(
+                tableStatisticsCache,
+                hiveTableName(databaseName, tableName),
+                () -> delegate.getTableStatistics(databaseName, tableName));
+    }
+
+    @Override
+    public Map<String, PartitionStatistics> getPartitionStatistics(String databaseName, String tableName, Set<String> partitionNames)
+    {
+        return loadValue(
+                partitionStatisticsCache,
+                getHivePartitionNames(databaseName, tableName, partitionNames),
+                () -> delegate.getPartitionStatistics(databaseName, tableName, partitionNames));
+    }
+
+    @Override
+    public void updateTableStatistics(String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    {
+        verifyRecordingMode();
+        delegate.updateTableStatistics(databaseName, tableName, update);
+    }
+
+    @Override
+    public void updatePartitionStatistics(String databaseName, String tableName, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    {
+        verifyRecordingMode();
+        delegate.updatePartitionStatistics(databaseName, tableName, partitionName, update);
+    }
+
+    @Override
+    public Optional<List<String>> getAllTables(String databaseName)
+    {
+        return loadValue(allTablesCache, databaseName, () -> delegate.getAllTables(databaseName));
+    }
+
+    @Override
+    public Optional<List<String>> getAllViews(String databaseName)
+    {
+        return loadValue(allViewsCache, databaseName, () -> delegate.getAllViews(databaseName));
+    }
+
+    @Override
+    public void createDatabase(Database database)
+    {
+        verifyRecordingMode();
+        delegate.createDatabase(database);
+    }
+
+    @Override
+    public void dropDatabase(String databaseName)
+    {
+        verifyRecordingMode();
+        delegate.dropDatabase(databaseName);
+    }
+
+    @Override
+    public void renameDatabase(String databaseName, String newDatabaseName)
+    {
+        verifyRecordingMode();
+        delegate.renameDatabase(databaseName, newDatabaseName);
+    }
+
+    @Override
+    public void createTable(Table table, PrincipalPrivileges principalPrivileges)
+    {
+        verifyRecordingMode();
+        delegate.createTable(table, principalPrivileges);
+    }
+
+    @Override
+    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    {
+        verifyRecordingMode();
+        delegate.dropTable(databaseName, tableName, deleteData);
+    }
+
+    @Override
+    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    {
+        verifyRecordingMode();
+        delegate.replaceTable(databaseName, tableName, newTable, principalPrivileges);
+    }
+
+    @Override
+    public void renameTable(String databaseName, String tableName, String newDatabaseName, String newTableName)
+    {
+        verifyRecordingMode();
+        delegate.renameTable(databaseName, tableName, newDatabaseName, newTableName);
+    }
+
+    @Override
+    public void addColumn(String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    {
+        verifyRecordingMode();
+        delegate.addColumn(databaseName, tableName, columnName, columnType, columnComment);
+    }
+
+    @Override
+    public void renameColumn(String databaseName, String tableName, String oldColumnName, String newColumnName)
+    {
+        verifyRecordingMode();
+        delegate.renameColumn(databaseName, tableName, oldColumnName, newColumnName);
+    }
+
+    @Override
+    public void dropColumn(String databaseName, String tableName, String columnName)
+    {
+        verifyRecordingMode();
+        delegate.dropColumn(databaseName, tableName, columnName);
+    }
+
+    @Override
+    public Optional<Partition> getPartition(String databaseName, String tableName, List<String> partitionValues)
+    {
+        return loadValue(
+                partitionCache,
+                hivePartitionName(databaseName, tableName, partitionValues),
+                () -> delegate.getPartition(databaseName, tableName, partitionValues));
+    }
+
+    @Override
+    public Optional<List<String>> getPartitionNames(String databaseName, String tableName)
+    {
+        return loadValue(
+                partitionNamesCache,
+                hiveTableName(databaseName, tableName),
+                () -> delegate.getPartitionNames(databaseName, tableName));
+    }
+
+    @Override
+    public Optional<List<String>> getPartitionNamesByParts(String databaseName, String tableName, List<String> parts)
+    {
+        return loadValue(
+                partitionNamesByPartsCache,
+                partitionFilter(databaseName, tableName, parts),
+                () -> delegate.getPartitionNamesByParts(databaseName, tableName, parts));
+    }
+
+    @Override
+    public Map<String, Optional<Partition>> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
+    {
+        return loadValue(
+                partitionsByNamesCache,
+                getHivePartitionNames(databaseName, tableName, ImmutableSet.copyOf(partitionNames)),
+                () -> delegate.getPartitionsByNames(databaseName, tableName, partitionNames));
+    }
+
+    @Override
+    public void addPartitions(String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    {
+        verifyRecordingMode();
+        delegate.addPartitions(databaseName, tableName, partitions);
+    }
+
+    @Override
+    public void dropPartition(String databaseName, String tableName, List<String> parts, boolean deleteData)
+    {
+        verifyRecordingMode();
+        delegate.dropPartition(databaseName, tableName, parts, deleteData);
+    }
+
+    @Override
+    public void alterPartition(String databaseName, String tableName, PartitionWithStatistics partition)
+    {
+        verifyRecordingMode();
+        delegate.alterPartition(databaseName, tableName, partition);
+    }
+
+    @Override
+    public Set<String> getRoles(String user)
+    {
+        return loadValue(rolesCache, user, () -> delegate.getRoles(user));
+    }
+
+    @Override
+    public Set<HivePrivilegeInfo> getDatabasePrivileges(String user, String databaseName)
+    {
+        return loadValue(
+                databasePrivilegesCache,
+                new UserDatabaseKey(user, databaseName),
+                () -> delegate.getDatabasePrivileges(user, databaseName));
+    }
+
+    @Override
+    public Set<HivePrivilegeInfo> getTablePrivileges(String user, String databaseName, String tableName)
+    {
+        return loadValue(
+                tablePrivilegesCache,
+                new UserTableKey(user, databaseName, tableName),
+                () -> delegate.getTablePrivileges(user, databaseName, tableName));
+    }
+
+    @Override
+    public void grantTablePrivileges(String databaseName, String tableName, String grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        verifyRecordingMode();
+        delegate.grantTablePrivileges(databaseName, tableName, grantee, privileges);
+    }
+
+    @Override
+    public void revokeTablePrivileges(String databaseName, String tableName, String grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        verifyRecordingMode();
+        delegate.revokeTablePrivileges(databaseName, tableName, grantee, privileges);
+    }
+
+    private Set<HivePartitionName> getHivePartitionNames(String databaseName, String tableName, Set<String> partitionNames)
+    {
+        return partitionNames.stream()
+                .map(partitionName -> HivePartitionName.hivePartitionName(databaseName, tableName, partitionName))
+                .collect(ImmutableSet.toImmutableSet());
+    }
+
+    private <K, V> V loadValue(Cache<K, V> cache, K key, Supplier<V> valueSupplier)
+    {
+        if (replay) {
+            return Optional.ofNullable(cache.getIfPresent(key))
+                    .orElseThrow(() -> new PrestoException(NOT_FOUND, "Missing entry found for key: " + key));
+        }
+
+        V value = valueSupplier.get();
+        cache.put(key, value);
+        return value;
+    }
+
+    private void verifyRecordingMode()
+    {
+        if (replay) {
+            throw new IllegalStateException("Cannot perform Metastore updates in replay mode");
+        }
+    }
+
+    @Immutable
+    public static class Recording
+    {
+        private final Optional<List<String>> allDatabases;
+        private final List<Pair<String, Optional<Database>>> databases;
+        private final List<Pair<HiveTableName, Optional<Table>>> tables;
+        private final List<Pair<String, Set<ColumnStatisticType>>> supportedColumnStatistics;
+        private final List<Pair<HiveTableName, PartitionStatistics>> tableStatistics;
+        private final List<Pair<Set<HivePartitionName>, Map<String, PartitionStatistics>>> partitionStatistics;
+        private final List<Pair<String, Optional<List<String>>>> allTables;
+        private final List<Pair<String, Optional<List<String>>>> allViews;
+        private final List<Pair<HivePartitionName, Optional<Partition>>> partitions;
+        private final List<Pair<HiveTableName, Optional<List<String>>>> partitionNames;
+        private final List<Pair<PartitionFilter, Optional<List<String>>>> partitionNamesByParts;
+        private final List<Pair<Set<HivePartitionName>, Map<String, Optional<Partition>>>> partitionsByNames;
+        private final List<Pair<String, Set<String>>> roles;
+        private final List<Pair<UserDatabaseKey, Set<HivePrivilegeInfo>>> databasePrivileges;
+        private final List<Pair<UserTableKey, Set<HivePrivilegeInfo>>> tablePrivileges;
+
+        @JsonCreator
+        public Recording(
+                @JsonProperty("allDatabases") Optional<List<String>> allDatabases,
+                @JsonProperty("databases") List<Pair<String, Optional<Database>>> databases,
+                @JsonProperty("tables") List<Pair<HiveTableName, Optional<Table>>> tables,
+                @JsonProperty("supportedColumnStatistics") List<Pair<String, Set<ColumnStatisticType>>> supportedColumnStatistics,
+                @JsonProperty("tableStatistics") List<Pair<HiveTableName, PartitionStatistics>> tableStatistics,
+                @JsonProperty("partitionStatistics") List<Pair<Set<HivePartitionName>, Map<String, PartitionStatistics>>> partitionStatistics,
+                @JsonProperty("allTables") List<Pair<String, Optional<List<String>>>> allTables,
+                @JsonProperty("allViews") List<Pair<String, Optional<List<String>>>> allViews,
+                @JsonProperty("partitions") List<Pair<HivePartitionName, Optional<Partition>>> partitions,
+                @JsonProperty("partitionNames") List<Pair<HiveTableName, Optional<List<String>>>> partitionNames,
+                @JsonProperty("partitionNamesByParts") List<Pair<PartitionFilter, Optional<List<String>>>> partitionNamesByParts,
+                @JsonProperty("partitionsByNames") List<Pair<Set<HivePartitionName>, Map<String, Optional<Partition>>>> partitionsByNames,
+                @JsonProperty("roles") List<Pair<String, Set<String>>> roles,
+                @JsonProperty("databasePrivileges") List<Pair<UserDatabaseKey, Set<HivePrivilegeInfo>>> databasePrivileges,
+                @JsonProperty("tablePrivileges") List<Pair<UserTableKey, Set<HivePrivilegeInfo>>> tablePrivileges)
+        {
+            this.allDatabases = allDatabases;
+            this.databases = databases;
+            this.tables = tables;
+            this.supportedColumnStatistics = supportedColumnStatistics;
+            this.tableStatistics = tableStatistics;
+            this.partitionStatistics = partitionStatistics;
+            this.allTables = allTables;
+            this.allViews = allViews;
+            this.partitions = partitions;
+            this.partitionNames = partitionNames;
+            this.partitionNamesByParts = partitionNamesByParts;
+            this.partitionsByNames = partitionsByNames;
+            this.roles = roles;
+            this.databasePrivileges = databasePrivileges;
+            this.tablePrivileges = tablePrivileges;
+        }
+
+        @JsonProperty
+        public Optional<List<String>> getAllDatabases()
+        {
+            return allDatabases;
+        }
+
+        @JsonProperty
+        public List<Pair<String, Optional<Database>>> getDatabases()
+        {
+            return databases;
+        }
+
+        @JsonProperty
+        public List<Pair<HiveTableName, Optional<Table>>> getTables()
+        {
+            return tables;
+        }
+
+        @JsonProperty
+        public List<Pair<String, Set<ColumnStatisticType>>> getSupportedColumnStatistics()
+        {
+            return supportedColumnStatistics;
+        }
+
+        @JsonProperty
+        public List<Pair<HiveTableName, PartitionStatistics>> getTableStatistics()
+        {
+            return tableStatistics;
+        }
+
+        @JsonProperty
+        public List<Pair<Set<HivePartitionName>, Map<String, PartitionStatistics>>> getPartitionStatistics()
+        {
+            return partitionStatistics;
+        }
+
+        @JsonProperty
+        public List<Pair<String, Optional<List<String>>>> getAllTables()
+        {
+            return allTables;
+        }
+
+        @JsonProperty
+        public List<Pair<String, Optional<List<String>>>> getAllViews()
+        {
+            return allViews;
+        }
+
+        @JsonProperty
+        public List<Pair<HivePartitionName, Optional<Partition>>> getPartitions()
+        {
+            return partitions;
+        }
+
+        @JsonProperty
+        public List<Pair<HiveTableName, Optional<List<String>>>> getPartitionNames()
+        {
+            return partitionNames;
+        }
+
+        @JsonProperty
+        public List<Pair<PartitionFilter, Optional<List<String>>>> getPartitionNamesByParts()
+        {
+            return partitionNamesByParts;
+        }
+
+        @JsonProperty
+        public List<Pair<Set<HivePartitionName>, Map<String, Optional<Partition>>>> getPartitionsByNames()
+        {
+            return partitionsByNames;
+        }
+
+        @JsonProperty
+        public List<Pair<String, Set<String>>> getRoles()
+        {
+            return roles;
+        }
+
+        @JsonProperty
+        public List<Pair<UserDatabaseKey, Set<HivePrivilegeInfo>>> getDatabasePrivileges()
+        {
+            return databasePrivileges;
+        }
+
+        @JsonProperty
+        public List<Pair<UserTableKey, Set<HivePrivilegeInfo>>> getTablePrivileges()
+        {
+            return tablePrivileges;
+        }
+    }
+
+    @Immutable
+    public static class Pair<K, V>
+    {
+        private final K key;
+        private final V value;
+
+        @JsonCreator
+        public Pair(@JsonProperty("key") K key, @JsonProperty("value") V value)
+        {
+            this.key = requireNonNull(key, "key is null");
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        @JsonProperty
+        public K getKey()
+        {
+            return key;
+        }
+
+        @JsonProperty
+        public V getValue()
+        {
+            return value;
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SortingColumn.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SortingColumn.java
@@ -20,9 +20,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Objects;
+
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_FIRST;
 import static com.facebook.presto.spi.block.SortOrder.DESC_NULLS_LAST;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -90,5 +93,35 @@ public class SortingColumn
     public static SortingColumn fromMetastoreApiOrder(org.apache.hadoop.hive.metastore.api.Order order, String tablePartitionName)
     {
         return new SortingColumn(order.getCol(), Order.fromMetastoreApiOrder(order.getOrder(), tablePartitionName));
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columnName", columnName)
+                .add("order", order)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SortingColumn that = (SortingColumn) o;
+        return Objects.equals(columnName, that.columnName) &&
+                order == that.order;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnName, order);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SortingColumn.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/SortingColumn.java
@@ -18,11 +18,14 @@ import com.facebook.presto.spi.block.SortOrder;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.concurrent.Immutable;
+
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_FIRST;
 import static com.facebook.presto.spi.block.SortOrder.DESC_NULLS_LAST;
 import static java.util.Objects.requireNonNull;
 
+@Immutable
 public class SortingColumn
 {
     public enum Order

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Storage.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Storage.java
@@ -20,8 +20,10 @@ import com.google.common.collect.ImmutableMap;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -75,6 +77,42 @@ public class Storage
     public Map<String, String> getSerdeParameters()
     {
         return serdeParameters;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("skewed", skewed)
+                .add("storageFormat", storageFormat)
+                .add("location", location)
+                .add("bucketProperty", bucketProperty)
+                .add("serdeParameters", serdeParameters)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Storage storage = (Storage) o;
+        return skewed == storage.skewed &&
+                Objects.equals(storageFormat, storage.storageFormat) &&
+                Objects.equals(location, storage.location) &&
+                Objects.equals(bucketProperty, storage.bucketProperty) &&
+                Objects.equals(serdeParameters, storage.serdeParameters);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(skewed, storageFormat, location, bucketProperty, serdeParameters);
     }
 
     public static Builder builder()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Table.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/Table.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -137,15 +138,6 @@ public class Table
         return viewExpandedText;
     }
 
-    @Override
-    public String toString()
-    {
-        return toStringHelper(this)
-                .add("databaseName", databaseName)
-                .add("tableName", tableName)
-                .toString();
-    }
-
     public static Builder builder()
     {
         return new Builder();
@@ -154,6 +146,62 @@ public class Table
     public static Builder builder(Table table)
     {
         return new Builder(table);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("databaseName", databaseName)
+                .add("tableName", tableName)
+                .add("owner", owner)
+                .add("tableType", tableType)
+                .add("dataColumns", dataColumns)
+                .add("partitionColumns", partitionColumns)
+                .add("storage", storage)
+                .add("parameters", parameters)
+                .add("viewOriginalText", viewOriginalText)
+                .add("viewExpandedText", viewExpandedText)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Table table = (Table) o;
+        return Objects.equals(databaseName, table.databaseName) &&
+                Objects.equals(tableName, table.tableName) &&
+                Objects.equals(owner, table.owner) &&
+                Objects.equals(tableType, table.tableType) &&
+                Objects.equals(dataColumns, table.dataColumns) &&
+                Objects.equals(partitionColumns, table.partitionColumns) &&
+                Objects.equals(storage, table.storage) &&
+                Objects.equals(parameters, table.parameters) &&
+                Objects.equals(viewOriginalText, table.viewOriginalText) &&
+                Objects.equals(viewExpandedText, table.viewExpandedText);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(
+                databaseName,
+                tableName,
+                owner,
+                tableType,
+                dataColumns,
+                partitionColumns,
+                storage,
+                parameters,
+                viewOriginalText,
+                viewExpandedText);
     }
 
     public static class Builder

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/UserDatabaseKey.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/UserDatabaseKey.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class UserDatabaseKey
+{
+    private final String user;
+    private final String database;
+
+    @JsonCreator
+    public UserDatabaseKey(@JsonProperty("user") String user, @JsonProperty("database") String database)
+    {
+        this.user = requireNonNull(user, "principalName is null");
+        this.database = requireNonNull(database, "database is null");
+    }
+
+    @JsonProperty
+    public String getUser()
+    {
+        return user;
+    }
+
+    @JsonProperty
+    public String getDatabase()
+    {
+        return database;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserDatabaseKey that = (UserDatabaseKey) o;
+        return Objects.equals(user, that.user) &&
+                Objects.equals(database, that.database);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(user, database);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("principalName", user)
+                .add("database", database)
+                .toString();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/UserTableKey.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/UserTableKey.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class UserTableKey
+{
+    private final String user;
+    private final String database;
+    private final String table;
+
+    @JsonCreator
+    public UserTableKey(@JsonProperty("user") String user, @JsonProperty("table") String table, @JsonProperty("database") String database)
+    {
+        this.user = requireNonNull(user, "user is null");
+        this.table = requireNonNull(table, "table is null");
+        this.database = requireNonNull(database, "database is null");
+    }
+
+    @JsonProperty
+    public String getUser()
+    {
+        return user;
+    }
+
+    @JsonProperty
+    public String getDatabase()
+    {
+        return database;
+    }
+
+    @JsonProperty
+    public String getTable()
+    {
+        return table;
+    }
+
+    public boolean matches(String databaseName, String tableName)
+    {
+        return this.database.equals(databaseName) && this.table.equals(tableName);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserTableKey that = (UserTableKey) o;
+        return Objects.equals(user, that.user) &&
+                Objects.equals(table, that.table) &&
+                Objects.equals(database, that.database);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(user, table, database);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("user", user)
+                .add("table", table)
+                .add("database", database)
+                .toString();
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -107,6 +107,9 @@ public class TestHiveClientConfig
                 .setHdfsWireEncryptionEnabled(false)
                 .setPartitionStatisticsSampleSize(100)
                 .setIgnoreCorruptedStatistics(false)
+                .setRecordingPath(null)
+                .setRecordingDuration(new Duration(0, TimeUnit.MINUTES))
+                .setReplay(false)
                 .setCollectColumnStatisticsOnWrite(false));
     }
 
@@ -183,6 +186,9 @@ public class TestHiveClientConfig
                 .put("hive.hdfs.wire-encryption.enabled", "true")
                 .put("hive.partition-statistics-sample-size", "1234")
                 .put("hive.ignore-corrupted-statistics", "true")
+                .put("hive.metastore-recording-path", "/foo/bar")
+                .put("hive.metastore-recoding-duration", "42s")
+                .put("hive.replay-metastore-recording", "true")
                 .put("hive.collect-column-statistics-on-write", "true")
                 .build();
 
@@ -256,6 +262,9 @@ public class TestHiveClientConfig
                 .setHdfsWireEncryptionEnabled(true)
                 .setPartitionStatisticsSampleSize(1234)
                 .setIgnoreCorruptedStatistics(true)
+                .setRecordingPath("/foo/bar")
+                .setRecordingDuration(new Duration(42, TimeUnit.SECONDS))
+                .setReplay(true)
                 .setCollectColumnStatisticsOnWrite(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.hive.HiveBasicStatistics;
+import com.facebook.presto.hive.HiveBucketProperty;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.PartitionStatistics;
+import com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import com.facebook.presto.hive.metastore.SortingColumn.Order;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.hive.HiveBasicStatistics.createEmptyStatistics;
+import static com.facebook.presto.spi.statistics.ColumnStatisticType.MAX_VALUE;
+import static com.facebook.presto.spi.statistics.ColumnStatisticType.MIN_VALUE;
+import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static org.testng.Assert.assertEquals;
+
+public class TestRecordingHiveMetastore
+{
+    private static final Database DATABASE = new Database(
+            "database",
+            Optional.of("location"),
+            "owner",
+            PrincipalType.USER,
+            Optional.of("comment"),
+            ImmutableMap.of("param", "value"));
+    private static final Column TABLE_COLUMN = new Column(
+            "column",
+            HiveType.HIVE_INT,
+            Optional.of("comment"));
+    private static final Storage TABLE_STORAGE = new Storage(
+            StorageFormat.create("serde", "input", "output"),
+            "location",
+            Optional.of(new HiveBucketProperty(ImmutableList.of("column"), 10, ImmutableList.of(new SortingColumn("column", Order.ASCENDING)))),
+            true,
+            ImmutableMap.of("param", "value2"));
+    private static final Table TABLE = new Table(
+            "database",
+            "table",
+            "owner",
+            "table_type",
+            TABLE_STORAGE,
+            ImmutableList.of(TABLE_COLUMN),
+            ImmutableList.of(TABLE_COLUMN),
+            ImmutableMap.of("param", "value3"),
+            Optional.of("original_text"),
+            Optional.of("expanded_text"));
+    private static final Partition PARTITION = new Partition(
+            "database",
+            "table",
+            ImmutableList.of("value"),
+            TABLE_STORAGE,
+            ImmutableList.of(TABLE_COLUMN),
+            ImmutableMap.of("param", "value4"));
+    private static final PartitionStatistics PARTITION_STATISTICS = new PartitionStatistics(
+            new HiveBasicStatistics(10, 11, 10000, 10001),
+            ImmutableMap.of("column", new HiveColumnStatistics(
+                    Optional.of(new IntegerStatistics(
+                            OptionalLong.of(-100),
+                            OptionalLong.of(102))),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.of(1234),
+                    OptionalLong.of(1235),
+                    OptionalLong.of(1),
+                    OptionalLong.of(8))));
+    private static final HivePrivilegeInfo PRIVILEGE_INFO = new HivePrivilegeInfo(HivePrivilege.SELECT, true);
+
+    @Test
+    public void testRecordingHiveMetastore()
+            throws IOException
+    {
+        HiveClientConfig recordingHiveClientConfig = new HiveClientConfig()
+                .setRecordingPath(File.createTempFile("recording_test", "json").getAbsolutePath())
+                .setRecordingDuration(new Duration(10, TimeUnit.MINUTES));
+
+        RecordingHiveMetastore recordingHiveMetastore = new RecordingHiveMetastore(new TestingHiveMetastore(), recordingHiveClientConfig);
+        validateMetadata(recordingHiveMetastore);
+        recordingHiveMetastore.dropDatabase("other_database");
+        recordingHiveMetastore.writeRecording();
+
+        HiveClientConfig replayingHiveClientConfig = recordingHiveClientConfig
+                .setReplay(true);
+
+        recordingHiveMetastore = new RecordingHiveMetastore(new UnimplementedHiveMetastore(), replayingHiveClientConfig);
+        recordingHiveMetastore.loadRecording();
+        validateMetadata(recordingHiveMetastore);
+    }
+
+    private void validateMetadata(ExtendedHiveMetastore hiveMetastore)
+    {
+        assertEquals(hiveMetastore.getDatabase("database"), Optional.of(DATABASE));
+        assertEquals(hiveMetastore.getAllDatabases(), ImmutableList.of("database"));
+        assertEquals(hiveMetastore.getTable("database", "table"), Optional.of(TABLE));
+        assertEquals(hiveMetastore.getSupportedColumnStatistics(createVarcharType(123)), ImmutableSet.of(MIN_VALUE, MAX_VALUE));
+        assertEquals(hiveMetastore.getTableStatistics("database", "table"), PARTITION_STATISTICS);
+        assertEquals(hiveMetastore.getPartitionStatistics("database", "table", ImmutableSet.of("value")), ImmutableMap.of("value", PARTITION_STATISTICS));
+        assertEquals(hiveMetastore.getAllTables("database"), Optional.of(ImmutableList.of("table")));
+        assertEquals(hiveMetastore.getAllViews("database"), Optional.empty());
+        assertEquals(hiveMetastore.getPartition("database", "table", ImmutableList.of("value")), Optional.of(PARTITION));
+        assertEquals(hiveMetastore.getPartitionNames("database", "table"), Optional.of(ImmutableList.of("value")));
+        assertEquals(hiveMetastore.getPartitionNamesByParts("database", "table", ImmutableList.of("value")), Optional.of(ImmutableList.of("value")));
+        assertEquals(hiveMetastore.getPartitionsByNames("database", "table", ImmutableList.of("value")), ImmutableMap.of("value", Optional.of(PARTITION)));
+        assertEquals(hiveMetastore.getRoles("user"), ImmutableSet.of("role1", "role2"));
+        assertEquals(hiveMetastore.getDatabasePrivileges("user", "database"), ImmutableSet.of(PRIVILEGE_INFO));
+        assertEquals(hiveMetastore.getTablePrivileges("user", "database", "table"), ImmutableSet.of(PRIVILEGE_INFO));
+    }
+
+    private static class TestingHiveMetastore
+            extends UnimplementedHiveMetastore
+    {
+        @Override
+        public Optional<Database> getDatabase(String databaseName)
+        {
+            if (databaseName.equals("database")) {
+                return Optional.of(DATABASE);
+            }
+
+            return Optional.empty();
+        }
+
+        @Override
+        public List<String> getAllDatabases()
+        {
+            return ImmutableList.of("database");
+        }
+
+        @Override
+        public Optional<Table> getTable(String databaseName, String tableName)
+        {
+            if (databaseName.equals("database") && tableName.equals("table")) {
+                return Optional.of(TABLE);
+            }
+
+            return Optional.empty();
+        }
+
+        @Override
+        public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
+        {
+            if (type.equals(createVarcharType(123))) {
+                return ImmutableSet.of(MIN_VALUE, MAX_VALUE);
+            }
+
+            return ImmutableSet.of();
+        }
+
+        @Override
+        public PartitionStatistics getTableStatistics(String databaseName, String tableName)
+        {
+            if (databaseName.equals("database") && tableName.equals("table")) {
+                return PARTITION_STATISTICS;
+            }
+
+            return new PartitionStatistics(createEmptyStatistics(), ImmutableMap.of());
+        }
+
+        @Override
+        public Map<String, PartitionStatistics> getPartitionStatistics(String databaseName, String tableName, Set<String> partitionNames)
+        {
+            if (databaseName.equals("database") && tableName.equals("table") && partitionNames.contains("value")) {
+                return ImmutableMap.of("value", PARTITION_STATISTICS);
+            }
+
+            return ImmutableMap.of();
+        }
+
+        @Override
+        public Optional<List<String>> getAllTables(String databaseName)
+        {
+            if (databaseName.equals("database")) {
+                return Optional.of(ImmutableList.of("table"));
+            }
+
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<List<String>> getAllViews(String databaseName)
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public void dropDatabase(String databaseName)
+        {
+            // noop for test purpose
+        }
+
+        @Override
+        public Optional<Partition> getPartition(String databaseName, String tableName, List<String> partitionValues)
+        {
+            if (databaseName.equals("database") && tableName.equals("table") && partitionValues.equals(ImmutableList.of("value"))) {
+                return Optional.of(PARTITION);
+            }
+
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<List<String>> getPartitionNames(String databaseName, String tableName)
+        {
+            if (databaseName.equals("database") && tableName.equals("table")) {
+                return Optional.of(ImmutableList.of("value"));
+            }
+
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<List<String>> getPartitionNamesByParts(String databaseName, String tableName, List<String> parts)
+        {
+            if (databaseName.equals("database") && tableName.equals("table") && parts.equals(ImmutableList.of("value"))) {
+                return Optional.of(ImmutableList.of("value"));
+            }
+
+            return Optional.empty();
+        }
+
+        @Override
+        public Map<String, Optional<Partition>> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
+        {
+            if (databaseName.equals("database") && tableName.equals("table") && partitionNames.contains("value")) {
+                return ImmutableMap.of("value", Optional.of(PARTITION));
+            }
+
+            return ImmutableMap.of();
+        }
+
+        @Override
+        public Set<String> getRoles(String user)
+        {
+            return ImmutableSet.of("role1", "role2");
+        }
+
+        @Override
+        public Set<HivePrivilegeInfo> getDatabasePrivileges(String user, String databaseName)
+        {
+            if (user.equals("user") && databaseName.equals("database")) {
+                return ImmutableSet.of(PRIVILEGE_INFO);
+            }
+
+            return ImmutableSet.of();
+        }
+
+        @Override
+        public Set<HivePrivilegeInfo> getTablePrivileges(String user, String databaseName, String tableName)
+        {
+            if (user.equals("user") && databaseName.equals("database") && tableName.equals("table")) {
+                return ImmutableSet.of(PRIVILEGE_INFO);
+            }
+
+            return ImmutableSet.of();
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.PartitionStatistics;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+class UnimplementedHiveMetastore
+        implements ExtendedHiveMetastore
+{
+    @Override
+    public Optional<Database> getDatabase(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getAllDatabases()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Table> getTable(String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PartitionStatistics getTableStatistics(String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, PartitionStatistics> getPartitionStatistics(String databaseName, String tableName, Set<String> partitionNames)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateTableStatistics(String databaseName, String tableName, Function<PartitionStatistics, PartitionStatistics> update)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updatePartitionStatistics(String databaseName, String tableName, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<String>> getAllTables(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<String>> getAllViews(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createDatabase(Database database)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropDatabase(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameDatabase(String databaseName, String newDatabaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createTable(Table table, PrincipalPrivileges principalPrivileges)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropTable(String databaseName, String tableName, boolean deleteData)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void replaceTable(String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameTable(String databaseName, String tableName, String newDatabaseName, String newTableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addColumn(String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameColumn(String databaseName, String tableName, String oldColumnName, String newColumnName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropColumn(String databaseName, String tableName, String columnName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Partition> getPartition(String databaseName, String tableName, List<String> partitionValues)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<String>> getPartitionNames(String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<String>> getPartitionNamesByParts(String databaseName, String tableName, List<String> parts)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Optional<Partition>> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addPartitions(String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropPartition(String databaseName, String tableName, List<String> parts, boolean deleteData)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void alterPartition(String databaseName, String tableName, PartitionWithStatistics partition)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<String> getRoles(String user)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<HivePrivilegeInfo> getDatabasePrivileges(String user, String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<HivePrivilegeInfo> getTablePrivileges(String user, String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void grantTablePrivileges(String databaseName, String tableName, String grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void revokeTablePrivileges(String databaseName, String tableName, String grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
    RecordingHiveMetastore will capture results of
    metastore calls for a predefined period of time.
    It can then save such collected results as a JSON
    file which can be loaded later on for debugging
    purpsoses.

    This change will simplify remote debugging of
    planner and CBO issues. Therefore community
    won't have to reproduce planner issues using
    TPCH connector which is sometimes impossible
    (e.g: CBO issues).

FYI: @electrum 