### PR TITLE
Fix PredicatePushdown join_distribution_type for CBO

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -81,6 +81,7 @@ import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionT
 import static com.facebook.presto.sql.planner.DeterminismEvaluator.isDeterministic;
 import static com.facebook.presto.sql.planner.EqualityInference.createEqualityInference;
 import static com.facebook.presto.sql.planner.ExpressionSymbolInliner.inlineSymbols;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
@@ -483,7 +484,7 @@ public class PredicatePushDown
                         newJoinFilter,
                         node.getLeftHashSymbol(),
                         node.getRightHashSymbol(),
-                        node.getDistributionType());
+                        equiJoinClauses.isEmpty() ? Optional.of(REPLICATED) : node.getDistributionType());
             }
 
             if (!postJoinPredicate.equals(TRUE_LITERAL)) {


### PR DESCRIPTION
When turning on Cost based optimizer, with join_distribution_type set to 'PARTITIONED' or 'AUTOMATIC', for some joins, users could get Error:
Equi criteria are empty, so INNER join should not have PARTITIONED distribution type

DetermineJoinDistributionType could set join_distribution_type to be 'PARTITIONED', PredicatePushdown should adjust join distribution type dynamically, instead of just copying from existing JoinNode
