### PR TITLE
Improve performance for DictionaryBlock.getSizeInBytes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -62,6 +62,12 @@ public class GroupByIdBlock
     }
 
     @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return block.getPositionsSizeInBytes(positions);
+    }
+
+    @Override
     public Block copyRegion(int positionOffset, int length)
     {
         return block.copyRegion(positionOffset, length);

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -48,6 +48,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
+import static java.util.Arrays.fill;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotSame;
@@ -224,6 +225,14 @@ public abstract class AbstractTestBlock
         long expectedSecondHalfSize = copyBlockViaBlockSerde(secondHalf).getSizeInBytes();
         assertEquals(secondHalf.getSizeInBytes(), expectedSecondHalfSize);
         assertEquals(block.getRegionSizeInBytes(firstHalf.getPositionCount(), secondHalf.getPositionCount()), expectedSecondHalfSize);
+
+        boolean[] positions = new boolean[block.getPositionCount()];
+        fill(positions, 0, firstHalf.getPositionCount(), true);
+        assertEquals(block.getPositionsSizeInBytes(positions), expectedFirstHalfSize);
+        fill(positions, true);
+        assertEquals(block.getPositionsSizeInBytes(positions), expectedBlockSize);
+        fill(positions, 0, firstHalf.getPositionCount(), false);
+        assertEquals(block.getPositionsSizeInBytes(positions), expectedSecondHalfSize);
     }
 
     // expectedValueType is required since otherwise the expected value type is unknown when expectedValue is null.

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/BenchmarkDictionaryBlockGetSizeInBytes.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/BenchmarkDictionaryBlockGetSizeInBytes.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.project;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static com.facebook.presto.block.BlockAssertions.createSlicesBlock;
+import static com.facebook.presto.spi.block.MethodHandleUtil.compose;
+import static com.facebook.presto.spi.block.MethodHandleUtil.nativeValueGetter;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(5)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkDictionaryBlockGetSizeInBytes
+{
+    @Benchmark
+    public long getSizeInBytes(BenchmarkData data)
+    {
+        return data.getDictionaryBlock().getSizeInBytes();
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private static final int POSITIONS = 100_000;
+        @Param({"100", "1000", "10000", "100000"})
+        private String selectedPositions = "100";
+
+        private DictionaryBlock dictionaryBlock;
+
+        @Setup(Level.Invocation)
+        public void setup()
+        {
+            dictionaryBlock = new DictionaryBlock(createMapBlock(POSITIONS), generateIds(Integer.parseInt(selectedPositions), POSITIONS));
+        }
+
+        private static Block createMapBlock(int positionCount)
+        {
+            Type keyType = VARCHAR;
+            Type valueType = VARCHAR;
+            MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
+            MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+            MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
+            MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+            MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
+            MapType mapType = new MapType(
+                    keyType,
+                    valueType,
+                    keyBlockNativeEquals,
+                    keyBlockEquals,
+                    keyNativeHashCode,
+                    keyBlockHashCode);
+            Block keyBlock = createDictionaryBlock(generateList("key", positionCount));
+            Block valueBlock = createDictionaryBlock(generateList("value", positionCount));
+            int[] offsets = new int[positionCount + 1];
+            int mapSize = keyBlock.getPositionCount() / positionCount;
+            for (int i = 0; i < offsets.length; i++) {
+                offsets[i] = mapSize * i;
+            }
+            return mapType.createBlockFromKeyValue(Optional.empty(), offsets, keyBlock, valueBlock);
+        }
+
+        private static Block createDictionaryBlock(List<String> values)
+        {
+            Block dictionary = createSliceArrayBlock(values);
+            int[] ids = new int[values.size()];
+            for (int i = 0; i < ids.length; i++) {
+                ids[i] = i;
+            }
+            return new DictionaryBlock(dictionary, ids);
+        }
+
+        private static Block createSliceArrayBlock(List<String> values)
+        {
+            // last position is reserved for null
+            Slice[] sliceArray = new Slice[values.size() + 1];
+            for (int i = 0; i < values.size(); i++) {
+                sliceArray[i] = utf8Slice(values.get(i));
+            }
+            return createSlicesBlock(sliceArray);
+        }
+
+        private static List<String> generateList(String prefix, int count)
+        {
+            ImmutableList.Builder<String> list = ImmutableList.builder();
+            for (int i = 0; i < count; i++) {
+                list.add(prefix + Integer.toString(i));
+            }
+            return list.build();
+        }
+
+        private static int[] generateIds(int count, int range)
+        {
+            return new Random().ints(count, 0, range).toArray();
+        }
+
+        public DictionaryBlock getDictionaryBlock()
+        {
+            return dictionaryBlock;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkDictionaryBlockGetSizeInBytes().getSizeInBytes(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkDictionaryBlockGetSizeInBytes.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.block;
 
 import static com.facebook.presto.spi.block.ArrayBlock.createArrayBlockInternal;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
@@ -98,6 +99,25 @@ public abstract class AbstractArrayBlock
         int valueEnd = getOffsets()[getOffsetBase() + position + length];
 
         return getRawElementBlock().getRegionSizeInBytes(valueStart, valueEnd - valueStart) + ((Integer.BYTES + Byte.BYTES) * (long) length);
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        checkValidPositions(positions, getPositionCount());
+        boolean[] used = new boolean[getRawElementBlock().getPositionCount()];
+        int usedPositionCount = 0;
+        for (int i = 0; i < positions.length; ++i) {
+            if (positions[i]) {
+                usedPositionCount++;
+                int valueStart = getOffsets()[getOffsetBase() + i];
+                int valueEnd = getOffsets()[getOffsetBase() + i + 1];
+                for (int j = valueStart; j < valueEnd; ++j) {
+                    used[j] = true;
+                }
+            }
+        }
+        return getRawElementBlock().getPositionsSizeInBytes(used) + ((Integer.BYTES + Byte.BYTES) * (long) usedPositionCount);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractFixedWidthBlock.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slices;
 import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
 
 public abstract class AbstractFixedWidthBlock
         implements Block
@@ -184,6 +185,12 @@ public abstract class AbstractFixedWidthBlock
         int positionCount = getPositionCount();
         checkValidRegion(positionCount, positionOffset, length);
         return (fixedSize + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (fixedSize + Byte.BYTES) * (long) countUsedPositions(positions);
     }
 
     private int valueOffset(int position)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.block;
 
 import static com.facebook.presto.spi.block.BlockUtil.arraySame;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
@@ -105,6 +106,30 @@ public abstract class AbstractRowBlock
             regionSizeInBytes += getRawFieldBlocks()[i].getRegionSizeInBytes(startFieldBlockOffset, fieldBlockLength);
         }
         return regionSizeInBytes;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        checkValidPositions(positions, getPositionCount());
+
+        int usedPositionCount = 0;
+        boolean[] fieldPositions = new boolean[getRawFieldBlocks()[0].getPositionCount()];
+        for (int i = 0; i < positions.length; i++) {
+            if (positions[i]) {
+                usedPositionCount++;
+                int startFieldBlockOffset = getFieldBlockOffset(i);
+                int endFieldBlockOffset = getFieldBlockOffset(i + 1);
+                for (int j = startFieldBlockOffset; j < endFieldBlockOffset; j++) {
+                    fieldPositions[j] = true;
+                }
+            }
+        }
+        long sizeInBytes = 0;
+        for (int j = 0; j < numFields; j++) {
+            sizeInBytes += getRawFieldBlocks()[j].getPositionsSizeInBytes(fieldPositions);
+        }
+        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -179,6 +179,12 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Block copyRegion(int position, int length)
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
@@ -247,6 +247,12 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Block copyPositions(int[] positions, int offset, int length)
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
@@ -161,6 +161,12 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Block copyPositions(int[] positions, int offset, int length)
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -190,6 +190,13 @@ public interface Block
     long getRegionSizeInBytes(int position, int length);
 
     /**
+     * Returns the size of of all positions marked true in the positions array.
+     * This is equivalent to multiple calls of {@code block.getRegionSizeInBytes(position, length)}
+     * where you mark all positions for the regions first.
+     */
+    long getPositionsSizeInBytes(boolean[] positions);
+
+    /**
      * Returns the retained size of this block in memory, including over-allocations.
      * This method is called from the inner most execution loop and must be fast.
      */

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
@@ -49,6 +49,13 @@ final class BlockUtil
         }
     }
 
+    static void checkValidPositions(boolean[] positions, int positionCount)
+    {
+        if (positions.length != positionCount) {
+            throw new IllegalArgumentException(format("Invalid positions array size %d, actual position count is %d", positions.length, positionCount));
+        }
+    }
+
     static void checkValidPosition(int position, int positionCount)
     {
         if (position < 0 || position >= positionCount) {
@@ -172,6 +179,16 @@ final class BlockUtil
             return array;
         }
         return Arrays.copyOfRange(array, index, index + length);
+    }
+    static int countUsedPositions(boolean[] positions)
+    {
+        int used = 0;
+        for (boolean position : positions) {
+            if (position) {
+                used++;
+            }
+        }
+        return used;
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
+import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ByteArrayBlock
@@ -79,6 +80,12 @@ public class ByteArrayBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return (Byte.BYTES + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (Byte.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
@@ -144,6 +145,12 @@ public class ByteArrayBlockBuilder
     public long getRegionSizeInBytes(int position, int length)
     {
         return (Byte.BYTES + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (Byte.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
+import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class IntArrayBlock
@@ -79,6 +80,12 @@ public class IntArrayBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return (Integer.BYTES + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (Integer.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
@@ -144,6 +145,12 @@ public class IntArrayBlockBuilder
     public long getRegionSizeInBytes(int position, int length)
     {
         return (Integer.BYTES + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (Integer.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -178,6 +178,13 @@ public class LazyBlock
     }
 
     @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        assureLoaded();
+        return block.getPositionsSizeInBytes(positions);
+    }
+
+    @Override
     public long getRetainedSizeInBytes()
     {
         assureLoaded();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
+import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.toIntExact;
 
@@ -80,6 +81,12 @@ public class LongArrayBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return (Long.BYTES + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (Long.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
@@ -145,6 +146,12 @@ public class LongArrayBlockBuilder
     public long getRegionSizeInBytes(int position, int length)
     {
         return (Long.BYTES + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (Long.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -146,6 +146,12 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return value.getSizeInBytes();
+    }
+
+    @Override
     public Block copyRegion(int positionOffset, int length)
     {
         checkValidRegion(positionCount, positionOffset, length);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
+import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ShortArrayBlock
@@ -79,6 +80,12 @@ public class ShortArrayBlock
     public long getRegionSizeInBytes(int position, int length)
     {
         return (Short.BYTES + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (Short.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
@@ -144,6 +145,12 @@ public class ShortArrayBlockBuilder
     public long getRegionSizeInBytes(int position, int length)
     {
         return (Short.BYTES + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (Short.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
@@ -124,6 +124,20 @@ public class VariableWidthBlock
     }
 
     @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        long sizeInBytes = 0;
+        int usedPositionCount = 0;
+        for (int i = 0; i < positions.length; ++i) {
+            if (positions[i]) {
+                usedPositionCount++;
+                sizeInBytes += offsets[arrayOffset + i + 1] - offsets[arrayOffset + i];
+            }
+        }
+        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount;
+    }
+
+    @Override
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -29,6 +29,7 @@ import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetBytes;
 import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPosition;
+import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
@@ -114,6 +115,21 @@ public class VariableWidthBlockBuilder
         checkValidRegion(positionCount, positionOffset, length);
         long arraysSizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) length;
         return getOffset(positionOffset + length) - getOffset(positionOffset) + arraysSizeInBytes;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        checkValidPositions(positions, getPositionCount());
+        long sizeInBytes = 0;
+        int usedPositionCount = 0;
+        for (int i = 0; i < positions.length; ++i) {
+            if (positions[i]) {
+                usedPositionCount++;
+                sizeInBytes += getOffset(i + 1) - getOffset(i);
+            }
+        }
+        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount;
     }
 
     @Override


### PR DESCRIPTION
```
    Before:
    Benchmark                                              (selectedPositions)  Mode  Cnt       Score       Error  Units
    BenchmarkDictionaryBlockGetSizeInBytes.getSizeInBytes                  100  avgt   20    5173.612 ±  6164.744  us/op
    BenchmarkDictionaryBlockGetSizeInBytes.getSizeInBytes                 1000  avgt   20   32607.266 ± 37310.523  us/op
    BenchmarkDictionaryBlockGetSizeInBytes.getSizeInBytes                10000  avgt   20  113352.382 ± 13933.478  us/op
    BenchmarkDictionaryBlockGetSizeInBytes.getSizeInBytes               100000  avgt   20  771976.351 ± 54696.701  us/op

    After:
    Benchmark                                              (selectedPositions)  Mode  Cnt     Score     Error  Units
    BenchmarkDictionaryBlockGetSizeInBytes.getSizeInBytes                  100  avgt   20   434.331 ±  49.481  us/op
    BenchmarkDictionaryBlockGetSizeInBytes.getSizeInBytes                 1000  avgt   20   612.484 ±  94.415  us/op
    BenchmarkDictionaryBlockGetSizeInBytes.getSizeInBytes                10000  avgt   20   908.409 ±  82.704  us/op
    BenchmarkDictionaryBlockGetSizeInBytes.getSizeInBytes               100000  avgt   20  3043.432 ± 289.973  us/op
```