### PR TITLE
[WIP] Check yield signal every 5s in generated project method

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -268,7 +268,7 @@ public class PageFunctionCompiler
         return classDefinition;
     }
 
-    private static MethodDefinition generateProcessMethod(
+    private MethodDefinition generateProcessMethod(
             ClassDefinition classDefinition,
             FieldDefinition blockBuilder,
             FieldDefinition session,
@@ -319,7 +319,7 @@ public class PageFunctionCompiler
         return method;
     }
 
-    private static BytecodeBlock generateCheckYieldBlock(Variable thisVariable, Variable index, FieldDefinition yieldSignal, FieldDefinition nextIndexOrPosition)
+    private BytecodeBlock generateCheckYieldBlock(Variable thisVariable, Variable index, FieldDefinition yieldSignal, FieldDefinition nextIndexOrPosition)
     {
         return new BytecodeBlock()
                 .comment("if (yieldSignal.isSet())")

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -46,6 +46,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
@@ -261,7 +262,7 @@ public class TestScanFilterAndProjectOperator
         metadata.getFunctionRegistry().addFunctions(functions.build());
 
         // match each column with a projection
-        ExpressionCompiler expressionCompiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
+        ExpressionCompiler expressionCompiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0, OptionalLong.of(0L)));
         ImmutableList.Builder<RowExpression> projections = ImmutableList.builder();
         for (int i = 0; i < totalColumns; i++) {
             projections.add(call(internalScalarFunction("generic_long_page_col" + i, BIGINT.getTypeSignature(), ImmutableList.of(BIGINT.getTypeSignature())), BIGINT, field(0, BIGINT)));

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
@@ -28,6 +28,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
@@ -66,7 +67,7 @@ public class TestPageFunctionCompiler
     @Test(dataProvider = "forceYield")
     public void testFailureDoesNotCorruptFutureResults(boolean forceYield)
     {
-        PageFunctionCompiler functionCompiler = new PageFunctionCompiler(createTestMetadataManager(), 0);
+        PageFunctionCompiler functionCompiler = new PageFunctionCompiler(createTestMetadataManager(), 0, OptionalLong.of(0L));
 
         Supplier<PageProjection> projectionSupplier = functionCompiler.compileProjection(ADD_10_EXPRESSION, Optional.empty());
         PageProjection projection = projectionSupplier.get();


### PR DESCRIPTION
As reported in the slack channel checking the yield signal at every row hits the performance. I experimented with the simple idea of checking the yield signal every `5s` (also tried `1s`, but it didn't perform as well). I didn't explore the more complex idea of profiling the project method first and then doing tricks after that, which would make the code generation logic pretty complex (maybe we can get better performance than this simple change though, we don't know).

I ran tpch q1, q10, and q15, which I arbitrarily picked, and I used a scale factor 100. Below are the improvements/savings (*none* of the tests resulted in worse performance, which is nice) in aggregate CPU time spent in the `ScanFilterAndProject` operators in these queries. When there are multiple numbers for a query it means that there are multiple stages with `ScanFilterAndProject` operators (these numbers are aggregated stage-wide). Also, here's the generated project method with this change: https://gist.github.com/nezihyigitbasi/b015a718e49280ed2079e14b2946e1a1

- **q1:** 4%
- **q11:** 20%, 17%, 31%, 19%
- **q15:** 19%, 1%, 1%

Overall, the results seem promising, and it may be worth applying this change. Curious to hear other thoughts.

[Update: tpch q11 is used, not q10]