### PR TITLE
Update documentation for guarantees provided by startMemoryRevoke()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Operator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Operator.java
@@ -56,11 +56,14 @@ public interface Operator
      * As soon as memory is revoked returned future should be marked as done.
      * <p>
      * Spawned threads can not modify OperatorContext because it's not thread safe.
-     * For this purpose use implement finishMemoryRevoke
+     * For this purpose implement {@link #finishMemoryRevoke()}
      * <p>
-     * After startMemoryRevoke is called on Operator the Driver is disallowed to call any
+     * Since memory revoking signal is delivered asynchronously to the Operator, implementation
+     * must gracefully handle the case when there no longer is any revocable memory allocated.
+     * <p>
+     * After this method is called on Operator the Driver is disallowed to call any
      * processing methods on it (isBlocked/needsInput/addInput/getOutput) until
-     * finishMemoryRevoke is called.
+     * {@link #finishMemoryRevoke()} is called.
      */
     default ListenableFuture<?> startMemoryRevoke()
     {


### PR DESCRIPTION
The guarantees were changed in 7d1157312873e83d9fa662855416bc21427cdf42
and cf50577d755c943f70dc9de01cfd6c2545c8fb3d.